### PR TITLE
ci: remove duplicate shell syntax check in verification baseline workflow

### DIFF
--- a/.github/workflows/verification-baseline.yml
+++ b/.github/workflows/verification-baseline.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Validate shell syntax
         run: sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh
 
-      - name: Validate shell syntax
-        run: sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh
-
       - name: Run verifier self-tests
         run: sh ./tools/ci/test_verify_baseline.sh
 


### PR DESCRIPTION
### Motivation
- Remove a duplicated `Validate shell syntax` step from the verification baseline workflow to avoid redundant CI work and potential confusion.

### Description
- Deleted the duplicate `Validate shell syntax` block in `.github/workflows/verification-baseline.yml` so a single syntax check runs before the verifier self-tests.

### Testing
- Executed `sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh`, `sh ./tools/ci/test_verify_baseline.sh`, and `sh ./tools/ci/verify_baseline.sh /tmp/baseline-report.txt`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8152ce14832aacae16c6eb1f8a3e)