### PR TITLE
Add minimal Makefile, scripts, and docs for evidence-based repo validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: bootstrap validate-schemas test dev-up sample-ingest catalog-validate
+
+bootstrap:
+	./scripts/bootstrap.sh
+
+validate-schemas:
+	python3 ./scripts/validate_schemas.py
+
+test:
+	python3 -m unittest discover -s tests/contracts -p 'test_*.py' -v
+
+dev-up:
+	./scripts/dev_up.sh
+
+sample-ingest:
+	./scripts/sample_ingest.sh ${SOURCE}
+
+catalog-validate:
+	python3 ./scripts/catalog_validate.py

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,19 @@
+# Backlog
+
+## High priority
+
+1. Decide authoritative API lane naming (`apps/api` vs `apps/governed-api`) and collapse duplicates.
+2. Add real package manifests for each implemented stack (Python/Node/etc.) once code lands.
+3. Replace placeholder README sections containing `NEEDS VERIFICATION` with commit-verified values.
+4. Expand tests beyond the single correction notice contract floor test.
+
+## Medium priority
+
+1. Add machine-checked schema validation (e.g., `jsonschema`) once dependency strategy is approved.
+2. Add CI workflow YAML that runs the standardized Makefile entrypoints.
+3. Add deterministic lint/doc checks for README cross-links.
+
+## Known unknowns
+
+- Intended runtime stack(s) for `apps/`, `packages/`, and `web/` are not yet implemented in this checkout.
+- Deployment targets and operational runtime shape remain documentation-level only.

--- a/docs/BUILD_PLAN.md
+++ b/docs/BUILD_PLAN.md
@@ -1,0 +1,20 @@
+# Build Plan
+
+Last verified: 2026-04-11 (UTC).
+
+## Goal
+Provide minimal, reversible, evidence-based build/test scaffolding for the current repository maturity.
+
+## Plan executed
+
+1. Inventory README intent and compare against executable reality.
+2. Add a single root `Makefile` to standardize developer entrypoints already referenced by docs.
+3. Add minimal scripts that are transparent and do not claim unverified runtime behavior.
+4. Validate with deterministic local commands.
+5. Document findings and remaining unknowns.
+
+## Why this plan is conservative
+
+- It avoids inventing services, deployments, or package ecosystems not present in the repo.
+- It preserves the documentation-first structure.
+- It keeps changes reversible (one Makefile + small scripts + docs updates).

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,14 +10,14 @@ updated: NEEDS VERIFICATION
 policy_label: NEEDS VERIFICATION
 related: [../README.md, ./governance/, ./runbooks/, ./standards/, ./templates/]
 tags: [kfm, docs, documentation, governance, runbooks, standards, templates]
-notes: [Current session directly verified a PDF-only workspace and a documentation-only evidence boundary; live docs subtree, owners, dates, labels, and exact README presence still require mounted-checkout inspection before commit.]
+notes: [Current session verified a mounted repository checkout. Directory shape is confirmed; many per-file metadata placeholders still require steward verification before merge.]
 [/KFM_META_BLOCK_V2] -->
 
 # docs
 
 Governed documentation index for Kansas Frontier Matrix (KFM): doctrine, architecture, governance, runbooks, templates, and adjacent documentation surfaces that keep the system inspectable.
 
