### PR TITLE
Create missing docs/standards canonical files and folders

### DIFF
--- a/docs/standards/_archive/2026-02-xx/README.md
+++ b/docs/standards/_archive/2026-02-xx/README.md
@@ -1,0 +1,3 @@
+# _archive/2026-02-xx
+
+Placeholder README for `_archive/2026-02-xx`.

--- a/docs/standards/_archive/README.md
+++ b/docs/standards/_archive/README.md
@@ -1,0 +1,3 @@
+# _archive
+
+Placeholder README for `_archive`.

--- a/docs/standards/api/KFM_API_CONTRACT_EXTENSION.md
+++ b/docs/standards/api/KFM_API_CONTRACT_EXTENSION.md
@@ -1,0 +1,3 @@
+# KFM API Contract Extension
+
+TODO

--- a/docs/standards/api/KFM_ERROR_MODEL_STANDARD.md
+++ b/docs/standards/api/KFM_ERROR_MODEL_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Error Model Standard
+
+TODO

--- a/docs/standards/api/KFM_EXPORT_DOWNLOAD_STANDARD.md
+++ b/docs/standards/api/KFM_EXPORT_DOWNLOAD_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Export Download Standard
+
+TODO

--- a/docs/standards/api/KFM_PAGINATION_FILTERING_STANDARD.md
+++ b/docs/standards/api/KFM_PAGINATION_FILTERING_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Pagination Filtering Standard
+
+TODO

--- a/docs/standards/api/README.md
+++ b/docs/standards/api/README.md
@@ -1,0 +1,3 @@
+# api
+
+Placeholder README for `api`.

--- a/docs/standards/api/examples/README.md
+++ b/docs/standards/api/examples/README.md
@@ -1,0 +1,3 @@
+# api/examples
+
+Placeholder README for `api/examples`.

--- a/docs/standards/authoring/KFM_CITATION_PROTOCOL.md
+++ b/docs/standards/authoring/KFM_CITATION_PROTOCOL.md
@@ -1,0 +1,3 @@
+# KFM Citation Protocol
+
+TODO

--- a/docs/standards/authoring/KFM_DIAGRAM_MERMAID_STANDARD.md
+++ b/docs/standards/authoring/KFM_DIAGRAM_MERMAID_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Diagram Mermaid Standard
+
+TODO

--- a/docs/standards/authoring/KFM_LINKING_STANDARD.md
+++ b/docs/standards/authoring/KFM_LINKING_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Linking Standard
+
+TODO

--- a/docs/standards/authoring/KFM_META_BLOCK_V2_STANDARD.md
+++ b/docs/standards/authoring/KFM_META_BLOCK_V2_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM MetaBlock v2 Standard
+
+TODO

--- a/docs/standards/authoring/KFM_NORMATIVE_LANGUAGE_STANDARD.md
+++ b/docs/standards/authoring/KFM_NORMATIVE_LANGUAGE_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Normative Language Standard
+
+TODO

--- a/docs/standards/authoring/README.md
+++ b/docs/standards/authoring/README.md
@@ -1,0 +1,3 @@
+# authoring
+
+Placeholder README for `authoring`.

--- a/docs/standards/authoring/examples/README.md
+++ b/docs/standards/authoring/examples/README.md
@@ -1,0 +1,3 @@
+# authoring/examples
+
+Placeholder README for `authoring/examples`.

--- a/docs/standards/authoring/examples/bad/README.md
+++ b/docs/standards/authoring/examples/bad/README.md
@@ -1,0 +1,3 @@
+# authoring/examples/bad
+
+Placeholder README for `authoring/examples/bad`.

--- a/docs/standards/authoring/examples/good/README.md
+++ b/docs/standards/authoring/examples/good/README.md
@@ -1,0 +1,3 @@
+# authoring/examples/good
+
+Placeholder README for `authoring/examples/good`.

--- a/docs/standards/catalog/README.md
+++ b/docs/standards/catalog/README.md
@@ -1,0 +1,3 @@
+# catalog
+
+Placeholder README for `catalog`.

