### PR TITLE
Add README placeholders and scaffold directories referenced by markdown links

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/apps/api/src/api/README.md
+++ b/apps/api/src/api/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/apps/api/tests/README.md
+++ b/apps/api/tests/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/contracts/vocab/README.md
+++ b/contracts/vocab/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/data/specs/README.md
+++ b/data/specs/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/_templates/analysis_readme.md
+++ b/docs/analyses/_templates/analysis_readme.md
@@ -1,0 +1,3 @@
+# Analysis Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/archaeology/results/cultural-landscapes/ecological-affordances/README.md
+++ b/docs/analyses/archaeology/results/cultural-landscapes/ecological-affordances/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/archaeology/results/geophysics/electromagnetic/README.md
+++ b/docs/analyses/archaeology/results/geophysics/electromagnetic/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/archaeology/results/notebooks/artifacts/README.md
+++ b/docs/analyses/archaeology/results/notebooks/artifacts/README.md
@@ -1,0 +1,3 @@
+# artifacts
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/notebooks/cultural-landscapes/README.md
+++ b/docs/analyses/archaeology/results/notebooks/cultural-landscapes/README.md
@@ -1,0 +1,3 @@
+# cultural-landscapes
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/notebooks/environmental/README.md
+++ b/docs/analyses/archaeology/results/notebooks/environmental/README.md
@@ -1,0 +1,3 @@
+# environmental
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/notebooks/geophysics/README.md
+++ b/docs/analyses/archaeology/results/notebooks/geophysics/README.md
@@ -1,0 +1,3 @@
+# geophysics
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/notebooks/predictive/README.md
+++ b/docs/analyses/archaeology/results/notebooks/predictive/README.md
@@ -1,0 +1,3 @@
+# predictive
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/notebooks/spatial/README.md
+++ b/docs/analyses/archaeology/results/notebooks/spatial/README.md
@@ -1,0 +1,3 @@
+# spatial
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/notebooks/temporal/README.md
+++ b/docs/analyses/archaeology/results/notebooks/temporal/README.md
@@ -1,0 +1,3 @@
+# temporal
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/paleoenvironment/climate/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/climate/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/archaeology/results/paleoenvironment/drought-cycles/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/drought-cycles/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/archaeology/results/paleoenvironment/metadata/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/metadata/README.md
@@ -1,0 +1,3 @@
+# metadata
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/paleoenvironment/paleohydrology/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/paleohydrology/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/archaeology/results/paleoenvironment/predictive/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/predictive/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/archaeology/results/paleoenvironment/provenance/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/provenance/README.md
@@ -1,0 +1,3 @@
+# provenance
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/paleoenvironment/seasonality/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/seasonality/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/archaeology/results/paleoenvironment/stac/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/stac/README.md
@@ -1,0 +1,3 @@
+# stac
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/archaeology/results/paleoenvironment/uncertainty/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/uncertainty/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/archaeology/results/paleoenvironment/vegetation/README.md
+++ b/docs/analyses/archaeology/results/paleoenvironment/vegetation/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/ecology/ecosystem-services.md
+++ b/docs/analyses/ecology/ecosystem-services.md
@@ -1,0 +1,3 @@
+# Ecosystem Services
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/ecology/landcover-analysis.md
+++ b/docs/analyses/ecology/landcover-analysis.md
@@ -1,0 +1,3 @@
+# Landcover Analysis
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/remote-sensing/change-detection/governance.md
+++ b/docs/analyses/remote-sensing/change-detection/governance.md
@@ -1,0 +1,3 @@
+# Governance
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/remote-sensing/change-detection/methods/README.md
+++ b/docs/analyses/remote-sensing/change-detection/methods/README.md
@@ -1,0 +1,3 @@
+# methods
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/remote-sensing/change-detection/reports/README.md
+++ b/docs/analyses/remote-sensing/change-detection/reports/README.md
@@ -1,0 +1,3 @@
+# reports
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/remote-sensing/change-detection/results/README.md
+++ b/docs/analyses/remote-sensing/change-detection/results/README.md
@@ -1,0 +1,3 @@
+# results
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/docs/analyses/remote-sensing/sar-lidar-fusion/README.md
+++ b/docs/analyses/remote-sensing/sar-lidar-fusion/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/remote-sensing/validation/governance.md
+++ b/docs/analyses/remote-sensing/validation/governance.md
@@ -1,0 +1,3 @@
+# Governance
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/remote-sensing/validation/methods/README.md
+++ b/docs/analyses/remote-sensing/validation/methods/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/analyses/remote-sensing/validation/results/README.md
+++ b/docs/analyses/remote-sensing/validation/results/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/domains/agriculture/README.md
+++ b/docs/domains/agriculture/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/domains/archives-heritage/README.md
+++ b/docs/domains/archives-heritage/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/domains/atmosphere/README.md
+++ b/docs/domains/atmosphere/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/domains/ecology/README.md
+++ b/docs/domains/ecology/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/domains/hazards/README.md
+++ b/docs/domains/hazards/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/domains/history-mobility/README.md
+++ b/docs/domains/history-mobility/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/domains/land-tenure/README.md
+++ b/docs/domains/land-tenure/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/domains/settlement-services/README.md
+++ b/docs/domains/settlement-services/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/domains/transport/README.md
+++ b/docs/domains/transport/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/reports/markdown-structure-build-2026-04-08.md
+++ b/docs/reports/markdown-structure-build-2026-04-08.md
@@ -1,0 +1,31 @@
+# Markdown Structure Build Notes (2026-04-08)
+
+Summary of repository scaffolding added to align with markdown-linked structure.
+
+## Added directory scaffolding
+
+- `apps/api/`, `apps/api/src/api/`, `apps/api/tests/`, `apps/ui/`
+- `contracts/vocab/`, `data/specs/`
+- `docs/analyses/archaeology/results/notebooks/{spatial,temporal,environmental,cultural-landscapes,artifacts,geophysics,predictive}/`
+- `docs/analyses/archaeology/results/paleoenvironment/{climate,paleohydrology,vegetation,seasonality,drought-cycles,predictive,uncertainty,metadata,provenance,stac}/`
+- `docs/analyses/remote-sensing/change-detection/{methods,results,reports}/`
+- `docs/analyses/remote-sensing/validation/{methods,results}/`
+- `docs/analyses/remote-sensing/sar-lidar-fusion/`
+- `docs/domains/{agriculture,archives-heritage,atmosphere,ecology,hazards,history-mobility,land-tenure,settlement-services,transport}/`
+- `docs/research/drafts/{assets,literature}/`
+- `docs/research/source_summaries/{_attachments,by_domain}/`
+- `infra/monitoring/{dashboards,otel}/`
+- `policy/bundles/runtime/`, `web/`
+
+## Added placeholders
+
+- README placeholders for all newly created directories.
+- Placeholder docs where markdown links referenced missing files:
+  - `docs/analyses/_templates/analysis_readme.md`
+  - `docs/analyses/ecology/ecosystem-services.md`
+  - `docs/analyses/ecology/landcover-analysis.md`
+  - `docs/analyses/remote-sensing/change-detection/governance.md`
+  - `docs/analyses/remote-sensing/validation/governance.md`
+  - `docs/runbooks/{correction.md,publication.md,rollback.md,stale_projection.md}`
+  - `docs/standards/governance/ROOT-GOVERNANCE.md`
+  - `pipelines/ssurgo_to_catchment.md`

