### PR TITLE
Scaffold missing docs/diagrams directories and placeholder files

### DIFF
--- a/docs/diagrams/NAMING.md
+++ b/docs/diagrams/NAMING.md
@@ -1,0 +1,3 @@
+# Diagram Naming Conventions
+
+Filename/versioning rules for diagram sources and exports.

--- a/docs/diagrams/STYLE_GUIDE.md
+++ b/docs/diagrams/STYLE_GUIDE.md
@@ -1,0 +1,3 @@
+# Diagram Style Guide
+
+Global style guidance for diagrams in this repository.

--- a/docs/diagrams/out/architecture/pdf/README.md
+++ b/docs/diagrams/out/architecture/pdf/README.md
@@ -1,0 +1,1 @@
+# out/architecture/pdf

--- a/docs/diagrams/out/architecture/png/README.md
+++ b/docs/diagrams/out/architecture/png/README.md
@@ -1,0 +1,1 @@
+# out/architecture/png

--- a/docs/diagrams/out/architecture/svg/README.md
+++ b/docs/diagrams/out/architecture/svg/README.md
@@ -1,0 +1,1 @@
+# out/architecture/svg

--- a/docs/diagrams/out/governance/pdf/README.md
+++ b/docs/diagrams/out/governance/pdf/README.md
@@ -1,0 +1,1 @@
+# out/governance/pdf

--- a/docs/diagrams/out/governance/png/README.md
+++ b/docs/diagrams/out/governance/png/README.md
@@ -1,0 +1,1 @@
+# out/governance/png

--- a/docs/diagrams/out/governance/svg/README.md
+++ b/docs/diagrams/out/governance/svg/README.md
@@ -1,0 +1,1 @@
+# out/governance/svg

--- a/docs/diagrams/out/interfaces/pdf/README.md
+++ b/docs/diagrams/out/interfaces/pdf/README.md
@@ -1,0 +1,1 @@
+# out/interfaces/pdf

--- a/docs/diagrams/out/interfaces/png/README.md
+++ b/docs/diagrams/out/interfaces/png/README.md
@@ -1,0 +1,1 @@
+# out/interfaces/png

--- a/docs/diagrams/out/interfaces/svg/README.md
+++ b/docs/diagrams/out/interfaces/svg/README.md
@@ -1,0 +1,1 @@
+# out/interfaces/svg

--- a/docs/diagrams/out/pipelines/pdf/README.md
+++ b/docs/diagrams/out/pipelines/pdf/README.md
@@ -1,0 +1,1 @@
+# out/pipelines/pdf

--- a/docs/diagrams/out/pipelines/png/README.md
+++ b/docs/diagrams/out/pipelines/png/README.md
@@ -1,0 +1,1 @@
+# out/pipelines/png

--- a/docs/diagrams/out/pipelines/svg/README.md
+++ b/docs/diagrams/out/pipelines/svg/README.md
@@ -1,0 +1,1 @@
+# out/pipelines/svg

--- a/docs/diagrams/out/thumbnails/README.md
+++ b/docs/diagrams/out/thumbnails/README.md
@@ -1,0 +1,1 @@
+# out/thumbnails

--- a/docs/diagrams/out/truth-path/pdf/README.md
+++ b/docs/diagrams/out/truth-path/pdf/README.md
@@ -1,0 +1,1 @@
+# out/truth-path/pdf

--- a/docs/diagrams/out/truth-path/png/README.md
+++ b/docs/diagrams/out/truth-path/png/README.md
@@ -1,0 +1,1 @@
+# out/truth-path/png

--- a/docs/diagrams/out/truth-path/svg/README.md
+++ b/docs/diagrams/out/truth-path/svg/README.md
@@ -1,0 +1,1 @@
+# out/truth-path/svg

--- a/docs/diagrams/out/ui/pdf/README.md
+++ b/docs/diagrams/out/ui/pdf/README.md
@@ -1,0 +1,1 @@
+# out/ui/pdf

--- a/docs/diagrams/out/ui/png/README.md
+++ b/docs/diagrams/out/ui/png/README.md
@@ -1,0 +1,1 @@
+# out/ui/png

--- a/docs/diagrams/out/ui/svg/README.md
+++ b/docs/diagrams/out/ui/svg/README.md
@@ -1,0 +1,1 @@
+# out/ui/svg

--- a/docs/diagrams/registry/checks/export-sync.rules.yml
+++ b/docs/diagrams/registry/checks/export-sync.rules.yml
@@ -1,0 +1,1 @@
+# Rules for ensuring out/* exports map to src/* sources

