### PR TITLE
Add skeletal placeholders for missing markdown-referenced paths and schema stubs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Placeholder CODEOWNERS
+* @bartytime4life

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+# .github/PULL_REQUEST_TEMPLATE
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/contracts/objects/source-descriptor/README.md
+++ b/contracts/objects/source-descriptor/README.md
@@ -1,0 +1,7 @@
+# contracts/objects/source-descriptor
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/contracts/vocab/README.md
+++ b/contracts/vocab/README.md
@@ -1,0 +1,7 @@
+# contracts/vocab
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/data/catalog/dcat/README.md
+++ b/data/catalog/dcat/README.md
@@ -1,0 +1,7 @@
+# data/catalog/dcat
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/data/catalog/prov/README.md
+++ b/data/catalog/prov/README.md
@@ -1,0 +1,7 @@
+# data/catalog/prov
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/data/catalog/stac/README.md
+++ b/data/catalog/stac/README.md
@@ -1,0 +1,7 @@
+# data/catalog/stac
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/architecture/governed-ai/README.md
+++ b/docs/architecture/governed-ai/README.md
@@ -1,0 +1,7 @@
+# docs/architecture/governed-ai
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/agriculture/README.md
+++ b/docs/domains/agriculture/README.md
@@ -1,0 +1,7 @@
+# docs/domains/agriculture
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/archaeology/README.md
+++ b/docs/domains/archaeology/README.md
@@ -1,0 +1,7 @@
+# docs/domains/archaeology
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/atmosphere-air/README.md
+++ b/docs/domains/atmosphere-air/README.md
@@ -1,0 +1,7 @@
+# docs/domains/atmosphere-air
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/fauna/README.md
+++ b/docs/domains/fauna/README.md
@@ -1,0 +1,7 @@
+# docs/domains/fauna
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/flora/README.md
+++ b/docs/domains/flora/README.md
@@ -1,0 +1,7 @@
+# docs/domains/flora
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/geology-natural-resources/README.md
+++ b/docs/domains/geology-natural-resources/README.md
@@ -1,0 +1,7 @@
+# docs/domains/geology-natural-resources
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/habitat/README.md
+++ b/docs/domains/habitat/README.md
@@ -1,0 +1,7 @@
+# docs/domains/habitat
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/hazards/README.md
+++ b/docs/domains/hazards/README.md
@@ -1,0 +1,7 @@
+# docs/domains/hazards
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/hydrology/README.md
+++ b/docs/domains/hydrology/README.md
@@ -1,0 +1,7 @@
+# docs/domains/hydrology
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/people-genealogy-dna-land/README.md
+++ b/docs/domains/people-genealogy-dna-land/README.md
@@ -1,0 +1,7 @@
+# docs/domains/people-genealogy-dna-land
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/roads-rail-trade-routes/README.md
+++ b/docs/domains/roads-rail-trade-routes/README.md
@@ -1,0 +1,7 @@
+# docs/domains/roads-rail-trade-routes
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/settlements-infrastructure/README.md
+++ b/docs/domains/settlements-infrastructure/README.md
@@ -1,0 +1,7 @@
+# docs/domains/settlements-infrastructure
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/domains/soil/README.md
+++ b/docs/domains/soil/README.md
@@ -1,0 +1,7 @@
+# docs/domains/soil
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -1,0 +1,7 @@
+# docs/sources
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -1,0 +1,7 @@
+# docs/standards
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# examples
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,7 @@
+# migrations
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -1,0 +1,7 @@
+# packages/catalog
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -1,0 +1,7 @@
+# packages/domain
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/packages/evidence/README.md
+++ b/packages/evidence/README.md
@@ -1,0 +1,7 @@
+# packages/evidence
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/packages/genealogy_ingest/README.md
+++ b/packages/genealogy_ingest/README.md
@@ -1,0 +1,7 @@
+# packages/genealogy_ingest
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/packages/indexers/README.md
+++ b/packages/indexers/README.md
@@ -1,0 +1,7 @@
+# packages/indexers
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/packages/ingest/README.md
+++ b/packages/ingest/README.md
@@ -1,0 +1,7 @@
+# packages/ingest
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/packages/policy/README.md
+++ b/packages/policy/README.md
@@ -1,0 +1,7 @@
+# packages/policy
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/policy/bundles/runtime/README.md
+++ b/policy/bundles/runtime/README.md
@@ -1,0 +1,7 @@
+# policy/bundles/runtime
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/schemas/contracts/README.md
+++ b/schemas/contracts/README.md
@@ -1,0 +1,7 @@
+# schemas/contracts
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/schemas/contracts/v1/common/header_profile.schema.json
+++ b/schemas/contracts/v1/common/header_profile.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/schemas/contracts/v1/common/header_profile.schema.json",
+  "title": "header_profile.schema",
+  "description": "Skeletal schema placeholder generated from linked documentation.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/correction/correction_notice.schema.json
+++ b/schemas/contracts/v1/correction/correction_notice.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/schemas/contracts/v1/correction/correction_notice.schema.json",
+  "title": "correction_notice.schema",
+  "description": "Skeletal schema placeholder generated from linked documentation.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/data/dataset_version.schema.json
+++ b/schemas/contracts/v1/data/dataset_version.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/schemas/contracts/v1/data/dataset_version.schema.json",
+  "title": "dataset_version.schema",
+  "description": "Skeletal schema placeholder generated from linked documentation.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/evidence/evidence_bundle.schema.json
+++ b/schemas/contracts/v1/evidence/evidence_bundle.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/schemas/contracts/v1/evidence/evidence_bundle.schema.json",
+  "title": "evidence_bundle.schema",
+  "description": "Skeletal schema placeholder generated from linked documentation.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/policy/decision_envelope.schema.json
+++ b/schemas/contracts/v1/policy/decision_envelope.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/schemas/contracts/v1/policy/decision_envelope.schema.json",
+  "title": "decision_envelope.schema",
+  "description": "Skeletal schema placeholder generated from linked documentation.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/release/release_manifest.schema.json
+++ b/schemas/contracts/v1/release/release_manifest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/schemas/contracts/v1/release/release_manifest.schema.json",
+  "title": "release_manifest.schema",
+  "description": "Skeletal schema placeholder generated from linked documentation.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/runtime/README.md
+++ b/schemas/contracts/v1/runtime/README.md
@@ -1,0 +1,7 @@
+# schemas/contracts/v1/runtime
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/schemas/contracts/v1/runtime/runtime_response_envelope.schema.json
+++ b/schemas/contracts/v1/runtime/runtime_response_envelope.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/schemas/contracts/v1/runtime/runtime_response_envelope.schema.json",
+  "title": "runtime_response_envelope.schema",
+  "description": "Skeletal schema placeholder generated from linked documentation.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/source/source_descriptor.schema.json
+++ b/schemas/contracts/v1/source/source_descriptor.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/schemas/contracts/v1/source/source_descriptor.schema.json",
+  "title": "source_descriptor.schema",
+  "description": "Skeletal schema placeholder generated from linked documentation.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/contracts/vocab/README.md
+++ b/schemas/contracts/vocab/README.md
@@ -1,0 +1,7 @@
+# schemas/contracts/vocab
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/schemas/schemas/README.md
+++ b/schemas/schemas/README.md
@@ -1,0 +1,7 @@
+# schemas/schemas
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/schemas/standards/README.md
+++ b/schemas/standards/README.md
@@ -1,0 +1,7 @@
+# schemas/standards
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/schemas/tests/README.md
+++ b/schemas/tests/README.md
@@ -1,0 +1,7 @@
+# schemas/tests
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/schemas/workflows/README.md
+++ b/schemas/workflows/README.md
@@ -1,0 +1,7 @@
+# schemas/workflows
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,7 @@
+# scripts
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tests/catalog/README.md
+++ b/tests/catalog/README.md
@@ -1,0 +1,7 @@
+# tests/catalog
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tests/contracts/README.md
+++ b/tests/contracts/README.md
@@ -1,0 +1,7 @@
+# tests/contracts
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tests/contracts/fixtures/runtime/README.md
+++ b/tests/contracts/fixtures/runtime/README.md
@@ -1,0 +1,7 @@
+# tests/contracts/fixtures/runtime
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,7 @@
+# tests/e2e
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,7 @@
+# tests/fixtures
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tools/attest/README.md
+++ b/tools/attest/README.md
@@ -1,0 +1,7 @@
+# tools/attest
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tools/catalog/README.md
+++ b/tools/catalog/README.md
@@ -1,0 +1,7 @@
+# tools/catalog
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -1,0 +1,7 @@
+# tools/ci
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tools/diff/README.md
+++ b/tools/diff/README.md
@@ -1,0 +1,7 @@
+# tools/diff
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tools/ingest/genealogy/README.md
+++ b/tools/ingest/genealogy/README.md
@@ -1,0 +1,7 @@
+# tools/ingest/genealogy
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tools/probes/README.md
+++ b/tools/probes/README.md
@@ -1,0 +1,7 @@
+# tools/probes
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tools/validators/connector_gate/README.md
+++ b/tools/validators/connector_gate/README.md
@@ -1,0 +1,7 @@
+# tools/validators/connector_gate
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/tools/validators/promotion_gate/README.md
+++ b/tools/validators/promotion_gate/README.md
@@ -1,0 +1,7 @@
+# tools/validators/promotion_gate
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,7 @@
+# ui
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,7 @@
+# web
+
+Skeletal placeholder created to satisfy repository documentation links.
+
+## Status
+
+Draft placeholder; expand with scoped ownership, contracts, and usage guidance.


### PR DESCRIPTION
### Motivation
- Many repository Markdown files referenced internal paths that did not exist, producing broken cross-references and incomplete doc navigation. 
- Provide a minimal, reviewable surface so documentation links resolve and maintainers can incrementally populate real content. 

### Description
- Added skeletal README placeholders across `docs/`, `packages/`, `tools/`, `tests/`, `data/catalog/`, `policy/bundles/`, `contracts/`, and top-level UI/app folders to satisfy internal links. 
- Added repository metadata placeholders ` .github/CODEOWNERS` and `.github/PULL_REQUEST_TEMPLATE.md`. 
- Added minimal JSON Schema stubs under `schemas/contracts/v1/` (examples: `evidence_bundle.schema.json`, `runtime_response_envelope.schema.json`, `source_descriptor.schema.json`, and related files) to satisfy referenced schema links. 
- Ensured internal Markdown cross-references resolve by creating the referenced paths without changing existing prose. 

### Testing
- Ran an internal Markdown link-target verification script (`python` link-checker) which returned `No missing internal Markdown link targets.` and thus succeeded. 
- Performed a repository status check (`git status --short`) after changes to confirm the working tree state and presence of the new placeholder files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e932e33ffc832ab125bf8138c91bac)