### PR TITLE
docs(heritage): reorganize lane into evidence-first KFM domain suite

### DIFF
--- a/docs/domains/heritage/README.md
+++ b/docs/domains/heritage/README.md
@@ -1,305 +1,132 @@
 <!-- [KFM_META_BLOCK_V2]
-doc_id: NEEDS VERIFICATION
-title: Heritage Domain
+doc_id: kfm://doc/NEEDS-VERIFICATION-heritage-lane-readme
+title: KFM Heritage Domain Lane
 type: standard
 version: v1
 status: draft
 owners: [@bartytime4life, NEEDS VERIFICATION]
 created: NEEDS VERIFICATION
-updated: 2026-04-02
+updated: 2026-04-10
 policy_label: public
-related: [docs/domains/README.md, docs/governance/ROOT_GOVERNANCE.md, docs/governance/ETHICS.md, docs/governance/SOVEREIGNTY.md, docs/domains/heritage/gedcom-intake-mapping.md]
-tags: [kfm, heritage, archives, oral-history, genealogy, provenance, geoprivacy]
-notes: ["Repo tree was not mounted in this session; path, owners, created date, and companion-file existence remain NEEDS VERIFICATION.", "Grounded in the uploaded heritage draft and March 2026 KFM atlas/manual doctrine; avoids claiming mounted implementation."]
+related: [../README.md, ../archives-heritage/README.md, ../../architecture/TRUTH_PATH_LIFECYCLE.md, ../../architecture/TRUST_MEMBRANE.md, ../../governance/ROOT_GOVERNANCE.md, ./sources.md, ./rights-and-sensitivity.md, ./entity-and-evidence-model.md, ./publication-and-review.md, ./roadmap.md, ./gedcom-intake-mapping.md, ./gedcom-map-timeline-pipeline.md, ./examples/README.md, ./fixtures/README.md]
+tags: [kfm, domains, heritage, archives, oral-history, public-memory, evidence-governance]
+notes: [Built from existing heritage lane drafts plus repo-visible architecture and domains doctrine., Keeps CONFIRMED/INFERRED/PROPOSED/UNKNOWN/NEEDS VERIFICATION distinctions explicit and avoids implementation overclaiming.]
 [/KFM_META_BLOCK_V2] -->
 
-# Heritage Domain
+# KFM Heritage Domain Lane
 
