### PR TITLE
Potential fix for code scanning alert no. 28: Empty except

### DIFF
--- a/src/kansas_geo_timeline/__init__.py
+++ b/src/kansas_geo_timeline/__init__.py
@@ -21,6 +21,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
+import logging
 
 # ---------------------------------------------------------------------------
 # Version (stdlib importlib.metadata with backport fallback)
@@ -95,8 +96,8 @@ def _resource_pkg_dir(subdir: str) -> Optional[Path]:
         p = Path(str(traversable))
         if p.exists() and p.is_dir():
             return p
-    except Exception:
-        pass
+    except Exception as e:
+        logging.debug(f"_resource_pkg_dir({subdir!r}): failed to resolve resource directory: {e}", exc_info=True)
     return None
 
 def _first_existing(paths: Iterable[Optional[Path]]) -> Optional[Path]:


### PR DESCRIPTION
Potential fix for [https://github.com/bartytime4life/Kansas-Frontier-Matrix/security/code-scanning/28](https://github.com/bartytime4life/Kansas-Frontier-Matrix/security/code-scanning/28)

The best way to fix this issue is to log the caught exception rather than simply passing, or otherwise provide an informative comment explaining why exceptions are intentionally ignored in this specific context. To preserve the current lightweight dependency requirements and avoid introducing heavy dependencies, the fix can use the standard library's `logging` module, and log the exception at the debug level, ensuring that those who want to debug issues have traceability, but the normal flow is unaffected. The log statement should be added inside the `except Exception:` block at line 98. If not already imported, the `logging` module should be imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
