### PR TITLE
Add missing README docs across uncovered directories

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,0 +1,13 @@
+# ci docs
+
+Documentation lane for CI governance, quality gates, and merge-readiness guidance.
+
+## Purpose
+
+Use this directory for human-readable CI policy notes, gate explanations, and workflow behavior documentation.
+
+## Recommended contents
+
+- Gate descriptions and pass/fail semantics
+- Evidence expectations for release and promotion checks
+- CI troubleshooting notes and runbook pointers

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -1,0 +1,11 @@
+# contracts docs
+
+Documentation bridge for contract-oriented materials under `docs/contracts/`.
+
+## Purpose
+
+This directory provides explanatory material for runtime verification and trust-federation behavior related to repository contracts.
+
+## Structure
+
+- [`runtime_verification/`](./runtime_verification/) — runtime verification and trust federation docs.

--- a/docs/contracts/runtime_verification/README.md
+++ b/docs/contracts/runtime_verification/README.md
@@ -1,0 +1,12 @@
+# runtime verification docs
+
+Runtime verification documentation for contract-governed behavior.
+
+## Files
+
+- [`tile_verification.md`](./tile_verification.md)
+- [`trust_federation.md`](./trust_federation.md)
+
+## Guidance
+
+Keep these documents synchronized with runtime gates, contract schema changes, and release evidence expectations.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,19 @@
+# specs
+
+Specification index for domain and system-specific contracts documented under `docs/specs/`.
+
+## Purpose
+
+This directory holds narrative specifications that complement machine-readable contracts and schemas elsewhere in the repository.
+
+## Structure
+
+- [`hydrology/`](./hydrology/) — hydrology-focused specs and connector contracts.
+
+## Authoring guidance
+
+When adding new specs:
+
+1. Link to the owning contract/schema where applicable.
+2. Mark assumptions and unresolved items explicitly.
+3. Avoid presenting draft guidance as enforced runtime behavior.

--- a/docs/specs/hydrology/README.md
+++ b/docs/specs/hydrology/README.md
@@ -1,0 +1,11 @@
+# hydrology specs
+
+Hydrology-specific specification documents.
+
+## Contents
+
+- [`environmental_connector_contract.md`](./environmental_connector_contract.md) — connector-level spec for environmental/hydrology data handling.
+
+## Usage
+
+Treat these docs as design and governance references. Enforced behavior must remain in the canonical contract/policy surfaces and associated tests.

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,0 +1,12 @@
+# tools docs
+
+Documentation index for tool-specific governance and usage notes.
+
+## Purpose
+
+This folder documents helper tools used for validation, attestation, and related trust checks.
+
+## Child lanes
+
+- [`validators/`](./validators/) — validator documentation and gate notes.
+- [`attest/`](./attest/) — attestation and verification gate documentation.

--- a/docs/tools/attest/README.md
+++ b/docs/tools/attest/README.md
@@ -1,0 +1,11 @@
+# attest docs
+
+Documentation for attestation-related checks and verification gates.
+
+## Current references
+
+- [`tile_verification_gate.md`](./tile_verification_gate.md) — tile verification and acceptance guidance.
+
+## Notes
+
+Attestation docs should pair with machine-checked proofs and reproducible evidence generated in the operational lanes.

--- a/docs/tools/validators/README.md
+++ b/docs/tools/validators/README.md
@@ -1,0 +1,11 @@
+# validators docs
+
+Documentation for validation gates and validator behavior.
+
+## Scope
+
+Use this directory to describe validator intent, expected inputs/outputs, and failure semantics.
+
+## Current references
+
+- [`../usfws-critical-habitat-gate.md`](../usfws-critical-habitat-gate.md) — critical habitat validation gate doc.

