### PR TITLE
Add missing docs/quality checklist files

### DIFF
--- a/docs/quality/doc-quality-checklist.md
+++ b/docs/quality/doc-quality-checklist.md
@@ -1,0 +1,53 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/1d4c0e66-f094-4cc4-b9e0-23a31a531234
+title: Documentation Quality Checklist
+type: checklist
+version: v1
+status: draft
+owners: kfm-core (TBD)
+created: 2026-03-01
+updated: 2026-03-01
+policy_label: public
+related:
+  - ./README.md
+  - ../README.md
+tags: [kfm, quality, docs, checklist]
+[/KFM_META_BLOCK_V2] -->
+
+# Documentation Quality Checklist
+
+Use this checklist before merging significant documentation updates.
+
+## Structure and navigation
+
+- [ ] File location is correct for the document type.
+- [ ] Title reflects the scope and intent.
+- [ ] Quick links / section anchors are present for long documents.
+- [ ] References to sibling docs use valid relative links.
+
+## Accuracy and governance alignment
+
+- [ ] Claims align with current implementation or are clearly marked as proposed.
+- [ ] Terms are consistent with the KFM glossary and governance language.
+- [ ] Normative requirements are unambiguous and testable.
+- [ ] Security/policy behavior is described as fail-closed when uncertain.
+
+## Evidence and traceability
+
+- [ ] User-facing claims include resolvable evidence links when required.
+- [ ] Required artifacts and validators are explicitly named.
+- [ ] Promotion/blocking criteria are documented where applicable.
+- [ ] Exception paths include approval and time-bound requirements.
+
+## Readability and maintenance
+
+- [ ] Markdown renders cleanly (lists, tables, code fences).
+- [ ] Long sections are broken into digestible subsections.
+- [ ] “Back to top” / navigation helpers are present for long docs.
+- [ ] Outdated TODOs or stale timestamps are removed or updated.
+
+## Final pre-merge checks
+
+- [ ] Local markdown lint/format checks pass.
+- [ ] Link checks pass for changed files.
+- [ ] Reviewer can identify what changed and why from the PR description.

--- a/docs/quality/promotion-readiness-checklist.md
+++ b/docs/quality/promotion-readiness-checklist.md
@@ -1,0 +1,69 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/5e2f6fdc-d4a8-49be-af1f-2cd71868c345
+title: Promotion Readiness Checklist
+type: checklist
+version: v1
+status: draft
+owners: kfm-core (TBD)
+created: 2026-03-01
+updated: 2026-03-01
+policy_label: public
+related:
+  - ./README.md
+  - ../governance/REVIEW_GATES.md
+tags: [kfm, quality, promotion, checklist]
+[/KFM_META_BLOCK_V2] -->
+
+# Promotion Readiness Checklist
+
+Use this checklist before promoting data/products toward `PUBLISHED`.
+
+## Gate A — Identity & versioning
+
+- [ ] `dataset_id` and `dataset_version_id` are stable and documented.
+- [ ] Spec hash is deterministic and captured.
+- [ ] Artifact digests are generated and retained.
+
+## Gate B — Licensing & rights
+
+- [ ] License/rights fields are populated and valid.
+- [ ] Upstream terms snapshot is retained.
+- [ ] Attribution requirements are documented.
+
+## Gate C — Sensitivity & redaction
+
+- [ ] `policy_label` is assigned and justified.
+- [ ] Required obligations are defined (redaction/generalization/deny).
+- [ ] Sensitive fields/geometry handling is verified.
+
+## Gate D — Catalog triplet
+
+- [ ] DCAT validates.
+- [ ] STAC validates.
+- [ ] PROV validates.
+- [ ] Cross-links resolve across all three catalogs.
+- [ ] Evidence references resolve deterministically.
+
+## Gate E — QA thresholds
+
+- [ ] Dataset-specific QA checks were executed.
+- [ ] Thresholds were met or quarantine rationale is documented.
+- [ ] QA outputs are attached or linked from the promotion record.
+
+## Gate F — Receipt & audit
+
+- [ ] Run receipt captures inputs, tools, hashes, and decisions.
+- [ ] Receipt validates against schema.
+- [ ] Audit trail append is confirmed.
+
+## Gate G — Release manifest
+
+- [ ] Manifest exists for the release candidate.
+- [ ] Manifest references correct artifact digests.
+- [ ] Version and timestamp metadata are complete.
+
+## Exceptions (only when necessary)
+
+- [ ] Exception is explicitly documented and time-bounded.
+- [ ] Governance/steward approval is linked.
+- [ ] Compensating controls and risk notes are included.

