### PR TITLE
Add CI renderer utilities, validation scripts, and extend verification-baseline workflow

### DIFF
--- a/.github/workflows/verification-baseline.yml
+++ b/.github/workflows/verification-baseline.yml
@@ -19,13 +19,22 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate shell syntax
-        run: sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh
+        run: sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh ./scripts/bootstrap.sh ./scripts/dev_up.sh ./scripts/sample_ingest.sh
 
       - name: Run verifier self-tests
         run: sh ./tools/ci/test_verify_baseline.sh
 
       - name: Run baseline verification script
         run: sh ./tools/ci/verify_baseline.sh baseline-report.txt
+
+      - name: Run scripts thin-slice checks
+        run: |
+          ./scripts/bootstrap.sh
+          python3 ./scripts/validate_schemas.py
+          python3 ./scripts/catalog_validate.py
+
+      - name: Run CI renderer tests
+        run: python3 -m pytest -q tests/ci
 
       - name: Upload baseline report
         if: always()

--- a/docs/runbooks/repository-next-steps.md
+++ b/docs/runbooks/repository-next-steps.md
@@ -1,0 +1,80 @@
+# Repository Next Steps (2026-04-24)
+
+This runbook captures the most practical next actions after a repository scan on 2026-04-24.
+
+## Current snapshot
+
+- The repository is documentation-heavy: 200 files total, with 130 Markdown files and only a small set of executable artifacts (shell, Rego, JSON schemas).  
+- The currently executable CI baseline path is narrow but healthy: `.github/workflows/verification-baseline.yml` runs shell syntax checks, self-tests, and `tools/ci/verify_baseline.sh`.  
+- `tools/ci/test_verify_baseline.sh` passes locally and validates both pass/fail behavior for the baseline verifier.
+
+## Key gaps discovered
+
+1. **Documentation-to-repo drift is high.**
+   - Several READMEs describe scripts or helpers that are not present in the current tree.
+   - Example drift:
+     - `scripts/README.md` lists helper files that do not exist.
+     - `tools/ci/README.md` lists renderer helpers and tests that do not exist.
+2. **Placeholder density is very high.**
+   - A scan found ~1,875 `TODO`, `UNKNOWN`, and `NEEDS VERIFICATION` markers across core documentation lanes.
+3. **Machine-enforced governance is minimal today.**
+   - Current CI checks structural baseline only.
+   - Contract, schema, and policy gates are represented in docs but are not yet wired into runnable enforcement from this checkout.
+
+## Recommended next steps (priority order)
+
+### P0 — Stabilize truth of repository documentation
+
+1. Align README claims to currently mounted files (or create the referenced files).
+2. Start with top drift surfaces:
+   - `scripts/README.md`
+   - `tools/ci/README.md`
+3. Introduce one explicit status marker in each README section:
+   - `Present in repo`
+   - `Planned`
+   - `Archived`
+
+**Definition of done:** no README claims file paths that do not exist without explicitly marking them as planned.
+
+### P1 — Expand thin-slice CI beyond baseline
+
+1. Add a lightweight docs consistency check script (for example, verify referenced local file paths exist).
+2. Add JSON schema validation smoke tests using existing `schemas/contracts/v1/*.schema.json` files and fixture payloads.
+3. Add policy smoke checks for `policy/bundles/runtime/*.rego` using existing fixtures.
+
+**Definition of done:** CI fails on broken local doc links/path claims, invalid schema fixtures, and broken runtime policy tests.
+
+### P2 — Build one end-to-end governed proof slice
+
+1. Select one claim type (recommended: runtime finite outcomes).
+2. Produce a minimal fixture-to-decision path:
+   - fixture input
+   - policy decision
+   - envelope validation
+   - receipt/proof artifact
+3. Document this in `docs/runbooks/` as the canonical “first governed release slice.”
+
+**Definition of done:** a single command path can reproduce a governed decision artifact from fixture input with deterministic output.
+
+### P3 — Reduce placeholder debt deliberately
+
+1. Triage top 20 files by unresolved marker count.
+2. For each file, choose one action:
+   - resolve now,
+   - downgrade claim scope,
+   - split into `planned` appendix.
+3. Track marker burn-down weekly.
+
+**Definition of done:** 30% reduction in unresolved markers in the top 20 files without introducing unverified implementation claims.
+
+## Suggested first sprint backlog (1 week)
+
+- Fix drift in `scripts/README.md` and `tools/ci/README.md`.
+- Add `tools/ci/check_readme_paths.sh`.
+- Add workflow job to run:
+  - baseline verifier
+  - README path check
+  - schema smoke check
+  - runtime policy smoke check
+- Add one concise runbook for “baseline + smoke CI failure triage”.
+

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+if command -v python3 >/dev/null 2>&1; then
+  pyv="$(python3 --version 2>&1)"
+  echo "python3: ${pyv}"
+  echo "bootstrap: docs-first workspace; no dependency installer is defined in this repo yet"
+  exit 0
+fi
+
+echo "python3 is required but was not found on PATH" >&2
+exit 1

