### PR TITLE
Add missing scaffold docs referenced by README files

### DIFF
--- a/docs/db/README.md
+++ b/docs/db/README.md
@@ -1,0 +1,3 @@
+# docs/db/
+
+Placeholder directory for database documentation referenced by migration docs.

--- a/docs/policies/README.md
+++ b/docs/policies/README.md
@@ -1,0 +1,3 @@
+# docs/policies/
+
+Placeholder README created to satisfy repository scaffold references.

--- a/docs/runbooks/db-migrations.md
+++ b/docs/runbooks/db-migrations.md
@@ -1,0 +1,3 @@
+# DB Migrations Runbook
+
+Placeholder runbook created from README scaffold references.

--- a/infra/docs/runbooks/apply.md
+++ b/infra/docs/runbooks/apply.md
@@ -1,0 +1,3 @@
+# Infra Apply Runbook
+
+Placeholder runbook for safely applying infrastructure changes.

--- a/infra/docs/runbooks/drift.md
+++ b/infra/docs/runbooks/drift.md
@@ -1,0 +1,3 @@
+# Infra Drift Runbook
+
+Placeholder runbook for drift detection and remediation.

--- a/infra/docs/runbooks/incident.md
+++ b/infra/docs/runbooks/incident.md
@@ -1,0 +1,3 @@
+# Infra Incident Runbook
+
+Placeholder runbook for infrastructure incident escalation.

--- a/infra/docs/runbooks/rollback.md
+++ b/infra/docs/runbooks/rollback.md
@@ -1,0 +1,3 @@
+# Infra Rollback Runbook
+
+Placeholder runbook for infrastructure rollback procedures.


### PR DESCRIPTION
### Motivation
- Several README files include TODOs and scaffold trees that reference runbooks and policy/db doc paths which did not exist, causing broken references; add minimal placeholders so the repo tree matches documented expectations.

### Description
- Create `docs/policies/README.md` as a placeholder to satisfy `docs/README.md` references.
- Create `docs/db/README.md` and `docs/runbooks/db-migrations.md` as placeholders referenced by migration and docs scaffolds.
- Add infra runbook placeholders under `infra/docs/runbooks/`: `apply.md`, `rollback.md`, `drift.md`, and `incident.md`, each containing minimal explanatory text.
- All new files are minimal scaffold placeholders intended to be replaced/expanded with authoritative content later.

### Testing
- Verified presence of all added files with the shell check `test -f docs/policies/README.md && test -f docs/db/README.md && test -f docs/runbooks/db-migrations.md && test -f infra/docs/runbooks/apply.md && test -f infra/docs/runbooks/rollback.md && test -f infra/docs/runbooks/drift.md && test -f infra/docs/runbooks/incident.md` which printed `scaffold files present`.
- Inspected file listings and basic contents using `nl`/`sed` to confirm each placeholder contains the expected header and short description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1dd9afd00832ab9e53447fe8e5799)