--- a/docs/standards/catalog/dcat/CONFORMANCE.md
+++ b/docs/standards/catalog/dcat/CONFORMANCE.md
@@ -1,0 +1,3 @@
+# DCAT Conformance
+
+TODO

--- a/docs/standards/catalog/dcat/README.md
+++ b/docs/standards/catalog/dcat/README.md
@@ -1,0 +1,3 @@
+# catalog/dcat
+
+Placeholder README for `catalog/dcat`.

--- a/docs/standards/catalog/dcat/examples/README.md
+++ b/docs/standards/catalog/dcat/examples/README.md
@@ -1,0 +1,3 @@
+# catalog/dcat/examples
+
+Placeholder README for `catalog/dcat/examples`.

--- a/docs/standards/catalog/prov/CONFORMANCE.md
+++ b/docs/standards/catalog/prov/CONFORMANCE.md
@@ -1,0 +1,3 @@
+# PROV Conformance
+
+TODO

--- a/docs/standards/catalog/prov/README.md
+++ b/docs/standards/catalog/prov/README.md
@@ -1,0 +1,3 @@
+# catalog/prov
+
+Placeholder README for `catalog/prov`.

--- a/docs/standards/catalog/prov/examples/README.md
+++ b/docs/standards/catalog/prov/examples/README.md
@@ -1,0 +1,3 @@
+# catalog/prov/examples
+
+Placeholder README for `catalog/prov/examples`.

--- a/docs/standards/catalog/stac/CONFORMANCE.md
+++ b/docs/standards/catalog/stac/CONFORMANCE.md
@@ -1,0 +1,3 @@
+# STAC Conformance
+
+TODO

--- a/docs/standards/catalog/stac/README.md
+++ b/docs/standards/catalog/stac/README.md
@@ -1,0 +1,3 @@
+# catalog/stac
+
+Placeholder README for `catalog/stac`.

--- a/docs/standards/catalog/stac/examples/README.md
+++ b/docs/standards/catalog/stac/examples/README.md
@@ -1,0 +1,3 @@
+# catalog/stac/examples
+
+Placeholder README for `catalog/stac/examples`.

--- a/docs/standards/catalog/triplet/KFM_TRIPLET_LINKING_STANDARD.md
+++ b/docs/standards/catalog/triplet/KFM_TRIPLET_LINKING_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Triplet Linking Standard
+
+TODO

--- a/docs/standards/catalog/triplet/README.md
+++ b/docs/standards/catalog/triplet/README.md
@@ -1,0 +1,3 @@
+# catalog/triplet
+
+Placeholder README for `catalog/triplet`.

--- a/docs/standards/catalog/triplet/examples/README.md
+++ b/docs/standards/catalog/triplet/examples/README.md
@@ -1,0 +1,3 @@
+# catalog/triplet/examples
+
+Placeholder README for `catalog/triplet/examples`.

--- a/docs/standards/catalog/triplet/examples/complex_triplet/README.md
+++ b/docs/standards/catalog/triplet/examples/complex_triplet/README.md
@@ -1,0 +1,3 @@
+# catalog/triplet/examples/complex_triplet
+
+Placeholder README for `catalog/triplet/examples/complex_triplet`.

--- a/docs/standards/catalog/triplet/examples/minimal_triplet/README.md
+++ b/docs/standards/catalog/triplet/examples/minimal_triplet/README.md
@@ -1,0 +1,3 @@
+# catalog/triplet/examples/minimal_triplet
+
+Placeholder README for `catalog/triplet/examples/minimal_triplet`.

--- a/docs/standards/conformance/KFM_CONFORMANCE_MATRIX.md
+++ b/docs/standards/conformance/KFM_CONFORMANCE_MATRIX.md
@@ -1,0 +1,3 @@
+# KFM Conformance Matrix
+
+TODO

--- a/docs/standards/conformance/KFM_FIXTURE_CONVENTIONS.md
+++ b/docs/standards/conformance/KFM_FIXTURE_CONVENTIONS.md
@@ -1,0 +1,3 @@
+# KFM Fixture Conventions
+
+TODO