--- a/scripts/catalog_validate.py
+++ b/scripts/catalog_validate.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+REQUIRED = [
+    Path("data/catalog/README.md"),
+    Path("data/catalog/stac/README.md"),
+    Path("data/catalog/dcat/README.md"),
+    Path("data/catalog/prov/README.md"),
+]
+
+missing = [str(p) for p in REQUIRED if not p.exists()]
+
+if missing:
+    print("catalog_validate: missing required scaffold paths:", file=sys.stderr)
+    for path in missing:
+        print(f"- {path}", file=sys.stderr)
+    sys.exit(1)
+
+print("catalog_validate: required catalog README scaffold is present")

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+echo "dev_up: no long-running local services are currently defined in this repository"
+echo "dev_up: use lane-specific scripts/workflows as they are introduced"

--- a/scripts/sample_ingest.sh
+++ b/scripts/sample_ingest.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <source_name>" >&2
+  exit 2
+fi
+
+source_name="$1"
+out_dir="data/work/sample_ingest"
+receipt_dir="data/receipts"
+
+mkdir -p "$out_dir" "$receipt_dir"
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+run_id="sample-${source_name}-$(date -u +%Y%m%dT%H%M%SZ)"
+out_file="${out_dir}/${run_id}.json"
+receipt_file="${receipt_dir}/${run_id}.json"
+
+cat > "$out_file" <<JSON
+{
+  "run_id": "${run_id}",
+  "source_name": "${source_name}",
+  "ingested_at": "${ts}",
+  "status": "work"
+}
+JSON
+
+cat > "$receipt_file" <<JSON
+{
+  "run_id": "${run_id}",
+  "artifact": "${out_file}",
+  "recorded_at": "${ts}",
+  "type": "sample_ingest_receipt"
+}
+JSON
+
+echo "wrote ${out_file}"
+echo "wrote ${receipt_file}"

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCHEMAS = [
+    Path("schemas/contracts/v1/correction/correction_notice.schema.json"),
+    Path("schemas/contracts/v1/release/release_manifest.schema.json"),
+    Path("schemas/contracts/v1/source/source_descriptor.schema.json"),
+    Path("schemas/contracts/v1/data/dataset_version.schema.json"),
+    Path("schemas/contracts/v1/policy/decision_envelope.schema.json"),
+    Path("schemas/contracts/v1/common/header_profile.schema.json"),
+    Path("schemas/contracts/v1/runtime/runtime_response_envelope.schema.json"),
+    Path("schemas/contracts/v1/evidence/evidence_bundle.schema.json"),
+]
+
+failures: list[str] = []
+
+for schema_path in SCHEMAS:
+    if not schema_path.exists():
+        failures.append(f"missing schema: {schema_path}")
+        continue
+
+    try:
+        payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        failures.append(f"invalid JSON: {schema_path} ({exc})")
+        continue
+
+    schema = payload.get("$schema")
+    if not isinstance(schema, str) or "json-schema.org" not in schema:
+        failures.append(f"invalid or missing $schema in {schema_path}")
+
+if failures:
+    print("validate_schemas: failed", file=sys.stderr)
+    for failure in failures:
+        print(f"- {failure}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"validate_schemas: validated {len(SCHEMAS)} schema files")

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -1,0 +1,15 @@
+# tests/ci
+
+CI-focused tests for helper renderers in `tools/ci/`.
+
+## Current thin slice
+
+- `test_render_diff_summary.py`
+- `test_render_bundle_diff_policy_summary.py`
+- `test_render_promotion_review_handoff.py`
+
+Run with:
+
+```bash
+python3 -m pytest -q tests/ci
+```

--- a/tests/ci/test_render_bundle_diff_policy_summary.py
+++ b/tests/ci/test_render_bundle_diff_policy_summary.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_render_bundle_diff_policy_summary() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "diff-policy.json"
+        out = root / "summary.md"
+        src.write_text(
+            json.dumps({"decision": "allow", "reasons": ["no breaking drift"]}),
+            encoding="utf-8",
+        )
+
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_bundle_diff_policy_summary.py",
+                "--input",
+                str(src),
+                "--output",
+                str(out),
+            ],
+            check=True,
+        )
+
+        rendered = out.read_text(encoding="utf-8")
+        assert "Decision: **allow**" in rendered
+        assert "no breaking drift" in rendered

