### PR TITLE
Add root-level schemas/ scaffold and placeholder schema files

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,4 @@
+# Schemas (placeholder scaffold)
+
+This folder was scaffolded to satisfy the expected KFM root-level schema layout.
+Replace dummy files with canonical machine-readable schemas as implementation lands.

--- a/schemas/dcat/.gitkeep
+++ b/schemas/dcat/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/schemas/prov/.gitkeep
+++ b/schemas/prov/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/schemas/run_manifest.v1.schema.json
+++ b/schemas/run_manifest.v1.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schemas/run_manifest.v1.schema.json",
+  "title": "Run Manifest v1 (placeholder)",
+  "type": "object",
+  "description": "Dummy placeholder schema. Replace with real contract.",
+  "additionalProperties": true
+}

--- a/schemas/run_receipt.v1.schema.json
+++ b/schemas/run_receipt.v1.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schemas/run_receipt.v1.schema.json",
+  "title": "Run Receipt v1 (placeholder)",
+  "type": "object",
+  "description": "Dummy placeholder schema. Replace with real contract.",
+  "additionalProperties": true
+}

--- a/schemas/stac/.gitkeep
+++ b/schemas/stac/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/schemas/storynodes/.gitkeep
+++ b/schemas/storynodes/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/schemas/telemetry/.gitkeep
+++ b/schemas/telemetry/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/schemas/ui/.gitkeep
+++ b/schemas/ui/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/schemas/watcher.v1.schema.json
+++ b/schemas/watcher.v1.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schemas/watcher.v1.schema.json",
+  "title": "Watcher v1 (placeholder)",
+  "type": "object",
+  "description": "Dummy placeholder schema. Replace with real contract.",
+  "additionalProperties": true
+}


### PR DESCRIPTION
### Motivation
- Provide the missing top-level `schemas/` layout expected by repository docs and CI so canonical machine-readable JSON Schema contracts have a known location.
- Surface a clear placeholder area to avoid merge-time surprises and indicate where real schema contracts should be added.

### Description
- Add a new `schemas/README.md` that documents the scaffold and notes placeholders must be replaced with canonical schemas.
- Add placeholder JSON Schema files `schemas/run_receipt.v1.schema.json`, `schemas/run_manifest.v1.schema.json`, and `schemas/watcher.v1.schema.json` containing minimal valid JSON Schema structure.
- Create schema family directories `schemas/stac`, `schemas/dcat`, `schemas/prov`, `schemas/storynodes`, `schemas/ui`, and `schemas/telemetry` with tracked `.gitkeep` placeholders to ensure those folders exist in the repo.

### Testing
- Ran `jq empty schemas/*.json` to validate the placeholder JSON files and it completed successfully with no parse errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2647411e4832a9967e275a4c20148)