--- a/docs/standards/conformance/README.md
+++ b/docs/standards/conformance/README.md
@@ -1,0 +1,3 @@
+# conformance
+
+Placeholder README for `conformance`.

--- a/docs/standards/conformance/fixtures/README.md
+++ b/docs/standards/conformance/fixtures/README.md
@@ -1,0 +1,3 @@
+# conformance/fixtures
+
+Placeholder README for `conformance/fixtures`.

--- a/docs/standards/conformance/fixtures/adversarial/README.md
+++ b/docs/standards/conformance/fixtures/adversarial/README.md
@@ -1,0 +1,3 @@
+# conformance/fixtures/adversarial
+
+Placeholder README for `conformance/fixtures/adversarial`.

--- a/docs/standards/conformance/fixtures/minimal/README.md
+++ b/docs/standards/conformance/fixtures/minimal/README.md
@@ -1,0 +1,3 @@
+# conformance/fixtures/minimal
+
+Placeholder README for `conformance/fixtures/minimal`.

--- a/docs/standards/conformance/fixtures/regression/README.md
+++ b/docs/standards/conformance/fixtures/regression/README.md
@@ -1,0 +1,3 @@
+# conformance/fixtures/regression
+
+Placeholder README for `conformance/fixtures/regression`.

--- a/docs/standards/evidence/KFM_EVIDENCE_BUNDLE_STANDARD.md
+++ b/docs/standards/evidence/KFM_EVIDENCE_BUNDLE_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Evidence Bundle Standard
+
+TODO

--- a/docs/standards/evidence/KFM_EVIDENCE_REF_STANDARD.md
+++ b/docs/standards/evidence/KFM_EVIDENCE_REF_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Evidence Ref Standard
+
+TODO

--- a/docs/standards/evidence/KFM_PROMOTION_MANIFEST_STANDARD.md
+++ b/docs/standards/evidence/KFM_PROMOTION_MANIFEST_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Promotion Manifest Standard
+
+TODO

--- a/docs/standards/evidence/KFM_RUN_RECEIPT_STANDARD.md
+++ b/docs/standards/evidence/KFM_RUN_RECEIPT_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Run Receipt Standard
+
+TODO

--- a/docs/standards/evidence/README.md
+++ b/docs/standards/evidence/README.md
@@ -1,0 +1,3 @@
+# evidence
+
+Placeholder README for `evidence`.

--- a/docs/standards/evidence/examples/README.md
+++ b/docs/standards/evidence/examples/README.md
@@ -1,0 +1,3 @@
+# evidence/examples
+
+Placeholder README for `evidence/examples`.

--- a/docs/standards/identity/KFM_DATASET_VERSION_ID_STANDARD.md
+++ b/docs/standards/identity/KFM_DATASET_VERSION_ID_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Dataset Version ID Standard
+
+TODO

--- a/docs/standards/identity/KFM_IDENTIFIER_FAMILIES_STANDARD.md
+++ b/docs/standards/identity/KFM_IDENTIFIER_FAMILIES_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Identifier Families Standard
+
+TODO

--- a/docs/standards/identity/KFM_SPEC_HASH_STANDARD.md
+++ b/docs/standards/identity/KFM_SPEC_HASH_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Spec Hash Standard
+
+TODO

--- a/docs/standards/identity/README.md
+++ b/docs/standards/identity/README.md
@@ -1,0 +1,3 @@
+# identity
+
+Placeholder README for `identity`.

--- a/docs/standards/identity/examples/README.md
+++ b/docs/standards/identity/examples/README.md
@@ -1,0 +1,3 @@
+# identity/examples
+
+Placeholder README for `identity/examples`.

--- a/docs/standards/interop/EXTERNAL_STANDARDS_INDEX.md
+++ b/docs/standards/interop/EXTERNAL_STANDARDS_INDEX.md
@@ -1,0 +1,3 @@
+# External Standards Index
+
+TODO

--- a/docs/standards/interop/README.md
+++ b/docs/standards/interop/README.md
@@ -1,0 +1,3 @@
+# interop
+
+Placeholder README for `interop`.