--- a/tests/ci/test_render_diff_summary.py
+++ b/tests/ci/test_render_diff_summary.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_render_diff_summary() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "diff.json"
+        out = root / "summary.md"
+        src.write_text(json.dumps({"added": 2, "changed": 3, "removed": 1}), encoding="utf-8")
+
+        subprocess.run(
+            ["python3", "tools/ci/render_diff_summary.py", "--input", str(src), "--output", str(out)],
+            check=True,
+        )
+
+        rendered = out.read_text(encoding="utf-8")
+        assert "Added: **2**" in rendered
+        assert "Changed: **3**" in rendered
+        assert "Removed: **1**" in rendered

--- a/tests/ci/test_render_promotion_review_handoff.py
+++ b/tests/ci/test_render_promotion_review_handoff.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_render_promotion_review_handoff() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        promotion = root / "promotion.json"
+        bundle = root / "bundle.json"
+        diff = root / "diff.json"
+        diff_policy = root / "diff-policy.json"
+        out = root / "handoff.md"
+
+        promotion.write_text(json.dumps({"release_id": "r1", "state": "approved"}), encoding="utf-8")
+        bundle.write_text(json.dumps({"bundle_id": "b1", "artifacts": ["a", "b"]}), encoding="utf-8")
+        diff.write_text(json.dumps({"added": 1, "changed": 0, "removed": 0}), encoding="utf-8")
+        diff_policy.write_text(json.dumps({"decision": "allow"}), encoding="utf-8")
+
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_promotion_review_handoff.py",
+                "--promotion",
+                str(promotion),
+                "--bundle",
+                str(bundle),
+                "--diff",
+                str(diff),
+                "--diff-policy",
+                str(diff_policy),
+                "--output",
+                str(out),
+            ],
+            check=True,
+        )
+
+        rendered = out.read_text(encoding="utf-8")
+        assert "Release: **r1**" in rendered
+        assert "Diff policy decision: **allow**" in rendered

