### PR TITLE
Add top-level CODE_OF_CONDUCT.md and link from README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,174 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/d6cacd55-64a0-417e-8148-92a4c2dbce1c
+title: Kansas Frontier Matrix (KFM) Code of Conduct
+type: standard
+version: v1
+status: published
+owners: TBD
+created: 2026-02-26
+updated: 2026-02-26
+policy_label: public
+related:
+  - kfm://doc/TBD
+tags: [kfm, governance, community]
+notes:
+  - Replace [CONDUCT_EMAIL] before publishing.
+[/KFM_META_BLOCK_V2] -->
+
+# Kansas Frontier Matrix (KFM) Code of Conduct
+
+A safe, respectful, and evidence-first community is part of how KFM earns trust.
+
+**Quick links:**  
+- [Our Pledge](#our-pledge)  
+- [Community Standards](#community-standards)  
+- [Enforcement Responsibilities](#enforcement-responsibilities)  
+- [Scope](#scope)  
+- [Reporting](#reporting)  
+- [Enforcement Guidelines](#enforcement-guidelines)  
+- [Attribution](#attribution)
+
+---
+
+## Our Pledge
+
+We are committed to making participation in the KFM project welcoming and safe.
+
+We will not tolerate harassment or discrimination. This includes (but is not limited to) harm based on:
+- age
+- body size
+- disability (visible or invisible)
+- ethnicity or national origin
+- gender identity or expression
+- level of experience or education
+- neurotype
+- personal appearance
+- race
+- religion
+- sexual identity or orientation
+- socioeconomic status
+- any other protected characteristic
+
+We also recognize that “safety” includes **privacy** and **cultural responsibility**, especially when working with historical, geospatial, and community-linked information.
+
+---
+
+## Community Standards
+
+### Expected behavior
+
+Examples of behavior that strengthens the community:
+- **Be respectful**: disagree without being disagreeable; critique ideas, not people.
+- **Be constructive**: ask clarifying questions, propose alternatives, and give actionable feedback.
+- **Be inclusive**: use welcoming language; make space for different perspectives and backgrounds.
+- **Assume good intent, request evidence**: treat claims as discussable, and ask for sources when needed.
+- **Practice evidence-first collaboration**:
+  - cite sources when making factual claims in project work (issues, PRs, docs)
+  - label uncertainty instead of overstating
+  - correct mistakes openly and promptly
+- **Respect privacy and safety boundaries**:
+  - don’t share personal data, private communications, or identifying details without consent
+  - don’t publish sensitive locations (e.g., precise coordinates) when policy or stewardship indicates those must be protected
+- **Honor stewardship decisions**: if a steward/reviewer flags something as sensitive (rights, privacy, cultural restrictions), treat that as a safety requirement—not a debate to “win.”
+
+### Unacceptable behavior
+
+Examples of behavior that is not acceptable:
+- Harassment, intimidation, threats, or hateful conduct (public or private).
+- Sexualized language, unwelcome attention, or harassment of any kind.
+- Doxxing, outing, or sharing anyone’s personal information without explicit consent.
+- Sharing or attempting to spread **restricted** or **sensitive** content (including protected-location details) outside allowed channels.
+- Deliberate deception in project work (e.g., knowingly falsifying citations, evidence, or provenance in official contributions).
+- Sustained disruption (derailing threads, trolling, “dogpiling,” or otherwise preventing others from participating).
+
+---
+
+## Enforcement Responsibilities
+
+Project maintainers / moderators / designated stewards are responsible for:
+- clarifying community standards when needed
+- addressing harmful behavior
+- taking appropriate action to protect participants and the project
+
+They may remove, edit, or reject contributions (issues, comments, PRs, docs) that violate this Code of Conduct.
+
+---
+
+## Scope
+
+This Code of Conduct applies to:
+- repository spaces (issues, PRs, reviews, discussions, wikis)
+- official project communication channels (as applicable)
+- project events or community spaces
+- public spaces when someone is representing KFM (e.g., speaking “as KFM,” using official accounts, or acting as a project representative)
+
+---
+
+## Reporting
+
+If you experience or witness conduct that violates this Code of Conduct, please report it.
+
+### Where to report
+
+**Primary contact:** `[CONDUCT_EMAIL]`  
+> **TODO:** Replace `[CONDUCT_EMAIL]` with a monitored address (or a documented reporting route) before publishing.
+
+If you believe you are in immediate danger, prioritize your safety and contact local emergency services.
+
+### What to include in a report (as available)
+
+- What happened (a concise description)
+- Where it happened (link(s) to thread/issue/PR, screenshots if relevant)
+- When it happened (date/time and time zone if possible)
+- Who was involved (usernames, if known)
+- Any context that might help (prior related interactions)
+- Your preference for confidentiality and follow-up
+
+### What you can expect
+
+- Reports are handled as sensitively as possible.
+- Only those needed to respond will be included.
+- If an outcome is possible to share safely, we will share what we can with the reporter.
+
+---
+
+## Enforcement Guidelines
+
+When action is needed, maintainers/stewards will choose a response proportionate to the behavior and the harm caused. In severe cases, steps may be skipped.
+
+### Level 1 — Correction
+
+**When:** minor boundary crossing; unintentional harm; correctable behavior  
+**Possible actions:** request to stop; edit/remove a comment; clarify expectations
+
+### Level 2 — Warning
+
+**When:** repeated Level 1 issues, or a clear violation that doesn’t warrant removal  
+**Possible actions:** formal warning; contribution restrictions for a limited scope
+
+### Level 3 — Temporary Restrictions
+
+**When:** sustained disruption; harassment; retaliation; ignoring warnings  
+**Possible actions:** temporary ban from participation; temporary removal of access to project spaces
+
+### Level 4 — Permanent Restrictions
+
+**When:** serious harassment, threats, hate conduct, or repeated violations after prior actions  
+**Possible actions:** permanent ban; removal of project access; escalation to platform enforcement when necessary
+
+### Appeals
+
+If you believe an enforcement decision was made in error, you may request review by replying to the enforcement contact and clearly stating:
+- the action you are appealing
+- why you believe it was incorrect
+- any additional context or evidence
+
+---
+
+## Attribution
+
+This Code of Conduct is **inspired by** widely used open-source community codes, including:
+- Contributor Covenant (v2.1): https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+- Contributor Covenant FAQ: https://www.contributor-covenant.org/faq/
+
+The enforcement ladder concept is informed by community moderation best practices, including Mozilla/MDN-style enforcement guidance.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ notes:
 Pick the path that matches what you’re doing:
 
 - **Contributing code/docs/data**
-  - Read: [`CONTRIBUTING.md`](CONTRIBUTING.md) (workflow, if present), [`.github/README.md`](.github/README.md) (CI gates + CODEOWNERS, if present), [`SECURITY.md`](SECURITY.md) (reporting, if present)
+  - Read: [`CONTRIBUTING.md`](CONTRIBUTING.md) (workflow, if present), [`.github/README.md`](.github/README.md) (CI gates + CODEOWNERS, if present), [`SECURITY.md`](SECURITY.md) (reporting, if present), [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) (community standards)
   - Know: changes to `.github/`, `policy/`, `contracts/`, and promotion tooling are **governance-critical**
 
 - **Stewardship and governance**


### PR DESCRIPTION
### Motivation
- Make the repository's community standards discoverable from the root as called out by the README’s governance guidance by adding a top-level code of conduct.

### Description
- Add `CODE_OF_CONDUCT.md` at the repository root and update the `README.md` "Start here" contributor guidance to include a link to `CODE_OF_CONDUCT.md`.

### Testing
- Ran `git diff --check` to verify no whitespace or conflict issues and the check completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a267019374832a8d95a6438c4fd10c)