### PR TITLE
Add README.md coverage for previously undocumented directories

### DIFF
--- a/apps/api/src/adapters/README.md
+++ b/apps/api/src/adapters/README.md
@@ -1,0 +1,12 @@
+# apps/api/src/adapters
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/api/src/api/middleware/README.md
+++ b/apps/api/src/api/middleware/README.md
@@ -1,0 +1,12 @@
+# apps/api/src/api/middleware
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/api/src/services/README.md
+++ b/apps/api/src/services/README.md
@@ -1,0 +1,12 @@
+# apps/api/src/services
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/api/tests/README.md
+++ b/apps/api/tests/README.md
@@ -1,0 +1,13 @@
+# apps/api/tests
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `contract/`
+- `integration/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/tests/contract/README.md
+++ b/apps/api/tests/contract/README.md
@@ -1,0 +1,12 @@
+# apps/api/tests/contract
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/api/tests/integration/README.md
+++ b/apps/api/tests/integration/README.md
@@ -1,0 +1,12 @@
+# apps/api/tests/integration
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/api/ui/src/README.md
+++ b/apps/api/ui/src/README.md
@@ -1,0 +1,16 @@
+# apps/api/ui/src
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `api/`
+- `components/`
+- `pages/`
+- `state/`
+- `styles/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/api/README.md
+++ b/apps/api/ui/src/api/README.md
@@ -1,0 +1,13 @@
+# apps/api/ui/src/api
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `client.ts`
+- `contracts.ts`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/components/EvidenceDrawer/README.md
+++ b/apps/api/ui/src/components/EvidenceDrawer/README.md
@@ -1,0 +1,12 @@
+# apps/api/ui/src/components/EvidenceDrawer
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `index.tsx`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/components/LayerPanel/README.md
+++ b/apps/api/ui/src/components/LayerPanel/README.md
@@ -1,0 +1,12 @@
+# apps/api/ui/src/components/LayerPanel
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `index.tsx`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/components/MapCanvas/README.md
+++ b/apps/api/ui/src/components/MapCanvas/README.md
@@ -1,0 +1,12 @@
+# apps/api/ui/src/components/MapCanvas
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `index.tsx`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/components/README.md
+++ b/apps/api/ui/src/components/README.md
@@ -1,0 +1,17 @@
+# apps/api/ui/src/components
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `EvidenceDrawer/`
+- `LayerPanel/`
+- `MapCanvas/`
+- `ReceiptViewer/`
+- `TimeControl/`
+- `TrustBadges/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/components/ReceiptViewer/README.md
+++ b/apps/api/ui/src/components/ReceiptViewer/README.md
@@ -1,0 +1,12 @@
+# apps/api/ui/src/components/ReceiptViewer
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `index.tsx`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/components/TimeControl/README.md
+++ b/apps/api/ui/src/components/TimeControl/README.md
@@ -1,0 +1,12 @@
+# apps/api/ui/src/components/TimeControl
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `index.tsx`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/components/TrustBadges/README.md
+++ b/apps/api/ui/src/components/TrustBadges/README.md
@@ -1,0 +1,12 @@
+# apps/api/ui/src/components/TrustBadges
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `index.tsx`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/pages/README.md
+++ b/apps/api/ui/src/pages/README.md
@@ -1,0 +1,14 @@
+# apps/api/ui/src/pages
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `Explorer.tsx`
+- `Focus.tsx`
+- `Story.tsx`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/src/state/README.md
+++ b/apps/api/ui/src/state/README.md
@@ -1,0 +1,13 @@
+# apps/api/ui/src/state
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `query_params.ts`
+- `view_state.ts`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/tests/README.md
+++ b/apps/api/ui/tests/README.md
@@ -1,0 +1,12 @@
+# apps/api/ui/tests
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `e2e/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/api/ui/tests/e2e/README.md
+++ b/apps/api/ui/tests/e2e/README.md
@@ -1,0 +1,12 @@
+# apps/api/ui/tests/e2e
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/cli/src/commands/README.md
+++ b/apps/cli/src/commands/README.md
@@ -1,0 +1,12 @@
+# apps/cli/src/commands
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/cli/src/output/README.md
+++ b/apps/cli/src/output/README.md
@@ -1,0 +1,12 @@
+# apps/cli/src/output
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/workers/src/README.md
+++ b/apps/workers/src/README.md
@@ -1,0 +1,14 @@
+# apps/workers/src
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `audit/`
+- `pipelines/`
+- `receipts/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/workers/src/audit/README.md
+++ b/apps/workers/src/audit/README.md
@@ -1,0 +1,12 @@
+# apps/workers/src/audit
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/workers/src/pipelines/README.md
+++ b/apps/workers/src/pipelines/README.md
@@ -1,0 +1,15 @@
+# apps/workers/src/pipelines
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `ingest/`
+- `promote/`
+- `rebuild_projections/`
+- `validate/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/apps/workers/src/pipelines/ingest/README.md
+++ b/apps/workers/src/pipelines/ingest/README.md
@@ -1,0 +1,12 @@
+# apps/workers/src/pipelines/ingest
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/workers/src/pipelines/promote/README.md
+++ b/apps/workers/src/pipelines/promote/README.md
@@ -1,0 +1,12 @@
+# apps/workers/src/pipelines/promote
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/workers/src/pipelines/rebuild_projections/README.md
+++ b/apps/workers/src/pipelines/rebuild_projections/README.md
@@ -1,0 +1,12 @@
+# apps/workers/src/pipelines/rebuild_projections
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/workers/src/pipelines/validate/README.md
+++ b/apps/workers/src/pipelines/validate/README.md
@@ -1,0 +1,12 @@
+# apps/workers/src/pipelines/validate
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/workers/src/receipts/README.md
+++ b/apps/workers/src/receipts/README.md
@@ -1,0 +1,12 @@
+# apps/workers/src/receipts
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/apps/workers/tests/README.md
+++ b/apps/workers/tests/README.md
@@ -1,0 +1,12 @@
+# apps/workers/tests
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/configs/pipelines/datasets/README.md
+++ b/configs/pipelines/datasets/README.md
@@ -1,0 +1,12 @@
+# configs/pipelines/datasets
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/configs/pipelines/profiles/README.md
+++ b/configs/pipelines/profiles/README.md
@@ -1,0 +1,12 @@
+# configs/pipelines/profiles
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/configs/pipelines/watchers/README.md
+++ b/configs/pipelines/watchers/README.md
@@ -1,0 +1,12 @@
+# configs/pipelines/watchers
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/configs/ui/layers/README.md
+++ b/configs/ui/layers/README.md
@@ -1,0 +1,12 @@
+# configs/ui/layers
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/configs/ui/themes/README.md
+++ b/configs/ui/themes/README.md
@@ -1,0 +1,12 @@
+# configs/ui/themes
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/contracts/openapi/components/README.md
+++ b/contracts/openapi/components/README.md
@@ -1,0 +1,12 @@
+# contracts/openapi/components
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/contracts/profiles/dcat/README.md
+++ b/contracts/profiles/dcat/README.md
@@ -1,0 +1,12 @@
+# contracts/profiles/dcat
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `tests/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/contracts/profiles/dcat/tests/README.md
+++ b/contracts/profiles/dcat/tests/README.md
@@ -1,0 +1,12 @@
+# contracts/profiles/dcat/tests
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/contracts/profiles/prov/README.md
+++ b/contracts/profiles/prov/README.md
@@ -1,0 +1,12 @@
+# contracts/profiles/prov
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `tests/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/contracts/profiles/prov/tests/README.md
+++ b/contracts/profiles/prov/tests/README.md
@@ -1,0 +1,12 @@
+# contracts/profiles/prov/tests
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/contracts/profiles/stac/README.md
+++ b/contracts/profiles/stac/README.md
@@ -1,0 +1,12 @@
+# contracts/profiles/stac
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `tests/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/contracts/profiles/stac/tests/README.md
+++ b/contracts/profiles/stac/tests/README.md
@@ -1,0 +1,12 @@
+# contracts/profiles/stac/tests
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/contracts/templates/README.md
+++ b/contracts/templates/README.md
@@ -1,0 +1,13 @@
+# contracts/templates
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `prov/`
+- `receipts/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/contracts/templates/prov/README.md
+++ b/contracts/templates/prov/README.md
@@ -1,0 +1,12 @@
+# contracts/templates/prov
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/contracts/templates/receipts/README.md
+++ b/contracts/templates/receipts/README.md
@@ -1,0 +1,12 @@
+# contracts/templates/receipts
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/docs/adr/_generated/README.md
+++ b/docs/adr/_generated/README.md
@@ -1,0 +1,16 @@
+# docs/adr/_generated
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `adr-graph.csv`
+- `adr-index.json`
+- `adr-index.md`
+- `adr-matrix.csv`
+- `adr-stats.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/docs/adr/archive/imported/20xx-legacy/README.md
+++ b/docs/adr/archive/imported/20xx-legacy/README.md
@@ -1,0 +1,12 @@
+# docs/adr/archive/imported/20xx-legacy
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/docs/adr/archive/imported/README.md
+++ b/docs/adr/archive/imported/README.md
@@ -1,0 +1,12 @@
+# docs/adr/archive/imported
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `20xx-legacy/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/docs/guides/onboarding/templates/README.md
+++ b/docs/guides/onboarding/templates/README.md
@@ -1,0 +1,15 @@
+# docs/guides/onboarding/templates
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `dataset-entry.yaml.example`
+- `dataset-spec.md.example`
+- `provenance-notes.md.example`
+- `qa-spec.yaml.example`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/fixtures/public/catalogs/README.md
+++ b/tests/fixtures/public/catalogs/README.md
@@ -1,0 +1,12 @@
+# tests/fixtures/public/catalogs
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/fixtures/public/datasets/README.md
+++ b/tests/fixtures/public/datasets/README.md
@@ -1,0 +1,12 @@
+# tests/fixtures/public/datasets
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/fixtures/public/evidence/README.md
+++ b/tests/fixtures/public/evidence/README.md
@@ -1,0 +1,12 @@
+# tests/fixtures/public/evidence
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/fixtures/public/view_states/README.md
+++ b/tests/fixtures/public/view_states/README.md
@@ -1,0 +1,12 @@
+# tests/fixtures/public/view_states
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/integration/harness/config/README.md
+++ b/tests/integration/harness/config/README.md
@@ -1,0 +1,13 @@
+# tests/integration/harness/config
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `overrides.yaml`
+- `test.env.example`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/integration/harness/scripts/README.md
+++ b/tests/integration/harness/scripts/README.md
@@ -1,0 +1,15 @@
+# tests/integration/harness/scripts
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `down.sh`
+- `reset.sh`
+- `seed.sh`
+- `up.sh`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/integration/harness/seed/README.md
+++ b/tests/integration/harness/seed/README.md
@@ -1,0 +1,15 @@
+# tests/integration/harness/seed
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `catalog_triplet/`
+- `evidence/`
+- `processed_artifacts/`
+- `receipts/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/integration/harness/seed/catalog_triplet/README.md
+++ b/tests/integration/harness/seed/catalog_triplet/README.md
@@ -1,0 +1,12 @@
+# tests/integration/harness/seed/catalog_triplet
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/integration/harness/seed/evidence/README.md
+++ b/tests/integration/harness/seed/evidence/README.md
@@ -1,0 +1,12 @@
+# tests/integration/harness/seed/evidence
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/integration/harness/seed/processed_artifacts/README.md
+++ b/tests/integration/harness/seed/processed_artifacts/README.md
@@ -1,0 +1,12 @@
+# tests/integration/harness/seed/processed_artifacts
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/integration/harness/seed/receipts/README.md
+++ b/tests/integration/harness/seed/receipts/README.md
@@ -1,0 +1,12 @@
+# tests/integration/harness/seed/receipts
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/policy/fixtures/README.md
+++ b/tests/policy/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/policy/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `expected/`
+- `inputs/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/policy/fixtures/expected/README.md
+++ b/tests/policy/fixtures/expected/README.md
@@ -1,0 +1,16 @@
+# tests/policy/fixtures/expected
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `focus_public_query_restricted_context.decision.json`
+- `public_export_public_dataset.decision.json`
+- `public_read_public_dataset.decision.json`
+- `public_read_restricted_dataset.decision.json`
+- `steward_read_restricted_dataset.decision.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/policy/fixtures/inputs/README.md
+++ b/tests/policy/fixtures/inputs/README.md
@@ -1,0 +1,16 @@
+# tests/policy/fixtures/inputs
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `focus_public_query_restricted_context.json`
+- `public_export_public_dataset.json`
+- `public_read_public_dataset.json`
+- `public_read_restricted_dataset.json`
+- `steward_read_restricted_dataset.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/registry/fixtures/README.md
+++ b/tests/registry/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/registry/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/registry/fixtures/invalid/README.md
+++ b/tests/registry/fixtures/invalid/README.md
@@ -1,0 +1,14 @@
+# tests/registry/fixtures/invalid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `bad_command_shape.json`
+- `missing_owner.json`
+- `unknown_gate.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/registry/fixtures/valid/README.md
+++ b/tests/registry/fixtures/valid/README.md
@@ -1,0 +1,13 @@
+# tests/registry/fixtures/valid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `tests.v1.full.json`
+- `tests.v1.min.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/registry/schemas/README.md
+++ b/tests/registry/schemas/README.md
@@ -1,0 +1,20 @@
+# tests/registry/schemas
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `error_envelope.v1.schema.json`
+- `evidence_bundle.v1.schema.json`
+- `evidence_ref.v1.schema.json`
+- `policy_decision.v1.schema.json`
+- `promotion_manifest.v1.schema.json`
+- `run_manifest.v1.schema.json`
+- `run_receipt.v1.schema.json`
+- `test_suite_manifest.v1.schema.json`
+- `tests_registry.v1.schema.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/dcat/README.md
+++ b/tests/schema/dcat/README.md
@@ -1,0 +1,13 @@
+# tests/schema/dcat
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `fixtures/`
+- `golden/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/dcat/fixtures/README.md
+++ b/tests/schema/dcat/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/schema/dcat/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/dcat/fixtures/invalid/README.md
+++ b/tests/schema/dcat/fixtures/invalid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/dcat/fixtures/invalid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/dcat/fixtures/valid/README.md
+++ b/tests/schema/dcat/fixtures/valid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/dcat/fixtures/valid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/dcat/golden/README.md
+++ b/tests/schema/dcat/golden/README.md
@@ -1,0 +1,12 @@
+# tests/schema/dcat/golden
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/linkcheck/README.md
+++ b/tests/schema/linkcheck/README.md
@@ -1,0 +1,12 @@
+# tests/schema/linkcheck
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `fixtures/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/linkcheck/fixtures/README.md
+++ b/tests/schema/linkcheck/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/schema/linkcheck/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/linkcheck/fixtures/invalid/README.md
+++ b/tests/schema/linkcheck/fixtures/invalid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/linkcheck/fixtures/invalid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/linkcheck/fixtures/valid/README.md
+++ b/tests/schema/linkcheck/fixtures/valid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/linkcheck/fixtures/valid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/prov/README.md
+++ b/tests/schema/prov/README.md
@@ -1,0 +1,13 @@
+# tests/schema/prov
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `fixtures/`
+- `golden/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/prov/fixtures/README.md
+++ b/tests/schema/prov/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/schema/prov/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/prov/fixtures/invalid/README.md
+++ b/tests/schema/prov/fixtures/invalid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/prov/fixtures/invalid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/prov/fixtures/valid/README.md
+++ b/tests/schema/prov/fixtures/valid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/prov/fixtures/valid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/prov/golden/README.md
+++ b/tests/schema/prov/golden/README.md
@@ -1,0 +1,12 @@
+# tests/schema/prov/golden
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/receipts/README.md
+++ b/tests/schema/receipts/README.md
@@ -1,0 +1,12 @@
+# tests/schema/receipts
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `fixtures/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/receipts/fixtures/README.md
+++ b/tests/schema/receipts/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/schema/receipts/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/receipts/fixtures/invalid/README.md
+++ b/tests/schema/receipts/fixtures/invalid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/receipts/fixtures/invalid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/receipts/fixtures/valid/README.md
+++ b/tests/schema/receipts/fixtures/valid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/receipts/fixtures/valid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/stac/README.md
+++ b/tests/schema/stac/README.md
@@ -1,0 +1,13 @@
+# tests/schema/stac
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `fixtures/`
+- `golden/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/stac/fixtures/README.md
+++ b/tests/schema/stac/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/schema/stac/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/stac/fixtures/invalid/README.md
+++ b/tests/schema/stac/fixtures/invalid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/stac/fixtures/invalid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/stac/fixtures/valid/README.md
+++ b/tests/schema/stac/fixtures/valid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/stac/fixtures/valid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/stac/golden/README.md
+++ b/tests/schema/stac/golden/README.md
@@ -1,0 +1,12 @@
+# tests/schema/stac/golden
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/triplet/README.md
+++ b/tests/schema/triplet/README.md
@@ -1,0 +1,12 @@
+# tests/schema/triplet
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `fixtures/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/triplet/fixtures/README.md
+++ b/tests/schema/triplet/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/schema/triplet/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/schema/triplet/fixtures/invalid/README.md
+++ b/tests/schema/triplet/fixtures/invalid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/triplet/fixtures/invalid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/schema/triplet/fixtures/valid/README.md
+++ b/tests/schema/triplet/fixtures/valid/README.md
@@ -1,0 +1,12 @@
+# tests/schema/triplet/fixtures/valid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/unit/hashing/README.md
+++ b/tests/unit/hashing/README.md
@@ -1,0 +1,12 @@
+# tests/unit/hashing
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `fixtures/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/unit/hashing/fixtures/README.md
+++ b/tests/unit/hashing/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/unit/hashing/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `FIXTURE_NOTES.md`
+- `vectors.v1.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/unit/invariants/README.md
+++ b/tests/unit/invariants/README.md
@@ -1,0 +1,12 @@
+# tests/unit/invariants
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/unit/snapshots/README.md
+++ b/tests/unit/snapshots/README.md
@@ -1,0 +1,12 @@
+# tests/unit/snapshots
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tests/unit/time/README.md
+++ b/tests/unit/time/README.md
@@ -1,0 +1,12 @@
+# tests/unit/time
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `fixtures/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/unit/time/fixtures/README.md
+++ b/tests/unit/time/fixtures/README.md
@@ -1,0 +1,12 @@
+# tests/unit/time/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `time_cases.v1.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/unit/vocab/README.md
+++ b/tests/unit/vocab/README.md
@@ -1,0 +1,12 @@
+# tests/unit/vocab
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `fixtures/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/unit/vocab/fixtures/README.md
+++ b/tests/unit/vocab/fixtures/README.md
@@ -1,0 +1,13 @@
+# tests/unit/vocab/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `FIXTURE_NOTES.md`
+- `vocab_inputs.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tests/utils/assertions/README.md
+++ b/tests/utils/assertions/README.md
@@ -1,0 +1,12 @@
+# tests/utils/assertions
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tools/fixtures/public/minimal_catalog_bundle/README.md
+++ b/tools/fixtures/public/minimal_catalog_bundle/README.md
@@ -1,0 +1,15 @@
+# tools/fixtures/public/minimal_catalog_bundle
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `prov/`
+- `receipts/`
+- `stac/`
+- `dcat.jsonld`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/fixtures/public/minimal_catalog_bundle/stac/items/README.md
+++ b/tools/fixtures/public/minimal_catalog_bundle/stac/items/README.md
@@ -1,0 +1,12 @@
+# tools/fixtures/public/minimal_catalog_bundle/stac/items
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `item-001.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/fixtures/public/minimal_openapi/README.md
+++ b/tools/fixtures/public/minimal_openapi/README.md
@@ -1,0 +1,12 @@
+# tools/fixtures/public/minimal_openapi
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `openapi.v1.yaml`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/fixtures/restricted_sanitized/generalized_geometry_bundle/stac/README.md
+++ b/tools/fixtures/restricted_sanitized/generalized_geometry_bundle/stac/README.md
@@ -1,0 +1,12 @@
+# tools/fixtures/restricted_sanitized/generalized_geometry_bundle/stac
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `items/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/fixtures/restricted_sanitized/generalized_geometry_bundle/stac/items/README.md
+++ b/tools/fixtures/restricted_sanitized/generalized_geometry_bundle/stac/items/README.md
@@ -1,0 +1,12 @@
+# tools/fixtures/restricted_sanitized/generalized_geometry_bundle/stac/items
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `item-001.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/hash/fixtures/expected/README.md
+++ b/tools/hash/fixtures/expected/README.md
@@ -1,0 +1,13 @@
+# tools/hash/fixtures/expected
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `FIXTURE_NOTES.md`
+- `vectors.v1.expected.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/hash/fixtures/inputs/README.md
+++ b/tools/hash/fixtures/inputs/README.md
@@ -1,0 +1,14 @@
+# tools/hash/fixtures/inputs
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `dataset_spec_invalid_nondeterminism.json`
+- `dataset_spec_minimal.json`
+- `dataset_spec_with_ordering_noise.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/README.md
+++ b/tools/linkcheck/fixtures/README.md
@@ -1,0 +1,13 @@
+# tools/linkcheck/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/invalid/README.md
+++ b/tools/linkcheck/fixtures/invalid/README.md
@@ -1,0 +1,14 @@
+# tools/linkcheck/fixtures/invalid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `triplet_broken_link/`
+- `evidence_ref_bad_scheme.json`
+- `receipt_missing_artifact.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/invalid/triplet_broken_link/README.md
+++ b/tools/linkcheck/fixtures/invalid/triplet_broken_link/README.md
@@ -1,0 +1,13 @@
+# tools/linkcheck/fixtures/invalid/triplet_broken_link
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `stac/`
+- `dcat.jsonld`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/invalid/triplet_broken_link/stac/README.md
+++ b/tools/linkcheck/fixtures/invalid/triplet_broken_link/stac/README.md
@@ -1,0 +1,12 @@
+# tools/linkcheck/fixtures/invalid/triplet_broken_link/stac
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `collection.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/valid/README.md
+++ b/tools/linkcheck/fixtures/valid/README.md
@@ -1,0 +1,13 @@
+# tools/linkcheck/fixtures/valid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `triplet_ok/`
+- `evidence_refs_ok.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/valid/triplet_ok/README.md
+++ b/tools/linkcheck/fixtures/valid/triplet_ok/README.md
@@ -1,0 +1,15 @@
+# tools/linkcheck/fixtures/valid/triplet_ok
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `prov/`
+- `receipts/`
+- `stac/`
+- `dcat.jsonld`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/valid/triplet_ok/prov/README.md
+++ b/tools/linkcheck/fixtures/valid/triplet_ok/prov/README.md
@@ -1,0 +1,12 @@
+# tools/linkcheck/fixtures/valid/triplet_ok/prov
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `prov.jsonld`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/valid/triplet_ok/receipts/README.md
+++ b/tools/linkcheck/fixtures/valid/triplet_ok/receipts/README.md
@@ -1,0 +1,12 @@
+# tools/linkcheck/fixtures/valid/triplet_ok/receipts
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `run_receipt.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/valid/triplet_ok/stac/README.md
+++ b/tools/linkcheck/fixtures/valid/triplet_ok/stac/README.md
@@ -1,0 +1,13 @@
+# tools/linkcheck/fixtures/valid/triplet_ok/stac
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `items/`
+- `collection.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/linkcheck/fixtures/valid/triplet_ok/stac/items/README.md
+++ b/tools/linkcheck/fixtures/valid/triplet_ok/stac/items/README.md
@@ -1,0 +1,12 @@
+# tools/linkcheck/fixtures/valid/triplet_ok/stac/items
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `item-001.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/lint/fixtures/README.md
+++ b/tools/lint/fixtures/README.md
@@ -1,0 +1,13 @@
+# tools/lint/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/lint/fixtures/invalid/README.md
+++ b/tools/lint/fixtures/invalid/README.md
@@ -1,0 +1,12 @@
+# tools/lint/fixtures/invalid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tools/lint/fixtures/valid/README.md
+++ b/tools/lint/fixtures/valid/README.md
@@ -1,0 +1,12 @@
+# tools/lint/fixtures/valid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tools/registry/fixtures/README.md
+++ b/tools/registry/fixtures/README.md
@@ -1,0 +1,13 @@
+# tools/registry/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/registry/schemas/README.md
+++ b/tools/registry/schemas/README.md
@@ -1,0 +1,15 @@
+# tools/registry/schemas
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `exit_codes.v1.schema.json`
+- `finding.v1.schema.json`
+- `tool_result.v1.schema.json`
+- `tools_registry.v1.schema.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/release/fixtures/README.md
+++ b/tools/release/fixtures/README.md
@@ -1,0 +1,13 @@
+# tools/release/fixtures
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/release/fixtures/invalid/README.md
+++ b/tools/release/fixtures/invalid/README.md
@@ -1,0 +1,12 @@
+# tools/release/fixtures/invalid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tools/release/fixtures/valid/README.md
+++ b/tools/release/fixtures/valid/README.md
@@ -1,0 +1,12 @@
+# tools/release/fixtures/valid
+
+This directory is reserved for artifacts in this scope.
+
+## Contents
+
+- _(currently empty)_
+
+## Notes
+
+- Add files here following the contracts and test expectations defined by parent directories.
+- Update this README when the structure changes.

