### PR TITLE
Add README scaffolding for archaeology cultural-landscapes, atmosphere bridge, and soils appendices

### DIFF
--- a/docs/analyses/archaeology/results/cultural-landscapes/README.md
+++ b/docs/analyses/archaeology/results/cultural-landscapes/README.md
@@ -1,0 +1,21 @@
+# Cultural Landscapes Results
+
+Index for archaeology cultural-landscape result artifacts in this lane.
+
+## Purpose
+
+This directory groups promoted, publication-safe cultural-landscape outputs and keeps links to child result modules explicit.
+
+## Current structure
+
+```text
+cultural-landscapes/
+├── README.md
+└── ecological-affordances/
+    └── README.md
+```
+
+## Notes
+
+- Keep exact-location or rights-sensitive details out of this results layer.
+- Route operational methods, contracts, and policy to their owning repository surfaces.

--- a/docs/domains/atmosphere/README.md
+++ b/docs/domains/atmosphere/README.md
@@ -1,0 +1,12 @@
+# Atmosphere Domain Lane
+
+Bridge README for the atmosphere lane referenced by `docs/domains/README.md`.
+
+## Repo placement
+
+The active atmosphere implementation docs currently live under:
+
+- `docs/domains/air/README.md`
+- `docs/domains/air/atmosphere/README.md`
+
+Use those files as the primary lane documentation.

--- a/docs/domains/soils/appendices/README.md
+++ b/docs/domains/soils/appendices/README.md
@@ -1,0 +1,16 @@
+# Soils Appendices
+
+Supporting appendix index for the soils domain lane.
+
+## Current structure
+
+```text
+appendices/
+├── README.md
+└── source-role-matrix.md
+```
+
+## Guidance
+
+- Use appendices for reference matrices and supplemental context.
+- Keep normative contracts, schemas, and enforceable policy in their owning top-level directories.


### PR DESCRIPTION
### Motivation
- Complete README-declared structure so relative links resolve and every documented directory has an explicit README to improve navigation and reduce verification friction.

### Description
- Add three lightweight README scaffolds: `docs/analyses/archaeology/results/cultural-landscapes/README.md` (index for cultural-landscape results), `docs/domains/atmosphere/README.md` (bridge README pointing to the active `docs/domains/air/...` docs), and `docs/domains/soils/appendices/README.md` (appendices index and guidance).

### Testing
- Verified README coverage with a filesystem scan using the `python - <<'PY' ... PY` script (no directories missing `README.md`), and inspected the new files with `find` and `nl -ba` to confirm content and placement; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a34d88f8832ab83ad4d1f0446f10)