### PR TITLE
Add ADR-0001 establishing canonical schema home and update ADR README

### DIFF
--- a/docs/adr/ADR-0001-schema-home.md
+++ b/docs/adr/ADR-0001-schema-home.md
@@ -1,0 +1,159 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/NEEDS-VERIFICATION
+title: ADR-0001: Canonical Schema Home for Machine Contracts
+type: standard
+version: v1
+status: draft
+owners: NEEDS-VERIFICATION
+created: 2026-04-23
+updated: 2026-04-23
+policy_label: NEEDS-VERIFICATION
+related: [../../README.md, ../README.md, ./README.md, ../../schemas/README.md, ../../contracts/README.md, ../../tests/README.md, ../../policy/README.md]
+tags: [kfm, adr, schema-home, contracts, governance]
+notes: [
+  Draft ADR created to resolve canonical schema authority conflict documented in root backlog.
+  Current repo contains both `schemas/contracts/v1/` JSON Schema files and `contracts/` narrative contract surfaces.
+  Owners, policy label, and acceptance state remain NEEDS VERIFICATION until steward review.
+]
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# ADR-0001: Canonical Schema Home for Machine Contracts
+
+Decide where machine-checkable contract truth lives, and how non-canonical mirrors/aliases are governed.
+
+| Field | Value |
+|---|---|
+| Status | proposed |
+| Date | 2026-04-23 |
+| Decision area | contracts / schemas / validation / release governance |
+| Related contradictions | Root backlog marks schema home as `CONFLICTED / NEEDS ADR` |
+| Related objects | DecisionEnvelope, EvidenceBundle, ReleaseManifest, source and policy schemas |
+| Owners | NEEDS VERIFICATION |
+
+## Context
+
+KFM currently exposes two nearby surfaces that can be interpreted as contract authority:
+
+1. `schemas/contracts/v1/` contains machine-readable JSON Schema artifacts across common, policy, evidence, runtime, release, source, correction, and data families.
+2. `contracts/` exists as a parallel contract lane used for API/object/vocabulary documentation and boundary explanation.
+
+Without a canonical-home decision, teams risk contract drift, ambiguous validator targets, mismatched fixture paths, and unclear upgrade/migration behavior.
+
+## Scope and non-goals
+
+### In scope
+
+- Canonical path for **machine-checkable** contracts.
+- Role separation between schema authority and narrative contract documentation.
+- Enforcement expectations for validators, tests, and CI.
+
+### Out of scope (for this ADR)
+
+- Rewriting existing contract/domain documentation content.
+- Defining schema versioning semantics beyond canonical home selection.
+- Deciding release cadence or branch-protection policy details.
+
+## Decision
+
+**Canonical machine-contract home is `schemas/contracts/v1/`.**
+
+`contracts/` remains a human-facing companion surface for:
+
+- explanatory narratives,
+- API shape guides,
+- object semantics,
+- vocabulary and implementation-facing orientation.
+
+Normative rules:
+
+1. Any machine-checkable contract that gates validation, policy, promotion, or release must be authored and versioned under `schemas/contracts/v1/` (or a future `vN` path approved by ADR).
+2. Files under `contracts/` must not silently become machine-truth substitutes for schema artifacts.
+3. If compatibility aliases are needed, alias mapping must be explicit and tested (no implicit duplication).
+4. Validators and tests must fail closed when contract path resolution is ambiguous.
+
+### Canonical split
+
+| Surface | Canonical for machine validation? | Primary role |
+|---|---:|---|
+| `schemas/contracts/v1/` | Yes | Versioned machine schemas used by validators, policy checks, CI gates, and release checks. |
+| `contracts/` | No | Human-facing contract narratives, API/object/vocab explanations, and implementation guidance. |
+
+## Alternatives considered
+
+- **Alternative A — Canonicalize `contracts/`:** rejected because this conflicts with existing JSON Schema concentration in `schemas/contracts/v1/` and would increase migration burden now.
+- **Alternative B — Dual authority (`schemas/` and `contracts/` both canonical):** rejected because it guarantees drift risk and weakens enforcement clarity.
+- **Alternative C — Do nothing:** rejected because the current state is explicitly flagged as conflicted and blocks reliable validation governance.
+
+## Evidence used
+
+| Evidence | Status | What it supports |
+|---|---|---|
+| Root README backlog item naming schema home conflict and ADR need | CONFIRMED | This decision is required before stronger implementation claims |
+| Presence of machine-readable schema files under `schemas/contracts/v1/` | CONFIRMED | Existing practical center of machine-contract gravity |
+| Presence of parallel `contracts/` tree with narrative sublanes | CONFIRMED | Need to distinguish narrative contract docs from machine authority |
+| Existing ADR README guidance that `ADR-0001-schema-home` is priority-high | CONFIRMED | This ADR is expected and should be first in sequence |
+
+## Consequences
+
+### Positive
+
+- Validator tooling gets a single authoritative root for schema resolution.
+- Fixture layout and CI checks can reference one canonical path.
+- Contract review discussions can cleanly separate normative machine schemas from explanatory documentation.
+- Promotion/release gates become easier to reason about and audit.
+
+### Costs and follow-up burden
+
+- Existing docs that imply dual authority must be updated.
+- Any scripts referencing `contracts/` as schema origin must migrate to `schemas/contracts/v1/`.
+- A compatibility/alias period may be required for downstream consumers.
+
+## Verification required
+
+Before upgrading this ADR from proposed to accepted:
+
+1. Confirm maintainers and stewards for schema and contracts surfaces.
+2. Inventory all validators/tests/scripts/workflows that resolve schema paths.
+3. Add or update checks that fail when machine schemas are introduced outside canonical homes.
+4. Add fixtures demonstrating valid/invalid contract path resolution.
+5. Confirm `contracts/README.md` and `schemas/README.md` wording aligns with this authority split.
+
+## Acceptance criteria (for ADR status upgrade)
+
+ADR-0001 may move from `proposed` to `accepted` only when all items below are true:
+
+- [ ] Owners/stewards for schema and contracts surfaces are confirmed.
+- [ ] Validator rule exists to reject machine-schema additions outside canonical homes.
+- [ ] CI executes that rule and fails closed.
+- [ ] Valid/invalid fixtures for canonical-path enforcement exist.
+- [ ] Root/contracts/schemas docs explicitly reference this ADR and authority split.
+- [ ] Any compatibility aliases are documented and covered by tests.
+
+## Migration / implementation plan (proposed)
+
+1. **Inventory:** enumerate schema-path consumers in `tools/`, `tests/`, and workflows.
+2. **Enforce:** add validator rule for canonical schema path policy.
+3. **Refactor:** update references to use `schemas/contracts/v1/`.
+4. **Document:** patch root/docs/contracts/schemas READMEs to reference this ADR.
+5. **Gate:** make canonical-path check part of CI.
+6. **Review:** upgrade ADR status after evidence links and reviewer sign-off.
+
+## Rollback or supersession path
+
+If this decision proves incorrect:
+
+- Create a superseding ADR (e.g., ADR-00xx) with explicit migration rationale.
+- Preserve this ADR; do not delete history.
+- Provide backward-compatible path aliases during transition.
+- Attach validation evidence showing no silent contract drift during rollback/supersession.
+
+## Open verification items
+
+- Final owners and review sign-off set.
+- Policy label confirmation for ADR publication scope.
+- Whether any hidden automation currently treats `contracts/` as normative schema authority.
+- Whether any external consumers require a temporary alias map or migration bridge.
+
+<p align="right"><a href="#top">Back to top ↑</a></p>

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -140,7 +140,7 @@ These materials should **not** be stored as ADRs.
 ```text
 docs/adr/
 ├── README.md                                # This file
-├── ADR-0001-schema-home.md                  # PROPOSED / priority high
+├── ADR-0001-schema-home.md                  # PRESENT in current branch / status: proposed
 ├── ADR-0002-source-ledger-authority.md      # PROPOSED / priority high
 ├── ADR-0003-evidencebundle-contract.md      # PROPOSED / priority high
 ├── ADR-0004-promotion-gate.md               # PROPOSED / priority high
@@ -153,7 +153,7 @@ docs/adr/
 ```
 
 > [!NOTE]
