### PR TITLE
Replace .gitkeep placeholders with README files

### DIFF
--- a/.github/.gitkeep
+++ b/.github/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep .github tracked

--- a/apps/.gitkeep
+++ b/apps/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep apps tracked

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,3 @@
+# apps
+
+This directory is intentionally kept in the repository, even when empty.

--- a/configs/.gitkeep
+++ b/configs/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep configs tracked

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,0 +1,3 @@
+# configs
+
+This directory is intentionally kept in the repository, even when empty.

--- a/contracts/.gitkeep
+++ b/contracts/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep contracts tracked

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,3 @@
+# contracts
+
+This directory is intentionally kept in the repository, even when empty.

--- a/data/.gitkeep
+++ b/data/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep data tracked

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,3 @@
+# data
+
+This directory is intentionally kept in the repository, even when empty.

--- a/docs/.gitkeep
+++ b/docs/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep docs tracked

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# docs
+
+This directory is intentionally kept in the repository, even when empty.

--- a/examples/.gitkeep
+++ b/examples/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep examples tracked

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# examples
+
+This directory is intentionally kept in the repository, even when empty.

--- a/infra/.gitkeep
+++ b/infra/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep infra tracked

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,3 @@
+# infra
+
+This directory is intentionally kept in the repository, even when empty.

--- a/migrations/.gitkeep
+++ b/migrations/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep migrations tracked

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,3 @@
+# migrations
+
+This directory is intentionally kept in the repository, even when empty.

--- a/packages/.gitkeep
+++ b/packages/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep packages tracked

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,3 @@
+# packages
+
+This directory is intentionally kept in the repository, even when empty.

--- a/policy/.gitkeep
+++ b/policy/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep policy tracked

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,0 +1,3 @@
+# policy
+
+This directory is intentionally kept in the repository, even when empty.

--- a/schemas/.gitkeep
+++ b/schemas/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep schemas tracked

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,3 @@
+# schemas
+
+This directory is intentionally kept in the repository, even when empty.

--- a/scripts/.gitkeep
+++ b/scripts/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep scripts tracked

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,3 @@
+# scripts
+
+This directory is intentionally kept in the repository, even when empty.

--- a/tests/.gitkeep
+++ b/tests/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep tests tracked

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+# tests
+
+This directory is intentionally kept in the repository, even when empty.

--- a/tools/.gitkeep
+++ b/tools/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder to keep tools tracked

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,3 @@
+# tools
+
+This directory is intentionally kept in the repository, even when empty.


### PR DESCRIPTION
### Motivation

- Replace empty `.gitkeep` placeholders with human-readable `README.md` markers to keep top-level directories tracked and document their purpose.
- Ensure `.github/` continues to be represented by its existing `README.md` rather than a placeholder file.

### Description

- Removed `.gitkeep` files from `apps`, `configs`, `contracts`, `data`, `docs`, `examples`, `infra`, `migrations`, `packages`, `policy`, `schemas`, `scripts`, `tests`, `tools`, and `.github`.
- Added a `README.md` to each affected directory containing a short purpose note (heading with the directory name and the line: "This directory is intentionally kept in the repository, even when empty.").
- Restored and preserved the existing `.github/README.md` and removed only `.github/.gitkeep`.
- Committed all changes in a single commit titled `Replace .gitkeep placeholders with README files`.

### Testing

- Ran `find . -name '.gitkeep'` and confirmed no `.gitkeep` files remain, which succeeded.
- Ran `git status --short` to inspect staged/unstaged changes and verify the expected deletions/creations, which succeeded.
- Ran `git commit -m "Replace .gitkeep placeholders with README files"` and confirmed the commit succeeded (reporting 29 files changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b619915790832aa0efc85101694cf0)