### PR TITLE
Add starter CorrectionNotice schema with fixtures and contract-floor tests

### DIFF
--- a/schemas/contracts/v1/correction/README.md
+++ b/schemas/contracts/v1/correction/README.md
@@ -10,7 +10,7 @@ updated: <NEEDS-VERIFICATION-YYYY-MM-DD>
 policy_label: <NEEDS-VERIFICATION>
 related: [schemas/contracts/v1/README.md, schemas/contracts/v1/correction/correction_notice.schema.json, tests/contracts/README.md, tests/e2e/correction/README.md, schemas/tests/fixtures/contracts/v1/README.md, .github/workflows/README.md]
 tags: [kfm, contracts, schemas, correction, correction-notice]
-notes: [Current public main confirms this lane and local schema file exist; correction_notice.schema.json is still `{}`; schema-home authority, dates, doc_id, and policy label still need direct branch-level verification.]
+notes: [Current branch now includes a Draft 2020-12 starter body in correction_notice.schema.json plus v1 valid/invalid fixtures and a contract-floor unit test; schema-home authority, dates, doc_id, and policy label still need direct branch-level verification.]
 [/KFM_META_BLOCK_V2] -->
 
 # Correction Contracts v1
@@ -23,11 +23,11 @@ Boundary-and-inventory README for the live `schemas/contracts/v1/correction/` la
 > **Owners:** `@bartytime4life` *(current strongest visible signal is the public `.github/CODEOWNERS` global fallback; no narrower `/schemas/contracts/v1/correction/` owner rule was directly verified on public `main`)*  
 > **Path:** `schemas/contracts/v1/correction/README.md`  
 > **Family file:** [`./correction_notice.schema.json`](./correction_notice.schema.json)  