--- a/habitat/README.md
+++ b/habitat/README.md
@@ -1,0 +1,15 @@
+# habitat
+
+Habitat-focused documentation and control surfaces for Kansas Frontier Matrix.
+
+## Scope
+
+This directory contains habitat domain materials that require extra governance care (for example, critical habitat handling, fail-closed controls, and publication safety constraints).
+
+## Contents
+
+- [`critical_habitat/`](./critical_habitat/) — critical-habitat specific policies, matrices, and operational notes.
+
+## Notes
+
+Habitat artifacts should be treated as governed evidence surfaces. Avoid adding runtime implementation logic here; place enforceable code and schemas in their authoritative lanes and reference them from this directory.

--- a/habitat/critical_habitat/README.md
+++ b/habitat/critical_habitat/README.md
@@ -1,0 +1,16 @@
+# critical_habitat
+
+Critical-habitat governance lane for sensitive habitat handling.
+
+## Purpose
+
+Use this folder for critical-habitat documentation that defines fail-closed behavior, review expectations, and publication safeguards.
+
+## Current files
+
+- [`FAIL_MATRIX.md`](./FAIL_MATRIX.md) — fail-closed decision matrix for intake, validation, publication, and runtime use.
+
+## Guardrails
+
+- Prefer conservative defaults (`ABSTAIN`, `DENY`, or `ERROR`) when source authority, geometry safety, or rights posture are unclear.
+- Keep legal and governance language aligned with policy and contract sources rather than duplicating logic here.

--- a/tools/air_quality/README.md
+++ b/tools/air_quality/README.md
@@ -1,0 +1,11 @@
+# air_quality tools
+
+Tooling lane for air-quality specific checks and gates.
+
+## Contents
+
+- [`smoke_gate/`](./smoke_gate/) — smoke/air-quality gate materials and documentation.
+
+## Notes
+
+Use this lane for bounded, reviewable helper tooling related to air-quality domain controls.

--- a/tools/map/README.md
+++ b/tools/map/README.md
@@ -1,0 +1,11 @@
+# map tools
+
+Mapping helper tooling and metadata support lane.
+
+## Contents
+
+- [`meta/`](./meta/) — map metadata documentation and related helper assets.
+
+## Notes
+
+Keep this directory focused on reusable map-support helpers rather than application runtime code.

--- a/tools/probes/species_watchers/README.md
+++ b/tools/probes/species_watchers/README.md
@@ -1,0 +1,11 @@
+# species_watchers probes
+
+Probe documentation for species-related watcher checks.
+
+## Current files
+
+- [`usfws_critical_habitat_probe.md`](./usfws_critical_habitat_probe.md) — probe definition for USFWS critical habitat watcher behavior.
+
+## Purpose
+
+These docs describe watcher/probe semantics, expected emitted evidence, and fail-safe handling boundaries.


### PR DESCRIPTION
### Motivation

- Improve discoverability and governance by adding missing `README.md` files for several previously undocumented documentation, habitat, and tools subdirectories. 
- Make lane-level intent, scope, and navigation explicit for `docs/` specs and CI guidance, for the `habitat/critical_habitat` governance lane, and for selected `tools/` helper lanes. 

### Description

- Added README files under `docs/` for `ci`, `contracts`, `contracts/runtime_verification`, `specs`, and `specs/hydrology` to document purpose, structure, and authoring guidance. 
- Added README files under `docs/tools/` and its children (`attest`, `validators`) and README files for `tools/air_quality`, `tools/map`, and `tools/probes/species_watchers` to explain tool intent and child lanes. 
- Added `habitat/README.md` and `habitat/critical_habitat/README.md` to surface critical-habitat fail-closed guidance and links to the existing `FAIL_MATRIX.md`; a total of 13 new README files were added. 

### Testing

- Ran a repository scan using the included Python snippet (`python - <<'PY' ...`) that verified no non-hidden directories are missing a `README.md` (scan result: `count 0`). 
- Verified the new README files are present and contain the intended lane-level summaries and links by listing and reviewing each created file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16fdcfc70832aaf01d4160a0e5bed)