### PR TITLE
Add missing docs/architecture scaffold directories and placeholder files

### DIFF
--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,3 @@
+# Decisions
+
+Placeholder for architecture documentation.

--- a/docs/architecture/decisions/adr-0000-template.md
+++ b/docs/architecture/decisions/adr-0000-template.md
@@ -1,0 +1,3 @@
+# Adr 0000 Template
+
+Placeholder for architecture documentation.

--- a/docs/architecture/decisions/adr-0001-example.md
+++ b/docs/architecture/decisions/adr-0001-example.md
@@ -1,0 +1,3 @@
+# Adr 0001 Example
+
+Placeholder for architecture documentation.

--- a/docs/architecture/decisions/adr-index.yml
+++ b/docs/architecture/decisions/adr-index.yml
@@ -1,0 +1,2 @@
+# Placeholder registry
+items: []

--- a/docs/architecture/diagrams/contracts.mmd
+++ b/docs/architecture/diagrams/contracts.mmd
@@ -1,0 +1,3 @@
+%% Placeholder Mermaid diagram
+flowchart TD
+  A[Placeholder] --> B[To be defined]

--- a/docs/architecture/diagrams/deployment.mmd
+++ b/docs/architecture/diagrams/deployment.mmd
@@ -1,0 +1,3 @@
+%% Placeholder Mermaid diagram
+flowchart TD
+  A[Placeholder] --> B[To be defined]

--- a/docs/architecture/diagrams/evidence-flow.mmd
+++ b/docs/architecture/diagrams/evidence-flow.mmd
@@ -1,0 +1,3 @@
+%% Placeholder Mermaid diagram
+flowchart TD
+  A[Placeholder] --> B[To be defined]

--- a/docs/architecture/diagrams/exports/README.md
+++ b/docs/architecture/diagrams/exports/README.md
@@ -1,0 +1,3 @@
+# Exports
+
+Placeholder for architecture documentation.

--- a/docs/architecture/diagrams/layering.mmd
+++ b/docs/architecture/diagrams/layering.mmd
@@ -1,0 +1,3 @@
+%% Placeholder Mermaid diagram
+flowchart TD
+  A[Placeholder] --> B[To be defined]

--- a/docs/architecture/diagrams/pep-pdp-obligations.mmd
+++ b/docs/architecture/diagrams/pep-pdp-obligations.mmd
@@ -1,0 +1,3 @@
+%% Placeholder Mermaid diagram
+flowchart TD
+  A[Placeholder] --> B[To be defined]

--- a/docs/architecture/diagrams/system-context.mmd
+++ b/docs/architecture/diagrams/system-context.mmd
@@ -1,0 +1,3 @@
+%% Placeholder Mermaid diagram
+flowchart TD
+  A[Placeholder] --> B[To be defined]

--- a/docs/architecture/diagrams/time-model.mmd
+++ b/docs/architecture/diagrams/time-model.mmd
@@ -1,0 +1,3 @@
+%% Placeholder Mermaid diagram
+flowchart TD
+  A[Placeholder] --> B[To be defined]

--- a/docs/architecture/diagrams/truth-path.mmd
+++ b/docs/architecture/diagrams/truth-path.mmd
@@ -1,0 +1,3 @@
+%% Placeholder Mermaid diagram
+flowchart TD
+  A[Placeholder] --> B[To be defined]

--- a/docs/architecture/enforcement/README.md
+++ b/docs/architecture/enforcement/README.md
@@ -1,0 +1,3 @@
+# Enforcement
+
+Placeholder for architecture documentation.

--- a/docs/architecture/enforcement/ci-checks.md
+++ b/docs/architecture/enforcement/ci-checks.md
@@ -1,0 +1,3 @@
+# Ci Checks
+
+Placeholder for architecture documentation.

--- a/docs/architecture/enforcement/contract-testing.md
+++ b/docs/architecture/enforcement/contract-testing.md
@@ -1,0 +1,3 @@
+# Contract Testing
+
+Placeholder for architecture documentation.

--- a/docs/architecture/enforcement/data-promotion-gates.md
+++ b/docs/architecture/enforcement/data-promotion-gates.md
@@ -1,0 +1,3 @@
+# Data Promotion Gates
+
+Placeholder for architecture documentation.

--- a/docs/architecture/enforcement/invariants.md
+++ b/docs/architecture/enforcement/invariants.md
@@ -1,0 +1,3 @@
+# Invariants
+
+Placeholder for architecture documentation.

--- a/docs/architecture/enforcement/policy-enforcement-points.md
+++ b/docs/architecture/enforcement/policy-enforcement-points.md
@@ -1,0 +1,3 @@
+# Policy Enforcement Points
+
+Placeholder for architecture documentation.

