### PR TITLE
Create missing top-level docs directories

### DIFF
--- a/docs/analyses/.gitkeep
+++ b/docs/analyses/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/docs/pipelines/.gitkeep
+++ b/docs/pipelines/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/docs/research/.gitkeep
+++ b/docs/research/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/docs/search/.gitkeep
+++ b/docs/search/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked

--- a/docs/security/.gitkeep
+++ b/docs/security/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to keep directory tracked


### PR DESCRIPTION
### Motivation
- Materialize the source-reported but missing top-level documentation surfaces so the repository has the expected `docs/` hubs for later content.
- Ensure the directory structure is preserved in Git-friendly form so downstream automation and doc authors can add content reliably.

### Description
- Added the directories `docs/analyses`, `docs/pipelines`, `docs/research`, `docs/search`, and `docs/security`.
- Placed a `.gitkeep` placeholder file in each new directory with the single line `# placeholder to keep directory tracked` to preserve the empty folders.
- No other files or content were modified under `docs/`.

### Testing
- Verified the top-level `docs/` directories with `find docs -maxdepth 1 -mindepth 1 -type d | sort`, which showed the new directories as expected and succeeded.
- Confirmed placeholder files and contents with `nl -ba docs/*/.gitkeep`, and checked working-tree cleanliness with `git status --short`, both of which succeeded and showed only the intended tracked placeholders.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80cd0bd30832a8bd789a77ab38c25)