### PR TITLE
Potential fix for code scanning alert no. 4: Jinja2 templating with autoescape=False

### DIFF
--- a/src/kansas_geo_timeline/cli.py
+++ b/src/kansas_geo_timeline/cli.py
@@ -60,6 +60,7 @@ except Exception:  # pragma: no cover
 try:
     import jinja2  # type: ignore
     HAS_JINJA2 = True
+    select_autoescape = jinja2.select_autoescape
 except Exception:  # pragma: no cover
     HAS_JINJA2 = False
 
@@ -282,7 +283,7 @@ def render_app_config(
     t_path = template_path(template_name)
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(str(t_path.parent)),
-        autoescape=False,
+        autoescape=jinja2.select_autoescape(['html', 'xml']),
         trim_blocks=True,
         lstrip_blocks=True,
     )


### PR DESCRIPTION
Potential fix for [https://github.com/bartytime4life/Kansas-Frontier-Matrix/security/code-scanning/4](https://github.com/bartytime4life/Kansas-Frontier-Matrix/security/code-scanning/4)

The general fix is to ensure that Jinja2’s autoescaping is only disabled where it is absolutely certain to be safe, and ideally, Jinja2’s own `select_autoescape` function should be used to automatically enable escaping based on file extensions. To fix this in the `src/kansas_geo_timeline/cli.py` file, update the construction of the Jinja2 environment at line 283 to use `select_autoescape(['html', 'xml'])`. This provides autoescaping for HTML/XML files, but not for JSON or other extensions, matching Jinja2’s prevailing recommendations and thus mitigating the XSS risk.

Specifically, you should:

- Add/reveal an import for `select_autoescape` from `jinja2` (if not already present).
- Change the `autoescape=False` argument to `autoescape=jinja2.select_autoescape(['html', 'xml'])` (or just `select_autoescape(['html', 'xml'])` depending on how it is imported).
- Do not otherwise change rendering logic or template/environment setup.

No project dependencies need to be added, as `select_autoescape` is part of core Jinja2.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
