### PR TITLE
Add verification-baseline workflow and baseline verifier; update docs and ownership

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,8 +21,8 @@ Governed GitHub Actions orchestration surface for validation, runtime proof, rec
 
 > [!NOTE]
 > **Status:** `experimental` · **Document status:** `draft` · **Owners:** `@bartytime4life` · **Path:** `.github/workflows/README.md`  
-> **Current public inventory:** `README.md` + `.gitkeep`; checked-in workflow YAML remains **UNKNOWN / NEEDS VERIFICATION** until verified from the active branch.  
-> **Badges:** ![status](https://img.shields.io/badge/status-experimental-orange) ![doc](https://img.shields.io/badge/doc-draft-8250df) ![owner](https://img.shields.io/badge/owner-%40bartytime4life-0969da) ![lane](https://img.shields.io/badge/lane-.github%2Fworkflows-6f42c1) ![posture](https://img.shields.io/badge/posture-governed%20automation-0a7d5a) ![inventory](https://img.shields.io/badge/current%20inventory-README%20%2B%20.gitkeep-lightgrey)  
+> **Current public inventory:** `README.md` + `verification-baseline.yml` (+ optional `.gitkeep` placeholder); checked-in workflow YAML now includes a baseline verification gate.
+> **Badges:** ![status](https://img.shields.io/badge/status-experimental-orange) ![doc](https://img.shields.io/badge/doc-draft-8250df) ![owner](https://img.shields.io/badge/owner-%40bartytime4life-0969da) ![lane](https://img.shields.io/badge/lane-.github%2Fworkflows-6f42c1) ![posture](https://img.shields.io/badge/posture-governed%20automation-0a7d5a) ![inventory](https://img.shields.io/badge/current%20inventory-README%20%2B%20verification--baseline.yml-lightgrey)
 > **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Inputs](#inputs) · [Exclusions](#exclusions) · [Directory tree](#directory-tree) · [Quickstart](#quickstart) · [Usage](#usage) · [Diagram](#diagram) · [Workflow lanes](#workflow-lanes) · [Task list](#task-list--definition-of-done) · [FAQ](#faq) · [Appendix](#appendix)
 
 > [!IMPORTANT]
@@ -109,10 +109,11 @@ This directory exists to answer a small set of consequential questions:
 | Item | Current visible or drafted state | Posture |
 |---|---|---|
 | `README.md` | current public-main directory listing exposes this README | **CONFIRMED** |
-| `.gitkeep` | current public-main directory listing exposes a placeholder file | **CONFIRMED** |
+| `verification-baseline.yml` | checked-in baseline workflow that calls `tools/ci/verify_baseline.sh` to verify root README casing, CODEOWNERS presence, core documentation surfaces, and uploads a baseline inventory artifact | **CONFIRMED** |
+| `.gitkeep` | optional placeholder file where present | **NON-BLOCKING** |
 | `runtime-proof-soil-moisture.yml` | documented as a drafted thin-slice workflow with contract tests, runtime-proof tests, emitted `actual.response.json`, reviewer summary, and uploaded artifacts | **NEEDS VERIFICATION on active branch** |
 | `probes.yml` | documented as a receipts-first scheduled/manual probe workflow with validation, policy evaluation, and artifact upload | **NEEDS VERIFICATION on active branch** |
-| broader `*.yml` / `*.yaml` files | not proven from the current public-main directory listing | **UNKNOWN** |
+| broader `*.yml` / `*.yaml` files | one baseline workflow is proven; additional lanes remain unverified | **PARTIALLY VERIFIED** |
 | Actions sidebar workflow labels | useful public UI signal where visible | **NEEDS VERIFICATION** before treating as checked-in YAML |
 | historical deleted workflow names | useful reconstruction clues | **NEEDS VERIFICATION** before reuse |
 | required checks / rulesets / environments | not derivable from this README alone | **UNKNOWN** |

--- a/.github/workflows/verification-baseline.yml
+++ b/.github/workflows/verification-baseline.yml
@@ -1,0 +1,28 @@
+name: verification-baseline
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repo-baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run baseline verification script
+        run: ./tools/ci/verify_baseline.sh baseline-report.txt
+
+      - name: Upload baseline report
+        uses: actions/upload-artifact@v4
+        with:
+          name: baseline-report
+          path: baseline-report.txt

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ title: Kansas Frontier Matrix
 type: standard
 version: v1
 status: draft
-owners: TODO-owner
+owners: @bartytime4life
 created: NEEDS-VERIFICATION
 updated: 2026-04-23
 policy_label: NEEDS-VERIFICATION
 related: [NEEDS-VERIFICATION]
 tags: [kfm, readme, spatial-evidence, governance, map-first, time-aware]
-notes: [Root README revision prepared from the uploaded KFM README draft, attached KFM doctrine, and current-session workspace scan. Target repository was not mounted. Confirm doc_id, owners, created date, policy label, related links, path casing, repo topology, package manager, workflows, schemas, contracts, tests, source registries, release artifacts, and runtime behavior before merge.]
+notes: [Root README revision prepared from the uploaded KFM README draft, attached KFM doctrine, and current-session workspace scan. Repository is mounted in this session and basic path inventory is now verified; implementation behavior and platform state still require deeper verification. Confirm doc_id, owners, created date, policy label, related links, package manager, workflows, schemas, contracts, tests, source registries, release artifacts, and runtime behavior before merge.]
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
@@ -20,7 +20,7 @@ notes: [Root README revision prepared from the uploaded KFM README draft, attach
 A governed, evidence-first, map-first, time-aware spatial knowledge system for producing inspectable public claims from spatial evidence.
 
 > [!IMPORTANT]
-> **Status:** `experimental` · **Document status:** `draft` · **Owners:** `TODO-owner`  
+> **Status:** `experimental` · **Document status:** `draft` · **Owners:** `@bartytime4life`  
 > **Target path:** `README.md` / `readme.md` — `NEEDS VERIFICATION`  
 > **Evidence posture:** `CONFIRMED doctrine` · `PROPOSED implementation plan` · `UNKNOWN mounted repo implementation`  
 > **Operating posture:** artifactization and verification before broad live-source ingestion, UI expansion, model integration, or public release.
@@ -325,16 +325,16 @@ A KFM change is not done because it renders, summarizes, or passes a happy-path 
 
 | Item | Status | Next check |
 |---|---|---|
-| Root file casing: `README.md` vs `readme.md` | `NEEDS VERIFICATION` | Confirm repo convention before merge |
-| Owner / CODEOWNERS coverage | `UNKNOWN` | Inspect `.github/CODEOWNERS` |
-| Package manager and test runner | `UNKNOWN` | Inspect lockfiles and CI workflows |
+| Root file casing: `README.md` vs `readme.md` | `CONFIRMED` (`README.md` present, `readme.md` absent) | Keep root filename stable as `README.md` |
+| Owner / CODEOWNERS coverage | `CONFIRMED` (broad fallback owner declared in `.github/CODEOWNERS`) | Add narrower team ownership only after GitHub teams and rulesets are active |
+| Package manager and test runner | `CONFIRMED GAP` (no package/lock manifests detected; root test runner remains undefined) | Declare canonical stack + add project-level test command contract |
 | Schema home | `CONFLICTED / NEEDS ADR` | Decide `schemas/contracts/v1/` vs `contracts/` authority |
-| Existing governed API | `UNKNOWN` | Inspect `apps/`, `packages/`, and route contracts |
-| Existing MapLibre shell | `UNKNOWN` | Inspect web app and layer registry |
-| Existing Evidence Drawer / Focus Mode | `UNKNOWN` | Inspect UI contracts and runtime envelopes |
-| CI gates | `UNKNOWN` | Inspect `.github/workflows/` and local validation tools |
-| Source registry | `UNKNOWN` | Inspect `data/registry/` and source descriptor conventions |
-| Release artifacts | `UNKNOWN` | Inspect `release/`, `data/proofs/`, `data/receipts/`, and `data/published/` |
+| Existing governed API | `CONFIRMED DOC SURFACE` (`apps/governed-api/README.md` present) | Confirm implemented routes, handlers, and contract tests (if code exists) |
+| Existing MapLibre shell | `CONFIRMED DOC SURFACE` (`apps/web/README.md` and `ui/README.md` present) | Confirm runnable shell code and layer registry implementation (if code exists) |
+| Existing Evidence Drawer / Focus Mode | `CONFIRMED DOC CLAIMS` (documented across app/contract READMEs) | Confirm concrete runtime payloads, fixtures, and UI wiring |
+| CI gates | `PARTIALLY VERIFIED` (`.github/workflows/verification-baseline.yml` now enforces baseline path checks) | Add contract/policy/runtime-proof gates and required-check settings |
+| Source registry | `CONFIRMED DOC SURFACE` (`data/registry/README.md` present) | Confirm active source descriptors, rights fields, and validator coverage |
+| Release artifacts | `CONFIRMED DOC SURFACE` (`release/README.md`, `data/proofs/README.md`, `data/receipts/README.md`, `data/published/README.md` present) | Confirm real emitted manifests/receipts/proofs on active branch |
 | Public exposure posture | `NEEDS VERIFICATION` | Verify firewall, reverse proxy, VPN, auth, audit logging, secrets, and least-privilege boundaries before semi-public access |
 
 ---

--- a/tools/ci/verify_baseline.sh
+++ b/tools/ci/verify_baseline.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+report_path="${1:-baseline-report.txt}"
+
+test -f README.md
+test ! -f readme.md
+test -f .github/CODEOWNERS
+
+required_paths=(
+  ".github/workflows/README.md"
+  "apps/governed-api/README.md"
+  "apps/web/README.md"
+  "ui/README.md"
+  "data/registry/README.md"
+  "data/proofs/README.md"
+  "data/receipts/README.md"
+  "data/published/README.md"
+  "release/README.md"
+)
+
+for path in "${required_paths[@]}"; do
+  test -f "$path"
+done
+
+workflow_yml_count="$(
+  git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml' \
+    | wc -l \
+    | tr -d '[:space:]'
+)"
+
+{
+  echo "README.md: yes"
+  echo "readme.md: no"
+  echo "CODEOWNERS: yes"
+  echo "workflow_yml_count: ${workflow_yml_count}"
+} | tee "${report_path}"


### PR DESCRIPTION
### Motivation

- Introduce a minimal, fail-closed baseline verification gate to assert repository inventory and basic governance artifacts exist. 
- Make the repository-level ownership and verification posture explicit in root documentation. 
- Provide a lightweight, reviewer-facing artifact that can be uploaded for PRs and pushes to `main` to simplify initial repo health checks.

### Description

- Add a GitHub Actions workflow ` .github/workflows/verification-baseline.yml` that runs on `pull_request`, `push` to `main`, and `workflow_dispatch`, and uploads a `baseline-report` artifact. 
- Add a verifier script `tools/ci/verify_baseline.sh` that performs file-existence assertions for `README.md`, `.github/CODEOWNERS`, key README surfaces, and counts workflow YAML files while emitting `baseline-report.txt`. 
- Update `.github/workflows/README.md` to reflect the new `verification-baseline.yml` inventory entry and mark the baseline as confirmed in the documented inventory. 
- Update the repository `README.md` meta block to set `owners: @bartytime4life` and to mark several repo inventory items as confirmed where applicable.

### Testing

- No automated tests were executed as part of this rollout; the new workflow is configured to run `./tools/ci/verify_baseline.sh baseline-report.txt` on PRs and pushes to `main` and will fail the job if the verifier script assertions fail. 
- The verifier script emits `baseline-report.txt` and the workflow uploads it as the `baseline-report` artifact for reviewer inspection. 
- The script uses shell assertions (`test` checks) as the verification mechanism so CI will surface failures directly when the workflow runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8c2cd0f8832aae9a1ae34a4757d9)