-> This tree is a **proposed first-wave ADR map**, not current repository proof. If the mounted checkout already uses another numbering or naming pattern, preserve existing anchors and record the migration or aliasing decision.
+> This tree is a first-wave ADR map. `ADR-0001-schema-home.md` is present in the current branch; other entries remain proposed placeholders unless separately added.
 
 <p align="right"><a href="#top">Back to top ↑</a></p>
 


### PR DESCRIPTION
### Motivation

- Resolve an identified repository conflict by designating a single canonical home for machine-checkable contracts to avoid drift and ambiguous validator targets.
- Separate machine-readable schema authority from human-facing contract narratives to clarify enforcement and CI gating responsibilities.
- Capture the decision, consequences, and a migration plan so downstream tooling and teams can align on schema ownership.

### Description

- Add `docs/adr/ADR-0001-schema-home.md`, a drafted ADR that declares `schemas/contracts/v1/` as the canonical machine-schema home and documents rules, alternatives, verification items, and migration steps.
- Include a repository metadata block and detailed rationale, acceptance criteria, and implementation plan in the new ADR document.
- Update `docs/adr/README.md` to reflect that `ADR-0001-schema-home.md` is present in the branch and adjust the ADR tree and explanatory note describing the ADR map state.

### Testing

- No automated tests were run as part of this documentation/ADR change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea88bbb0ac832a863ba022a6e9b692)