--- a/docs/research/drafts/README.md
+++ b/docs/research/drafts/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/research/drafts/assets/README.md
+++ b/docs/research/drafts/assets/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/research/drafts/literature/README.md
+++ b/docs/research/drafts/literature/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/research/source_summaries/_attachments/README.md
+++ b/docs/research/source_summaries/_attachments/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/research/source_summaries/by_domain/README.md
+++ b/docs/research/source_summaries/by_domain/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/runbooks/correction.md
+++ b/docs/runbooks/correction.md
@@ -1,0 +1,3 @@
+# Correction
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/runbooks/publication.md
+++ b/docs/runbooks/publication.md
@@ -1,0 +1,3 @@
+# Publication
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/runbooks/rollback.md
+++ b/docs/runbooks/rollback.md
@@ -1,0 +1,3 @@
+# Rollback
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/runbooks/stale_projection.md
+++ b/docs/runbooks/stale_projection.md
@@ -1,0 +1,3 @@
+# Stale Projection
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/docs/standards/governance/ROOT-GOVERNANCE.md
+++ b/docs/standards/governance/ROOT-GOVERNANCE.md
@@ -1,0 +1,3 @@
+# Root Governance
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/infra/monitoring/dashboards/README.md
+++ b/infra/monitoring/dashboards/README.md
@@ -1,0 +1,3 @@
+# dashboards
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/infra/monitoring/otel/README.md
+++ b/infra/monitoring/otel/README.md
@@ -1,0 +1,3 @@
+# otel
+
+Placeholder README to preserve directory structure referenced by repository documentation.

--- a/pipelines/ssurgo_to_catchment.md
+++ b/pipelines/ssurgo_to_catchment.md
@@ -1,0 +1,3 @@
+# ssurgo to catchment
+
+Placeholder document added to satisfy repository markdown-linked structure.

--- a/policy/bundles/runtime/README.md
+++ b/policy/bundles/runtime/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Placeholder file added to align with repository markdown-linked structure.


### PR DESCRIPTION
### Motivation
- Align the on-disk repository with the structure implied by existing markdown links so referenced paths are resolvable and no intended directories are empty. 
- Provide minimal placeholder content so documentation consumers and link-checking tools can navigate the tree and maintainers can fill in authoritative content later. 

### Description
- Created directory scaffolding and added placeholder `README.md` files across multiple areas (examples include `apps/`, `docs/analyses/archaeology/results/notebooks/`, `docs/analyses/archaeology/results/paleoenvironment/`, `docs/analyses/remote-sensing/`, `docs/domains/`, `infra/monitoring/`, `policy/bundles/runtime/`, and `web/`). 
- Added a small set of placeholder documents that were referenced but missing, including `docs/analyses/_templates/analysis_readme.md`, runbooks under `docs/runbooks/`, `docs/standards/governance/ROOT-GOVERNANCE.md`, and `pipelines/ssurgo_to_catchment.md`. 
- Wrote a short reconciliation note documenting the scaffolding action as `docs/reports/markdown-structure-build-2026-04-08.md`. 
- In total ~61 placeholder files were introduced to preserve markdown link targets and avoid empty directories reported by repository docs. 

### Testing
- Ran a link-scan script (`python - <<'PY' ... PY`) that enumerates markdown links and reports unresolved targets, which showed unresolved markdown link targets reduced from 78 to 38 after scaffolding. 
- Verified there are no non-git empty directories using `find . -type d -empty | sed 's#^./##'`, with only internal `.git` directories remaining empty. 
- Confirmed the placeholder files exist at the expected paths by listing and inspecting a selection of the created readme files, and the reconciliation note was created at `docs/reports/markdown-structure-build-2026-04-08.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66dfadb68832ab2bf7dce8441fb43)