### PR TITLE
Potential fix for code scanning alert no. 35: Empty except

### DIFF
--- a/src/kansas_geo_timeline/utils.py
+++ b/src/kansas_geo_timeline/utils.py
@@ -464,7 +464,8 @@ def coerce_year(value: Any) -> Optional[int]:
             y = int(value[:4])
             if 0 <= y <= 9999:
                 return y
-    except Exception:
+    except (ValueError, TypeError):
+        # Expected: value cannot be coerced to a valid year (int/str parse failed)
         pass
     return None
 


### PR DESCRIPTION
Potential fix for [https://github.com/bartytime4life/Kansas-Frontier-Matrix/security/code-scanning/35](https://github.com/bartytime4life/Kansas-Frontier-Matrix/security/code-scanning/35)

To fix the problem, the best way is to explicitly document the intent behind catching exceptions, or better, to log or print details about exceptions to preserve debugging information while retaining the function's intended silent-fail behavior. Ideally, we should restrict the exception handler to the known failure types (e.g., `ValueError`, `TypeError`) and, if we want entirely silent failure, add a comment explaining why.

The most robust fix, without changing functionality, is to either:
- Log the exception at debug level (but avoid introducing non-stdlib logging if it's outside the permitted scope). Or,
- Add a brief comment specifying that exceptions are intentionally suppressed because failure to coerce is an expected, non-fatal outcome, and optionally restrict the exception type.

For this codebase (which currently does not use `logging`), the best fix is to change `except Exception:` to `except (ValueError, TypeError):  # Expected: cannot coerce to year` and add an explanatory comment.

Only the function `coerce_year` in `src/kansas_geo_timeline/utils.py` needs to be edited, at lines 467-468.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
