### PR TITLE
docs: scaffold top-level directory README files from root README guidance

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,1 +1,10 @@
+# .github
 
+GitHub-native control plane for workflows, templates, review routing, and merge discipline.
+
+## Purpose
+This directory is the repository’s automation and collaboration surface. Keep branch protections, workflow logic, and contribution templates here.
+
+## Notes
+- Prefer policy-aware CI checks and explicit merge gates.
+- Keep templates aligned with governance and evidence-first practices described in the root `README.md`.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# apps
 
-This directory is intentionally kept in version control.
+Runnable services and user-facing applications.
+
+## Purpose
+Use this directory for deployable app surfaces (for example, API services and UI apps) that implement the governed KFM experience.
+
+## Notes
+- Route access through governed APIs (no direct client-to-store access).
+- Ensure user-visible claims can resolve to evidence (cite-or-abstain).

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# configs
 
-This directory is intentionally kept in version control.
+Shared configuration that must not hard-code secrets.
+
+## Purpose
+Store reusable, environment-safe configuration for local development, CI, and deployments.
+
+## Notes
+- Never commit secrets, credentials, or tokens.
+- Prefer documented defaults and explicit environment overrides.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# contracts
 
-This directory is intentionally kept in version control.
+API contracts, schemas, vocabularies, and machine-enforced interface surfaces.
+
+## Purpose
+Define and version interface-level agreements used by services, clients, and validation tooling.
+
+## Notes
+- Treat contracts as production artifacts.
+- Keep changes additive and versioned where possible.

--- a/data/README.md
+++ b/data/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# data
 
-This directory is intentionally kept in version control.
+Data specs, registries, examples, manifests, and governed data-facing artifacts.
+
+## Purpose
+Host data-adjacent definitions and governance metadata that support the RAW → WORK/QUARANTINE → PROCESSED → CATALOG/TRIPLET → PUBLISHED flow.
+
+## Notes
+- Preserve provenance and reproducibility metadata.
+- Do not place secrets or uncontrolled publication artifacts here.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# docs
 
-This directory is intentionally kept in version control.
+Architecture docs, ADRs, standards, runbooks, and long-form guidance.
+
+## Purpose
+This is the primary documentation surface for repository behavior, operating procedures, and design decisions.
+
+## Notes
+- Update docs in the same change that updates behavior.
+- Prefer explicit `CONFIRMED` / `PROPOSED` / `UNKNOWN` posture where applicable.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# examples
 
-This directory is intentionally kept in version control.
+Safe example material and demonstration assets.
+
+## Purpose
+Provide illustrative sample inputs, outputs, and usage patterns that are non-sensitive and easy for contributors to run.
+
+## Notes
+- Keep examples reproducible and clearly labeled.
+- Avoid shipping rights-ambiguous or policy-restricted data in examples.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# infra
 
-This directory is intentionally kept in version control.
+Deployment, platform, and operations definitions.
+
+## Purpose
+Store infrastructure-as-code and operational configuration used to provision and run KFM services.
+
+## Notes
+- Keep infrastructure changes reviewable and reversible.
+- Align infrastructure policy with default-deny / fail-closed governance.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# migrations
 
-This directory is intentionally kept in version control.
+Database or data-structure migrations.
+
+## Purpose
+Track deterministic, reviewable evolution of persistent structures.
+
+## Notes
+- Prefer forward-safe migrations with clear rollback strategy.
+- Link migrations to relevant contract/schema and test updates.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# packages
 
-This directory is intentionally kept in version control.
+Shared libraries and internal core modules.
+
+## Purpose
+Place reusable code shared across apps, tools, and services.
+
+## Notes
+- Keep package boundaries explicit and cohesive.
+- Version and test shared modules to prevent cross-app drift.

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# policy
 
-This directory is intentionally kept in version control.
+Policy-as-code, fixtures, and policy tests.
+
+## Purpose
+Encode governance and trust-membrane rules in machine-enforced policy artifacts.
+
+## Notes
+- Treat unresolved rights/sensitivity as fail-closed.
+- Keep fixture coverage aligned to real decision scenarios.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# schemas
 
-This directory is intentionally kept in version control.
+Schemas that back validation, ingestion, and contract enforcement.
+
+## Purpose
+Define structural expectations for data and interfaces used throughout the system.
+
+## Notes
+- Keep schema evolution explicit and reviewed.
+- Ensure validators and tests consume the canonical schema definitions.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# scripts
 
-This directory is intentionally kept in version control.
+Automation and helper scripts.
+
+## Purpose
+Store lightweight operational scripts for repeatable repository tasks.
+
+## Notes
+- Favor idempotent scripts with clear usage help.
+- Avoid embedding secrets or environment-specific assumptions.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# tests
 
-This directory is intentionally kept in version control.
+Unit, integration, policy, and end-to-end tests.
+
+## Purpose
+Central location for test suites that verify contracts, policies, and behavior.
+
+## Notes
+- Prioritize evidence-linked and policy-significant test coverage.
+- Keep fixtures deterministic and easy to execute in CI.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,3 +1,10 @@
-# Placeholder
+# tools
 
-This directory is intentionally kept in version control.
+Validators, CLIs, link checkers, and support tooling.
+
+## Purpose
+Host internal utilities used by contributors and automation to validate and operate the repo.
+
+## Notes
+- Prefer tools that improve governance visibility and reproducibility.
+- Document usage and expected outputs for each maintained tool.


### PR DESCRIPTION
### Motivation
- Provide consistent, governance-aligned onboarding and usage guidance for every top-level area based on the root `README.md` directory-role definitions.
- Replace placeholder files with actionable notes so contributors can quickly understand what belongs in each top-level folder.

### Description
- Replaced or updated the `README.md` files for `.github`, `apps`, `configs`, `contracts`, `data`, `docs`, `examples`, `infra`, `migrations`, `packages`, `policy`, `schemas`, `scripts`, `tests`, and `tools` with purpose-driven content.
- Each file now includes a short description plus `## Purpose` and `## Notes` sections with governance-focused guidance derived from the root README.
- All edits are documentation-only and do not modify code, runtime configuration, or behavior.

### Testing
- Verified the presence of all target directories using `for d in .github apps configs contracts data docs examples infra migrations packages policy schemas scripts tests tools; do test -d "$d" && echo "$d ok" || echo "$d missing"; done`, which reported all directories present.
- Confirmed workspace state with `git status --short` which executed successfully.
- Inspected the root and per-directory README contents via `sed`/`nl` checks to validate the new text, and those inspections completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab7df1fe50832a9bead94657cb95ac)