--- a/docs/architecture/enforcement/redaction-and-generalization-tests.md
+++ b/docs/architecture/enforcement/redaction-and-generalization-tests.md
@@ -1,0 +1,3 @@
+# Redaction And Generalization Tests
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/README.md
+++ b/docs/architecture/overview/README.md
@@ -1,0 +1,3 @@
+# Overview
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/actors-and-trust-surfaces.md
+++ b/docs/architecture/overview/actors-and-trust-surfaces.md
@@ -1,0 +1,3 @@
+# Actors And Trust Surfaces
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/canonical-vs-rebuildable.md
+++ b/docs/architecture/overview/canonical-vs-rebuildable.md
@@ -1,0 +1,3 @@
+# Canonical Vs Rebuildable
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/component-decomposition.md
+++ b/docs/architecture/overview/component-decomposition.md
@@ -1,0 +1,3 @@
+# Component Decomposition
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/deployment-topology.md
+++ b/docs/architecture/overview/deployment-topology.md
@@ -1,0 +1,3 @@
+# Deployment Topology
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/evidence-and-claims.md
+++ b/docs/architecture/overview/evidence-and-claims.md
@@ -1,0 +1,3 @@
+# Evidence And Claims
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/focus-mode-constraints.md
+++ b/docs/architecture/overview/focus-mode-constraints.md
@@ -1,0 +1,3 @@
+# Focus Mode Constraints
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/glossary.md
+++ b/docs/architecture/overview/glossary.md
@@ -1,0 +1,3 @@
+# Glossary
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/identity-and-hashing.md
+++ b/docs/architecture/overview/identity-and-hashing.md
@@ -1,0 +1,3 @@
+# Identity And Hashing
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/layering.md
+++ b/docs/architecture/overview/layering.md
@@ -1,0 +1,3 @@
+# Layering
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/observability.md
+++ b/docs/architecture/overview/observability.md
@@ -1,0 +1,3 @@
+# Observability
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/policy-boundary.md
+++ b/docs/architecture/overview/policy-boundary.md
@@ -1,0 +1,3 @@
+# Policy Boundary
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/promotion-contract.md
+++ b/docs/architecture/overview/promotion-contract.md
@@ -1,0 +1,3 @@
+# Promotion Contract
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/provenance-and-audit.md
+++ b/docs/architecture/overview/provenance-and-audit.md
@@ -1,0 +1,3 @@
+# Provenance And Audit
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/security-and-privacy.md
+++ b/docs/architecture/overview/security-and-privacy.md
@@ -1,0 +1,3 @@
+# Security And Privacy
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/sensitive-locations.md
+++ b/docs/architecture/overview/sensitive-locations.md
@@ -1,0 +1,3 @@
+# Sensitive Locations
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/system-context.md
+++ b/docs/architecture/overview/system-context.md
@@ -1,0 +1,3 @@
+# System Context
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/time-model.md
+++ b/docs/architecture/overview/time-model.md
@@ -1,0 +1,3 @@
+# Time Model
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/time-queries-and-snapshots.md
+++ b/docs/architecture/overview/time-queries-and-snapshots.md
@@ -1,0 +1,3 @@
+# Time Queries And Snapshots
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/trust-membrane.md
+++ b/docs/architecture/overview/trust-membrane.md
@@ -1,0 +1,3 @@
+# Trust Membrane
+
+Placeholder for architecture documentation.

--- a/docs/architecture/overview/truth-path.md
+++ b/docs/architecture/overview/truth-path.md
@@ -1,0 +1,3 @@
+# Truth Path
+
+Placeholder for architecture documentation.

--- a/docs/architecture/registries/README.md
+++ b/docs/architecture/registries/README.md
@@ -1,0 +1,3 @@
+# Registries
+
+Placeholder for architecture documentation.

--- a/docs/architecture/registries/boundary-surface-registry.yml
+++ b/docs/architecture/registries/boundary-surface-registry.yml
@@ -1,0 +1,2 @@
+# Placeholder registry
+items: []

--- a/docs/architecture/registries/contract-index.yml
+++ b/docs/architecture/registries/contract-index.yml
@@ -1,0 +1,2 @@
+# Placeholder registry
+items: []

--- a/docs/architecture/registries/pep-registry.yml
+++ b/docs/architecture/registries/pep-registry.yml
@@ -1,0 +1,2 @@
+# Placeholder registry
+items: []

--- a/docs/architecture/registries/policy-label-registry.yml
+++ b/docs/architecture/registries/policy-label-registry.yml
@@ -1,0 +1,2 @@
+# Placeholder registry
+items: []

--- a/docs/architecture/registries/service-catalog.yml
+++ b/docs/architecture/registries/service-catalog.yml
@@ -1,0 +1,2 @@
+# Placeholder registry
+items: []