--- a/docs/diagrams/registry/checks/mermaid-lint.yml
+++ b/docs/diagrams/registry/checks/mermaid-lint.yml
@@ -1,0 +1,1 @@
+# Mermaid lint configuration

--- a/docs/diagrams/registry/checks/plantuml-lint.yml
+++ b/docs/diagrams/registry/checks/plantuml-lint.yml
@@ -1,0 +1,1 @@
+# PlantUML lint configuration

--- a/docs/diagrams/registry/diagrams.schema.json
+++ b/docs/diagrams/registry/diagrams.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Diagram Registry",
+  "type": "object",
+  "properties": {
+    "diagrams": {
+      "type": "array"
+    }
+  },
+  "required": ["diagrams"]
+}

--- a/docs/diagrams/registry/diagrams.yaml
+++ b/docs/diagrams/registry/diagrams.yaml
@@ -1,0 +1,2 @@
+# Canonical diagram registry
+diagrams: []

--- a/docs/diagrams/registry/tags.yaml
+++ b/docs/diagrams/registry/tags.yaml
@@ -1,0 +1,2 @@
+# Controlled vocabulary for diagram tags
+tags: []

--- a/docs/diagrams/src/architecture/README.md
+++ b/docs/diagrams/src/architecture/README.md
@@ -1,0 +1,1 @@
+# Architecture Diagrams

--- a/docs/diagrams/src/architecture/c4/component/README.md
+++ b/docs/diagrams/src/architecture/c4/component/README.md
@@ -1,0 +1,1 @@
+# src/architecture/c4/component

--- a/docs/diagrams/src/architecture/c4/container/README.md
+++ b/docs/diagrams/src/architecture/c4/container/README.md
@@ -1,0 +1,1 @@
+# src/architecture/c4/container

--- a/docs/diagrams/src/architecture/c4/context/README.md
+++ b/docs/diagrams/src/architecture/c4/context/README.md
@@ -1,0 +1,1 @@
+# src/architecture/c4/context

--- a/docs/diagrams/src/architecture/data-architecture/README.md
+++ b/docs/diagrams/src/architecture/data-architecture/README.md
@@ -1,0 +1,1 @@
+# src/architecture/data-architecture

--- a/docs/diagrams/src/architecture/deployment/README.md
+++ b/docs/diagrams/src/architecture/deployment/README.md
@@ -1,0 +1,1 @@
+# src/architecture/deployment

--- a/docs/diagrams/src/architecture/trust-membrane/README.md
+++ b/docs/diagrams/src/architecture/trust-membrane/README.md
@@ -1,0 +1,1 @@
+# src/architecture/trust-membrane

--- a/docs/diagrams/src/governance/README.md
+++ b/docs/diagrams/src/governance/README.md
@@ -1,0 +1,1 @@
+# Governance Diagrams

--- a/docs/diagrams/src/governance/audit/README.md
+++ b/docs/diagrams/src/governance/audit/README.md
@@ -1,0 +1,1 @@
+# src/governance/audit

--- a/docs/diagrams/src/governance/review-gates/README.md
+++ b/docs/diagrams/src/governance/review-gates/README.md
@@ -1,0 +1,1 @@
+# src/governance/review-gates

--- a/docs/diagrams/src/governance/sensitivity/README.md
+++ b/docs/diagrams/src/governance/sensitivity/README.md
@@ -1,0 +1,1 @@
+# src/governance/sensitivity

--- a/docs/diagrams/src/interfaces/README.md
+++ b/docs/diagrams/src/interfaces/README.md
@@ -1,0 +1,1 @@
+# Interface and Boundary Diagrams

--- a/docs/diagrams/src/interfaces/api/README.md
+++ b/docs/diagrams/src/interfaces/api/README.md
@@ -1,0 +1,1 @@
+# src/interfaces/api

--- a/docs/diagrams/src/interfaces/evidence/README.md
+++ b/docs/diagrams/src/interfaces/evidence/README.md
@@ -1,0 +1,1 @@
+# src/interfaces/evidence

--- a/docs/diagrams/src/interfaces/policy/README.md
+++ b/docs/diagrams/src/interfaces/policy/README.md
@@ -1,0 +1,1 @@
+# src/interfaces/policy

--- a/docs/diagrams/src/operations/README.md
+++ b/docs/diagrams/src/operations/README.md
@@ -1,0 +1,1 @@
+# Operations Diagrams

--- a/docs/diagrams/src/operations/access-management/README.md
+++ b/docs/diagrams/src/operations/access-management/README.md
@@ -1,0 +1,1 @@
+# src/operations/access-management

