### PR TITLE
docs: scaffold missing docs/ layout items from docs/README.md

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/MASTER_GUIDE_v13.md
+++ b/docs/MASTER_GUIDE_v13.md
@@ -1,0 +1,5 @@
+# MASTER_GUIDE_v13.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/_registry/README.md
+++ b/docs/_registry/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/_registry/docs.index.schema.json
+++ b/docs/_registry/docs.index.schema.json
@@ -1,0 +1,1 @@
+{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Placeholder","type":"object"}

--- a/docs/_registry/docs.index.yml
+++ b/docs/_registry/docs.index.yml
@@ -1,0 +1,3 @@
+# Placeholder registry file
+version: 1
+entries: []

--- a/docs/adr/ADR-0001-template.md
+++ b/docs/adr/ADR-0001-template.md
@@ -1,0 +1,5 @@
+# ADR-0001-template.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/ai/EVALUATION_AND_BENCHMARKS.md
+++ b/docs/ai/EVALUATION_AND_BENCHMARKS.md
@@ -1,0 +1,5 @@
+# EVALUATION_AND_BENCHMARKS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/ai/FOCUS_MODE_OVERVIEW.md
+++ b/docs/ai/FOCUS_MODE_OVERVIEW.md
@@ -1,0 +1,5 @@
+# FOCUS_MODE_OVERVIEW.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/ai/MODEL_CARDS_INDEX.md
+++ b/docs/ai/MODEL_CARDS_INDEX.md
@@ -1,0 +1,5 @@
+# MODEL_CARDS_INDEX.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/ai/OLLAMA_INTEGRATION.md
+++ b/docs/ai/OLLAMA_INTEGRATION.md
@@ -1,0 +1,5 @@
+# OLLAMA_INTEGRATION.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/DEPLOYMENT_TOPOLOGY.md
+++ b/docs/architecture/DEPLOYMENT_TOPOLOGY.md
@@ -1,0 +1,5 @@
+# DEPLOYMENT_TOPOLOGY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/SYSTEM_CONTEXT.md
+++ b/docs/architecture/SYSTEM_CONTEXT.md
@@ -1,0 +1,5 @@
+# SYSTEM_CONTEXT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/TRUST_MEMBRANE.md
+++ b/docs/architecture/TRUST_MEMBRANE.md
@@ -1,0 +1,5 @@
+# TRUST_MEMBRANE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/TRUTH_PATH_LIFECYCLE.md
+++ b/docs/architecture/TRUTH_PATH_LIFECYCLE.md
@@ -1,0 +1,5 @@
+# TRUTH_PATH_LIFECYCLE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/interfaces/API_LAYER_CONTRACT.md
+++ b/docs/architecture/interfaces/API_LAYER_CONTRACT.md
@@ -1,0 +1,5 @@
+# API_LAYER_CONTRACT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/interfaces/CATALOG_TRIPLET_CONTRACT.md
+++ b/docs/architecture/interfaces/CATALOG_TRIPLET_CONTRACT.md
@@ -1,0 +1,5 @@
+# CATALOG_TRIPLET_CONTRACT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/interfaces/EVIDENCE_RESOLVER_CONTRACT.md
+++ b/docs/architecture/interfaces/EVIDENCE_RESOLVER_CONTRACT.md
@@ -1,0 +1,5 @@
+# EVIDENCE_RESOLVER_CONTRACT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/interfaces/POLICY_ENGINE_CONTRACT.md
+++ b/docs/architecture/interfaces/POLICY_ENGINE_CONTRACT.md
@@ -1,0 +1,5 @@
+# POLICY_ENGINE_CONTRACT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/interfaces/README.md
+++ b/docs/architecture/interfaces/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/architecture/interfaces/REPOSITORY_LAYER_CONTRACT.md
+++ b/docs/architecture/interfaces/REPOSITORY_LAYER_CONTRACT.md
@@ -1,0 +1,5 @@
+# REPOSITORY_LAYER_CONTRACT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/data/DATASET_REGISTRY.md
+++ b/docs/data/DATASET_REGISTRY.md
@@ -1,0 +1,5 @@
+# DATASET_REGISTRY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/data/DATA_LIFECYCLE.md
+++ b/docs/data/DATA_LIFECYCLE.md
@@ -1,0 +1,5 @@
+# DATA_LIFECYCLE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/data/LICENSING_AND_ATTRIBUTION.md
+++ b/docs/data/LICENSING_AND_ATTRIBUTION.md
@@ -1,0 +1,5 @@
+# LICENSING_AND_ATTRIBUTION.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/data/PROVENANCE_AND_RECEIPTS.md
+++ b/docs/data/PROVENANCE_AND_RECEIPTS.md
@@ -1,0 +1,5 @@
+# PROVENANCE_AND_RECEIPTS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/air/DATA_SOURCES.md
+++ b/docs/domains/air/DATA_SOURCES.md
@@ -1,0 +1,5 @@
+# DATA_SOURCES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/air/PIPELINES.md
+++ b/docs/domains/air/PIPELINES.md
@@ -1,0 +1,5 @@
+# PIPELINES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/air/README.md
+++ b/docs/domains/air/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/hazards/DATA_SOURCES.md
+++ b/docs/domains/hazards/DATA_SOURCES.md
@@ -1,0 +1,5 @@
+# DATA_SOURCES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/hazards/PIPELINES.md
+++ b/docs/domains/hazards/PIPELINES.md
@@ -1,0 +1,5 @@
+# PIPELINES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/hazards/README.md
+++ b/docs/domains/hazards/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/hydrology/DATA_SOURCES.md
+++ b/docs/domains/hydrology/DATA_SOURCES.md
@@ -1,0 +1,5 @@
+# DATA_SOURCES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/hydrology/PIPELINES.md
+++ b/docs/domains/hydrology/PIPELINES.md
@@ -1,0 +1,5 @@
+# PIPELINES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/hydrology/README.md
+++ b/docs/domains/hydrology/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/soils/DATA_SOURCES.md
+++ b/docs/domains/soils/DATA_SOURCES.md
@@ -1,0 +1,5 @@
+# DATA_SOURCES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/soils/PIPELINES.md
+++ b/docs/domains/soils/PIPELINES.md
@@ -1,0 +1,5 @@
+# PIPELINES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/domains/soils/README.md
+++ b/docs/domains/soils/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,5 @@
+# glossary.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/governance/DATA_CLASSIFICATION.md
+++ b/docs/governance/DATA_CLASSIFICATION.md
@@ -1,0 +1,5 @@
+# DATA_CLASSIFICATION.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/governance/ROLES_AND_RACI.md
+++ b/docs/governance/ROLES_AND_RACI.md
@@ -1,0 +1,5 @@
+# ROLES_AND_RACI.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/governance/SENSITIVE_LOCATIONS_PLAYBOOK.md
+++ b/docs/governance/SENSITIVE_LOCATIONS_PLAYBOOK.md
@@ -1,0 +1,5 @@
+# SENSITIVE_LOCATIONS_PLAYBOOK.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/governance/WAIVERS_AND_EXCEPTIONS.md
+++ b/docs/governance/WAIVERS_AND_EXCEPTIONS.md
@@ -1,0 +1,5 @@
+# WAIVERS_AND_EXCEPTIONS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/acquisition/CONNECTOR_AUTHORING.md
+++ b/docs/guides/acquisition/CONNECTOR_AUTHORING.md
@@ -1,0 +1,5 @@
+# CONNECTOR_AUTHORING.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/acquisition/RAW_INGEST_PLAYBOOK.md
+++ b/docs/guides/acquisition/RAW_INGEST_PLAYBOOK.md
@@ -1,0 +1,5 @@
+# RAW_INGEST_PLAYBOOK.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/apis/ADD_NEW_ENDPOINT.md
+++ b/docs/guides/apis/ADD_NEW_ENDPOINT.md
@@ -1,0 +1,5 @@
+# ADD_NEW_ENDPOINT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/apis/FOCUS_MODE_ENDPOINTS.md
+++ b/docs/guides/apis/FOCUS_MODE_ENDPOINTS.md
@@ -1,0 +1,5 @@
+# FOCUS_MODE_ENDPOINTS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/catalogs/EMIT_STAC_DCAT_PROV.md
+++ b/docs/guides/catalogs/EMIT_STAC_DCAT_PROV.md
@@ -1,0 +1,5 @@
+# EMIT_STAC_DCAT_PROV.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/catalogs/VALIDATE_CATALOGS.md
+++ b/docs/guides/catalogs/VALIDATE_CATALOGS.md
@@ -1,0 +1,5 @@
+# VALIDATE_CATALOGS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/geo/HYDROLOGY_WORKFLOWS.md
+++ b/docs/guides/geo/HYDROLOGY_WORKFLOWS.md
@@ -1,0 +1,5 @@
+# HYDROLOGY_WORKFLOWS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/geo/RASTER_ETL_PIPELINES.md
+++ b/docs/guides/geo/RASTER_ETL_PIPELINES.md
@@ -1,0 +1,5 @@
+# RASTER_ETL_PIPELINES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/geo/README.md
+++ b/docs/guides/geo/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/geo/VECTOR_ETL_PIPELINES.md
+++ b/docs/guides/geo/VECTOR_ETL_PIPELINES.md
@@ -1,0 +1,5 @@
+# VECTOR_ETL_PIPELINES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/observability/READ_RUN_RECEIPTS.md
+++ b/docs/guides/observability/READ_RUN_RECEIPTS.md
@@ -1,0 +1,5 @@
+# READ_RUN_RECEIPTS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/observability/TRACE_A_REQUEST.md
+++ b/docs/guides/observability/TRACE_A_REQUEST.md
@@ -1,0 +1,5 @@
+# TRACE_A_REQUEST.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/onboarding/DEV_ENV_SETUP.md
+++ b/docs/guides/onboarding/DEV_ENV_SETUP.md
@@ -1,0 +1,5 @@
+# DEV_ENV_SETUP.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/onboarding/FIRST_DATASET_WALKTHROUGH.md
+++ b/docs/guides/onboarding/FIRST_DATASET_WALKTHROUGH.md
@@ -1,0 +1,5 @@
+# FIRST_DATASET_WALKTHROUGH.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/onboarding/FIRST_STORY_WALKTHROUGH.md
+++ b/docs/guides/onboarding/FIRST_STORY_WALKTHROUGH.md
@@ -1,0 +1,5 @@
+# FIRST_STORY_WALKTHROUGH.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/pipelines/BUILD_A_PIPELINE_STEP.md
+++ b/docs/guides/pipelines/BUILD_A_PIPELINE_STEP.md
@@ -1,0 +1,5 @@
+# BUILD_A_PIPELINE_STEP.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/pipelines/PROMOTION_FLOW.md
+++ b/docs/guides/pipelines/PROMOTION_FLOW.md
@@ -1,0 +1,5 @@
+# PROMOTION_FLOW.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/policy/DEBUG_POLICY_DENIALS.md
+++ b/docs/guides/policy/DEBUG_POLICY_DENIALS.md
@@ -1,0 +1,5 @@
+# DEBUG_POLICY_DENIALS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/policy/WRITE_A_POLICY.md
+++ b/docs/guides/policy/WRITE_A_POLICY.md
@@ -1,0 +1,5 @@
+# WRITE_A_POLICY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/security/SECRETS_AND_OIDC.md
+++ b/docs/guides/security/SECRETS_AND_OIDC.md
@@ -1,0 +1,5 @@
+# SECRETS_AND_OIDC.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/security/THREAT_MODELING_HOWTO.md
+++ b/docs/guides/security/THREAT_MODELING_HOWTO.md
@@ -1,0 +1,5 @@
+# THREAT_MODELING_HOWTO.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/ui/RUN_UI_LOCALLY.md
+++ b/docs/guides/ui/RUN_UI_LOCALLY.md
@@ -1,0 +1,5 @@
+# RUN_UI_LOCALLY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/guides/ui/STORY_AUTHORING.md
+++ b/docs/guides/ui/STORY_AUTHORING.md
@@ -1,0 +1,5 @@
+# STORY_AUTHORING.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/knowledge_graph/GRAPH_DATA_MODEL.md
+++ b/docs/knowledge_graph/GRAPH_DATA_MODEL.md
@@ -1,0 +1,5 @@
+# GRAPH_DATA_MODEL.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/knowledge_graph/GRAPH_RAG_PATTERNS.md
+++ b/docs/knowledge_graph/GRAPH_RAG_PATTERNS.md
@@ -1,0 +1,5 @@
+# GRAPH_RAG_PATTERNS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/knowledge_graph/NEO4J_OPERATIONS.md
+++ b/docs/knowledge_graph/NEO4J_OPERATIONS.md
@@ -1,0 +1,5 @@
+# NEO4J_OPERATIONS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/knowledge_graph/ONTOLOGY_AND_VOCAB.md
+++ b/docs/knowledge_graph/ONTOLOGY_AND_VOCAB.md
@@ -1,0 +1,5 @@
+# ONTOLOGY_AND_VOCAB.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/knowledge_graph/README.md
+++ b/docs/knowledge_graph/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/quality/CONTRACT_TESTS.md
+++ b/docs/quality/CONTRACT_TESTS.md
@@ -1,0 +1,5 @@
+# CONTRACT_TESTS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/quality/DETERMINISM_AND_REPRO.md
+++ b/docs/quality/DETERMINISM_AND_REPRO.md
@@ -1,0 +1,5 @@
+# DETERMINISM_AND_REPRO.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/quality/GATES_DEFINITION_OF_DONE.md
+++ b/docs/quality/GATES_DEFINITION_OF_DONE.md
@@ -1,0 +1,5 @@
+# GATES_DEFINITION_OF_DONE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/quality/PERFORMANCE_SLOS.md
+++ b/docs/quality/PERFORMANCE_SLOS.md
@@ -1,0 +1,5 @@
+# PERFORMANCE_SLOS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/quality/SECURITY_BASELINE.md
+++ b/docs/quality/SECURITY_BASELINE.md
@@ -1,0 +1,5 @@
+# SECURITY_BASELINE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/reference/OPENAPI_INDEX.md
+++ b/docs/reference/OPENAPI_INDEX.md
@@ -1,0 +1,5 @@
+# OPENAPI_INDEX.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/reference/POLICY_BUNDLE_INDEX.md
+++ b/docs/reference/POLICY_BUNDLE_INDEX.md
@@ -1,0 +1,5 @@
+# POLICY_BUNDLE_INDEX.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/reference/SCHEMA_REGISTRY.md
+++ b/docs/reference/SCHEMA_REGISTRY.md
@@ -1,0 +1,5 @@
+# SCHEMA_REGISTRY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/reference/TOOLING_INDEX.md
+++ b/docs/reference/TOOLING_INDEX.md
@@ -1,0 +1,5 @@
+# TOOLING_INDEX.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/runbooks/BACKUP_RESTORE.md
+++ b/docs/runbooks/BACKUP_RESTORE.md
@@ -1,0 +1,5 @@
+# BACKUP_RESTORE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/runbooks/DATA_PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/DATA_PROMOTION_RUNBOOK.md
@@ -1,0 +1,5 @@
+# DATA_PROMOTION_RUNBOOK.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/runbooks/DEPLOY.md
+++ b/docs/runbooks/DEPLOY.md
@@ -1,0 +1,5 @@
+# DEPLOY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/runbooks/DR_AND_ROLLBACK.md
+++ b/docs/runbooks/DR_AND_ROLLBACK.md
@@ -1,0 +1,5 @@
+# DR_AND_ROLLBACK.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/runbooks/INCIDENT_RESPONSE.md
+++ b/docs/runbooks/INCIDENT_RESPONSE.md
@@ -1,0 +1,5 @@
+# INCIDENT_RESPONSE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/runbooks/LOCAL_STACK.md
+++ b/docs/runbooks/LOCAL_STACK.md
@@ -1,0 +1,5 @@
+# LOCAL_STACK.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/runbooks/POLICY_CHANGE_RUNBOOK.md
+++ b/docs/runbooks/POLICY_CHANGE_RUNBOOK.md
@@ -1,0 +1,5 @@
+# POLICY_CHANGE_RUNBOOK.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/specs/agents/EXECUTOR_CONTRACT.md
+++ b/docs/specs/agents/EXECUTOR_CONTRACT.md
@@ -1,0 +1,5 @@
+# EXECUTOR_CONTRACT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/specs/agents/PLANNER_CONTRACT.md
+++ b/docs/specs/agents/PLANNER_CONTRACT.md
@@ -1,0 +1,5 @@
+# PLANNER_CONTRACT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/specs/agents/README.md
+++ b/docs/specs/agents/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/specs/agents/WATCHER_CONTRACT.md
+++ b/docs/specs/agents/WATCHER_CONTRACT.md
@@ -1,0 +1,5 @@
+# WATCHER_CONTRACT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/specs/observability/README.md
+++ b/docs/specs/observability/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/specs/pipelines/README.md
+++ b/docs/specs/pipelines/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/specs/storage/README.md
+++ b/docs/specs/storage/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/specs/ui/README.md
+++ b/docs/specs/ui/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/ai/AI_EVAL_AND_REDTEAM_STANDARD.md
+++ b/docs/standards/ai/AI_EVAL_AND_REDTEAM_STANDARD.md
@@ -1,0 +1,5 @@
+# AI_EVAL_AND_REDTEAM_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/ai/MODEL_CARD_STANDARD.md
+++ b/docs/standards/ai/MODEL_CARD_STANDARD.md
@@ -1,0 +1,5 @@
+# MODEL_CARD_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/ai/RAG_RETRIEVAL_STANDARD.md
+++ b/docs/standards/ai/RAG_RETRIEVAL_STANDARD.md
@@ -1,0 +1,5 @@
+# RAG_RETRIEVAL_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/ai/README.md
+++ b/docs/standards/ai/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/api/API_VERSIONING_AND_ERRORS.md
+++ b/docs/standards/api/API_VERSIONING_AND_ERRORS.md
@@ -1,0 +1,5 @@
+# API_VERSIONING_AND_ERRORS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/catalog/CATALOG_TRIPLET_STANDARD.md
+++ b/docs/standards/catalog/CATALOG_TRIPLET_STANDARD.md
@@ -1,0 +1,5 @@
+# CATALOG_TRIPLET_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/docs/DIAGRAMS_STYLE_GUIDE.md
+++ b/docs/standards/docs/DIAGRAMS_STYLE_GUIDE.md
@@ -1,0 +1,5 @@
+# DIAGRAMS_STYLE_GUIDE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/docs/DOC_IDS_AND_METADATA.md
+++ b/docs/standards/docs/DOC_IDS_AND_METADATA.md
@@ -1,0 +1,5 @@
+# DOC_IDS_AND_METADATA.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/docs/LINKING_AND_ANCHORS.md
+++ b/docs/standards/docs/LINKING_AND_ANCHORS.md
@@ -1,0 +1,5 @@
+# LINKING_AND_ANCHORS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/docs/README.md
+++ b/docs/standards/docs/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/evidence/EVIDENCE_REF_STANDARD.md
+++ b/docs/standards/evidence/EVIDENCE_REF_STANDARD.md
@@ -1,0 +1,5 @@
+# EVIDENCE_REF_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/geo/CRS_AND_PROJECTIONS.md
+++ b/docs/standards/geo/CRS_AND_PROJECTIONS.md
@@ -1,0 +1,5 @@
+# CRS_AND_PROJECTIONS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/geo/RASTER_FORMATS_COG.md
+++ b/docs/standards/geo/RASTER_FORMATS_COG.md
@@ -1,0 +1,5 @@
+# RASTER_FORMATS_COG.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/geo/README.md
+++ b/docs/standards/geo/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/geo/TILE_FORMATS_PMTILES.md
+++ b/docs/standards/geo/TILE_FORMATS_PMTILES.md
@@ -1,0 +1,5 @@
+# TILE_FORMATS_PMTILES.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/geo/VECTOR_FORMATS_GEOPARQUET.md
+++ b/docs/standards/geo/VECTOR_FORMATS_GEOPARQUET.md
@@ -1,0 +1,5 @@
+# VECTOR_FORMATS_GEOPARQUET.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/identity/HASHING_AND_DIGESTS.md
+++ b/docs/standards/identity/HASHING_AND_DIGESTS.md
@@ -1,0 +1,5 @@
+# HASHING_AND_DIGESTS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/identity/IDENTIFIERS_AND_NAMING.md
+++ b/docs/standards/identity/IDENTIFIERS_AND_NAMING.md
@@ -1,0 +1,5 @@
+# IDENTIFIERS_AND_NAMING.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/oci/DELTA_REFERRERS_STANDARD.md
+++ b/docs/standards/oci/DELTA_REFERRERS_STANDARD.md
@@ -1,0 +1,5 @@
+# DELTA_REFERRERS_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/oci/MEDIA_TYPES_REGISTRY.md
+++ b/docs/standards/oci/MEDIA_TYPES_REGISTRY.md
@@ -1,0 +1,5 @@
+# MEDIA_TYPES_REGISTRY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/oci/OCI_GEOSPATIAL_ARTIFACTS.md
+++ b/docs/standards/oci/OCI_GEOSPATIAL_ARTIFACTS.md
@@ -1,0 +1,5 @@
+# OCI_GEOSPATIAL_ARTIFACTS.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/oci/README.md
+++ b/docs/standards/oci/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/ontology/KFM_ONTOLOGY_PROFILE.md
+++ b/docs/standards/ontology/KFM_ONTOLOGY_PROFILE.md
@@ -1,0 +1,5 @@
+# KFM_ONTOLOGY_PROFILE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/ontology/README.md
+++ b/docs/standards/ontology/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/policy/POLICY_PACK_STANDARD.md
+++ b/docs/standards/policy/POLICY_PACK_STANDARD.md
@@ -1,0 +1,5 @@
+# POLICY_PACK_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/policy/REGO_V1_MIGRATION.md
+++ b/docs/standards/policy/REGO_V1_MIGRATION.md
@@ -1,0 +1,5 @@
+# REGO_V1_MIGRATION.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/supply_chain/README.md
+++ b/docs/standards/supply_chain/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/supply_chain/SBOM_STANDARD.md
+++ b/docs/standards/supply_chain/SBOM_STANDARD.md
@@ -1,0 +1,5 @@
+# SBOM_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/supply_chain/SIGNING_AND_VERIFICATION.md
+++ b/docs/standards/supply_chain/SIGNING_AND_VERIFICATION.md
@@ -1,0 +1,5 @@
+# SIGNING_AND_VERIFICATION.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/supply_chain/SLSA_ATTESTATION_STANDARD.md
+++ b/docs/standards/supply_chain/SLSA_ATTESTATION_STANDARD.md
@@ -1,0 +1,5 @@
+# SLSA_ATTESTATION_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/telemetry/PIPELINE_RUN_TELEMETRY.md
+++ b/docs/standards/telemetry/PIPELINE_RUN_TELEMETRY.md
@@ -1,0 +1,5 @@
+# PIPELINE_RUN_TELEMETRY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/telemetry/README.md
+++ b/docs/standards/telemetry/README.md
@@ -1,0 +1,5 @@
+# README.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/telemetry/TELEMETRY_EVENT_NAMING.md
+++ b/docs/standards/telemetry/TELEMETRY_EVENT_NAMING.md
@@ -1,0 +1,5 @@
+# TELEMETRY_EVENT_NAMING.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/telemetry/UI_TELEMETRY.md
+++ b/docs/standards/telemetry/UI_TELEMETRY.md
@@ -1,0 +1,5 @@
+# UI_TELEMETRY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/standards/ui/UI_TRUST_SURFACES_STANDARD.md
+++ b/docs/standards/ui/UI_TRUST_SURFACES_STANDARD.md
@@ -1,0 +1,5 @@
+# UI_TRUST_SURFACES_STANDARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/templates/TEMPLATE__ADR.md
+++ b/docs/templates/TEMPLATE__ADR.md
@@ -1,0 +1,5 @@
+# TEMPLATE__ADR.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/templates/TEMPLATE__COMPONENT_SPEC.md
+++ b/docs/templates/TEMPLATE__COMPONENT_SPEC.md
@@ -1,0 +1,5 @@
+# TEMPLATE__COMPONENT_SPEC.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/templates/TEMPLATE__DATASET_ENTRY.md
+++ b/docs/templates/TEMPLATE__DATASET_ENTRY.md
@@ -1,0 +1,5 @@
+# TEMPLATE__DATASET_ENTRY.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/templates/TEMPLATE__MODEL_CARD.md
+++ b/docs/templates/TEMPLATE__MODEL_CARD.md
@@ -1,0 +1,5 @@
+# TEMPLATE__MODEL_CARD.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/templates/TEMPLATE__POLICY_CHANGE.md
+++ b/docs/templates/TEMPLATE__POLICY_CHANGE.md
@@ -1,0 +1,5 @@
+# TEMPLATE__POLICY_CHANGE.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/templates/TEMPLATE__RUNBOOK.md
+++ b/docs/templates/TEMPLATE__RUNBOOK.md
@@ -1,0 +1,5 @@
+# TEMPLATE__RUNBOOK.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.

--- a/docs/templates/TEMPLATE__RUN_RECEIPT.md
+++ b/docs/templates/TEMPLATE__RUN_RECEIPT.md
@@ -1,0 +1,5 @@
+# TEMPLATE__RUN_RECEIPT.md
+
+> Placeholder stub created to satisfy the required docs layout declared in `docs/README.md`.
+
+> TODO: Replace with authoritative content.


### PR DESCRIPTION
### Motivation
- Ensure the repository `docs/` tree matches the canonical `Required docs layout` declared in `docs/README.md` so CI and consumers can rely on the expected doc surface. 
- Treat absent entries in the layout as “docs debt” and create safe placeholders so reviewers can populate authoritative content later.

### Description
- Added placeholder stubs and directories for the missing entries referenced by `docs/README.md`, covering subtrees such as `docs/standards/`, `docs/specs/`, `docs/guides/`, `docs/runbooks/`, `docs/architecture/`, `docs/ai/`, `docs/reference/`, `docs/_registry/`, `docs/templates/`, and domain README/files. 
- Created a minimal machine-readable registry skeleton at `docs/_registry/docs.index.yml` and `docs/_registry/docs.index.schema.json` to satisfy the registry contract. 
- Each placeholder file includes a short header, a one-line note that it was created to satisfy the `docs/README.md` layout, and a `TODO` marker for follow-up content replacement. 
- Approximately 139 files were scaffolded to bring the actual tree into conformance with the declared layout.

### Testing
- Ran the layout parser/validator script (`python - <<'PY' ... PY`) that walks the `Required docs layout` block in `docs/README.md` and verified `missing_count=0`, indicating all required non-placeholder paths are present. 
- Ran `git status --short` to confirm there were no remaining missing/non-staged paths reported by the local check. 
- All automated checks described above passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a854e630a8832a97cf699d26716a94)