### PR TITLE
docs(domains): scaffold missing domains structure

### DIFF
--- a/docs/domains/_templates/context.README.template.md
+++ b/docs/domains/_templates/context.README.template.md
@@ -1,0 +1,24 @@
+# <Context Name>
+
+## Purpose
+## Responsibilities
+## Non-responsibilities
+
+## Owned entities
+- ...
+
+## Invariants
+- MUST ...
+- SHOULD ...
+
+## Interfaces
+### Inputs
+### Outputs
+
+## Policy and evidence considerations
+- Default-deny conditions:
+- Redaction obligations:
+
+## Testing expectations
+- Contract tests:
+- Golden tests:

--- a/docs/domains/_templates/decision.template.md
+++ b/docs/domains/_templates/decision.template.md
@@ -1,0 +1,9 @@
+# <YYYY-MM-DD short title>
+
+## What changed
+
+## Why
+
+## Impacted interfaces/contracts
+
+## Migration notes

--- a/docs/domains/contexts/catalog/README.md
+++ b/docs/domains/contexts/catalog/README.md
@@ -1,0 +1,27 @@
+# Catalog Context
+
+## Purpose
+Owns discoverability metadata and machine-readable catalog artifacts.
+
+## Responsibilities
+- Build and validate STAC/DCAT/PROV-facing metadata
+- Maintain versioned dataset descriptors
+
+## Non-responsibilities
+- Policy adjudication
+- Story claim authoring
+
+## Owned entities
+- Catalog entry
+- Dataset metadata projection
+
+## Invariants
+- MUST keep version lineage traceable.
+- MUST not publish entries with unresolved required provenance links.
+
+## Interfaces
+### Inputs
+- Ingest outputs
+
+### Outputs
+- Catalog documents and contract-valid metadata

--- a/docs/domains/contexts/evidence/README.md
+++ b/docs/domains/contexts/evidence/README.md
@@ -1,0 +1,26 @@
+# Evidence Context
+
+## Purpose
+Owns resolution from references to verifiable evidence bundles.
+
+## Responsibilities
+- Resolve EvidenceRef to EvidenceBundle
+- Track support/insufficient evidence outcomes
+
+## Non-responsibilities
+- Final policy decisioning
+
+## Owned entities
+- EvidenceRef
+- EvidenceBundle
+
+## Invariants
+- MUST provide deterministic resolution against fixed inputs.
+- MUST include reason codes when support is insufficient.
+
+## Interfaces
+### Inputs
+- Evidence references from stories/focus/policy
+
+### Outputs
+- Evidence bundles and resolution reports

--- a/docs/domains/contexts/focus/README.md
+++ b/docs/domains/contexts/focus/README.md
@@ -1,0 +1,27 @@
+# Focus Context
+
+## Purpose
+Owns ask/answer flows with evidence-bound, policy-safe responses.
+
+## Responsibilities
+- Accept focus queries
+- Build responses grounded in evidence + policy outcomes
+
+## Non-responsibilities
+- Catalog indexing internals
+
+## Owned entities
+- Focus query
+- Focus response
+
+## Invariants
+- MUST bind every response to supporting evidence or explicit insufficiency.
+- MUST enforce policy constraints before emitting results.
+
+## Interfaces
+### Inputs
+- Query intents
+- Evidence/policy outputs
+
+### Outputs
+- Focus answers with citations and reason codes

--- a/docs/domains/contexts/ingest/README.md
+++ b/docs/domains/contexts/ingest/README.md
@@ -1,0 +1,28 @@
+# Ingest Context
+
+## Purpose
+Owns acquisition intake and normalization hand-off into catalog-ready structures.
+
+## Responsibilities
+- Intake source manifests and acquisition metadata
+- Validate source-level shape before catalog hand-off
+- Emit deterministic ingest outputs and receipts
+
+## Non-responsibilities
+- Public catalog publication
+- Story composition
+
+## Owned entities
+- Acquisition request
+- Ingest receipt
+
+## Invariants
+- MUST produce deterministic outputs for same input/versioned transform.
+- MUST preserve source lineage required for downstream provenance.
+
+## Interfaces
+### Inputs
+- Acquisition manifests
+
+### Outputs
+- Catalog-ready datasets + ingest receipts

