### PR TITLE
Add web/.codex markdown path audit and reconstruction report

### DIFF
--- a/web/.codex/markdown-path-audit.json
+++ b/web/.codex/markdown-path-audit.json
@@ -1,0 +1,146 @@
+[
+  {
+    "normalized_path": "web/README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L14 markdown link ./README.md",
+    "evidence_excerpt": "Current public `main` now exposes both [`web/README.md`](./README.md)..."
+  },
+  {
+    "normalized_path": "README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L9 markdown link ../README.md",
+    "evidence_excerpt": "root [`../README.md`](../README.md)"
+  },
+  {
+    "normalized_path": "apps/README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L9 markdown link ../apps/README.md",
+    "evidence_excerpt": "runtime family [`../apps/README.md`](../apps/README.md)"
+  },
+  {
+    "normalized_path": "apps/explorer-web/README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L9 markdown link ../apps/explorer-web/README.md",
+    "evidence_excerpt": "parallel shell boundary [`../apps/explorer-web/README.md`](../apps/explorer-web/README.md)"
+  },
+  {
+    "normalized_path": "apps/governed-api/README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L9 markdown link ../apps/governed-api/README.md",
+    "evidence_excerpt": "governed API [`../apps/governed-api/README.md`](../apps/governed-api/README.md)"
+  },
+  {
+    "normalized_path": "contracts/README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L9 markdown link ../contracts/README.md",
+    "evidence_excerpt": "shared law [`../contracts/README.md`](../contracts/README.md)"
+  },
+  {
+    "normalized_path": "policy/README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L9 markdown link ../policy/README.md",
+    "evidence_excerpt": "shared law ... [`../policy/README.md`](../policy/README.md)"
+  },
+  {
+    "normalized_path": "tests/README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L9 markdown link ../tests/README.md",
+    "evidence_excerpt": "shared law ... [`../tests/README.md`](../tests/README.md)"
+  },
+  {
+    "normalized_path": "data/README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L9 markdown link ../data/README.md",
+    "evidence_excerpt": "shared law ... [`../data/README.md`](../data/README.md)"
+  },
+  {
+    "normalized_path": ".github/README.md",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L9 markdown link ../.github/README.md",
+    "evidence_excerpt": "shared law ... [`../.github/README.md`](../.github/README.md)"
+  },
+  {
+    "normalized_path": ".github/CODEOWNERS",
+    "kind": "file",
+    "exists_now": true,
+    "confidence": "CONFIRMED",
+    "source_file": "web/README.md",
+    "source_locator": "L6 markdown link ../.github/CODEOWNERS",
+    "evidence_excerpt": "confirm against [`../.github/CODEOWNERS`](../.github/CODEOWNERS)"
+  },
+  {
+    "normalized_path": "web/package.json",
+    "kind": "file",
+    "exists_now": false,
+    "confidence": "UNKNOWN",
+    "source_file": "web/README.md",
+    "source_locator": "L149-L154 proposed directory tree",
+    "evidence_excerpt": "├── package.json # NEEDS VERIFICATION"
+  },
+  {
+    "normalized_path": "web/tsconfig.json",
+    "kind": "file",
+    "exists_now": false,
+    "confidence": "UNKNOWN",
+    "source_file": "web/README.md",
+    "source_locator": "L149-L154 proposed directory tree",
+    "evidence_excerpt": "├── tsconfig.json # NEEDS VERIFICATION"
+  },
+  {
+    "normalized_path": "web/.env.example",
+    "kind": "file",
+    "exists_now": false,
+    "confidence": "UNKNOWN",
+    "source_file": "web/README.md",
+    "source_locator": "L149-L155 proposed directory tree",
+    "evidence_excerpt": "├── .env.example # PROPOSED / NEEDS VERIFICATION"
+  },
+  {
+    "normalized_path": "web/public",
+    "kind": "directory",
+    "exists_now": false,
+    "confidence": "UNKNOWN",
+    "source_file": "web/README.md",
+    "source_locator": "L155-L157 proposed directory tree",
+    "evidence_excerpt": "├── public/ # PROPOSED"
+  },
+  {
+    "normalized_path": "web/src",
+    "kind": "directory",
+    "exists_now": false,
+    "confidence": "UNKNOWN",
+    "source_file": "web/README.md",
+    "source_locator": "L157-L186 proposed directory tree",
+    "evidence_excerpt": "└── src/ # PROPOSED"
+  }
+]