--- a/docs/diagrams/src/operations/backup-and-recovery/README.md
+++ b/docs/diagrams/src/operations/backup-and-recovery/README.md
@@ -1,0 +1,1 @@
+# src/operations/backup-and-recovery

--- a/docs/diagrams/src/operations/incident-response/README.md
+++ b/docs/diagrams/src/operations/incident-response/README.md
@@ -1,0 +1,1 @@
+# src/operations/incident-response

--- a/docs/diagrams/src/pipelines/README.md
+++ b/docs/diagrams/src/pipelines/README.md
@@ -1,0 +1,1 @@
+# Pipeline Diagrams

--- a/docs/diagrams/src/pipelines/index-and-tiles/README.md
+++ b/docs/diagrams/src/pipelines/index-and-tiles/README.md
@@ -1,0 +1,1 @@
+# src/pipelines/index-and-tiles

--- a/docs/diagrams/src/pipelines/ingest/README.md
+++ b/docs/diagrams/src/pipelines/ingest/README.md
@@ -1,0 +1,1 @@
+# src/pipelines/ingest

--- a/docs/diagrams/src/pipelines/monitoring/README.md
+++ b/docs/diagrams/src/pipelines/monitoring/README.md
@@ -1,0 +1,1 @@
+# src/pipelines/monitoring

--- a/docs/diagrams/src/pipelines/promote/README.md
+++ b/docs/diagrams/src/pipelines/promote/README.md
@@ -1,0 +1,1 @@
+# src/pipelines/promote

--- a/docs/diagrams/src/pipelines/validate/README.md
+++ b/docs/diagrams/src/pipelines/validate/README.md
@@ -1,0 +1,1 @@
+# src/pipelines/validate

--- a/docs/diagrams/src/shared/includes/README.md
+++ b/docs/diagrams/src/shared/includes/README.md
@@ -1,0 +1,1 @@
+# src/shared/includes

--- a/docs/diagrams/src/shared/libraries/README.md
+++ b/docs/diagrams/src/shared/libraries/README.md
@@ -1,0 +1,1 @@
+# src/shared/libraries

--- a/docs/diagrams/src/truth-path/README.md
+++ b/docs/diagrams/src/truth-path/README.md
@@ -1,0 +1,1 @@
+# Truth Path Diagrams

--- a/docs/diagrams/src/truth-path/catalog-linkage/README.md
+++ b/docs/diagrams/src/truth-path/catalog-linkage/README.md
@@ -1,0 +1,1 @@
+# src/truth-path/catalog-linkage

--- a/docs/diagrams/src/truth-path/receipts/README.md
+++ b/docs/diagrams/src/truth-path/receipts/README.md
@@ -1,0 +1,1 @@
+# src/truth-path/receipts

--- a/docs/diagrams/src/truth-path/zones/README.md
+++ b/docs/diagrams/src/truth-path/zones/README.md
@@ -1,0 +1,1 @@
+# src/truth-path/zones

--- a/docs/diagrams/src/ui/README.md
+++ b/docs/diagrams/src/ui/README.md
@@ -1,0 +1,1 @@
+# UI Diagrams

--- a/docs/diagrams/src/ui/focus-mode/README.md
+++ b/docs/diagrams/src/ui/focus-mode/README.md
@@ -1,0 +1,1 @@
+# src/ui/focus-mode

--- a/docs/diagrams/src/ui/interaction-flows/README.md
+++ b/docs/diagrams/src/ui/interaction-flows/README.md
@@ -1,0 +1,1 @@
+# src/ui/interaction-flows

--- a/docs/diagrams/src/ui/routes/README.md
+++ b/docs/diagrams/src/ui/routes/README.md
@@ -1,0 +1,1 @@
+# src/ui/routes

--- a/docs/diagrams/src/ui/story-nodes/README.md
+++ b/docs/diagrams/src/ui/story-nodes/README.md
@@ -1,0 +1,1 @@
+# src/ui/story-nodes

--- a/docs/diagrams/templates/DIAGRAM_HEADER.template.yml
+++ b/docs/diagrams/templates/DIAGRAM_HEADER.template.yml
@@ -1,0 +1,6 @@
+id: kfm://diagram/example
+title: Example Diagram
+status: draft
+owners:
+  - KFM Maintainers
+updated: 2026-03-01

--- a/docs/diagrams/templates/README.md
+++ b/docs/diagrams/templates/README.md
@@ -1,0 +1,3 @@
+# Diagram Templates
+
+Starter templates for diagram authoring.

--- a/docs/diagrams/templates/drawio/template.drawio
+++ b/docs/diagrams/templates/drawio/template.drawio
@@ -1,0 +1,1 @@
+<mxfile host="app.diagrams.net"></mxfile>