-_Governed lane for archives, oral histories, public memory, genealogy, and heritage-sensitive place-linked materials._
-
-> **Lane status:** `experimental`  
-> **Doc status:** `draft`  
-> **Owners:** `@bartytime4life`, `NEEDS VERIFICATION`  
-> **Repo fit:** **PROPOSED** path `docs/domains/heritage/README.md`  
-> **Workspace evidence limit:** current-session repo tree not mounted; adjacent files, CODEOWNERS, and path existence remain `NEEDS VERIFICATION`
-
-![Status](https://img.shields.io/badge/status-experimental-orange) ![Doc](https://img.shields.io/badge/doc-lane--readme-1f6feb) ![Evidence](https://img.shields.io/badge/evidence-corpus--grounded-0a7f5a) ![Repo fit](https://img.shields.io/badge/repo_fit-NEEDS%20VERIFICATION-lightgrey)
-
-**Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Source ecosystem](#representative-source-ecosystem) · [Directory tree](#directory-tree) · [Quickstart](#quickstart) · [Usage](#usage) · [Operating posture](#operating-posture) · [Exposure classes](#exposure-classes) · [Companion docs](#companion-docs) · [Task list](#task-list) · [FAQ](#faq) · [Appendix](#appendix)
+Heritage in KFM is a **governed evidence lane** for documentary and memory-bearing materials that require explicit provenance, rights, sensitivity, and review handling before publication.
 
 > [!IMPORTANT]
-> Heritage material is **not publish-by-default**. Historical value does not erase privacy, cultural sensitivity, living-person risk, descendant risk, or exact-location exposure.
+> **Doctrinal baseline for this lane:** [`../../architecture/TRUTH_PATH_LIFECYCLE.md`](../../architecture/TRUTH_PATH_LIFECYCLE.md) and [`../../architecture/TRUST_MEMBRANE.md`](../../architecture/TRUST_MEMBRANE.md). Heritage content must stay downstream of evidence, policy, review, and correction, not narrative convenience.
 
-> [!NOTE]
-> In KFM doctrine, archives, newspapers, oral histories, public memory, and heritage are a **structural operating lane**, not a decorative content tag. Documentary evidence must keep context, provenance, rights posture, and reuse limits visible at the point of use.
+## Scope and lane fit
 
-## Scope
+- **CONFIRMED:** KFM doctrine treats archives/newspapers/oral-history/public-memory/heritage as a structural burdened lane in domain guidance. 
+- **CONFIRMED:** `docs/domains/heritage/` exists in this repository and already contains lane-specific docs.
+- **INFERRED:** this subtree is a focused split of the broader `archives-heritage` burden described in `docs/domains/README.md`.
+- **NEEDS VERIFICATION:** final long-term split decision between `archives-heritage/` and `heritage/` as canonical lane root.
 
-This lane exists for materials where **time, place, memory, identity, and stewardship** intersect. Many of these artifacts look deceptively simple in file form—spreadsheets, scans, transcripts, coordinates, family exports, notes, or map sheets—but they become higher-risk once they are recombined into searchable, mapped, inferential, or story-facing surfaces.
+Heritage-lane evidence includes, but is not limited to:
 
-Use this lane for materials such as:
+- archival description, scans, map sheets, and captions
+- newspapers and clipping records
+- oral history transcripts and audio-linked records
+- genealogy-linked documentary records (with strict disclosure handling)
+- commemorative and public-memory documentation
+- heritage documentation packages (including 2.5D/3D where warranted)
 
-- historical records tied to people, families, settlements, routes, or communities
-- genealogical exports and their derived place/time products
-- archival references containing sensitive names, locations, affiliations, or narrative context
-- cemetery, memorial, burial, and commemorative materials
-- oral-history support materials and transcript-linked place evidence
-- migration, settlement, and kinship-linked documentation
-- heritage documentation bundles such as scans, orthophotos, 2.5D surfaces, georeferenced meshes, CT-derived volumes, and interpretive reconstructions
+## Source-role taxonomy (lane-specific)
 
-This lane is a **governance and documentation surface**, not a blanket license to turn historical material into public overlays. KFM’s archival and heritage doctrine is explicit on three points:
-
-1. keep the original artifact first
-2. treat OCR cleanup, entity extraction, and interpretive summarization as separate downstream lanes
-3. do not let narrative convenience erase provenance, rights, or sensitivity context
-
-## Repo fit
-
-| Field | Value |
-|---|---|
-| Target path | `docs/domains/heritage/README.md` |
-| Alternate plausible placement | `docs/domains/archives/README.md` |
-| Parent domain index | [`../README.md`][domains-readme] |
-| Governance anchors | [`../../governance/ROOT_GOVERNANCE.md`][root-governance], [`../../governance/ETHICS.md`][ethics], [`../../governance/SOVEREIGNTY.md`][sovereignty] |
-| Immediate companion | [`./gedcom-intake-mapping.md`][gedcom-intake] |
-| Downstream fit | generalized public maps, evidence-linked story surfaces, dossier context, steward review, release/correction documentation |
-| Verification state | `NEEDS VERIFICATION` |
-
-This README is intentionally written so it can survive either of two repo outcomes:
-
-- a dedicated `heritage/` lane
-- an eventual merge into a broader `archives/` lane
-
-The mounted corpus supports the **lane concept** strongly. It does **not** prove the mounted repo path in this session.
-
-## Accepted inputs
-
-| Input class | Examples | Status |
+| Source role | What it means in heritage lane | Core restriction |
 |---|---|---|
-| genealogical exports | GEDCOM 5.5.1, GEDCOM 7.x, GEDZIP | `INFERRED` |
-| archival texts and scans | registers, letters, diaries, reports, index cards, county histories, map sheets | `CONFIRMED` |
-| newspapers and captions | OCR text, image captions, event coverage, timeline enrichment material | `CONFIRMED` |
-| oral-history support materials | interview indexes, transcripts, consent notes, place references, streaming/audio companions | `CONFIRMED` |
-| memorial / cemetery records | burial registers, memorial datasets, plot lists, recent-burial-sensitive records | `PROPOSED` |
-| heritage documentation bundles | scan + image derivative + 2.5D/3D package + interpretive companion | `CONFIRMED` |
-| steward guidance | release notes, restrictions, rights tokens, review instructions | `PROPOSED` |
+| Documentary / archival | Primary records, scans, finding aids, transcripts, newspapers, captions | Must retain context and locator trace; never flatten into unsupported fact tables. |
+| Community-contributed | Community memory, local submissions, oral-history contributions | Governed input only; never auto-promoted as truth without review and evidence linkage. |
+| Statutory / administrative | Register entries, legal designations, administrative listings | Administrative status is not full interpretive truth; keep scope explicit. |
+| Direct observational / field | Site notes, survey observations, steward field documentation | Requires chain-of-custody and sensitivity review before publication. |
+| Modeled / derived | OCR, entity extraction, summaries, embeddings, reconstructions | Must be visibly derived and linked back to inspectable source evidence. |
+| Mirror / discovery service | Index portals and discovery mirrors | Discovery aid only; do not treat mirror metadata as authority by default. |
 
-> [!NOTE]
-> “Accepted input” here means the lane is conceptually responsible for the material type. It does **not** prove that every listed source class already has active ingestion code or finalized schemas in the mounted repo.
+For detailed role handling and examples, use [`./sources.md`](./sources.md).
 
-## Exclusions
+## Rights and sensitivity summary
 
-### Not for default public release
+Heritage lane is **not publish-by-default**.
 
-- exact home addresses or modern residence histories
-- exact coordinates for culturally sensitive or vulnerable sites
-- inferred ethnicity, religion, tribal/community identity, or kinship-sensitive claims not explicitly supported
-- living-person personal detail published from convenience exports
-- narrative summaries that detach claims from their source artifact
-- “generic 3D” packaging that collapses scans, orthophotos, 2.5D surfaces, meshes, and interpretive models into one undifferentiated object
-- decorative 3D/2.5D presentation that weakens evidence, policy, or correction visibility
-- sovereign use of derived overlays where the authoritative record remains narrower, disputed, or rights-limited
+- Rights posture, reuse constraints, and quote safety are first-class publication gates.
+- Culturally sensitive material and exact-location exposure are explicit risk classes.
+- Generalized/public-safe derivatives are preferred when precise disclosure creates harm.
+- Steward-only and withheld outcomes are valid, expected outcomes.
 
-### Usually belongs elsewhere
+Detailed rules and example handling are in [`./rights-and-sensitivity.md`](./rights-and-sensitivity.md).
 
-- hydrology, hazards, climate, ecology, or agriculture without heritage sensitivity → use the corresponding domain lane
-- generic ingestion, runtime, or platform architecture → keep in architecture / platform / governance docs
-- land-tenure or legal-description mechanics where the dominant burden is deed, parcel, or tract resolution → prefer the land-tenure / parcel / deed lane
+## Publication surfaces and trust rules
 
-## Representative source ecosystem
-
-| Source or source family | What it contributes | KFM handling note |
+| Surface | Allowed heritage output | Must remain visible |
 |---|---|---|
-| Kansas Memory / Kansas Historical Society | maps, photographs, letters, diaries, reports, archival description | metadata-first, rights-aware use |
-| Chronicling America | digitized Kansas newspapers with OCR and date retrieval | useful for discourse evidence, event narrative, and timeline enrichment |
-| Kansas Oral History Project (KOHP) | named oral-history corpus with transcripts, thematic collections, and audio/streaming context | derivative and publication strategy must respect `CC BY-NC-ND` limits |
-| KHRI / NRHP | historic resources and listed sites with map/context layers | some heritage layers need sensitivity controls |
-| local archives / university collections | regionally important documentary artifacts and collection-specific metadata | rights, quote limits, and exact-location posture may vary by collection |
+| Dossier | Evidence-linked summary claims | Evidence route, uncertainty, correction state |
+| Story surface | Bounded narrative claims | Claim-to-evidence linkage; no unsupported certainty upgrade |
+| Evidence Drawer | Source and support inspection | Locator, provenance, rights/sensitivity posture |
+| Focus Mode | Bounded synthesis over released scope | Citations, finite outcomes, policy-bounded response envelope |
+| Export | Release-scoped derivative package | Release lineage, disclosure class, correction linkage |
+| Review / Stewardship | Restricted and precise handling | Decision record, reviewer action, rationale, escalation path |
 
-### Interpretation rule
+Detailed publication model: [`./publication-and-review.md`](./publication-and-review.md).
 
-Treat documentary and archival material as **documentary / interpretive evidence**, not as automatically flattened fact tables. Preserve original identifiers, transcript anchors, page or image references, and contextual notes whenever claims are extracted.
-
-## Directory tree
+## Directory map
 
 ```text
-docs/
-└── domains/
-    ├── README.md
-    ├── heritage/                           # PROPOSED; NEEDS VERIFICATION
-    │   ├── README.md                       # this file
-    │   ├── gedcom-intake-mapping.md        # PROPOSED companion
-    │   ├── fixtures/
-    │   │   └── README.md                   # PROPOSED
-    │   └── examples/
-    │       └── README.md                   # PROPOSED
-    └── archives/                           # alternate plausible lane
-        └── ...
+docs/domains/heritage/
+├── README.md                            # lane definition and routing (this file)
+├── sources.md                           # source-role discipline and source-family handling
+├── rights-and-sensitivity.md            # rights, quote safety, sensitivity, and disclosure policy
+├── entity-and-evidence-model.md         # entity families, evidence objects, and trust artifacts
+├── publication-and-review.md            # publication surfaces, review gates, correction posture
+├── roadmap.md                           # open unknowns and next artifacts
+├── gedcom-intake-mapping.md             # genealogy intake mapping standard
+├── gedcom-map-timeline-pipeline.md      # map/timeline downstream pipeline standard
+├── examples/
+│   └── README.md
+└── fixtures/
+    └── README.md
 ```
 
-## Quickstart
-
-```text
-1. Classify the source as heritage-sensitive or not.
-2. Preserve the original artifact and source descriptor before transformation.
-3. Record rights, quote/derivative posture, and exact-location constraints.
-4. Separate documentary source facts from OCR, extraction, and summary layers.
-5. Assess living-person, descendant, site, and cultural sensitivity.
-6. Choose an explicit exposure class before public release.
-7. Publish only evidence-resolvable claims with visible correction lineage.
-```
-
-## Usage
-
-### Place a document in this lane when it is primarily about
-
-- historical people or family-linked place/time records
-- archival or oral-history material that needs exposure controls
-- public-memory or heritage documentation with contextual or rights burden
-- documentation for how such sources are ingested, generalized, reviewed, or published
-
-### Prefer another lane when the material is primarily about
-
-- hydrology, hazards, climate, ecology, or agriculture without heritage sensitivity
-- generic ingestion/platform architecture not specific to heritage material
-- public-domain historical narrative with no location/identity sensitivity and no lane-specific governance burden
-- cadastral, deed, or parcel mechanics where the dominant burden is land-tenure/legal-description handling rather than archival/heritage handling
-
-### Working rules
-
-- **Source intake is a contract, not a download.**
-- **Preserve the original first; extract second.**
-- **Do not collapse scan, OCR, extraction, summary, and interpretive model into one opaque workflow.**
-- **Keep rights ambiguity, quote limits, and derivative limits visible.**
-- **Generalize before public release when place/time precision could disclose sensitive detail.**
-- **Narrative convenience must not erase provenance.**
-
-## Operating posture
+## Working lane flow
 
 ```mermaid
 flowchart TD
-    A[Historical / heritage source] --> B[RAW intake]
-    B --> C[WORK or QUARANTINE]
-    C --> D[Normalization + provenance]
-    D --> E[Evidence review]
-    E --> F{Sensitivity / consent / living-risk / site-risk}
-    F -->|high| G[Withhold or steward-only]
-    F -->|moderate| H[Generalize and narrow]
-    F -->|low| I[Public-safe derivative candidate]
-    G --> J[Catalog with visible restriction]
-    H --> J
-    I --> K[Published generalized surface]
+    A[Heritage source intake] --> B[SourceDescriptor + IngestReceipt]
+    B --> C[Validation + rights/sensitivity triage]
+    C --> D{Policy and steward review}
+    D -->|approved public-safe| E[Generalized published derivative]
+    D -->|restricted| F[Steward-only representation]
+    D -->|unsafe or unresolved| G[Withheld or quarantine]
+    E --> H[Dossier / Story / Focus / Export]
+    F --> I[Review console and controlled access]
+    H --> J[CorrectionNotice and supersession path]
+    I --> J
 ```
 
-### Domain rule
+## Contributor guidance
 
-Heritage outputs should prefer:
+1. Keep claim-bearing text tethered to inspectable documentary evidence.
+2. Preserve original context before extraction, summary, or visualization.
+3. Use explicit status labels (`CONFIRMED`, `INFERRED`, `PROPOSED`, `UNKNOWN`, `NEEDS VERIFICATION`) when certainty differs.
+4. Do not import hydrology-style public-safe assumptions into heritage; this lane has a higher disclosure burden.
+5. Prefer narrow, link-rich edits over broad speculative rewrites.
 
-- generalized place over exact place
-- bounded dates over exact dates when risk exists
-- visible uncertainty over polished certainty
-- steward review over inertia
-- evidence-linked correction over silent replacement
+## Verification backlog (open unknowns)
 
-### Required public-surface behaviors
+- **UNKNOWN:** executable schema location for all heritage-specific objects.
+- **NEEDS VERIFICATION:** implemented workflow checks that enforce quote safety and sensitivity publication gates.
+- **NEEDS VERIFICATION:** lane-specific policy bundles tied to heritage disclosure classes.
+- **UNKNOWN:** complete source descriptor registry for heritage source families.
+- **NEEDS VERIFICATION:** canonical owner list and reviewer/steward rota for this lane.
 
-| Requirement | Why it matters |
-|---|---|
-| visible uncertainty | prevents historical overclaim |
-| visible narrowing | makes policy action legible |
-| visible correction lineage | avoids quiet supersession |
-| evidence route for consequential claims | supports trust |
-| no exact sensitive geographies by default | prevents exposure by map polish |
+## Related docs
 
-## Exposure classes
+- Domains hub: [`../README.md`](../README.md)
+- Adjacent combined lane: [`../archives-heritage/README.md`](../archives-heritage/README.md)
+- Doctrine baseline: [`../../architecture/TRUTH_PATH_LIFECYCLE.md`](../../architecture/TRUTH_PATH_LIFECYCLE.md), [`../../architecture/TRUST_MEMBRANE.md`](../../architecture/TRUST_MEMBRANE.md)
+- Governance anchors: [`../../governance/ROOT_GOVERNANCE.md`](../../governance/ROOT_GOVERNANCE.md), [`../../governance/ETHICS.md`](../../governance/ETHICS.md), [`../../governance/SOVEREIGNTY.md`](../../governance/SOVEREIGNTY.md)
 
-Public release decisions in this lane should be explicit.
-
-| Exposure class | Meaning | Typical use |
-|---|---|---|
-| `public_safe` | suitable for broad release | generalized, non-reidentifying summaries |
-| `generalized` | releasable only after narrowing place/time/detail | public maps, timelines, counts |
-| `steward_only` | visible only to authorized reviewers/stewards | precise site-linked or identity-sensitive material |
-| `restricted_precise` | exact details retained internally under policy | internal evidence handling |
-| `withheld` | not published | unsafe, revoked, contested, unconsented, or rights-blocked material |
-
-When uncertainty exists, prefer one of `generalized`, `steward_only`, or `withheld` rather than silently publishing a finer-grained derivative.
-
-## Companion docs
-
-| Document | Role | Status |
-|---|---|---|
-| `docs/domains/heritage/README.md` | lane overview and posture | `PROPOSED` |
-| `docs/domains/heritage/gedcom-intake-mapping.md` | genealogy export intake and privacy mapping | `PROPOSED` |
-| `docs/domains/heritage/fixtures/README.md` | parser, redaction, and review fixtures | `PROPOSED` |
-| `docs/domains/heritage/examples/README.md` | safe examples, generalized outputs, release patterns | `PROPOSED` |
-| governance anchors | root doctrine for publication, ethics, sovereignty, and sensitivity handling | `INFERRED` |
-
-## Task list
-
-- [ ] **NEEDS VERIFICATION:** confirm whether `heritage/` already exists
-- [ ] **NEEDS VERIFICATION:** confirm whether this lane should instead live under `archives/`
-- [ ] **NEEDS VERIFICATION:** align owners with `.github/CODEOWNERS`
-- [ ] confirm that companion paths resolve
-- [ ] link this README from the parent domain index
-- [ ] add shared exposure-class glossary if another sensitive lane already defines one
-- [ ] add domain-specific examples for cemetery, oral-history, and migration materials
-- [ ] add one generalized-vs-precise comparison example
-- [ ] confirm public/restricted policy-label expectations for lane docs
-
-### Definition of done
-
-- [ ] lane path is confirmed
-- [ ] adjacent links resolve
-- [ ] companion standard paths are validated
-- [ ] no unverified implementation claims remain unlabeled
-- [ ] examples reflect actual repo conventions
-
-## FAQ
-
-### Why not keep this under a generic archives or ingestion path?
-
-That may still be the correct final placement. This README proposes a dedicated heritage lane because the dominant problem is not file format management; it is **governed historical exposure**.
-
-### Is “historical” automatically safe?
-
-No. Historical materials can still expose living descendants, culturally sensitive locations, or community-vulnerable patterns.
-
-### Are public maps allowed in this lane?
-
-Yes, but only when they preserve KFM trust posture: generalized when necessary, evidence-linked, correction-capable, and visibly narrowed where policy requires it.
-
-### Does this lane govern final release for every downstream use?
-
-No. This lane defines posture and documentation expectations. Final release decisions still depend on downstream policy, audience, implementation controls, and review state.
-
-## Appendix
-
-<details>
-<summary><strong>Descriptor fields that should be explicit for heritage sources</strong></summary>
-
-| Field family | Minimum expectation |
-|---|---|
-| object identity | `object_id`, collection/archive identifier, source URI |
-| anchor | page ID, image ID, transcript anchor, or timestamp anchor |
-| rights | rights token, quote limit, derivative-allowed flag, public/restricted posture |
-| extraction quality | OCR confidence, extraction confidence, reviewer note |
-| role context | speaker/interviewer roles, contributor role, steward/reviewer role |
-| model/package type | scan, orthophoto, 2.5D surface, georeferenced mesh, CT-derived volume, interpretive reconstruction |
-
-</details>
-
-<details>
-<summary><strong>Editorial note</strong></summary>
-
-This README intentionally avoids claiming that a heritage ingestion pipeline, enforcement gate, companion fixtures, or publication UI already exists unless that implementation is visible in the mounted repo. In this session, the mounted workspace evidence was document-only.
-
-</details>
-
-[Back to top](#heritage-domain)
-
-[domains-readme]: ../README.md
-[root-governance]: ../../governance/ROOT_GOVERNANCE.md
-[ethics]: ../../governance/ETHICS.md
-[sovereignty]: ../../governance/SOVEREIGNTY.md
-[gedcom-intake]: ./gedcom-intake-mapping.md

--- a/docs/domains/heritage/entity-and-evidence-model.md
+++ b/docs/domains/heritage/entity-and-evidence-model.md
@@ -1,0 +1,48 @@
+# Heritage Entity and Evidence Model
+
+Scope: domain entities, evidence objects, and trust-critical object families used to keep heritage claims inspectable and correction-ready.
+
+## Entity families (domain-facing)
+
+| Entity family | Role in heritage lane |
+|---|---|
+| Place / site / district / route | Spatial anchor for documentary records and derived interpretations. |
+| Collection | Archival grouping and provenance container for documentary materials. |
+| Narrative object | Structured claim-bearing narrative unit with explicit evidence linkage. |
+| Documentary evidence object | Source-native artifact or faithful representation with locator and rights context. |
+| Event | Time-scoped occurrence tied to evidence and uncertainty posture. |
+| Claim / assertion | Interpreted statement that must remain evidence-linked and reviewable. |
+| Governance object | Policy/review decision with auditable rationale and scope. |
+| Source descriptor | Intake boundary object defining source identity and handling posture. |
+| Evidence bundle | Runtime-facing support package for trust-visible surfaces. |
+| Review / decision / correction objects | Lifecycle objects for approvals, denials, supersession, and withdrawal. |
+
+## Trust artifact expectations (lane mapping)
+
+| Artifact family | Heritage-lane status | Note |
+|---|---|---|
+| SourceDescriptor | INFERRED | Named consistently in architecture/contracts docs; heritage should use it explicitly. |
+| IngestReceipt | INFERRED | Required to preserve intake trace for documentary sources. |
+| ValidationReport | INFERRED | Needed for parse/rights/sensitivity gate visibility. |
+| DatasetVersion | INFERRED | Needed to anchor released heritage derivatives. |
+| CatalogClosure | INFERRED | Needed for release-scoped discoverability and lineage. |
+| DecisionEnvelope | INFERRED | Needed for explicit allow/generalize/withhold decisions. |
+| ReviewRecord | INFERRED | Needed for steward action trace and separation-of-duty posture. |
+| ReleaseManifest / proof pack | PROPOSED | Mentioned doctrinally; exact heritage implementation path unverified. |
+| EvidenceBundle | INFERRED | Trust-critical for dossier/story/focus evidence resolution. |
+| RuntimeResponseEnvelope | INFERRED | Needed for finite runtime outcomes and citation-governed responses. |
+| CorrectionNotice | INFERRED | Needed for supersession/withdrawal visibility across surfaces. |
+
+## Model constraints
+
+1. Documentary evidence objects remain distinct from derived narrative objects.
+2. Claim objects must carry evidence references and confidence/uncertainty signals.
+3. Governance objects must be legible at point-of-use for sensitive publication decisions.
+4. Correction objects must propagate to every downstream surface that displayed superseded output.
+
+## Open unknowns
+
+- **UNKNOWN:** exact contract/schema file paths for all artifacts listed above.
+- **NEEDS VERIFICATION:** object field-level compatibility with existing repo schemas/contracts.
+- **PROPOSED:** heritage-specific object examples under `docs/domains/heritage/examples/` and schema fixtures.
+

--- a/docs/domains/heritage/publication-and-review.md
+++ b/docs/domains/heritage/publication-and-review.md
@@ -1,0 +1,55 @@
+# Heritage Publication and Review Model
+
+Scope: how heritage outputs are published across KFM surfaces while preserving trust-critical visibility, review state, and correction posture.
+
+## Surface-by-surface publication rules
+
+| Surface | Heritage output type | Trust-critical contents that must remain visible |
+|---|---|---|
+| Dossier | Structured summary of evidence-backed heritage context | Evidence links, uncertainty posture, rights/sensitivity class, correction state |
+| Story surface | Narrative framing with bounded claims | Claim-to-source linkage, narrowing notes, abstain/deny handling |
+| Evidence Drawer | Direct support inspection | Source locator, provenance, rights status, review/decision refs |
+| Focus Mode | Governed synthesis over released scope | Citations, policy-bounded finite outcomes, response envelope state |
+| Export | Release-scoped package | Manifest lineage, disclosure class, corrections/supersession metadata |
+| Review / Stewardship | Restricted review interface | Decision records, reviewer actions, escalation notes, withheld rationale |
+
+## Review gates
+
+A publication candidate should fail closed if any of these remain unresolved:
+
+- rights/reuse or quote-safety ambiguity
+- sensitivity class and precision decision ambiguity
+- missing claim-to-evidence linkage
+- unresolved steward review requirement
+- unresolved correction/supersession propagation
+
+## Finite outcomes (runtime/publication)
+
+- `ANSWER`: release-safe and evidence-resolvable.
+- `ABSTAIN`: insufficient support, unresolved conflict, or incomplete evidence route.
+- `DENY`: blocked by policy/rights/sensitivity constraints.
+- `ERROR`: system failure to produce governed response.
+
+## Lane-specific caution
+
+Heritage lane is not equivalent to hydrology or other public-safe-first lanes.
+
+- Heritage requires stronger default narrowing.
+- Narrative surfaces must keep provenance and decision visibility foregrounded.
+- Documentary interpretation remains subordinate to source and governance evidence.
+
+## Correction posture
+
+| Correction type | Required publication behavior |
+|---|---|
+| Supersession | mark prior output as superseded and link forward to correction notice |
+| Withdrawal | remove from public-safe exposure and keep visible withdrawal rationale |
+| Narrowing/generalization | visibly show that precision was reduced and why |
+| Denial after review | preserve decision reason and non-public rationale path for stewards |
+
+## Unknowns and verification flags
+
+- **NEEDS VERIFICATION:** exact API/output contract fields used by current runtime surfaces.
+- **UNKNOWN:** current CI checks that assert heritage-specific trust-critical visibility requirements.
+- **PROPOSED:** lane-specific publication checklist in runbook form.
+

--- a/docs/domains/heritage/rights-and-sensitivity.md
+++ b/docs/domains/heritage/rights-and-sensitivity.md
@@ -1,0 +1,56 @@
+# Heritage Rights and Sensitivity Rules
+
+Scope: publication and review rules for copyright/reuse, quote safety, culturally sensitive material, and exact-location exposure in the heritage lane.
+
+## Rights and reuse controls
+
+| Control area | Heritage-lane rule |
+|---|---|
+| Copyright / reuse | Record rights posture before extraction or publication; unresolved rights fails closed. |
+| Redistribution limits | Respect item-level or collection-level restrictions; derivative publication may be narrower than access rights. |
+| Quote safety | Quotes require locator trace and policy-safe excerpt behavior. |
+| Excerpt policy | Prefer minimal excerpts tied to source context over decontextualized copy blocks. |
+| Derivative summaries | Must stay linked to inspectable evidence and marked as derived. |
+
+## Sensitivity controls
+
+| Sensitivity class | Typical handling |
+|---|---|
+| Culturally sensitive material | Steward review required before publication; default to restricted or withheld if unresolved. |
+| Exact-location-sensitive sites | Generalize geography for public outputs; precise geometry stays steward-only or withheld. |
+| Living-person-linked records | Narrow place/time and personal detail by default; no direct public precision release. |
+| Burial / memorial precision | Treat plot/row exactness as restricted unless explicit policy basis permits release. |
+
+## Publication precision policy
+
+- `public_safe`: generalized, non-reidentifying representation only.
+- `generalized`: visible narrowing (place/time/detail) with explanation.
+- `steward_only`: precise or sensitive view restricted to authorized reviewers.
+- `restricted_precise`: exact detail retained internally under governance.
+- `withheld`: no publication; may expose only withholding rationale.
+
+## Steward review requirements
+
+Minimum steward review triggers:
+
+1. unresolved rights or derivative-use ambiguity
+2. culturally sensitive context uncertainty
+3. exact-location exposure risk
+4. living-person or descendant risk
+5. contested interpretation with policy impact
+
+## Public-safe vs steward-only outputs
+
+| Field type | Public-safe default | Steward-only allowance |
+|---|---|---|
+| Place | County/state/country or coarse bucket | Exact site/address/plot where policy allows |
+| Time | Year or bounded range | Exact dates/timestamps where policy allows |
+| Personal detail | Minimal context | Extended detail under controlled access |
+| Source excerpt | Short, contextualized, policy-safe excerpt | Broader excerpt where rights permit |
+
+## Unknowns and verification flags
+
+- **NEEDS VERIFICATION:** quote-length enforcement location in policy/tests.
+- **UNKNOWN:** complete steward authorization workflow implementation path.
+- **NEEDS VERIFICATION:** established rights vocabulary and enum set in machine contracts.
+

--- a/docs/domains/heritage/roadmap.md
+++ b/docs/domains/heritage/roadmap.md
@@ -1,0 +1,48 @@
+# Heritage Lane Roadmap and Verification Backlog
+
+Scope: prioritized follow-on artifacts and open verification tasks for making the heritage lane fully enforcement-ready.
+
+## Phase 1 survey summary (current-state audit)
+
+### Strong docs to preserve
+
+- `README.md` lane framing and evidence-first posture.
+- GEDCOM intake and downstream pipeline docs.
+- examples/fixtures lane-local companion docs.
+
+### Thin or redundant areas to repair
+
+- Source-role guidance was distributed but not consolidated into one lane reference.
+- Rights/sensitivity rules were present but not centralized for reviewer use.
+- Entity/evidence artifact mapping to trust objects needed explicit lane-level table.
+
+### Gaps now filled in this pass
+
+- Added dedicated docs for source roles, rights/sensitivity, entity/evidence model, and publication/review.
+- Added explicit open unknowns rather than implied implementation certainty.
+
+## Priority roadmap
+
+| Priority | Artifact | Status | Why it matters |
+|---|---|---|---|
+| P0 | Heritage source descriptor examples tied to lane roles | PROPOSED | Converts doctrine into reviewable, machine-adjacent examples. |
+| P0 | Rights/sensitivity decision templates for steward review | PROPOSED | Reduces inconsistent publication decisions. |
+| P1 | Heritage contract/fixture alignment pass with schemas/contracts | NEEDS VERIFICATION | Prevents doc-contract drift. |
+| P1 | Publication checklist runbook for dossier/story/focus/export | PROPOSED | Makes trust-critical visibility testable before release. |
+| P2 | Lane-specific CI checks for quote-safety and precision narrowing | UNKNOWN | Moves heritage policy from prose to enforcement. |
+| P2 | Canonical split decision: `archives-heritage` vs standalone `heritage` | NEEDS VERIFICATION | Clarifies long-term lane topology. |
+
+## Open unknowns
+
+- **UNKNOWN:** exact schema and policy bundles currently enforcing heritage rights/sensitivity gates.
+- **NEEDS VERIFICATION:** active workflow/CI checks for lane-specific publication constraints.
+- **NEEDS VERIFICATION:** maintainer and steward ownership map for this lane.
+- **UNKNOWN:** full registry of heritage source families with machine-usable descriptors.
+
+## Definition of done (for next pass)
+
+- Heritage source-role and rights rules reflected in fixtures/tests (not prose only).
+- At least one lane-specific publication review checklist runnable in CI or review tooling.
+- Contract/schema references for lane-critical artifacts are path-accurate and verified.
+- Unknowns reduced; remaining uncertainty explicitly tracked.
+

--- a/docs/domains/heritage/sources.md
+++ b/docs/domains/heritage/sources.md
@@ -1,0 +1,46 @@
+# Heritage Sources and Source-Role Discipline
+
+Scope: lane-specific source-role semantics and minimum evidence handling expectations for heritage materials.
+
+## Status posture
+
+- **CONFIRMED:** heritage lane must preserve documentary context, provenance, and source-role distinctions.
+- **INFERRED:** source-role tables below align with existing KFM domain and architecture docs.
+- **NEEDS VERIFICATION:** exact repo path(s) for machine-enforced source-role validation.
+
+## Source-role matrix
+
+| Source role | Allowed claims in heritage lane | Not allowed without escalation |
+|---|---|---|
+| Documentary / archival | “Source X records Y at locator Z.” | Flattening archival record into unsupported contemporary fact claims. |
+| Community-contributed | “Contributor report states Y, pending corroboration/review.” | Treating single contribution as authoritative heritage fact. |
+| Statutory / administrative | “Registry/designation contains Y under authority A.” | Conflating legal designation with full historical narrative certainty. |
+| Direct observational / field | “Steward field observation records condition/time/place under protocol P.” | Publishing precise sensitive locations without rights/sensitivity clearance. |
+| Modeled / derived | “Derived output summarizes source corpus under method M.” | Presenting OCR/extraction/summaries as if they were primary records. |
+| Mirror / discovery service | “Mirror index points to origin source at locator L.” | Using mirror content as final authority when origin records are available. |
+
+## Representative source families (current lane context)
+
+| Source family | Role tendency | Lane handling note |
+|---|---|---|
+| Kansas Historical Society / Kansas Memory | Documentary / archival | Preserve item-level context, rights fields, and citation locators. |
+| Chronicling America / newspaper corpora | Documentary / archival + mirror | Treat OCR as derived convenience; keep issue/date/page anchors. |
+| Oral history programs | Documentary / archival + community-contributed | Keep transcript/audio identity aligned and quote-safe. |
+| Heritage registers | Statutory / administrative | Keep designation scope separate from interpretation claims. |
+| Local archive mirrors | Mirror / discovery service | Use for discovery, then resolve to origin authority when possible. |
+
+## Intake checklist for source notes
+
+- Source role assigned.
+- Origin authority and mirror status recorded.
+- Quote-safe locator recorded (page/timecode/item-id/etc.).
+- Rights/reuse/quote constraints attached.
+- Sensitivity class assigned.
+- Claim extraction status marked as derived where applicable.
+
+## Open unknowns
+
+- **UNKNOWN:** complete machine-readable source-role enum currently enforced in this repo.
+- **NEEDS VERIFICATION:** source registry completeness for heritage families.
+- **NEEDS VERIFICATION:** test fixtures that prove mirror-vs-origin handling behavior.
+


### PR DESCRIPTION
### Motivation
- Make the heritage lane a compact, KFM-native, evidence-first documentation suite that treats documentary materials as governed evidence rather than a narrative bucket. 
- Preserve provenance, rights, quote-safety, review posture, and explicit uncertainty labels (`CONFIRMED` / `INFERRED` / `PROPOSED` / `UNKNOWN`), and align the lane with the repo's doctrine (`TRUTH_PATH_LIFECYCLE` / `TRUST_MEMBRANE`).

### Description
- Rewrote `docs/domains/heritage/README.md` into a doctrine-anchored lane index that defines scope, source-role taxonomy, rights/sensitivity summary, publication trust rules, contributor guidance, a directory map, and a verification backlog. 
- Added focused companion docs to centralize lane behavior: `docs/domains/heritage/sources.md`, `docs/domains/heritage/rights-and-sensitivity.md`, `docs/domains/heritage/entity-and-evidence-model.md`, `docs/domains/heritage/publication-and-review.md`, and `docs/domains/heritage/roadmap.md`. 
- Kept existing GEDCOM companion drafts and examples referenced (e.g., `gedcom-intake-mapping.md`, `gedcom-map-timeline-pipeline.md`, `examples/`, `fixtures/`) and explicitly marked implementation/verification status where the repo does not prove it (`NEEDS VERIFICATION`, `UNKNOWN`, etc.).
- Preserved KFM conventions for meta blocks, one `H1` per file, Mermaid diagrams in README-like flow charts, and clear guidance to avoid inventing implementation claims (all open/uncertain items are labeled). 

### Testing
- Ran the contract test `pytest -q tests/contracts/test_correction_notice_contract.py` which completed successfully with `3 passed`. 
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9817b5130832a8871fe743a04b55c)