### PR TITLE
Add missing README placeholders for policy bundles, fixtures, and tests

### DIFF
--- a/policy/bundles/admission/README.md
+++ b/policy/bundles/admission/README.md
@@ -1,0 +1,3 @@
+# Admission
+
+This directory is reserved for policy/bundles/admission artifacts.

--- a/policy/bundles/correction/README.md
+++ b/policy/bundles/correction/README.md
@@ -1,0 +1,3 @@
+# Correction
+
+This directory is reserved for policy/bundles/correction artifacts.

--- a/policy/bundles/export/README.md
+++ b/policy/bundles/export/README.md
@@ -1,0 +1,3 @@
+# Export
+
+This directory is reserved for policy/bundles/export artifacts.

--- a/policy/bundles/release/README.md
+++ b/policy/bundles/release/README.md
@@ -1,0 +1,3 @@
+# Release
+
+This directory is reserved for policy/bundles/release artifacts.

--- a/policy/bundles/review/README.md
+++ b/policy/bundles/review/README.md
@@ -1,0 +1,3 @@
+# Review
+
+This directory is reserved for policy/bundles/review artifacts.

--- a/policy/bundles/rights/README.md
+++ b/policy/bundles/rights/README.md
@@ -1,0 +1,3 @@
+# Rights
+
+This directory is reserved for policy/bundles/rights artifacts.

--- a/policy/bundles/sensitivity/README.md
+++ b/policy/bundles/sensitivity/README.md
@@ -1,0 +1,3 @@
+# Sensitivity
+
+This directory is reserved for policy/bundles/sensitivity artifacts.

--- a/policy/fixtures/README.md
+++ b/policy/fixtures/README.md
@@ -1,0 +1,3 @@
+# Fixtures
+
+This directory is reserved for policy/fixtures artifacts.

--- a/policy/fixtures/allow/README.md
+++ b/policy/fixtures/allow/README.md
@@ -1,0 +1,3 @@
+# Allow
+
+This directory is reserved for policy/fixtures/allow artifacts.

--- a/policy/fixtures/deny/README.md
+++ b/policy/fixtures/deny/README.md
@@ -1,0 +1,3 @@
+# Deny
+
+This directory is reserved for policy/fixtures/deny artifacts.

--- a/policy/fixtures/generalize/README.md
+++ b/policy/fixtures/generalize/README.md
@@ -1,0 +1,3 @@
+# Generalize
+
+This directory is reserved for policy/fixtures/generalize artifacts.

--- a/policy/fixtures/needs-review/README.md
+++ b/policy/fixtures/needs-review/README.md
@@ -1,0 +1,3 @@
+# Needs Review
+
+This directory is reserved for policy/fixtures/needs-review artifacts.

--- a/policy/fixtures/restrict/README.md
+++ b/policy/fixtures/restrict/README.md
@@ -1,0 +1,3 @@
+# Restrict
+
+This directory is reserved for policy/fixtures/restrict artifacts.

--- a/policy/fixtures/runtime/README.md
+++ b/policy/fixtures/runtime/README.md
@@ -1,0 +1,3 @@
+# Runtime
+
+This directory is reserved for policy/fixtures/runtime artifacts.

--- a/policy/fixtures/supersede/README.md
+++ b/policy/fixtures/supersede/README.md
@@ -1,0 +1,3 @@
+# Supersede
+
+This directory is reserved for policy/fixtures/supersede artifacts.

--- a/policy/fixtures/withdraw/README.md
+++ b/policy/fixtures/withdraw/README.md
@@ -1,0 +1,3 @@
+# Withdraw
+
+This directory is reserved for policy/fixtures/withdraw artifacts.

--- a/policy/tests/decision-grammar/README.md
+++ b/policy/tests/decision-grammar/README.md
@@ -1,0 +1,3 @@
+# Decision Grammar
+
+This directory is reserved for policy/tests/decision-grammar artifacts.

--- a/policy/tests/deny-by-default/README.md
+++ b/policy/tests/deny-by-default/README.md
@@ -1,0 +1,3 @@
+# Deny By Default
+
+This directory is reserved for policy/tests/deny-by-default artifacts.

--- a/policy/tests/import-resolution/README.md
+++ b/policy/tests/import-resolution/README.md
@@ -1,0 +1,3 @@
+# Import Resolution
+
+This directory is reserved for policy/tests/import-resolution artifacts.

--- a/tests/policy/README.md
+++ b/tests/policy/README.md
@@ -1,0 +1,3 @@
+# Policy
+
+This directory is reserved for tests/policy artifacts.


### PR DESCRIPTION
### Motivation
- Several policy and test subdirectories contained only placeholder files and lacked a `README.md`, making the intended contents unclear.
- Add simple README placeholders to make the directory skeleton self-describing and easier for contributors to navigate.

### Description
- Added 20 `README.md` placeholder files under `policy/bundles/*`, `policy/fixtures/*`, `policy/tests/*`, and `tests/policy` to document intended artifacts.
- Each file contains a short header and a single-line explanation like `This directory is reserved for <path> artifacts.`
- These are documentation-only changes and do not alter runtime code or tests.

### Testing
- Ran a directory audit via a `python` script that searches for directories with `.gitkeep` but no `README.md` and confirmed the pattern no longer exists, with the script completing successfully.
- Inspected the created files with `nl -ba` to verify the README contents were written as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa78e26f4832aa8423f2c4085b986)