### PR TITLE
Harden env validator file discovery for nested templates

### DIFF
--- a/configs/env/scripts/validate_env.*
+++ b/configs/env/scripts/validate_env.*
@@ -258,6 +258,8 @@ def iter_candidate_files(repo_root: Path, include_workflows: bool) -> List[Path]
         if p.exists() and p.is_file():
             candidates.append(p)
 
+    env_template_suffixes = (".example", ".sample", ".template", ".dist")
+
     # Typical config dirs
     for rel in [
         "configs",
@@ -272,14 +274,24 @@ def iter_candidate_files(repo_root: Path, include_workflows: bool) -> List[Path]
     ]:
         d = repo_root / rel
         if d.exists() and d.is_dir():
+            # Direct children first
             for name in COMPOSE_NAMES + ENV_TEMPLATE_NAMES:
                 p = d / name
                 if p.exists() and p.is_file():
                     candidates.append(p)
 
-            # also grab any *.env.example files in these dirs (non-recursive)
-            for p in d.glob("*.env*"):
-                if p.is_file() and p.name.endswith((".example", ".sample", ".template", ".dist")):
+            # Recursively pick up compose files and env templates in nested config dirs.
+            # Many repos store these under paths like configs/env/templates/*.env.example.
+            for p in d.rglob("*"):
+                if not p.is_file():
+                    continue
+
+                lower_name = p.name.lower()
+                if lower_name in COMPOSE_NAMES:
+                    candidates.append(p)
+                    continue
+
+                if "env" in lower_name and lower_name.endswith(env_template_suffixes):
                     candidates.append(p)
 
     if include_workflows:


### PR DESCRIPTION
### Motivation
- The environment validator failed to discover nested env templates (e.g., `configs/env/templates/*.env.example`), causing it to infer `0` variables and weakening fail-closed checks. 
- This blind spot could allow missing/unsafe production environment settings to slip past local checks and CI gating, reducing the repository's security posture.

### Description
- Updated `configs/env/scripts/validate_env.*` to introduce `env_template_suffixes` and preserve direct-child scanning for expected files. 
- Added recursive discovery using `d.rglob("*")` to pick up nested compose files and env template files under common config directories. 
- Filtered candidates by checking `p.name.lower()` against `COMPOSE_NAMES` and presence of `"env"` with `env_template_suffixes` to avoid noisy matches while retaining de-dup behavior.

### Testing
- Ran `python3 'configs/env/scripts/validate_env.*' --help` to verify the CLI remains functional, which succeeded. 
- Ran the validator before the change and it exited with code `4` reporting `Unable to infer environment variables`, reproducing the blind spot. 
- Ran `python3 'configs/env/scripts/validate_env.*' --repo-root . --mode prod --include-workflows` after the change; the script inferred `147` variables and correctly failed with missing-required-var errors (expected in a repo without a populated `.env`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1df0adf88832ab91e0599d4abc762)