--- a/docs/domains/contexts/policy/README.md
+++ b/docs/domains/contexts/policy/README.md
@@ -1,0 +1,28 @@
+# Policy Context
+
+## Purpose
+Owns allow/deny and obligations decisions from policy rules.
+
+## Responsibilities
+- Evaluate policy labels and constraints
+- Produce explainable decision outputs
+
+## Non-responsibilities
+- Data acquisition
+- Search ranking logic
+
+## Owned entities
+- Policy decision
+- Obligation set
+
+## Invariants
+- MUST default deny when required evidence/policy context is missing.
+- MUST include machine-readable reason codes.
+
+## Interfaces
+### Inputs
+- Evidence outcomes
+- Policy labels and request context
+
+### Outputs
+- allow/deny + obligations + reasons

--- a/docs/domains/contexts/story/README.md
+++ b/docs/domains/contexts/story/README.md
@@ -1,0 +1,26 @@
+# Story Context
+
+## Purpose
+Owns narrative claim structures and publishable Story Node composition.
+
+## Responsibilities
+- Manage claims and claim-to-evidence links
+- Produce story publish payloads
+
+## Non-responsibilities
+- Raw ingest pipeline operations
+
+## Owned entities
+- Story node
+- Claim graph
+
+## Invariants
+- MUST bind claims to evidence references.
+- MUST fail publication when required links are unresolved.
+
+## Interfaces
+### Inputs
+- Claims, evidence references, policy outcomes
+
+### Outputs
+- Story publish contracts

--- a/docs/domains/core/entities.md
+++ b/docs/domains/core/entities.md
@@ -1,0 +1,26 @@
+# Core Entities
+
+Starting baseline entities and minimum invariants.
+
+## Entity set
+
+- Place
+- Event
+- Observation
+- Artifact
+- Dataset
+- DatasetVersion
+- Agent
+- Claim
+- EvidenceBundle
+- Relationship
+
+## Invariant checklist
+
+For each entity definition, document:
+
+- Identity rule
+- Time semantics
+- Policy label propagation
+- Evidence requirement
+- Failure behavior (default-deny/fail-closed)

--- a/docs/domains/core/glossary.md
+++ b/docs/domains/core/glossary.md
@@ -1,0 +1,12 @@
+# Domain Glossary
+
+Canonical definitions for KFM's ubiquitous language.
+
+## Terms
+
+- **Bounded context**: A boundary inside which a term has one explicit meaning and one owner.
+- **Entity**: A domain object with stable identity across changes in state.
+- **Value object**: A domain object defined by value equality and no independent identity.
+- **Invariant**: A rule that MUST remain true for all valid states/transitions.
+- **EvidenceBundle**: Resolved evidence package used to support a claim or answer.
+- **Policy label**: Classification that drives visibility, sharing, and redaction behavior.

--- a/docs/domains/core/identity-and-time.md
+++ b/docs/domains/core/identity-and-time.md
@@ -1,0 +1,19 @@
+# Identity and Time Semantics
+
+## Identity
+
+Each entity type MUST define:
+
+- Canonical identifier shape
+- De-duplication/equivalence rules
+- Merge/split behavior over time
+
+## Time
+
+Entity and event documents SHOULD distinguish:
+
+- Event time
+- Valid time
+- Transaction/processing time
+
+When time is ambiguous, policy and evidence checks MUST fail closed.

--- a/docs/domains/decisions/README.md
+++ b/docs/domains/decisions/README.md
@@ -1,0 +1,14 @@
+# Domain Decisions
+
+Use this folder for small ADR-style notes about boundary, terminology, and invariant changes.
+
+## Naming convention
+
+`YYYY-MM-DD-short-title.md`
+
+## Minimum sections
+
+- What changed
+- Why
+- Impacted interfaces/contracts
+- Migration notes


### PR DESCRIPTION
### Motivation
- Fulfill the directory layout required by `docs/domains/README.md` so bounded-context documentation and domain language guidance have a canonical home. 
- Provide starter content and templates so contributors can add context-specific details and decision notes consistently.

### Description
- Added core domain guidance under `docs/domains/core/` with `glossary.md`, `entities.md`, and `identity-and-time.md` as canonical references. 
- Created bounded-context folders and starter `README.md` files under `docs/domains/contexts/` for `ingest`, `catalog`, `evidence`, `policy`, `story`, and `focus`. 
- Added a `docs/domains/decisions/README.md` to capture ADR-style notes naming and required sections. 
- Added documentation templates under `docs/domains/_templates/` with `context.README.template.md` and `decision.template.md` to standardize new context and decision pages.

### Testing
- Verified the created files list with `find docs/domains -maxdepth 3 -type f | sort`, which returned the expected scaffolded files and succeeded. 
- Verified repository status with `git status --short`, which showed no uncommitted changes after staging, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d3178d60832a8767eea078802054)