### PR TITLE
Add verification-baseline workflow and baseline verifier scripts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,8 +21,8 @@ Governed GitHub Actions orchestration surface for validation, runtime proof, rec
 
 > [!NOTE]
 > **Status:** `experimental` · **Document status:** `draft` · **Owners:** `@bartytime4life` · **Path:** `.github/workflows/README.md`  
-> **Current public inventory:** `README.md` + `.gitkeep`; checked-in workflow YAML remains **UNKNOWN / NEEDS VERIFICATION** until verified from the active branch.  
-> **Badges:** ![status](https://img.shields.io/badge/status-experimental-orange) ![doc](https://img.shields.io/badge/doc-draft-8250df) ![owner](https://img.shields.io/badge/owner-%40bartytime4life-0969da) ![lane](https://img.shields.io/badge/lane-.github%2Fworkflows-6f42c1) ![posture](https://img.shields.io/badge/posture-governed%20automation-0a7d5a) ![inventory](https://img.shields.io/badge/current%20inventory-README%20%2B%20.gitkeep-lightgrey)  
+> **Current public inventory:** `README.md` + `verification-baseline.yml` (+ optional `.gitkeep` placeholder); checked-in workflow YAML now includes a baseline verification gate.
+> **Badges:** ![status](https://img.shields.io/badge/status-experimental-orange) ![doc](https://img.shields.io/badge/doc-draft-8250df) ![owner](https://img.shields.io/badge/owner-%40bartytime4life-0969da) ![lane](https://img.shields.io/badge/lane-.github%2Fworkflows-6f42c1) ![posture](https://img.shields.io/badge/posture-governed%20automation-0a7d5a) ![inventory](https://img.shields.io/badge/current%20inventory-README%20%2B%20verification--baseline.yml-lightgrey)
 > **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Inputs](#inputs) · [Exclusions](#exclusions) · [Directory tree](#directory-tree) · [Quickstart](#quickstart) · [Usage](#usage) · [Diagram](#diagram) · [Workflow lanes](#workflow-lanes) · [Task list](#task-list--definition-of-done) · [FAQ](#faq) · [Appendix](#appendix)
 
 > [!IMPORTANT]
@@ -109,10 +109,11 @@ This directory exists to answer a small set of consequential questions:
 | Item | Current visible or drafted state | Posture |
 |---|---|---|
 | `README.md` | current public-main directory listing exposes this README | **CONFIRMED** |
-| `.gitkeep` | current public-main directory listing exposes a placeholder file | **CONFIRMED** |
+| `verification-baseline.yml` | checked-in baseline workflow that runs `verify_baseline.sh`, shell syntax checks, verifier self-tests, and uploads a baseline inventory artifact | **CONFIRMED** |
+| `.gitkeep` | optional placeholder file where present | **NON-BLOCKING** |
 | `runtime-proof-soil-moisture.yml` | documented as a drafted thin-slice workflow with contract tests, runtime-proof tests, emitted `actual.response.json`, reviewer summary, and uploaded artifacts | **NEEDS VERIFICATION on active branch** |
 | `probes.yml` | documented as a receipts-first scheduled/manual probe workflow with validation, policy evaluation, and artifact upload | **NEEDS VERIFICATION on active branch** |
-| broader `*.yml` / `*.yaml` files | not proven from the current public-main directory listing | **UNKNOWN** |
+| broader `*.yml` / `*.yaml` files | one baseline workflow is proven; additional lanes remain unverified | **PARTIALLY VERIFIED** |
 | Actions sidebar workflow labels | useful public UI signal where visible | **NEEDS VERIFICATION** before treating as checked-in YAML |
 | historical deleted workflow names | useful reconstruction clues | **NEEDS VERIFICATION** before reuse |
 | required checks / rulesets / environments | not derivable from this README alone | **UNKNOWN** |

--- a/.github/workflows/verification-baseline.yml
+++ b/.github/workflows/verification-baseline.yml
@@ -1,0 +1,36 @@
+name: verification-baseline
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repo-baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate shell syntax
+        run: sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh
+
+      - name: Run verifier self-tests
+        run: sh ./tools/ci/test_verify_baseline.sh
+
+      - name: Run baseline verification script
+        run: sh ./tools/ci/verify_baseline.sh baseline-report.txt
+
+      - name: Upload baseline report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: baseline-report
+          path: baseline-report.txt
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ updated: 2026-04-23
 policy_label: NEEDS-VERIFICATION
 related: [NEEDS-VERIFICATION]
 tags: [kfm, readme, spatial-evidence, governance, map-first, time-aware]
-notes: [Root README revision prepared from the uploaded KFM README draft, attached KFM doctrine, and current-session workspace scan. Target repository was not mounted. Confirm doc_id, owners, created date, policy label, related links, path casing, repo topology, package manager, workflows, schemas, contracts, tests, source registries, release artifacts, and runtime behavior before merge.]
+notes: [Root README revision prepared from the uploaded KFM README draft, attached KFM doctrine, and current-session workspace scan. Repository is mounted in this session and basic path inventory is now verified; implementation behavior and platform state still require deeper verification. Confirm doc_id, owners, created date, policy label, related links, package manager, workflows, schemas, contracts, tests, source registries, release artifacts, and runtime behavior before merge.]
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
@@ -20,7 +20,7 @@ notes: [Root README revision prepared from the uploaded KFM README draft, attach
 A governed, evidence-first, map-first, time-aware spatial knowledge system for producing inspectable public claims from spatial evidence.
 
 > [!IMPORTANT]
-> **Status:** `experimental` · **Document status:** `draft` · **Owners:** `TODO-owner`  
+> **Status:** `experimental` · **Document status:** `draft` · **Owners:** `TODO-owner`
 > **Target path:** `README.md` / `readme.md` — `NEEDS VERIFICATION`  
 > **Evidence posture:** `CONFIRMED doctrine` · `PROPOSED implementation plan` · `UNKNOWN mounted repo implementation`  
 > **Operating posture:** artifactization and verification before broad live-source ingestion, UI expansion, model integration, or public release.
@@ -325,14 +325,14 @@ A KFM change is not done because it renders, summarizes, or passes a happy-path 
 
 | Item | Status | Next check |
 |---|---|---|
-| Root file casing: `README.md` vs `readme.md` | `NEEDS VERIFICATION` | Confirm repo convention before merge |
-| Owner / CODEOWNERS coverage | `UNKNOWN` | Inspect `.github/CODEOWNERS` |
-| Package manager and test runner | `UNKNOWN` | Inspect lockfiles and CI workflows |
+| Root file casing: `README.md` vs `readme.md` | `CONFIRMED` (`README.md` present, `readme.md` absent) | Keep root filename stable as `README.md` |
+| Owner / CODEOWNERS coverage | `NEEDS VERIFICATION` | Confirm steward ownership model and CODEOWNERS intent with maintainers |
+| Package manager and test runner | `UNKNOWN` | Confirm authoritative runtime/toolchain and executable verification commands |
 | Schema home | `CONFLICTED / NEEDS ADR` | Decide `schemas/contracts/v1/` vs `contracts/` authority |
 | Existing governed API | `UNKNOWN` | Inspect `apps/`, `packages/`, and route contracts |
 | Existing MapLibre shell | `UNKNOWN` | Inspect web app and layer registry |
 | Existing Evidence Drawer / Focus Mode | `UNKNOWN` | Inspect UI contracts and runtime envelopes |
-| CI gates | `UNKNOWN` | Inspect `.github/workflows/` and local validation tools |
+| CI gates | `PARTIALLY VERIFIED` (`.github/workflows/verification-baseline.yml` now enforces baseline path checks) | Add contract/policy/runtime-proof gates and required-check settings |
 | Source registry | `UNKNOWN` | Inspect `data/registry/` and source descriptor conventions |
 | Release artifacts | `UNKNOWN` | Inspect `release/`, `data/proofs/`, `data/receipts/`, and `data/published/` |
 | Public exposure posture | `NEEDS VERIFICATION` | Verify firewall, reverse proxy, VPN, auth, audit logging, secrets, and least-privilege boundaries before semi-public access |

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -47,6 +47,7 @@ Reusable CI-facing helpers for reviewer-readable summaries, annotations, and com
 > - `tools/ci/render_diff_summary.py`
 > - `tools/ci/render_bundle_diff_policy_summary.py`
 > - `tools/ci/render_promotion_review_handoff.py`
+> - `tools/ci/verify_baseline.sh` (baseline repository inventory verifier used by `.github/workflows/verification-baseline.yml`)
 >
 > Surfaced proof surfaces for the same thin slice include:
 >
@@ -246,7 +247,15 @@ sed -n '1,220p' tests/ci/test_render_bundle_diff_policy_summary.py 2>/dev/null |
 sed -n '1,220p' tests/ci/test_render_promotion_review_handoff.py 2>/dev/null || true
 
 # Reconfirm references before widening claims
-git grep -n "render_diff_summary\|render_bundle_diff_policy_summary\|render_promotion_review_handoff\|render_promotion_summary\|render_promotion_bundle_summary\|tests/ci" -- . || true
+git grep -n "render_diff_summary\|render_bundle_diff_policy_summary\|render_promotion_review_handoff\|render_promotion_summary\|render_promotion_bundle_summary\|verify_baseline\|tests/ci" -- . || true
+```
+
+For baseline repository inventory verification (used by `.github/workflows/verification-baseline.yml`):
+
+```bash
+sh ./tools/ci/verify_baseline.sh baseline-report.txt
+cat baseline-report.txt
+sh ./tools/ci/test_verify_baseline.sh
 ```
 
 When the checked-out branch uses `pytest` for this lane, the documented thin slice should remain runnable locally as well as in CI:

--- a/tools/ci/test_verify_baseline.sh
+++ b/tools/ci/test_verify_baseline.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+verifier="${script_dir}/verify_baseline.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+seed_repo() {
+  root="$1"
+  mkdir -p \
+    "${root}/.github/workflows" \
+    "${root}/apps/governed-api" \
+    "${root}/apps/web" \
+    "${root}/ui" \
+    "${root}/data/registry" \
+    "${root}/data/proofs" \
+    "${root}/data/receipts" \
+    "${root}/data/published" \
+    "${root}/release"
+
+  touch \
+    "${root}/README.md" \
+    "${root}/.github/CODEOWNERS" \
+    "${root}/.github/workflows/README.md" \
+    "${root}/apps/governed-api/README.md" \
+    "${root}/apps/web/README.md" \
+    "${root}/ui/README.md" \
+    "${root}/data/registry/README.md" \
+    "${root}/data/proofs/README.md" \
+    "${root}/data/receipts/README.md" \
+    "${root}/data/published/README.md" \
+    "${root}/release/README.md" \
+    "${root}/.github/workflows/verification-baseline.yml"
+
+  (
+    cd "${root}"
+    git init -q
+    git add .
+  )
+}
+
+# PASS case
+pass_root="${tmpdir}/pass"
+mkdir -p "${pass_root}"
+seed_repo "${pass_root}"
+"${verifier}" report.txt --root "${pass_root}"
+[ -f "${pass_root}/report.txt" ]
+grep -q "workflow_yml_count: 1" "${pass_root}/report.txt"
+
+# FAIL case: lowercase readme should fail verification
+fail_root="${tmpdir}/fail"
+mkdir -p "${fail_root}"
+seed_repo "${fail_root}"
+touch "${fail_root}/readme.md"
+if "${verifier}" --root "${fail_root}" >/dev/null 2>&1; then
+  echo "expected verifier to fail when readme.md is present"
+  exit 1
+fi
+
+# FAIL case: unknown option should fail with usage error
+if "${verifier}" --unknown >/dev/null 2>&1; then
+  echo "expected verifier to fail on unknown option"
+  exit 1
+fi
+
+# FAIL case: multiple positional args should fail
+if "${verifier}" report-a.txt report-b.txt --root "${pass_root}" >/dev/null 2>&1; then
+  echo "expected verifier to fail on multiple report paths"
+  exit 1
+fi
+
+echo "verify_baseline tests passed"

--- a/tools/ci/verify_baseline.sh
+++ b/tools/ci/verify_baseline.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -eu
+
+report_path="baseline-report.txt"
+repo_root="."
+report_path_set="0"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --root" >&2
+        exit 2
+      fi
+      repo_root="$2"
+      shift 2
+      ;;
+    --help|-h)
+      echo "usage: $0 [report_path] [--root <repo_root>]"
+      exit 0
+      ;;
+    --*)
+      echo "unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [ "${report_path_set}" = "1" ]; then
+        echo "unexpected extra argument: $1" >&2
+        exit 2
+      fi
+      report_path="$1"
+      report_path_set="1"
+      shift
+      ;;
+  esac
+done
+
+cd "${repo_root}"
+
+[ -f "README.md" ]
+[ ! -f "readme.md" ]
+[ -f ".github/CODEOWNERS" ]
+
+for path in \
+  ".github/workflows/README.md" \
+  "apps/governed-api/README.md" \
+  "apps/web/README.md" \
+  "ui/README.md" \
+  "data/registry/README.md" \
+  "data/proofs/README.md" \
+  "data/receipts/README.md" \
+  "data/published/README.md" \
+  "release/README.md"
+do
+  [ -f "$path" ]
+done
+
+workflow_yml_count="$(
+  git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml' \
+    | wc -l \
+    | tr -d '[:space:]'
+)"
+
+{
+  echo "README.md: yes"
+  echo "readme.md: no"
+  echo "CODEOWNERS: yes"
+  echo "workflow_yml_count: ${workflow_yml_count}"
+} | tee "${report_path}"


### PR DESCRIPTION
### Motivation

- Introduce a minimal, fail-closed baseline verification lane to make the repo's workflow inventory and basic layout reviewer-verifiable.
- Provide a small, testable verifier implementation so CI can assert repository-structure expectations before wider workflow automation is trusted.

### Description

- Add a GitHub Actions workflow `./.github/workflows/verification-baseline.yml` that runs on `pull_request`, `push` to `main`, and `workflow_dispatch` and which checks shell syntax, runs verifier self-tests, runs the baseline verifier, and uploads a `baseline-report` artifact.  
- Add `tools/ci/verify_baseline.sh`, a POSIX shell verifier that asserts presence/absence of key files and emits `baseline-report.txt`.  
- Add `tools/ci/test_verify_baseline.sh`, a shell test that seeds temporary repo layouts to exercise pass and fail conditions for the verifier.  
- Update documentation to reflect the new baseline workflow and the verifier helper: `README.md`, `.github/workflows/README.md`, and `tools/ci/README.md` were updated to list the new inventory item and usage examples.

### Testing

- Added automated shell tests in `tools/ci/test_verify_baseline.sh` which exercise a passing repo layout and several failing cases (lowercase `readme.md`, unknown option, multiple report args) and exit with code 0 on success.  
- The new workflow `verification-baseline` is configured to run `sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh`, execute `sh ./tools/ci/test_verify_baseline.sh`, run `sh ./tools/ci/verify_baseline.sh baseline-report.txt`, and upload `baseline-report.txt` as an artifact.  
- The test script was run locally and completed successfully (exit code 0); the workflow will run the same tests on `push`/`pull_request`/`workflow_dispatch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8c2cd0f8832aae9a1ae34a4757d9)