--- a/tools/ci/render_bundle_diff_policy_summary.py
+++ b/tools/ci/render_bundle_diff_policy_summary.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render markdown summary for bundle diff-policy report.")
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    decision = payload.get("decision", "unknown")
+    reasons = payload.get("reasons", [])
+
+    lines = ["# Bundle Diff Policy Summary", "", f"- Decision: **{decision}**"]
+    if reasons:
+        lines.append("- Reasons:")
+        lines.extend([f"  - {reason}" for reason in reasons])
+
+    md = "\n".join(lines)
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_diff_summary.py
+++ b/tools/ci/render_diff_summary.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render a markdown summary for a diff report.")
+    parser.add_argument("--input", required=True, help="Path to JSON diff report")
+    parser.add_argument("--output", help="Optional output markdown path")
+    args = parser.parse_args()
+
+    payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    added = payload.get("added", 0)
+    changed = payload.get("changed", 0)
+    removed = payload.get("removed", 0)
+
+    md = "\n".join(
+        [
+            "# Diff Summary",
+            "",
+            f"- Added: **{added}**",
+            f"- Changed: **{changed}**",
+            f"- Removed: **{removed}**",
+        ]
+    )
+
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_promotion_bundle_summary.py
+++ b/tools/ci/render_promotion_bundle_summary.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render markdown summary for promotion bundle.")
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    bundle_id = payload.get("bundle_id", "unknown")
+    artifacts = payload.get("artifacts", [])
+
+    md = "\n".join([
+        "# Promotion Bundle Summary",
+        "",
+        f"- Bundle: **{bundle_id}**",
+        f"- Artifacts: **{len(artifacts)}**",
+    ])
+
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_promotion_review_handoff.py
+++ b/tools/ci/render_promotion_review_handoff.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compose promotion review handoff markdown.")
+    parser.add_argument("--promotion", required=True)
+    parser.add_argument("--bundle", required=True)
+    parser.add_argument("--diff", required=True)
+    parser.add_argument("--diff-policy", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    promotion = json.loads(Path(args.promotion).read_text(encoding="utf-8"))
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    diff = json.loads(Path(args.diff).read_text(encoding="utf-8"))
+    diff_policy = json.loads(Path(args.diff_policy).read_text(encoding="utf-8"))
+
+    md = "\n".join([
+        "# Promotion Review Handoff",
+        "",
+        f"- Release: **{promotion.get('release_id', 'n/a')}**",
+        f"- Promotion state: **{promotion.get('state', 'unknown')}**",
+        f"- Bundle id: **{bundle.get('bundle_id', 'unknown')}**",
+        f"- Diff totals: added={diff.get('added', 0)}, changed={diff.get('changed', 0)}, removed={diff.get('removed', 0)}",
+        f"- Diff policy decision: **{diff_policy.get('decision', 'unknown')}**",
+    ])
+
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_promotion_summary.py
+++ b/tools/ci/render_promotion_summary.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render markdown summary for promotion decision.")
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    state = payload.get("state", "unknown")
+    release_id = payload.get("release_id", "n/a")
+
+    md = "\n".join([
+        "# Promotion Summary",
+        "",
+        f"- Release: **{release_id}**",
+        f"- State: **{state}**",
+    ])
+
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Expand the repository's baseline CI to exercise a small runnable thin-slice of scripts, schema checks, and renderer helpers beyond static shell syntax checks.  
- Provide minimal, docs-first scaffolding for common developer entrypoints (`bootstrap`, `dev_up`, `sample_ingest`) so CI can validate their presence and behavior.  
- Introduce simple markdown renderer utilities for CI reporting and accompanying unit tests to ensure renderers produce expected output.  
- Capture practical next steps and triage guidance in a runbook to reduce documentation drift and guide follow-ups.

### Description

- Updated `.github/workflows/verification-baseline.yml` to include syntax checks for the new scripts, run catalog/schema validation scripts, and execute `pytest` on `tests/ci`.  
- Added lightweight scripts: `scripts/bootstrap.sh`, `scripts/dev_up.sh`, and `scripts/sample_ingest.sh` to provide minimal local entrypoints and predictable behavior.  
- Added validation utilities `scripts/validate_schemas.py` and `scripts/catalog_validate.py` that verify presence and basic correctness of JSON schemas and catalog README scaffolds.  
- Added CI renderer tools under `tools/ci/` (`render_diff_summary.py`, `render_bundle_diff_policy_summary.py`, `render_promotion_bundle_summary.py`, `render_promotion_summary.py`, `render_promotion_review_handoff.py`) and matching unit tests under `tests/ci/`, plus a `tests/ci/README.md` and a repository runbook `docs/runbooks/repository-next-steps.md`.

### Testing

- Ran shell syntax validation via `sh -n` on the baseline verifier and the new scripts, which completed successfully.  
- Executed the baseline verifier and self-tests with `sh ./tools/ci/test_verify_baseline.sh` and `sh ./tools/ci/verify_baseline.sh baseline-report.txt`, which completed successfully.  
- Ran the thin-slice script checks `./scripts/bootstrap.sh`, `python3 ./scripts/validate_schemas.py`, and `python3 ./scripts/catalog_validate.py`, which completed successfully.  
- Ran unit tests with `python3 -m pytest -q tests/ci`, confirming the new renderer tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8480dd18832aa23c8d4bc69437ab)