-> ![Status](https://img.shields.io/badge/status-experimental-orange?style=flat-square) ![Doc](https://img.shields.io/badge/doc-draft-lightgrey?style=flat-square) ![Lane](https://img.shields.io/badge/lane-correction-6f42c1?style=flat-square) ![Schema body](https://img.shields.io/badge/correction__notice-placeholder_%7B%7D-yellow?style=flat-square) ![Schema home](https://img.shields.io/badge/schema__home-NEEDS__VERIFICATION-red?style=flat-square) ![Branch](https://img.shields.io/badge/branch-main-0a7d5a?style=flat-square)  
+> ![Status](https://img.shields.io/badge/status-experimental-orange?style=flat-square) ![Doc](https://img.shields.io/badge/doc-draft-lightgrey?style=flat-square) ![Lane](https://img.shields.io/badge/lane-correction-6f42c1?style=flat-square) ![Schema body](https://img.shields.io/badge/correction__notice-draft%202020--12%20starter-green?style=flat-square) ![Schema home](https://img.shields.io/badge/schema__home-NEEDS__VERIFICATION-red?style=flat-square) ![Branch](https://img.shields.io/badge/branch-main-0a7d5a?style=flat-square)  
 > **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Accepted inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Current verified snapshot](#current-verified-snapshot) · [Directory tree](#directory-tree) · [Quickstart](#quickstart) · [Usage](#usage) · [Diagram](#diagram) · [Contract shape](#contract-shape) · [Validation & gates](#validation--gates) · [Task list](#task-list--definition-of-done) · [FAQ](#faq) · [Appendix](#appendix)
 
 > [!WARNING]
-> Current public `main` proves this correction lane is real, but adjacent repo docs still do **not** settle whether `schemas/` or `contracts/` is the authoritative machine-contract home. The local `correction_notice.schema.json` file is currently placeholder-only `{}`.
+> Current public `main` proves this correction lane is real, but adjacent repo docs still do **not** settle whether `schemas/` or `contracts/` is the authoritative machine-contract home. The local `correction_notice.schema.json` file now contains a Draft 2020-12 starter contract body.
 
 > [!NOTE]
 > The KFM Meta Block v2 above uses reviewable placeholders for `doc_id`, `created`, `updated`, and `policy_label` because those values were not directly confirmed from the public repo surfaces reviewed for this revision.
@@ -36,7 +36,7 @@ Boundary-and-inventory README for the live `schemas/contracts/v1/correction/` la
 |---|---|
 | Family role | Preserve visible lineage under supersession, withdrawal, narrowing, or reissue |
 | Current local inventory | `README.md` + `correction_notice.schema.json` |
-| Current schema body | Placeholder `{}` |
+| Current schema body | Draft 2020-12 starter schema |
 | Stronger neighboring proof surfaces | [`tests/contracts/`](../../../../tests/contracts/README.md) for contract-facing validation; [`tests/e2e/correction/`](../../../../tests/e2e/correction/README.md) for whole-path correction proof |
 | Local schema-side fixture scaffold | [`schemas/tests/fixtures/contracts/v1/`](../../../tests/fixtures/contracts/v1/README.md) exists generically, but no correction-specific fixture leaf was directly verified here |
 | Authority posture | **UNKNOWN / NEEDS VERIFICATION** between `schemas/` and `contracts/` |
@@ -162,7 +162,7 @@ This directory should stay small, explicit, and hard to misread.
 | `schemas/contracts/v1/correction/` | **CONFIRMED** present | The correction-family lane is a real checked-in public path |
 | `./README.md` | **CONFIRMED** present | This directory already has a substantive family README surface |
 | `./correction_notice.schema.json` | **CONFIRMED** present | The family filename is materialized |
-| `./correction_notice.schema.json` body | **CONFIRMED** current body is `{}` | The local schema is still placeholder-only, not enforcement-grade |
+| `./correction_notice.schema.json` body | **CONFIRMED** Draft 2020-12 starter body is present | The local schema now encodes a first-wave contract floor, but full enforcement maturity still needs broader suite coverage |
 | [`../../../../tests/e2e/correction/README.md`](../../../../tests/e2e/correction/README.md) | **CONFIRMED** present; current public leaf is README-only | Whole-path correction proof has a named home, but executable depth remains **NEEDS VERIFICATION** |
 | [`../../../../tests/contracts/README.md`](../../../../tests/contracts/README.md) | **CONFIRMED** present and explicitly names `CorrectionNotice` in the family role | Stronger contract-facing validation surface exists outside this schema lane |
 | [`../../../tests/fixtures/contracts/v1/README.md`](../../../tests/fixtures/contracts/v1/README.md) plus `valid/` and `invalid/` leaves | **CONFIRMED** present as generic schema-side fixture scaffold | Versioned generic fixture scaffolding exists, but no correction-specific fixture payloads were directly verified here |
@@ -178,7 +178,7 @@ Right now this lane proves five things and no more:
 2. the local README is substantive
 3. the local schema filename exists
 4. adjacent correction-proof and contract-validation lanes exist elsewhere in the repo
-5. local contract implementation maturity is still incomplete because the checked-in schema body is `{}`
+5. local contract implementation maturity is improving with a checked-in starter schema body, but broader cross-family validation is still incomplete
 
 [Back to top](#correction-contracts-v1)
 
@@ -337,12 +337,12 @@ flowchart LR
 
 ## Contract shape
 
-### What current public `main` proves locally
+### What this branch now proves locally
 
 | Local fact | Meaning |
 |---|---|
 | `correction_notice.schema.json` exists | The family filename is materialized in the `schemas/` lane |
-| `correction_notice.schema.json` currently equals `{}` | The local field list is **not** yet encoded here as a substantive schema |
+| `correction_notice.schema.json` now has a Draft 2020-12 body | The local field list now has a machine-checkable starter floor |
 | this README already contains doctrinal field guidance | The repo has contract intent documented even though machine enforcement is not yet proven locally |
 
 ### Confirmed doctrinal minimum contract floor
@@ -503,7 +503,7 @@ A thin but honest correction drill should prove three linked objects:
 ## Task list — definition of done
 
 - [ ] one authoritative schema-home decision is recorded or explicitly linked
-- [ ] `correction_notice.schema.json` grows beyond `{}` under JSON Schema Draft 2020-12
+- [x] `correction_notice.schema.json` now has a JSON Schema Draft 2020-12 starter body
 - [ ] contract-facing valid / invalid cases exist in the authoritative verification lane
 - [ ] any schema-side `valid/` / `invalid/` mirrors are explicitly marked non-authoritative, generated, or pointer-only
 - [ ] at least one correction drill exists under `tests/e2e/correction/**`

--- a/schemas/contracts/v1/correction/correction_notice.schema.json
+++ b/schemas/contracts/v1/correction/correction_notice.schema.json
@@ -1,1 +1,134 @@
-{}
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.example/schemas/contracts/v1/correction/correction_notice.schema.json",
+  "title": "CorrectionNotice",
+  "description": "Visible correction lineage for supersession, withdrawal, narrowing, or reissue.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "schema_version",
+    "correction_id",
+    "correction_type",
+    "targets",
+    "affected_surface_classes",
+    "cause",
+    "public_note"
+  ],
+  "properties": {
+    "kind": {
+      "const": "CorrectionNotice"
+    },
+    "schema_version": {
+      "const": "v1"
+    },
+    "correction_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "correction_type": {
+      "type": "string",
+      "enum": ["SUPERSEDE", "WITHDRAW", "NARROW", "REISSUE"]
+    },
+    "targets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "replacement_releases": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "affected_surface_classes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["map", "dossier", "story", "export", "focus"]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "rebuild_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "cause": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason_code", "issued_at"],
+      "properties": {
+        "reason_code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "effective_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "audit_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "public_note": {
+      "type": "string",
+      "minLength": 1
+    },
+    "replaces": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "correction_type": {
+            "const": "SUPERSEDE"
+          }
+        }
+      },
+      "then": {
+        "required": ["replacement_releases"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "correction_type": {
+            "const": "WITHDRAW"
+          }
+        }
+      },
+      "then": {
+        "not": {
+          "required": ["replacement_releases"]
+        }
+      }
+    }
+  ]
+}