--- a/docs/quality/threat-model-checklist.md
+++ b/docs/quality/threat-model-checklist.md
@@ -1,0 +1,53 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/c4e6a92f-1db7-4933-979f-e18061ef4567
+title: Threat Model Checklist
+type: checklist
+version: v1
+status: draft
+owners: kfm-core (TBD)
+created: 2026-03-01
+updated: 2026-03-01
+policy_label: public
+related:
+  - ./README.md
+  - ../security/README.md
+tags: [kfm, quality, security, threat-model, checklist]
+[/KFM_META_BLOCK_V2] -->
+
+# Threat Model Checklist
+
+Use this checklist when introducing or changing APIs, data flows, or policy enforcement paths.
+
+## Scope and assets
+
+- [ ] Threat model scope is defined (component, boundary, data classes).
+- [ ] Sensitive assets and trust boundaries are identified.
+- [ ] Data-flow diagram is updated or linked.
+
+## Trust membrane controls
+
+- [ ] Clients cannot bypass governed APIs.
+- [ ] Policy decisions are enforced at request time.
+- [ ] Evidence resolution is required for user-facing claims.
+- [ ] Error payloads avoid leaking restricted metadata.
+
+## Identity, authorization, and abuse resistance
+
+- [ ] AuthN/AuthZ assumptions are documented.
+- [ ] Deny-by-default behavior is verified for unknown cases.
+- [ ] Rate limiting / abuse controls are documented where relevant.
+- [ ] Privileged operations are auditable.
+
+## Data protection and integrity
+
+- [ ] Sensitive fields are redacted/generalized per policy.
+- [ ] Artifact hashes/digests are verified where required.
+- [ ] Input validation covers schema and boundary conditions.
+- [ ] Supply-chain dependencies are reviewed for critical risk.
+
+## Operational readiness
+
+- [ ] Security-relevant logs and receipts are emitted.
+- [ ] Alerting/triage ownership is clear.
+- [ ] Rollback or kill-switch path is documented.
+- [ ] Residual risks and accepted risks are listed with approvers.


### PR DESCRIPTION
### Motivation
- The repository `docs/README.md` references three checklist files under `docs/quality/` that were missing; this change restores the expected documentation surface. 
- Provide explicit, reviewable checklists to make promotion, documentation, and threat-model reviews testable and discoverable.

### Description
- Add `docs/quality/doc-quality-checklist.md` containing a documentation QA checklist (structure, governance alignment, evidence, readability, pre-merge checks).
- Add `docs/quality/promotion-readiness-checklist.md` containing gate-aligned promotion readiness checks for Gates A–G and exception requirements.
- Add `docs/quality/threat-model-checklist.md` containing security/threat-model review items for trust membrane, auth/abuse resistance, data protection, and operational readiness; each file includes the repo `KFM_META_BLOCK_V2` header and is committed to the current branch.

### Testing
- Verified file presence with `find docs/quality -maxdepth 2 -type f | sort`, which listed the three new files (success).
- Verified repository state with `git status --short` and recorded a commit (`git rev-parse --short HEAD` returned the new commit hash), and the files were committed successfully (success).
- Displayed file contents with `nl`/`sed` checks to ensure files contain the intended checklist content (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d0631440832a914f86590f2e74f4)