--- a/docs/diagrams/templates/excalidraw/template.excalidraw
+++ b/docs/diagrams/templates/excalidraw/template.excalidraw
@@ -1,0 +1,5 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://excalidraw.com"
+}

--- a/docs/diagrams/templates/mermaid/c4-context.template.md
+++ b/docs/diagrams/templates/mermaid/c4-context.template.md
@@ -1,0 +1,4 @@
+```mermaid
+flowchart LR
+  User((User)) --> System[System Context]
+```

--- a/docs/diagrams/templates/mermaid/flowchart.template.md
+++ b/docs/diagrams/templates/mermaid/flowchart.template.md
@@ -1,0 +1,4 @@
+```mermaid
+flowchart TD
+  A[Start] --> B[Process]
+```

--- a/docs/diagrams/templates/mermaid/sequence.template.md
+++ b/docs/diagrams/templates/mermaid/sequence.template.md
@@ -1,0 +1,7 @@
+```mermaid
+sequenceDiagram
+  participant A as Caller
+  participant B as Service
+  A->>B: Request
+  B-->>A: Response
+```

--- a/docs/diagrams/templates/mermaid/state-machine.template.md
+++ b/docs/diagrams/templates/mermaid/state-machine.template.md
@@ -1,0 +1,6 @@
+```mermaid
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Review
+  Review --> Approved
+```

--- a/docs/diagrams/templates/plantuml/component.template.puml
+++ b/docs/diagrams/templates/plantuml/component.template.puml
@@ -1,0 +1,5 @@
+@startuml
+component Client
+component API
+Client --> API
+@enduml

--- a/docs/diagrams/templates/plantuml/deployment.template.puml
+++ b/docs/diagrams/templates/plantuml/deployment.template.puml
@@ -1,0 +1,5 @@
+@startuml
+node "App" {
+  component Service
+}
+@enduml

--- a/docs/diagrams/templates/plantuml/sequence.template.puml
+++ b/docs/diagrams/templates/plantuml/sequence.template.puml
@@ -1,0 +1,6 @@
+@startuml
+actor Caller
+participant Service
+Caller -> Service : Request
+Service --> Caller : Response
+@enduml

--- a/docs/diagrams/tools/README.md
+++ b/docs/diagrams/tools/README.md
@@ -1,0 +1,3 @@
+# Diagram Tooling
+
+Helpers for rendering/linting/CI for diagrams.

--- a/docs/diagrams/tools/ci/README.md
+++ b/docs/diagrams/tools/ci/README.md
@@ -1,0 +1,1 @@
+# tools/ci

--- a/docs/diagrams/tools/lint/README.md
+++ b/docs/diagrams/tools/lint/README.md
@@ -1,0 +1,1 @@
+# tools/lint

--- a/docs/diagrams/tools/render/README.md
+++ b/docs/diagrams/tools/render/README.md
@@ -1,0 +1,1 @@
+# tools/render


### PR DESCRIPTION
### Motivation
- The `docs/diagrams` README describes a rich scaffold (registry, templates, canonical `src/`, rendered `out/`, and tooling) that was only partially present, so the repo needs the missing directories and starter artifacts to match that guidance. 
- Provide a clear single-source-of-truth location for diagram sources and an inventory/validation surface so downstream consumers and CI can rely on predictable paths. 
- Make it easy to author new diagrams consistently by adding header templates and format-specific starters for Mermaid/PlantUML/Draw.io/Excalidraw.

### Description
- Added top-level guidance files `STYLE_GUIDE.md` and `NAMING.md` as placeholders for diagram style and naming conventions. 
- Added a registry area with `registry/diagrams.yaml`, `registry/diagrams.schema.json`, `registry/tags.yaml`, and lint/check placeholders under `registry/checks/`. 
- Created template starter files for multiple formats under `templates/` including Mermaid, PlantUML, Draw.io, and Excalidraw plus a `DIAGRAM_HEADER.template.yml` header template. 
- Scaffolded the recommended `src/` domain structure (architecture, truth-path, pipelines, interfaces, ui, governance, operations, shared includes/libraries) and the `out/` rendered-export buckets and `tools/` subdirs with README placeholders so the structure is tracked in git.

### Testing
- Verified the new tree with `find docs/diagrams -maxdepth 4 -print | sort` and confirmed the expected directories and placeholder READMEs were present (succeeded). 
- Checked repository status with `git status --short` to ensure the new files were staged/visible (succeeded). 
- Confirmed files were added to version control and appear in the repo index after the scaffold operation (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3cd5a6c90832aa3c17b136217ed87)