--- a/schemas/tests/fixtures/contracts/v1/invalid/README.md
+++ b/schemas/tests/fixtures/contracts/v1/invalid/README.md
@@ -45,6 +45,9 @@ Negative-example boundary README for `schemas/tests/fixtures/contracts/v1/invali
 > In KFM, an “invalid fixture” is not arbitrary broken JSON.
 > It is a deliberately failing example meant to prove that a named contract, schema, or gate rejects the wrong shape for the right reason — fail-closed, with the owning authority surface still explicit.
 
+> [!IMPORTANT]
+> Current branch now includes `correction_notice.supersession.missing_replacement.invalid.json` as a concrete negative fixture for the correction contract floor.
+
 ## Scope
 
 This README is intentionally leaf-sized and boundary-heavy.
@@ -154,7 +157,7 @@ These do **not** belong here by default.
 | Item | Status | Why it matters |
 |---|---|---|
 | `schemas/tests/fixtures/contracts/v1/invalid/README.md` exists on current public `main` | **CONFIRMED** | This leaf path is real, not speculative |
-| Current public directory inventory is `README.md` only | **CONFIRMED** | Public `main` does **not** currently prove mounted invalid example files here |
+| Current branch inventory includes `README.md` plus a correction notice invalid fixture | **CONFIRMED** | Public `main` does **not** currently prove mounted invalid example files here |
 | [`../README.md`](../README.md) exists | **CONFIRMED** | The version lane is visible |
 | [`../valid/README.md`](../valid/README.md) exists | **CONFIRMED** | Positive/negative leaves are paired in the current tree |
 | Parent `schemas/tests/README.md` describes `fixtures/contracts/v1/{valid,invalid}` as scaffold-only | **CONFIRMED** | This leaf should preserve that boundary language |
@@ -187,7 +190,8 @@ repo-root/
 
 ```text
 schemas/tests/fixtures/contracts/v1/invalid/