--- a/docs/architecture/templates/README.md
+++ b/docs/architecture/templates/README.md
@@ -1,0 +1,3 @@
+# Templates
+
+Placeholder for architecture documentation.

--- a/docs/architecture/templates/adr.template.md
+++ b/docs/architecture/templates/adr.template.md
@@ -1,0 +1,3 @@
+# Adr.Template
+
+Placeholder for architecture documentation.

--- a/docs/architecture/templates/contract-doc.template.md
+++ b/docs/architecture/templates/contract-doc.template.md
@@ -1,0 +1,3 @@
+# Contract Doc.Template
+
+Placeholder for architecture documentation.

--- a/docs/architecture/templates/diagram.template.mmd
+++ b/docs/architecture/templates/diagram.template.mmd
@@ -1,0 +1,3 @@
+%% Placeholder Mermaid diagram
+flowchart TD
+  A[Placeholder] --> B[To be defined]

--- a/docs/architecture/templates/kfm-meta-block-v2.txt
+++ b/docs/architecture/templates/kfm-meta-block-v2.txt
@@ -1,0 +1,1 @@
+[KFM_META_BLOCK_V2 template placeholder]

--- a/docs/architecture/templates/review-checklist.md
+++ b/docs/architecture/templates/review-checklist.md
@@ -1,0 +1,3 @@
+# Review Checklist
+
+Placeholder for architecture documentation.

--- a/docs/architecture/templates/standard-doc.template.md
+++ b/docs/architecture/templates/standard-doc.template.md
@@ -1,0 +1,3 @@
+# Standard Doc.Template
+
+Placeholder for architecture documentation.

--- a/docs/architecture/threat-model/README.md
+++ b/docs/architecture/threat-model/README.md
@@ -1,0 +1,3 @@
+# Threat Model
+
+Placeholder for architecture documentation.

--- a/docs/architecture/threat-model/abuse-cases.md
+++ b/docs/architecture/threat-model/abuse-cases.md
@@ -1,0 +1,3 @@
+# Abuse Cases
+
+Placeholder for architecture documentation.

--- a/docs/architecture/threat-model/actors-and-entrypoints.md
+++ b/docs/architecture/threat-model/actors-and-entrypoints.md
@@ -1,0 +1,3 @@
+# Actors And Entrypoints
+
+Placeholder for architecture documentation.

--- a/docs/architecture/threat-model/control-mapping.md
+++ b/docs/architecture/threat-model/control-mapping.md
@@ -1,0 +1,3 @@
+# Control Mapping
+
+Placeholder for architecture documentation.

--- a/docs/architecture/threat-model/data-classification-and-handling.md
+++ b/docs/architecture/threat-model/data-classification-and-handling.md
@@ -1,0 +1,3 @@
+# Data Classification And Handling
+
+Placeholder for architecture documentation.

--- a/docs/architecture/threat-model/residual-risk.md
+++ b/docs/architecture/threat-model/residual-risk.md
@@ -1,0 +1,3 @@
+# Residual Risk
+
+Placeholder for architecture documentation.

--- a/docs/architecture/threat-model/risk-register.md
+++ b/docs/architecture/threat-model/risk-register.md
@@ -1,0 +1,3 @@
+# Risk Register
+
+Placeholder for architecture documentation.

--- a/docs/architecture/threat-model/scope-and-assets.md
+++ b/docs/architecture/threat-model/scope-and-assets.md
@@ -1,0 +1,3 @@
+# Scope And Assets
+
+Placeholder for architecture documentation.


### PR DESCRIPTION
### Motivation

- The `docs/architecture/README.md` documents a fully-expanded directory layout but many referenced subfolders and files were missing, which blocks linking and downstream doc tooling that expects those paths. 
- Populate the documented architecture subtree so contributors and CI validators have a usable scaffold to author and validate architecture artifacts.

### Description

- Created the full `docs/architecture/` subtree and major subdirectories `overview/`, `decisions/`, `diagrams/` (with `exports/`), `enforcement/`, `registries/`, `templates/`, and `threat-model/`. 
- Added 63 new placeholder files including markdown overviews, ADR templates, mermaid diagram sources (`*.mmd`), registry YAMLs (`*.yml`), and a `kfm-meta-block-v2` template text file. 
- Added diagram export support via `docs/architecture/diagrams/exports/.gitkeep` and `README.md` so generated assets have a stable target. 
- Inserted minimal placeholder content into each new file so the layout is immediately navigable and safe for CI/link-check tooling to reference.

### Testing

- Ran the creation script (`python` script) to materialize the scaffold which executed without error. 
- Executed an existence-check script (`python` verification) that reported `missing 0`, confirming all expected paths under `docs/architecture/` were created. 
- Verified the repository tree with quick inspections using `find` and `rg` to ensure the new files and directories appear in the project layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3cf5e1948832a80699f961ff9e198)