-> **Status:** experimental — live checkout verification still pending  
+> **Status:** experimental — live checkout verified on 2026-04-11  
 > **Owners:** `NEEDS VERIFICATION` — confirm against `../.github/CODEOWNERS` before commit  
 > ![status](https://img.shields.io/badge/status-experimental-orange) ![surface](https://img.shields.io/badge/surface-docs--index-2f81f7) ![evidence](https://img.shields.io/badge/evidence-pdf--corpus+manual--verified-lightgrey) ![trust](https://img.shields.io/badge/posture-docs--as--production-blueviolet) ![checkout](https://img.shields.io/badge/live--checkout-NEEDS_VERIFICATION-lightgrey)  
 > **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Accepted inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Evidence boundary](#current-evidence-boundary) · [Baseline](#baseline-and-doctrinal-anchor) · [Directory tree](#source-reported-docs-footprint) · [Quickstart](#quickstart) · [Usage](#usage) · [Diagram](#diagram) · [Tables](#tables) · [Task list](#task-list--definition-of-done) · [FAQ](#faq) · [Appendix](#appendix)
@@ -34,7 +34,7 @@ Its job is to make doctrine, architecture, standards, review rules, templates, a
 ## Repo fit
 
 **Path target:** `docs/README.md`  
-**Path status:** `NEEDS VERIFICATION` in a mounted checkout
+**Path status:** present in mounted checkout (metadata fields still include placeholders)
 
 **Upstream neighbors:** [repo root](../README.md) · [`../contracts/`](../contracts/) · [`../policy/`](../policy/) · [`../data/`](../data/) · [`../apps/`](../apps/) · [`../packages/`](../packages/) · [`../.github/`](../.github/)
 
@@ -316,10 +316,10 @@ Because KFM doctrine treats trust-visible explanation, evidence access, correcti
 <details>
 <summary>Current-session limits that still matter before merge</summary>
 
-- The directly visible mounted workspace exposed PDFs only.
-- No live repo subtree, `.github/CODEOWNERS`, workflow YAML, schemas, tests, manifests, or runtime logs were directly inspected.
+- The mounted workspace included the repository checkout and was directly inspected.
+- Large portions of the repo tree were directly inspected, but many metadata placeholders and runtime maturity claims remain unverified.
 - This index is therefore **review-ready**, not falsely “fully verified.”
-- Any conflicting live-tree reality should outrank this draft once a mounted checkout is available.
+- Any conflicting branch-local reality should still outrank documentation assumptions.
 
 </details>
 
@@ -333,3 +333,12 @@ Because KFM doctrine treats trust-visible explanation, evidence access, correcti
 </details>
 
 [Back to top](#docs)
+
+## Repository operations addenda
+
+The following repo-level planning/verification docs are now tracked under `docs/`:
+
+- [`./REPO_MAP.md`](./REPO_MAP.md)
+- [`./BUILD_PLAN.md`](./BUILD_PLAN.md)
+- [`./VALIDATION_SUMMARY.md`](./VALIDATION_SUMMARY.md)
+- [`./BACKLOG.md`](./BACKLOG.md)

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -1,0 +1,34 @@
+# Repository Map (Evidence-Based)
+
+Last verified: 2026-04-11 (UTC).
+
+## README inventory snapshot
+
+- Total `README.md` files: **396**.
+- README-heavy directories (README is the only file in directory): **250**.
+- This is currently a **documentation-first scaffold** with a small amount of executable validation code.
+
+## Top-level map (actual files and directories)
+
+- Governance/docs: `.github/`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `LICENSE`.
+- Domain/structure lanes: `apps/`, `brand/`, `configs/`, `contracts/`, `data/`, `docs/`, `examples/`, `infra/`, `migrations/`, `packages/`, `pipelines/`, `policy/`, `schemas/`, `tests/`, `tools/`, `web/`.
+- Executable implementation currently confirmed:
+  - `tests/contracts/test_correction_notice_contract.py`
+  - `schemas/contracts/v1/correction/correction_notice.schema.json`
+  - fixture JSON under `schemas/tests/fixtures/contracts/v1/{valid,invalid}/`
+  - utility scripts under `scripts/` and `Makefile` (added in this change set)
+
+## Structural reality
+
+1. Most subtrees are contract/README placeholders, not full implementations.
+2. No package manager workspace manifest was found (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml` absent).
+3. Build and test entrypoints referenced by root docs now resolve through `Makefile` targets.
+
+## Current entrypoints
+
+- `make bootstrap`
+- `make validate-schemas`
+- `make test`
+- `make dev-up`
+- `make sample-ingest SOURCE=<name>`
+- `make catalog-validate`

--- a/docs/VALIDATION_SUMMARY.md
+++ b/docs/VALIDATION_SUMMARY.md
@@ -1,0 +1,24 @@
+# Validation Summary
+
+Validation date: 2026-04-11 (UTC).
+
+## Commands run
+
+- `make bootstrap`
+- `make validate-schemas`
+- `make test`
+- `make dev-up`
+- `make sample-ingest SOURCE=example_fixture`
+- `make catalog-validate`
+
+## Results
+
+- All commands above completed successfully in the current environment.
+- `make test` currently executes one unittest module at `tests/contracts/test_correction_notice_contract.py`.
+- JSON schema/fixture parsing and basic contract floor checks pass.
+
+## Evidence boundaries
+
+- This validation does **not** prove production runtime services exist.
+- This validation does **not** prove CI workflows are wired beyond documented scaffolding.
+- This validation does prove local command entrypoints are now present and runnable.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -549,3 +549,16 @@ Check these against the actual checkout before promoting this README from draft:
 </details>
 
 [Back to top](#scripts)
+
+## Current executable entrypoints (verified 2026-04-11)
+
+The root `Makefile` now standardizes local developer entrypoints that were already referenced by the root README:
+
+- `make bootstrap` → `./scripts/bootstrap.sh`
+- `make validate-schemas` → `python3 ./scripts/validate_schemas.py`
+- `make test` → `python3 -m unittest discover -s tests/contracts -p 'test_*.py' -v`
+- `make dev-up` → `./scripts/dev_up.sh`
+- `make sample-ingest SOURCE=<name>` → `./scripts/sample_ingest.sh <name>`
+- `make catalog-validate` → `python3 ./scripts/catalog_validate.py`
+
+These commands are intentionally conservative and evidence-first; they scaffold repeatable validation without claiming unverified runtime services.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 --version >/dev/null
+
+echo "bootstrap: python3 detected"
+echo "bootstrap: repo is docs-first; no package install step is currently defined"

--- a/scripts/catalog_validate.py
+++ b/scripts/catalog_validate.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+root = Path(__file__).resolve().parents[1]
+required = [
+    root / "data/catalog/README.md",
+    root / "data/catalog/stac/README.md",
+    root / "data/catalog/dcat/README.md",
+    root / "data/catalog/prov/README.md",
+]
+missing = [str(p.relative_to(root)) for p in required if not p.exists()]
+
+if missing:
+    print("catalog-validate: FAILED")
+    for item in missing:
+        print(f" - missing {item}")
+    sys.exit(1)
+
+print("catalog-validate: OK (catalog README scaffold present)")

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "dev-up: no long-running local services are currently defined in this repository"
+echo "dev-up: run 'make test' and 'make validate-schemas' for current validation entrypoints"

--- a/scripts/sample_ingest.sh
+++ b/scripts/sample_ingest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_NAME="${1:-example_fixture}"
+OUT_DIR="data/work/sample_ingest"
+mkdir -p "$OUT_DIR"
+
+cp schemas/tests/fixtures/contracts/v1/valid/correction_notice.supersession.valid.json "$OUT_DIR/${SOURCE_NAME}.json"
+cat > "$OUT_DIR/${SOURCE_NAME}.receipt.json" <<JSON
+{
+  "source": "$SOURCE_NAME",
+  "copied_from": "schemas/tests/fixtures/contracts/v1/valid/correction_notice.supersession.valid.json",
+  "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "note": "Sample ingest scaffold for local validation only."
+}
+JSON
+
+echo "sample-ingest: wrote $OUT_DIR/${SOURCE_NAME}.json"
+echo "sample-ingest: wrote $OUT_DIR/${SOURCE_NAME}.receipt.json"

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import json
+import sys
+
+root = Path(__file__).resolve().parents[1]
+json_files = sorted(root.rglob("*.json"))
+errors = []
+
+for path in json_files:
+    try:
+        json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        errors.append(f"{path.relative_to(root)}: invalid json ({exc})")
+
+schema_path = root / "schemas/contracts/v1/correction/correction_notice.schema.json"
+if schema_path.exists():
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        errors.append("schemas/contracts/v1/correction/correction_notice.schema.json: unexpected $schema")
+
+if errors:
+    print("validate-schemas: FAILED")
+    for err in errors:
+        print(f" - {err}")
+    sys.exit(1)
+
+print(f"validate-schemas: OK ({len(json_files)} json files parsed)")


### PR DESCRIPTION
### Motivation
- Close the gap between root README quickstart commands and actual runnable entrypoints by providing minimal, reversible scaffolding.
- Provide transparent, inspectable helpers for local validation without inventing unverified runtime services or package ecosystems.
- Produce an evidence-first repo map and backlog to record remaining unknowns and next steps.

### Description
- Add a root `Makefile` with standardized targets: `bootstrap`, `validate-schemas`, `test`, `dev-up`, `sample-ingest`, and `catalog-validate` that call transparent scripts or Python validators. 
- Add conservative scripts under `scripts/`: `bootstrap.sh`, `dev_up.sh`, `sample_ingest.sh`, `validate_schemas.py`, and `catalog_validate.py` which perform lightweight checks, JSON parsing, and sample ingest scaffolding. 
- Add planning and validation docs under `docs/`: `REPO_MAP.md`, `BUILD_PLAN.md`, `VALIDATION_SUMMARY.md`, and `BACKLOG.md`, and update `docs/README.md` and `scripts/README.md` to reference the new entrypoints. 
- Keep changes reversible and intentionally conservative (no new package installs, no claims about runtime services, explicit UNKNOWNs documented). 

### Testing
- Ran the standardized entrypoints: `make bootstrap`, `make validate-schemas`, `make test`, `make dev-up`, `make sample-ingest SOURCE=example_fixture`, and `make catalog-validate`, and each completed successfully. 
- Executed unit tests via `python3 -m unittest discover -s tests/contracts -p 'test_*.py' -v` which ran 3 tests (all passed). 
- `validate-schemas` parsed repository JSON files (parsed count reported during run) and reported `OK`; `catalog-validate` confirmed catalog README scaffold presence. 
- All automated checks in this change set succeeded in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9cf87a69c832a8b4fbee0b32eb826)