-└── README.md   # local negative-example boundary README
+├── README.md
+└── correction_notice.supersession.missing_replacement.invalid.json
 ```
 
 ### Future leaf shape after explicit authority and consumer decisions (**PROPOSED**)

--- a/schemas/tests/fixtures/contracts/v1/invalid/correction_notice.supersession.missing_replacement.invalid.json
+++ b/schemas/tests/fixtures/contracts/v1/invalid/correction_notice.supersession.missing_replacement.invalid.json
@@ -1,0 +1,18 @@
+{
+  "kind": "CorrectionNotice",
+  "schema_version": "v1",
+  "correction_id": "cn.example.2026-03-28.002",
+  "correction_type": "SUPERSEDE",
+  "targets": [
+    "rel.example.2026-03-01.v1"
+  ],
+  "affected_surface_classes": [
+    "map",
+    "story"
+  ],
+  "cause": {
+    "reason_code": "validation.schema_failed",
+    "issued_at": "2026-03-28T00:00:00Z"
+  },
+  "public_note": "Replacement release is not provided."
+}

--- a/schemas/tests/fixtures/contracts/v1/valid/README.md
+++ b/schemas/tests/fixtures/contracts/v1/valid/README.md
@@ -41,6 +41,9 @@ Positive-example boundary README for the live `schemas/tests/fixtures/contracts/
 >
 > This leaf can support that pattern as a documented scaffold, but the current public tree does not yet prove mounted positive example files or active workflow enforcement at this path.
 
+> [!IMPORTANT]
+> Current branch now includes `correction_notice.supersession.valid.json` as a concrete positive fixture for the correction contract floor.
+
 ## Scope
 
 `schemas/tests/fixtures/contracts/v1/valid/` is the positive-example leaf inside the visible schema-side contract-fixture scaffold.
@@ -153,7 +156,8 @@ schemas/tests/fixtures/contracts/v1/
 
 ```text
 schemas/tests/fixtures/contracts/v1/valid/
-└── README.md
+├── README.md
+└── correction_notice.supersession.valid.json
 ```
 
 ### Candidate future local shape (`PROPOSED`)
@@ -259,7 +263,7 @@ flowchart TB
 | Statement | Posture | Why it matters |
 |---|---|---|
 | `schemas/tests/fixtures/contracts/v1/valid/README.md` exists on current public `main` | **CONFIRMED** | This leaf is real, not hypothetical |
-| No checked-in positive example files beyond `README.md` were verified in this leaf | **CONFIRMED** | The local positive lane is visible but still placeholder-level |
+| A checked-in positive correction notice fixture now exists in this leaf | **CONFIRMED** | The local positive lane is visible but still placeholder-level |
 | `../invalid/README.md` exists beside this leaf | **CONFIRMED** | The `v1` scaffold has paired positive and negative leaves |
 | `../../README.md` already treats `v1/{valid,invalid}` as local scaffold lanes | **CONFIRMED** | This leaf should describe inventory, not invent canonical authority |
 | `../../../../../../contracts/README.md` remains the stronger current machine-contract surface | **CONFIRMED / INFERRED** | Positive examples here should not silently outrank the contract lane |

--- a/schemas/tests/fixtures/contracts/v1/valid/correction_notice.supersession.valid.json
+++ b/schemas/tests/fixtures/contracts/v1/valid/correction_notice.supersession.valid.json
@@ -1,0 +1,32 @@
+{
+  "kind": "CorrectionNotice",
+  "schema_version": "v1",
+  "correction_id": "cn.example.2026-03-28.001",
+  "correction_type": "SUPERSEDE",
+  "targets": [
+    "rel.example.2026-03-01.v1"
+  ],
+  "replacement_releases": [
+    "rel.example.2026-03-15.v2"
+  ],
+  "affected_surface_classes": [
+    "map",
+    "dossier",
+    "story",
+    "export",
+    "focus"
+  ],
+  "rebuild_refs": [
+    "pbr.example.001"
+  ],
+  "cause": {
+    "reason_code": "validation.schema_failed",
+    "issued_at": "2026-03-28T00:00:00Z",
+    "effective_at": "2026-03-28T00:00:00Z",
+    "audit_ref": "audit:correction:example:001"
+  },
+  "public_note": "This release has been superseded by a corrected release.",
+  "replaces": [
+    "rel.example.2026-03-01.v1"
+  ]
+}