--- a/tools/validators/fixtures/dcat/README.md
+++ b/tools/validators/fixtures/dcat/README.md
@@ -1,0 +1,13 @@
+# tools/validators/fixtures/dcat
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/dcat/invalid/README.md
+++ b/tools/validators/fixtures/dcat/invalid/README.md
@@ -1,0 +1,14 @@
+# tools/validators/fixtures/dcat/invalid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `bad_distribution_href.jsonld`
+- `FIXTURE_NOTES.md`
+- `missing_license.jsonld`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/dcat/valid/README.md
+++ b/tools/validators/fixtures/dcat/valid/README.md
@@ -1,0 +1,13 @@
+# tools/validators/fixtures/dcat/valid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `FIXTURE_NOTES.md`
+- `minimal_dcat.jsonld`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/prov/README.md
+++ b/tools/validators/fixtures/prov/README.md
@@ -1,0 +1,13 @@
+# tools/validators/fixtures/prov
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/prov/invalid/README.md
+++ b/tools/validators/fixtures/prov/invalid/README.md
@@ -1,0 +1,14 @@
+# tools/validators/fixtures/prov/invalid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `FIXTURE_NOTES.md`
+- `missing_activity.jsonld`
+- `orphan_entity.jsonld`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/prov/valid/README.md
+++ b/tools/validators/fixtures/prov/valid/README.md
@@ -1,0 +1,13 @@
+# tools/validators/fixtures/prov/valid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `FIXTURE_NOTES.md`
+- `prov.jsonld`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/receipts/README.md
+++ b/tools/validators/fixtures/receipts/README.md
@@ -1,0 +1,13 @@
+# tools/validators/fixtures/receipts
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/receipts/invalid/README.md
+++ b/tools/validators/fixtures/receipts/invalid/README.md
@@ -1,0 +1,14 @@
+# tools/validators/fixtures/receipts/invalid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `FIXTURE_NOTES.md`
+- `missing_checksums.json`
+- `missing_policy_fields.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/receipts/valid/README.md
+++ b/tools/validators/fixtures/receipts/valid/README.md
@@ -1,0 +1,14 @@
+# tools/validators/fixtures/receipts/valid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `FIXTURE_NOTES.md`
+- `promotion_manifest.json`
+- `run_receipt.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/stac/README.md
+++ b/tools/validators/fixtures/stac/README.md
@@ -1,0 +1,13 @@
+# tools/validators/fixtures/stac
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `invalid/`
+- `valid/`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/stac/invalid/README.md
+++ b/tools/validators/fixtures/stac/invalid/README.md
@@ -1,0 +1,14 @@
+# tools/validators/fixtures/stac/invalid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `FIXTURE_NOTES.md`
+- `invalid_bbox.json`
+- `missing_datetime.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.

--- a/tools/validators/fixtures/stac/valid/README.md
+++ b/tools/validators/fixtures/stac/valid/README.md
@@ -1,0 +1,14 @@
+# tools/validators/fixtures/stac/valid
+
+This directory contains project assets for this scope.
+
+## Contents
+
+- `collection.json`
+- `FIXTURE_NOTES.md`
+- `item.json`
+
+## Notes
+
+- Keep artifacts in this directory aligned with adjacent contracts/tests and fail-closed governance expectations.
+- Update this README when adding new top-level files or folders here.


### PR DESCRIPTION
### Motivation
- Improve discoverability and governance by eliminating undocumented directories that created contributor blind spots. 
- Make intended contents and test/contract expectations visible in-place so review gates and maintainers can reason about empty or placeholder folders. 
- Surface expected fixture/test shapes for validation tools and CI by adding local guidance next to artifacts. 
- Preserve a documentation-first posture without changing runtime code, schemas, or policy logic. 

### Description
- Added 140 new `README.md` files across the repository (apps, configs, contracts, docs, tests, and tools) documenting local scope, immediate contents, and maintenance notes. 
- Created explicit stub READMEs for directories that are intentionally empty with a clear `_(currently empty)_` marker and instructions for future contributors. 
- Followed existing README patterns used in root and major subsystems (e.g., UI, linkcheck, tools fixtures) to keep language and governance cues consistent. 
- No source code, schema, policy, or executable logic was modified. 

### Testing
- Ran a repository scan using the `python - <<'PY' ...` script to detect directories missing a `README.md` and confirmed the result was `0` (no undocumented directories remaining). 
- Spot-checked representative READMEs such as `apps/api/ui/src/README.md` and `tools/linkcheck/fixtures/valid/triplet_ok/stac/items/README.md` to confirm content and formatting. 
- Verified the change set contains only README additions and that directory coverage is complete via local inspection of the repository tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a63d057cd0832a85939a06b21670bb)