--- a/docs/standards/interop/examples/README.md
+++ b/docs/standards/interop/examples/README.md
@@ -1,0 +1,3 @@
+# interop/examples
+
+Placeholder README for `interop/examples`.

--- a/docs/standards/policy/KFM_POLICY_LABEL_STANDARD.md
+++ b/docs/standards/policy/KFM_POLICY_LABEL_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Policy Label Standard
+
+TODO

--- a/docs/standards/policy/KFM_POLICY_SAFE_ERRORS_STANDARD.md
+++ b/docs/standards/policy/KFM_POLICY_SAFE_ERRORS_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Policy Safe Errors Standard
+
+TODO

--- a/docs/standards/policy/KFM_REDACTION_OBLIGATIONS_STANDARD.md
+++ b/docs/standards/policy/KFM_REDACTION_OBLIGATIONS_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Redaction Obligations Standard
+
+TODO

--- a/docs/standards/policy/README.md
+++ b/docs/standards/policy/README.md
@@ -1,0 +1,3 @@
+# policy
+
+Placeholder README for `policy`.

--- a/docs/standards/policy/examples/README.md
+++ b/docs/standards/policy/examples/README.md
@@ -1,0 +1,3 @@
+# policy/examples
+
+Placeholder README for `policy/examples`.

--- a/docs/standards/policy/examples/public/README.md
+++ b/docs/standards/policy/examples/public/README.md
@@ -1,0 +1,3 @@
+# policy/examples/public
+
+Placeholder README for `policy/examples/public`.

--- a/docs/standards/policy/examples/restricted/README.md
+++ b/docs/standards/policy/examples/restricted/README.md
@@ -1,0 +1,3 @@
+# policy/examples/restricted
+
+Placeholder README for `policy/examples/restricted`.

--- a/docs/standards/registry/README.md
+++ b/docs/standards/registry/README.md
@@ -1,0 +1,3 @@
+# registry
+
+Placeholder README for `registry`.

--- a/docs/standards/registry/checks.registry.yaml
+++ b/docs/standards/registry/checks.registry.yaml
@@ -1,0 +1,2 @@
+# TODO: CI checks mapped to standards
+checks: []

--- a/docs/standards/registry/deprecations.yaml
+++ b/docs/standards/registry/deprecations.yaml
@@ -1,0 +1,2 @@
+# TODO: deprecation and supersession records
+deprecations: []

--- a/docs/standards/registry/standards.registry.yaml
+++ b/docs/standards/registry/standards.registry.yaml
@@ -1,0 +1,2 @@
+# TODO: canonical inventory of standards
+standards: []

--- a/docs/standards/registry/vocab/README.md
+++ b/docs/standards/registry/vocab/README.md
@@ -1,0 +1,3 @@
+# registry/vocab
+
+Placeholder README for `registry/vocab`.

--- a/docs/standards/registry/vocab/artifact.zone.yaml
+++ b/docs/standards/registry/vocab/artifact.zone.yaml
@@ -1,0 +1,2 @@
+# TODO: artifact zone vocabulary
+artifact_zones: []

--- a/docs/standards/registry/vocab/citation.kind.yaml
+++ b/docs/standards/registry/vocab/citation.kind.yaml
@@ -1,0 +1,2 @@
+# TODO: citation kind vocabulary
+citation_kinds: []

--- a/docs/standards/registry/vocab/media_types.yaml
+++ b/docs/standards/registry/vocab/media_types.yaml
@@ -1,0 +1,2 @@
+# TODO: media type conventions
+media_types: []

--- a/docs/standards/registry/vocab/policy_label.yaml
+++ b/docs/standards/registry/vocab/policy_label.yaml
@@ -1,0 +1,2 @@
+# TODO: policy label vocabulary
+policy_labels: []

--- a/docs/standards/repo/KFM_BRANCHING_RELEASE_STANDARD.md
+++ b/docs/standards/repo/KFM_BRANCHING_RELEASE_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Branching Release Standard
+
+TODO

