### PR TITLE
Replace docs .gitkeep placeholders with README.md files

### DIFF
--- a/docs/analyses/.gitkeep
+++ b/docs/analyses/.gitkeep
@@ -1,1 +1,0 @@
-# placeholder to keep directory tracked

--- a/docs/analyses/README.md
+++ b/docs/analyses/README.md
@@ -1,0 +1,6 @@
+# Analyses
+
+This directory stores analyses-related documentation for Kansas Frontier Matrix.
+
+- Add documents here as work is produced.
+- Keep filenames descriptive and scoped to a single topic.

--- a/docs/pipelines/.gitkeep
+++ b/docs/pipelines/.gitkeep
@@ -1,1 +1,0 @@
-# placeholder to keep directory tracked

--- a/docs/pipelines/README.md
+++ b/docs/pipelines/README.md
@@ -1,0 +1,6 @@
+# Pipelines
+
+This directory stores pipelines-related documentation for Kansas Frontier Matrix.
+
+- Add documents here as work is produced.
+- Keep filenames descriptive and scoped to a single topic.

--- a/docs/research/.gitkeep
+++ b/docs/research/.gitkeep
@@ -1,1 +1,0 @@
-# placeholder to keep directory tracked

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,6 @@
+# Research
+
+This directory stores research-related documentation for Kansas Frontier Matrix.
+
+- Add documents here as work is produced.
+- Keep filenames descriptive and scoped to a single topic.

--- a/docs/search/.gitkeep
+++ b/docs/search/.gitkeep
@@ -1,1 +1,0 @@
-# placeholder to keep directory tracked

--- a/docs/search/README.md
+++ b/docs/search/README.md
@@ -1,0 +1,6 @@
+# Search
+
+This directory stores search-related documentation for Kansas Frontier Matrix.
+
+- Add documents here as work is produced.
+- Keep filenames descriptive and scoped to a single topic.

--- a/docs/security/.gitkeep
+++ b/docs/security/.gitkeep
@@ -1,1 +1,0 @@
-# placeholder to keep directory tracked

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,6 @@
+# Security
+
+This directory stores security-related documentation for Kansas Frontier Matrix.
+
+- Add documents here as work is produced.
+- Keep filenames descriptive and scoped to a single topic.


### PR DESCRIPTION
### Motivation
- Replace inert `.gitkeep` placeholders in documentation subdirectories with human-readable `README.md` files to provide guidance and make the dirs self-describing.
- Ensure future contributors have a clear place to add documentation and reduce confusion from empty placeholder files.

### Description
- Removed `.gitkeep` files from `docs/analyses`, `docs/pipelines`, `docs/research`, `docs/search`, and `docs/security`.
- Added `README.md` to each of those directories containing a title and a short template with guidance for adding documents.
- Standardized the content across these READMEs to be a simple starting point for future documentation contributions.

### Testing
- Ran `find docs -name '.gitkeep' | wc -l` and confirmed it returned `0`, indicating no remaining `.gitkeep` files.
- Inspected the top of each new README with `sed -n '1,6p'` and confirmed expected headings and guidance were present.
- Ran `git status --short` to verify the working tree reflects the removed placeholders and the new `README.md` files, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b815a3b8cc832a8c5dc2f8d669cb4c)