--- a/web/.codex/markdown-path-audit.md
+++ b/web/.codex/markdown-path-audit.md
@@ -1,0 +1,34 @@
+# Markdown Path Audit
+
+Source corpus scanned (within `web/`):
+- `README.md`
+
+## Method
+- Parsed strong-evidence markdown links and fenced directory trees from `web/README.md`.
+- Resolved relative paths against `web/README.md` and normalized to repo-root paths.
+- Marked proposed/needs-verification tree entries as `UNKNOWN` to stay conservative.
+
+## Audit entries
+
+| normalized_path | kind | exists_now | confidence | source_file | source_locator | evidence_excerpt |
+|---|---|---:|---|---|---|---|
+| web/README.md | file | true | CONFIRMED | web/README.md | L14 markdown link `./README.md` | Current public `main` now exposes both [`web/README.md`](./README.md) |
+| README.md | file | true | CONFIRMED | web/README.md | L9 markdown link `../README.md` | root [`../README.md`](../README.md) |
+| apps/README.md | file | true | CONFIRMED | web/README.md | L9 markdown link `../apps/README.md` | runtime family [`../apps/README.md`](../apps/README.md) |
+| apps/explorer-web/README.md | file | true | CONFIRMED | web/README.md | L9 markdown link `../apps/explorer-web/README.md` | parallel shell boundary [`../apps/explorer-web/README.md`](../apps/explorer-web/README.md) |
+| apps/governed-api/README.md | file | true | CONFIRMED | web/README.md | L9 markdown link `../apps/governed-api/README.md` | governed API [`../apps/governed-api/README.md`](../apps/governed-api/README.md) |
+| contracts/README.md | file | true | CONFIRMED | web/README.md | L9 markdown link `../contracts/README.md` | shared law [`../contracts/README.md`](../contracts/README.md) |
+| policy/README.md | file | true | CONFIRMED | web/README.md | L9 markdown link `../policy/README.md` | shared law [`../policy/README.md`](../policy/README.md) |
+| tests/README.md | file | true | CONFIRMED | web/README.md | L9 markdown link `../tests/README.md` | shared law [`../tests/README.md`](../tests/README.md) |
+| data/README.md | file | true | CONFIRMED | web/README.md | L9 markdown link `../data/README.md` | shared law [`../data/README.md`](../data/README.md) |
+| .github/README.md | file | true | CONFIRMED | web/README.md | L9 markdown link `../.github/README.md` | shared law [`../.github/README.md`](../.github/README.md) |
+| .github/CODEOWNERS | file | true | CONFIRMED | web/README.md | L6 markdown link `../.github/CODEOWNERS` | confirm against [`../.github/CODEOWNERS`](../.github/CODEOWNERS) |
+| web/package.json | file | false | UNKNOWN | web/README.md | L149-L154 proposed directory tree | `package.json # NEEDS VERIFICATION` |
+| web/tsconfig.json | file | false | UNKNOWN | web/README.md | L149-L154 proposed directory tree | `tsconfig.json # NEEDS VERIFICATION` |
+| web/.env.example | file | false | UNKNOWN | web/README.md | L149-L155 proposed directory tree | `.env.example # PROPOSED / NEEDS VERIFICATION` |
+| web/public | directory | false | UNKNOWN | web/README.md | L155-L157 proposed directory tree | `public/ # PROPOSED` |
+| web/src | directory | false | UNKNOWN | web/README.md | L157-L186 proposed directory tree | `src/ # PROPOSED` |
+
+## Creation decision
+- Missing `CONFIRMED` paths: none.
+- Therefore no repository paths were auto-created.

--- a/web/.codex/markdown-path-report.md
+++ b/web/.codex/markdown-path-report.md
@@ -1,0 +1,42 @@
+# Markdown Path Reconstruction Report
+
+## Scope and corpus
+- Working directory: `web/`
+- Markdown-like files scanned in reconstruction pass:
+  - `web/README.md`
+- Rescan after audit/create pass found:
+  - `web/README.md`
+  - `web/.codex/markdown-path-audit.md`
+
+## Created paths
+- None.
+
+## Already-existing confirmed paths
+- `web/README.md`
+- `README.md`
+- `apps/README.md`
+- `apps/explorer-web/README.md`
+- `apps/governed-api/README.md`
+- `contracts/README.md`
+- `policy/README.md`
+- `tests/README.md`
+- `data/README.md`
+- `.github/README.md`
+- `.github/CODEOWNERS`
+
+## Unresolved unknown paths (not auto-created)
+- `web/package.json`
+- `web/tsconfig.json`
+- `web/.env.example`
+- `web/public/`
+- `web/src/`
+
+Reason: all unknown entries came from a section explicitly labeled “Proposed working subtree” and “NEEDS VERIFICATION”, so they were treated as ambiguous and intentionally not created.
+
+## Confirmed paths still missing
+- None.
+
+## Verification summary
+- No missing `CONFIRMED` paths remained after the create pass.
+- No `UNKNOWN` paths were auto-created.
+- Final diff was checked for speculative creations; only `.codex` audit/report files were added.


### PR DESCRIPTION
### Motivation

- Record and freeze the explicit repo-relative path evidence found in `web/README.md` so downstream automation and reviewers have a machine-readable inventory.  
- Preserve a conservative decision record that avoids creating speculative or “PROPOSED / NEEDS VERIFICATION” files from the README’s suggested working tree.  

### Description

- Add `web/.codex/markdown-path-audit.json` containing the normalized-path inventory with fields `normalized_path`, `kind`, `exists_now`, `confidence`, `source_file`, `source_locator`, and `evidence_excerpt`.  
- Add `web/.codex/markdown-path-audit.md` as a human-readable summary of the scan method, findings, and confidence decisions.  
- Add `web/.codex/markdown-path-report.md` summarizing created paths (none), already-existing confirmed paths, unresolved unknown paths (left uncreated), and verification notes.  

### Testing

- Ran a markdown file discovery check with `cd web && find . \( -name '*.md' -o -name '*.mdx' -o -name 'README*' \) -type f | sort` to confirm the scanned corpus.  
- Validated the generated JSON with `python -m json.tool web/.codex/markdown-path-audit.json` which succeeded.  
- Rescanned and verified the presence of the added audit/report files and that no `CONFIRMED` paths remained missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da63eb234c832aac98ae730b7c1b7c)