--- a/docs/standards/repo/KFM_VERSIONING_DEPRECATION_STANDARD.md
+++ b/docs/standards/repo/KFM_VERSIONING_DEPRECATION_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Versioning Deprecation Standard
+
+TODO

--- a/docs/standards/repo/README.md
+++ b/docs/standards/repo/README.md
@@ -1,0 +1,3 @@
+# repo
+
+Placeholder README for `repo`.

--- a/docs/standards/repo/examples/README.md
+++ b/docs/standards/repo/examples/README.md
@@ -1,0 +1,3 @@
+# repo/examples
+
+Placeholder README for `repo/examples`.

--- a/docs/standards/repo/examples/repo_trees/README.md
+++ b/docs/standards/repo/examples/repo_trees/README.md
@@ -1,0 +1,3 @@
+# repo/examples/repo_trees
+
+Placeholder README for `repo/examples/repo_trees`.

--- a/docs/standards/ui/KFM_EVIDENCE_DRAWER_STANDARD.md
+++ b/docs/standards/ui/KFM_EVIDENCE_DRAWER_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Evidence Drawer Standard
+
+TODO

--- a/docs/standards/ui/KFM_EVIDENCE_FIRST_UX_STANDARD.md
+++ b/docs/standards/ui/KFM_EVIDENCE_FIRST_UX_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Evidence First UX Standard
+
+TODO

--- a/docs/standards/ui/KFM_STORY_NODE_STANDARD.md
+++ b/docs/standards/ui/KFM_STORY_NODE_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM Story Node Standard
+
+TODO

--- a/docs/standards/ui/README.md
+++ b/docs/standards/ui/README.md
@@ -1,0 +1,3 @@
+# ui
+
+Placeholder README for `ui`.

--- a/docs/standards/ui/accessibility/KFM_A11Y_MINIMUM_STANDARD.md
+++ b/docs/standards/ui/accessibility/KFM_A11Y_MINIMUM_STANDARD.md
@@ -1,0 +1,3 @@
+# KFM A11Y Minimum Standard
+
+TODO

--- a/docs/standards/ui/accessibility/README.md
+++ b/docs/standards/ui/accessibility/README.md
@@ -1,0 +1,3 @@
+# ui/accessibility
+
+Placeholder README for `ui/accessibility`.

--- a/docs/standards/ui/examples/README.md
+++ b/docs/standards/ui/examples/README.md
@@ -1,0 +1,3 @@
+# ui/examples
+
+Placeholder README for `ui/examples`.


### PR DESCRIPTION
### Motivation
- Populate the `docs/standards/` tree to match the canonical layout described in `docs/standards/README.md` so standards authors and CI have a discoverable place for normative material. 
- Ensure every new directory contains a `README.md` to document scope and prevent accidental omission by tooling or reviewers. 
- Provide machine-readable placeholders (registry and vocab YAMLs) so downstream validation tooling and registry updates have a known landing spot.

### Description
- Created the top-level standards subtrees including `registry`, `authoring`, `identity`, `conformance`, `repo`, `catalog`, `policy`, `evidence`, `api`, `ui`, `interop`, and `_archive` with their expected subfolders. 
- Added placeholder `README.md` files in each new directory to capture scope and aid discoverability. 
- Added placeholder standard documents (e.g. `KFM_*_STANDARD.md`, `CONFORMANCE.md`, `KFM_TRIPLET_LINKING_STANDARD.md`, accessibility standard) where the README indicated items were required. 
- Added machine-readable placeholders under `docs/standards/registry/` including `standards.registry.yaml`, `deprecations.yaml`, `checks.registry.yaml`, and controlled-vocab files under `registry/vocab/`.

### Testing
- Verified the created tree with `find docs/standards -maxdepth 4 -print | sort` which returned the new directories and files as expected. 
- Inspected staged changes with `git status --short` to confirm the files are tracked and present. 
- Spot-checked several placeholder files with `nl -ba <path>` to confirm content (non-empty placeholder headers); all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3c8394c34832aac49b8e70ad05a41)