--- a/tests/contracts/test_correction_notice_contract.py
+++ b/tests/contracts/test_correction_notice_contract.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas/contracts/v1/correction/correction_notice.schema.json"
+VALID_FIXTURE = ROOT / "schemas/tests/fixtures/contracts/v1/valid/correction_notice.supersession.valid.json"
+INVALID_FIXTURE = ROOT / "schemas/tests/fixtures/contracts/v1/invalid/correction_notice.supersession.missing_replacement.invalid.json"
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_contract_floor(payload: dict) -> list[str]:
+    errors: list[str] = []
+
+    required = {
+        "kind",
+        "schema_version",
+        "correction_id",
+        "correction_type",
+        "targets",
+        "affected_surface_classes",
+        "cause",
+        "public_note",
+    }
+    missing = sorted(required - set(payload))
+    if missing:
+        errors.append(f"missing required fields: {', '.join(missing)}")
+
+    if payload.get("kind") != "CorrectionNotice":
+        errors.append("kind must be CorrectionNotice")
+
+    if payload.get("schema_version") != "v1":
+        errors.append("schema_version must be v1")
+
+    correction_type = payload.get("correction_type")
+    if correction_type == "SUPERSEDE" and not payload.get("replacement_releases"):
+        errors.append("SUPERSEDE correction requires replacement_releases")
+
+    if correction_type == "WITHDRAW" and payload.get("replacement_releases"):
+        errors.append("WITHDRAW correction must not include replacement_releases")
+
+    cause = payload.get("cause", {})
+    if isinstance(cause, dict):
+        if not cause.get("reason_code"):
+            errors.append("cause.reason_code is required")
+        if not cause.get("issued_at"):
+            errors.append("cause.issued_at is required")
+    else:
+        errors.append("cause must be an object")
+
+    return errors
+
+
+class CorrectionNoticeContractTests(unittest.TestCase):
+    def test_schema_is_not_placeholder(self):
+        schema = load_json(SCHEMA_PATH)
+        self.assertEqual(schema.get("$schema"), "https://json-schema.org/draft/2020-12/schema")
+        self.assertEqual(schema.get("title"), "CorrectionNotice")
+        self.assertEqual(schema.get("type"), "object")
+        self.assertIn("required", schema)
+
+    def test_valid_fixture_satisfies_contract_floor(self):
+        payload = load_json(VALID_FIXTURE)
+        self.assertEqual(validate_contract_floor(payload), [])
+
+    def test_invalid_fixture_fails_contract_floor(self):
+        payload = load_json(INVALID_FIXTURE)
+        errors = validate_contract_floor(payload)
+        self.assertIn("SUPERSEDE correction requires replacement_releases", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Several READMEs flagged `schemas/contracts/v1/correction/correction_notice.schema.json` as a placeholder `{}` and recommended a first-wave substantive schema plus valid/invalid examples. 
- Provide a minimal, machine-checkable contract floor and example fixtures so downstream verification and test families have concrete inputs to consume.

### Description
- Replace the `{}` placeholder with a Draft 2020-12 `CorrectionNotice` JSON Schema that defines required fields (`kind`, `schema_version`, `correction_id`, `correction_type`, `targets`, `affected_surface_classes`, `cause`, `public_note`) and conditional rules for `SUPERSEDE` vs `WITHDRAW` (`schemas/contracts/v1/correction/correction_notice.schema.json`).
- Add a positive fixture `correction_notice.supersession.valid.json` and a negative fixture `correction_notice.supersession.missing_replacement.invalid.json` under `schemas/tests/fixtures/contracts/v1/valid/` and `schemas/tests/fixtures/contracts/v1/invalid/` respectively.
- Add a contract-floor unit test `tests/contracts/test_correction_notice_contract.py` that asserts the schema is non-placeholder and that the valid fixture passes and the invalid fixture fails the minimum contract rules.
- Update the nearest README files to note that this branch includes a starter schema body and concrete fixtures (`schemas/contracts/v1/correction/README.md`, `schemas/tests/fixtures/contracts/v1/valid/README.md`, `schemas/tests/fixtures/contracts/v1/invalid/README.md`).

### Testing
- Ran the contract-floor unit tests with `python -m unittest tests/contracts/test_correction_notice_contract.py`, which ran 3 tests and reported `OK`.
- Verified JSON syntax for the schema and both fixtures with `python -m json.tool <file>`, which returned successfully for `schemas/contracts/v1/correction/correction_notice.schema.json` and both fixture files.
- All automated checks executed in this branch passed (unit tests and JSON parsing validations succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9586db84c832a837d5b5d98b7dfc2)