### PR TITLE
Add renderer tools, schemas, fixtures and CI baseline checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -125,6 +125,25 @@ This directory exists to answer a small set of consequential questions:
 
 ---
 
+
+## Required check baseline (current)
+
+The repository’s currently actionable required-check baseline is:
+
+- `verification-baseline / repo-baseline`
+
+This job now validates:
+
+1. shell syntax for thin-slice scripts,
+2. baseline verifier self-tests,
+3. README path checker self-tests and path checks,
+4. baseline inventory verification,
+5. schema/catalog thin-slice scripts,
+6. renderer fixture contract validation,
+7. renderer test suite in `tests/ci`.
+
+When branch protection is configured, use this job as the minimum required status while adding stronger gates incrementally.
+
 ## Inputs
 
 Accepted inputs for this directory include:
@@ -211,9 +230,12 @@ The following do **not** belong here as canonical truth:
 ```text
 .github/
 └── workflows/
-    ├── .gitkeep     # CONFIRMED: placeholder visible in current public-main directory listing
-    └── README.md    # CONFIRMED: this directory README
+    ├── README.md
+    └── verification-baseline.yml
 ```
+
+> [!NOTE]
+> `verification-baseline.yml` is the currently verified workflow lane in this checkout. Other drafted workflow names remain planning signals until they exist in the mounted branch.
 
 ### Drafted thin-slice intent
 

--- a/.github/workflows/verification-baseline.yml
+++ b/.github/workflows/verification-baseline.yml
@@ -19,13 +19,29 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate shell syntax
-        run: sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh
+        run: sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh ./tools/ci/check_readme_paths.sh ./tools/ci/test_check_readme_paths.sh ./scripts/bootstrap.sh ./scripts/dev_up.sh ./scripts/sample_ingest.sh
 
       - name: Run verifier self-tests
         run: sh ./tools/ci/test_verify_baseline.sh
 
+      - name: Run README-path checker self-tests
+        run: sh ./tools/ci/test_check_readme_paths.sh
+
+      - name: Run README-path checks
+        run: sh ./tools/ci/check_readme_paths.sh
+
       - name: Run baseline verification script
         run: sh ./tools/ci/verify_baseline.sh baseline-report.txt
+
+      - name: Run scripts thin-slice checks
+        run: |
+          ./scripts/bootstrap.sh
+          python3 ./scripts/validate_schemas.py
+          python3 ./scripts/catalog_validate.py
+          python3 ./tools/ci/validate_renderer_fixtures.py
+
+      - name: Run CI renderer tests
+        run: python3 -m pytest -q tests/ci
 
       - name: Upload baseline report
         if: always()

--- a/docs/runbooks/repository-next-steps.md
+++ b/docs/runbooks/repository-next-steps.md
@@ -1,0 +1,122 @@
+# Repository Next Steps (2026-04-24)
+
+This runbook captures the most practical next actions after a repository scan on 2026-04-24.
+
+## Current snapshot
+
+- The repository is documentation-heavy: 200 files total, with 130 Markdown files and only a small set of executable artifacts (shell, Rego, JSON schemas).  
+- The currently executable CI baseline path is narrow but healthy: `.github/workflows/verification-baseline.yml` runs shell syntax checks, self-tests, and `tools/ci/verify_baseline.sh`.  
+- `tools/ci/test_verify_baseline.sh` passes locally and validates both pass/fail behavior for the baseline verifier.
+
+## Key gaps discovered
+
+1. **Documentation-to-repo drift is high.**
+   - Several READMEs describe scripts or helpers that are not present in the current tree.
+   - Example drift:
+     - `scripts/README.md` lists helper files that do not exist.
+     - `tools/ci/README.md` lists renderer helpers and tests that do not exist.
+2. **Placeholder density is very high.**
+   - A scan found ~1,875 `TODO`, `UNKNOWN`, and `NEEDS VERIFICATION` markers across core documentation lanes.
+3. **Machine-enforced governance is minimal today.**
+   - Current CI checks structural baseline only.
+   - Contract, schema, and policy gates are represented in docs but are not yet wired into runnable enforcement from this checkout.
+
+## Recommended next steps (priority order)
+
+### P0 — Stabilize truth of repository documentation
+
+1. Align README claims to currently mounted files (or create the referenced files).
+2. Start with top drift surfaces:
+   - `scripts/README.md`
+   - `tools/ci/README.md`
+3. Introduce one explicit status marker in each README section:
+   - `Present in repo`
+   - `Planned`
+   - `Archived`
+
+**Definition of done:** no README claims file paths that do not exist without explicitly marking them as planned.
+
+### P1 — Expand thin-slice CI beyond baseline
+
+1. Add a lightweight docs consistency check script (for example, verify referenced local file paths exist).
+2. Add JSON schema validation smoke tests using existing `schemas/contracts/v1/*.schema.json` files and fixture payloads.
+3. Add policy smoke checks for `policy/bundles/runtime/*.rego` using existing fixtures.
+
+**Definition of done:** CI fails on broken local doc links/path claims, invalid schema fixtures, and broken runtime policy tests.
+
+### P2 — Build one end-to-end governed proof slice
+
+1. Select one claim type (recommended: runtime finite outcomes).
+2. Produce a minimal fixture-to-decision path:
+   - fixture input
+   - policy decision
+   - envelope validation
+   - receipt/proof artifact
+3. Document this in `docs/runbooks/` as the canonical “first governed release slice.”
+
+**Definition of done:** a single command path can reproduce a governed decision artifact from fixture input with deterministic output.
+
+### P3 — Reduce placeholder debt deliberately
+
+1. Triage top 20 files by unresolved marker count.
+2. For each file, choose one action:
+   - resolve now,
+   - downgrade claim scope,
+   - split into `planned` appendix.
+3. Track marker burn-down weekly.
+
+**Definition of done:** 30% reduction in unresolved markers in the top 20 files without introducing unverified implementation claims.
+
+## Suggested first sprint backlog (1 week)
+
+- Fix drift in `scripts/README.md` and `tools/ci/README.md`.
+- Add `tools/ci/check_readme_paths.sh`.
+- Add workflow job to run:
+  - baseline verifier
+  - README path check
+  - schema smoke check
+  - runtime policy smoke check
+- Add one concise runbook for “baseline + smoke CI failure triage”.
+
+
+## Immediate next (post thin-slice implementation)
+
+Now that baseline scripts and renderer tests exist, the next highest-value moves are:
+
+1. **Lock input contracts for renderer scripts**
+   - Add JSON Schema files for renderer input reports.
+   - Validate inputs before rendering so CI fails with clear contract errors.
+
+2. **Add negative-path CI tests**
+   - Add tests for malformed JSON, missing required keys, and empty report files.
+   - Ensure each renderer exits non-zero with deterministic error messaging.
+
+3. **Wire documentation drift checks**
+   - Add `tools/ci/check_readme_paths.sh` that validates declared “current” file trees in READMEs.
+   - Gate pull requests on this check to prevent docs/repo divergence.
+
+4. **Promote one governed end-to-end fixture**
+   - Add a single fixture set under `tests/contracts/fixtures/runtime/`.
+   - Validate fixture -> policy decision -> envelope -> rendered summary in one deterministic test path.
+
+5. **Define merge gates explicitly**
+   - Document required checks in `.github/workflows/README.md` and align branch protection expectations.
+   - Keep `verification-baseline` as the minimum required status while expanding gates incrementally.
+
+
+## Next execution packet (recommended order)
+
+Use this as the concrete next implementation sequence:
+
+1. Add renderer input schemas under `schemas/contracts/v1/runtime/` and reject invalid payloads in each `tools/ci/render_*.py` entrypoint.
+2. Add failing-path tests in `tests/ci/` for malformed JSON and missing required keys.
+3. Add one integration test that runs: fixture -> policy output -> renderer handoff markdown.
+4. Document required status checks in `.github/workflows/README.md` and mirror them in branch protection settings.
+
+### Exit criteria for this packet
+
+- Every renderer has at least one negative-path test.
+- Invalid renderer input fails before markdown generation.
+- One deterministic end-to-end CI artifact is produced from fixture data.
+- Required checks are documented in-repo and enforced in GitHub settings.
+

--- a/schemas/contracts/v1/runtime/renderers/diff_policy_summary_input.schema.json
+++ b/schemas/contracts/v1/runtime/renderers/diff_policy_summary_input.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/runtime/renderers/diff_policy_summary_input/v1",
+  "type": "object",
+  "required": ["decision"],
+  "properties": {
+    "decision": {"type": "string"},
+    "reasons": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/runtime/renderers/diff_summary_input.schema.json
+++ b/schemas/contracts/v1/runtime/renderers/diff_summary_input.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/runtime/renderers/diff_summary_input/v1",
+  "type": "object",
+  "required": ["added", "changed", "removed"],
+  "properties": {
+    "added": {"type": "integer"},
+    "changed": {"type": "integer"},
+    "removed": {"type": "integer"}
+  },
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/runtime/renderers/promotion_bundle_summary_input.schema.json
+++ b/schemas/contracts/v1/runtime/renderers/promotion_bundle_summary_input.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/runtime/renderers/promotion_bundle_summary_input/v1",
+  "type": "object",
+  "required": ["bundle_id", "artifacts"],
+  "properties": {
+    "bundle_id": {"type": "string"},
+    "artifacts": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/runtime/renderers/promotion_summary_input.schema.json
+++ b/schemas/contracts/v1/runtime/renderers/promotion_summary_input.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/runtime/renderers/promotion_summary_input/v1",
+  "type": "object",
+  "required": ["release_id", "state"],
+  "properties": {
+    "release_id": {"type": "string"},
+    "state": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/schemas/contracts/v1/runtime/renderers/review_handoff_inputs.schema.json
+++ b/schemas/contracts/v1/runtime/renderers/review_handoff_inputs.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/runtime/renderers/review_handoff_inputs/v1",
+  "type": "object",
+  "required": ["promotion", "bundle", "diff", "diff_policy"],
+  "properties": {
+    "promotion": {
+      "type": "object",
+      "required": ["release_id", "state"],
+      "properties": {
+        "release_id": {"type": "string"},
+        "state": {"type": "string"}
+      }
+    },
+    "bundle": {
+      "type": "object",
+      "required": ["bundle_id"],
+      "properties": {
+        "bundle_id": {"type": "string"}
+      }
+    },
+    "diff": {
+      "type": "object",
+      "required": ["added", "changed", "removed"],
+      "properties": {
+        "added": {"type": "integer"},
+        "changed": {"type": "integer"},
+        "removed": {"type": "integer"}
+      }
+    },
+    "diff_policy": {
+      "type": "object",
+      "required": ["decision"],
+      "properties": {
+        "decision": {"type": "string"}
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+if command -v python3 >/dev/null 2>&1; then
+  pyv="$(python3 --version 2>&1)"
+  echo "python3: ${pyv}"
+  echo "bootstrap: docs-first workspace; no dependency installer is defined in this repo yet"
+  exit 0
+fi
+
+echo "python3 is required but was not found on PATH" >&2
+exit 1

--- a/scripts/catalog_validate.py
+++ b/scripts/catalog_validate.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+REQUIRED = [
+    Path("data/catalog/README.md"),
+    Path("data/catalog/stac/README.md"),
+    Path("data/catalog/dcat/README.md"),
+    Path("data/catalog/prov/README.md"),
+]
+
+missing = [str(p) for p in REQUIRED if not p.exists()]
+
+if missing:
+    print("catalog_validate: missing required scaffold paths:", file=sys.stderr)
+    for path in missing:
+        print(f"- {path}", file=sys.stderr)
+    sys.exit(1)
+
+print("catalog_validate: required catalog README scaffold is present")

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+echo "dev_up: no long-running local services are currently defined in this repository"
+echo "dev_up: use lane-specific scripts/workflows as they are introduced"

--- a/scripts/sample_ingest.sh
+++ b/scripts/sample_ingest.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <source_name>" >&2
+  exit 2
+fi
+
+source_name="$1"
+out_dir="data/work/sample_ingest"
+receipt_dir="data/receipts"
+
+mkdir -p "$out_dir" "$receipt_dir"
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+run_id="sample-${source_name}-$(date -u +%Y%m%dT%H%M%SZ)"
+out_file="${out_dir}/${run_id}.json"
+receipt_file="${receipt_dir}/${run_id}.json"
+
+cat > "$out_file" <<JSON
+{
+  "run_id": "${run_id}",
+  "source_name": "${source_name}",
+  "ingested_at": "${ts}",
+  "status": "work"
+}
+JSON
+
+cat > "$receipt_file" <<JSON
+{
+  "run_id": "${run_id}",
+  "artifact": "${out_file}",
+  "recorded_at": "${ts}",
+  "type": "sample_ingest_receipt"
+}
+JSON
+
+echo "wrote ${out_file}"
+echo "wrote ${receipt_file}"

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCHEMAS = [
+    Path("schemas/contracts/v1/correction/correction_notice.schema.json"),
+    Path("schemas/contracts/v1/release/release_manifest.schema.json"),
+    Path("schemas/contracts/v1/source/source_descriptor.schema.json"),
+    Path("schemas/contracts/v1/data/dataset_version.schema.json"),
+    Path("schemas/contracts/v1/policy/decision_envelope.schema.json"),
+    Path("schemas/contracts/v1/common/header_profile.schema.json"),
+    Path("schemas/contracts/v1/runtime/runtime_response_envelope.schema.json"),
+    Path("schemas/contracts/v1/evidence/evidence_bundle.schema.json"),
+]
+
+failures: list[str] = []
+
+for schema_path in SCHEMAS:
+    if not schema_path.exists():
+        failures.append(f"missing schema: {schema_path}")
+        continue
+
+    try:
+        payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        failures.append(f"invalid JSON: {schema_path} ({exc})")
+        continue
+
+    schema = payload.get("$schema")
+    if not isinstance(schema, str) or "json-schema.org" not in schema:
+        failures.append(f"invalid or missing $schema in {schema_path}")
+
+if failures:
+    print("validate_schemas: failed", file=sys.stderr)
+    for failure in failures:
+        print(f"- {failure}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"validate_schemas: validated {len(SCHEMAS)} schema files")

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -1,0 +1,27 @@
+# tests/ci
+
+CI-focused tests for helper renderers in `tools/ci/`.
+
+## Current thin slice
+
+- `test_render_diff_summary.py`
+- `test_render_bundle_diff_policy_summary.py`
+- `test_render_promotion_review_handoff.py`
+- `test_end_to_end_review_handoff.py`
+- `test_end_to_end_diff_policy_summary.py`
+- `test_end_to_end_diff_summary.py`
+- `test_end_to_end_promotion_summary.py`
+- `test_end_to_end_promotion_bundle_summary.py`
+- `test_validate_renderer_fixtures.py`
+
+Run with:
+
+```bash
+python3 -m pytest -q tests/ci
+```
+
+Contract check for committed fixtures:
+
+```bash
+python3 tools/ci/validate_renderer_fixtures.py
+```

--- a/tests/ci/fixtures/diff_policy/diff_policy.json
+++ b/tests/ci/fixtures/diff_policy/diff_policy.json
@@ -1,0 +1,1 @@
+{"decision":"deny","reasons":["breaking schema drift","missing approval"]}

--- a/tests/ci/fixtures/diff_summary/diff.json
+++ b/tests/ci/fixtures/diff_summary/diff.json
@@ -1,0 +1,1 @@
+{"added":5,"changed":2,"removed":1}

--- a/tests/ci/fixtures/promotion_bundle/bundle.json
+++ b/tests/ci/fixtures/promotion_bundle/bundle.json
@@ -1,0 +1,1 @@
+{"bundle_id":"bundle-xyz","artifacts":["one.json","two.json","three.json"]}

--- a/tests/ci/fixtures/promotion_summary/promotion.json
+++ b/tests/ci/fixtures/promotion_summary/promotion.json
@@ -1,0 +1,1 @@
+{"release_id":"release-2026-05-01","state":"pending_review"}

--- a/tests/ci/fixtures/review_handoff/bundle.json
+++ b/tests/ci/fixtures/review_handoff/bundle.json
@@ -1,0 +1,1 @@
+{"bundle_id":"bundle-001","artifacts":["artifact-a.json","artifact-b.json"]}

--- a/tests/ci/fixtures/review_handoff/diff.json
+++ b/tests/ci/fixtures/review_handoff/diff.json
@@ -1,0 +1,1 @@
+{"added":2,"changed":1,"removed":0}

--- a/tests/ci/fixtures/review_handoff/diff_policy.json
+++ b/tests/ci/fixtures/review_handoff/diff_policy.json
@@ -1,0 +1,1 @@
+{"decision":"allow","reasons":["no breaking drift"]}

--- a/tests/ci/fixtures/review_handoff/promotion.json
+++ b/tests/ci/fixtures/review_handoff/promotion.json
@@ -1,0 +1,1 @@
+{"release_id":"release-2026-04-24","state":"approved"}

--- a/tests/ci/golden/diff_policy_summary.md
+++ b/tests/ci/golden/diff_policy_summary.md
@@ -1,0 +1,6 @@
+# Bundle Diff Policy Summary
+
+- Decision: **deny**
+- Reasons:
+  - breaking schema drift
+  - missing approval

--- a/tests/ci/golden/diff_summary.md
+++ b/tests/ci/golden/diff_summary.md
@@ -1,0 +1,5 @@
+# Diff Summary
+
+- Added: **5**
+- Changed: **2**
+- Removed: **1**

--- a/tests/ci/golden/promotion_bundle_summary.md
+++ b/tests/ci/golden/promotion_bundle_summary.md
@@ -1,0 +1,4 @@
+# Promotion Bundle Summary
+
+- Bundle: **bundle-xyz**
+- Artifacts: **3**

--- a/tests/ci/golden/promotion_summary.md
+++ b/tests/ci/golden/promotion_summary.md
@@ -1,0 +1,4 @@
+# Promotion Summary
+
+- Release: **release-2026-05-01**
+- State: **pending_review**

--- a/tests/ci/golden/review_handoff.md
+++ b/tests/ci/golden/review_handoff.md
@@ -1,0 +1,7 @@
+# Promotion Review Handoff
+
+- Release: **release-2026-04-24**
+- Promotion state: **approved**
+- Bundle id: **bundle-001**
+- Diff totals: added=2, changed=1, removed=0
+- Diff policy decision: **allow**

--- a/tests/ci/test_end_to_end_diff_policy_summary.py
+++ b/tests/ci/test_end_to_end_diff_policy_summary.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_end_to_end_diff_policy_summary_golden() -> None:
+    fixture = Path("tests/ci/fixtures/diff_policy/diff_policy.json")
+    out_path = Path("tests/ci/golden/.tmp-diff-policy-summary.md")
+    golden_path = Path("tests/ci/golden/diff_policy_summary.md")
+
+    try:
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_bundle_diff_policy_summary.py",
+                "--input",
+                str(fixture),
+                "--output",
+                str(out_path),
+            ],
+            check=True,
+        )
+
+        assert out_path.read_text(encoding="utf-8") == golden_path.read_text(encoding="utf-8")
+    finally:
+        if out_path.exists():
+            out_path.unlink()

--- a/tests/ci/test_end_to_end_diff_summary.py
+++ b/tests/ci/test_end_to_end_diff_summary.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_end_to_end_diff_summary_golden() -> None:
+    fixture = Path("tests/ci/fixtures/diff_summary/diff.json")
+    out_path = Path("tests/ci/golden/.tmp-diff-summary.md")
+    golden_path = Path("tests/ci/golden/diff_summary.md")
+
+    try:
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_diff_summary.py",
+                "--input",
+                str(fixture),
+                "--output",
+                str(out_path),
+            ],
+            check=True,
+        )
+
+        assert out_path.read_text(encoding="utf-8") == golden_path.read_text(encoding="utf-8")
+    finally:
+        if out_path.exists():
+            out_path.unlink()

--- a/tests/ci/test_end_to_end_promotion_bundle_summary.py
+++ b/tests/ci/test_end_to_end_promotion_bundle_summary.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_end_to_end_promotion_bundle_summary_golden() -> None:
+    fixture = Path("tests/ci/fixtures/promotion_bundle/bundle.json")
+    out_path = Path("tests/ci/golden/.tmp-promotion-bundle-summary.md")
+    golden_path = Path("tests/ci/golden/promotion_bundle_summary.md")
+
+    try:
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_promotion_bundle_summary.py",
+                "--input",
+                str(fixture),
+                "--output",
+                str(out_path),
+            ],
+            check=True,
+        )
+
+        assert out_path.read_text(encoding="utf-8") == golden_path.read_text(encoding="utf-8")
+    finally:
+        if out_path.exists():
+            out_path.unlink()

--- a/tests/ci/test_end_to_end_promotion_summary.py
+++ b/tests/ci/test_end_to_end_promotion_summary.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_end_to_end_promotion_summary_golden() -> None:
+    fixture = Path("tests/ci/fixtures/promotion_summary/promotion.json")
+    out_path = Path("tests/ci/golden/.tmp-promotion-summary.md")
+    golden_path = Path("tests/ci/golden/promotion_summary.md")
+
+    try:
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_promotion_summary.py",
+                "--input",
+                str(fixture),
+                "--output",
+                str(out_path),
+            ],
+            check=True,
+        )
+
+        assert out_path.read_text(encoding="utf-8") == golden_path.read_text(encoding="utf-8")
+    finally:
+        if out_path.exists():
+            out_path.unlink()

--- a/tests/ci/test_end_to_end_review_handoff.py
+++ b/tests/ci/test_end_to_end_review_handoff.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_end_to_end_review_handoff_golden() -> None:
+    fixture_root = Path("tests/ci/fixtures/review_handoff")
+    out_path = Path("tests/ci/golden/.tmp-review-handoff.md")
+    golden_path = Path("tests/ci/golden/review_handoff.md")
+
+    try:
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_promotion_review_handoff.py",
+                "--promotion",
+                str(fixture_root / "promotion.json"),
+                "--bundle",
+                str(fixture_root / "bundle.json"),
+                "--diff",
+                str(fixture_root / "diff.json"),
+                "--diff-policy",
+                str(fixture_root / "diff_policy.json"),
+                "--output",
+                str(out_path),
+            ],
+            check=True,
+        )
+
+        actual = out_path.read_text(encoding="utf-8")
+        expected = golden_path.read_text(encoding="utf-8")
+        assert actual == expected
+    finally:
+        if out_path.exists():
+            out_path.unlink()

--- a/tests/ci/test_render_bundle_diff_policy_summary.py
+++ b/tests/ci/test_render_bundle_diff_policy_summary.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_render_bundle_diff_policy_summary() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "diff-policy.json"
+        out = root / "summary.md"
+        src.write_text(
+            json.dumps({"decision": "allow", "reasons": ["no breaking drift"]}),
+            encoding="utf-8",
+        )
+
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_bundle_diff_policy_summary.py",
+                "--input",
+                str(src),
+                "--output",
+                str(out),
+            ],
+            check=True,
+        )
+
+        rendered = out.read_text(encoding="utf-8")
+        assert "Decision: **allow**" in rendered
+        assert "no breaking drift" in rendered
+
+
+def test_render_bundle_diff_policy_summary_missing_decision_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "diff-policy.json"
+        src.write_text(json.dumps({"reasons": ["x"]}), encoding="utf-8")
+
+        proc = subprocess.run(
+            ["python3", "tools/ci/render_bundle_diff_policy_summary.py", "--input", str(src)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0
+        assert "missing required string key: decision" in proc.stderr

--- a/tests/ci/test_render_diff_summary.py
+++ b/tests/ci/test_render_diff_summary.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_render_diff_summary() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "diff.json"
+        out = root / "summary.md"
+        src.write_text(json.dumps({"added": 2, "changed": 3, "removed": 1}), encoding="utf-8")
+
+        subprocess.run(
+            ["python3", "tools/ci/render_diff_summary.py", "--input", str(src), "--output", str(out)],
+            check=True,
+        )
+
+        rendered = out.read_text(encoding="utf-8")
+        assert "Added: **2**" in rendered
+        assert "Changed: **3**" in rendered
+        assert "Removed: **1**" in rendered
+
+
+def test_render_diff_summary_missing_key_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "diff.json"
+        src.write_text(json.dumps({"added": 2, "changed": 3}), encoding="utf-8")
+
+        proc = subprocess.run(
+            ["python3", "tools/ci/render_diff_summary.py", "--input", str(src)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0
+        assert "missing required key" in proc.stderr
+
+
+def test_render_diff_summary_invalid_json_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "diff.json"
+        src.write_text("{not-json", encoding="utf-8")
+
+        proc = subprocess.run(
+            ["python3", "tools/ci/render_diff_summary.py", "--input", str(src)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0
+        assert "invalid JSON" in proc.stderr

--- a/tests/ci/test_render_promotion_review_handoff.py
+++ b/tests/ci/test_render_promotion_review_handoff.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_render_promotion_review_handoff() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        promotion = root / "promotion.json"
+        bundle = root / "bundle.json"
+        diff = root / "diff.json"
+        diff_policy = root / "diff-policy.json"
+        out = root / "handoff.md"
+
+        promotion.write_text(json.dumps({"release_id": "r1", "state": "approved"}), encoding="utf-8")
+        bundle.write_text(json.dumps({"bundle_id": "b1", "artifacts": ["a", "b"]}), encoding="utf-8")
+        diff.write_text(json.dumps({"added": 1, "changed": 0, "removed": 0}), encoding="utf-8")
+        diff_policy.write_text(json.dumps({"decision": "allow"}), encoding="utf-8")
+
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_promotion_review_handoff.py",
+                "--promotion",
+                str(promotion),
+                "--bundle",
+                str(bundle),
+                "--diff",
+                str(diff),
+                "--diff-policy",
+                str(diff_policy),
+                "--output",
+                str(out),
+            ],
+            check=True,
+        )
+
+        rendered = out.read_text(encoding="utf-8")
+        assert "Release: **r1**" in rendered
+        assert "Diff policy decision: **allow**" in rendered
+
+
+def test_render_promotion_review_handoff_missing_key_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        promotion = root / "promotion.json"
+        bundle = root / "bundle.json"
+        diff = root / "diff.json"
+        diff_policy = root / "diff-policy.json"
+
+        promotion.write_text(json.dumps({"release_id": "r1"}), encoding="utf-8")
+        bundle.write_text(json.dumps({"bundle_id": "b1", "artifacts": ["a", "b"]}), encoding="utf-8")
+        diff.write_text(json.dumps({"added": 1, "changed": 0, "removed": 0}), encoding="utf-8")
+        diff_policy.write_text(json.dumps({"decision": "allow"}), encoding="utf-8")
+
+        proc = subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_promotion_review_handoff.py",
+                "--promotion",
+                str(promotion),
+                "--bundle",
+                str(bundle),
+                "--diff",
+                str(diff),
+                "--diff-policy",
+                str(diff_policy),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0
+        assert "missing required str key: state" in proc.stderr

--- a/tests/ci/test_validate_renderer_fixtures.py
+++ b/tests/ci/test_validate_renderer_fixtures.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REQUIRED_FILES = [
+    "tests/ci/fixtures/diff_summary/diff.json",
+    "tests/ci/fixtures/diff_policy/diff_policy.json",
+    "tests/ci/fixtures/promotion_summary/promotion.json",
+    "tests/ci/fixtures/promotion_bundle/bundle.json",
+    "tests/ci/fixtures/review_handoff/promotion.json",
+    "tests/ci/fixtures/review_handoff/bundle.json",
+    "tests/ci/fixtures/review_handoff/diff.json",
+    "tests/ci/fixtures/review_handoff/diff_policy.json",
+    "schemas/contracts/v1/runtime/renderers/diff_summary_input.schema.json",
+    "schemas/contracts/v1/runtime/renderers/diff_policy_summary_input.schema.json",
+    "schemas/contracts/v1/runtime/renderers/promotion_summary_input.schema.json",
+    "schemas/contracts/v1/runtime/renderers/promotion_bundle_summary_input.schema.json",
+    "schemas/contracts/v1/runtime/renderers/review_handoff_inputs.schema.json",
+]
+
+
+def test_validate_renderer_fixtures_passes_current_repo() -> None:
+    subprocess.run(["python3", "tools/ci/validate_renderer_fixtures.py"], check=True)
+
+
+def test_validate_renderer_fixtures_fails_on_invalid_fixture() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+
+        for rel in REQUIRED_FILES:
+            src = Path(rel)
+            dst = root / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+
+        broken = root / "tests/ci/fixtures/diff_summary/diff.json"
+        broken.write_text(json.dumps({"added": "bad", "changed": 2, "removed": 1}), encoding="utf-8")
+
+        proc = subprocess.run(
+            ["python3", "tools/ci/validate_renderer_fixtures.py", "--root", str(root)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0
+        assert "diff_summary.added: expected integer" in proc.stderr

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -171,6 +171,12 @@ This README intentionally distinguishes the **documented thin slice** from broad
 ```text
 tools/ci/
 ├── README.md
+├── check_readme_paths.sh
+├── readme_required_paths.txt
+├── test_check_readme_paths.sh
+├── verify_baseline.sh
+├── test_verify_baseline.sh
+├── validate_renderer_fixtures.py
 ├── render_promotion_summary.py
 ├── render_promotion_bundle_summary.py
 ├── render_diff_summary.py
@@ -181,7 +187,15 @@ tests/ci/
 ├── README.md
 ├── test_render_diff_summary.py
 ├── test_render_bundle_diff_policy_summary.py
-└── test_render_promotion_review_handoff.py
+├── test_render_promotion_review_handoff.py
+├── test_validate_renderer_fixtures.py
+├── test_end_to_end_diff_summary.py
+├── test_end_to_end_diff_policy_summary.py
+├── test_end_to_end_promotion_summary.py
+├── test_end_to_end_promotion_bundle_summary.py
+├── test_end_to_end_review_handoff.py
+├── fixtures/
+└── golden/
 ```
 
 > [!WARNING]
@@ -256,14 +270,15 @@ For baseline repository inventory verification (used by `.github/workflows/verif
 sh ./tools/ci/verify_baseline.sh baseline-report.txt
 cat baseline-report.txt
 sh ./tools/ci/test_verify_baseline.sh
+sh ./tools/ci/test_check_readme_paths.sh
+sh ./tools/ci/check_readme_paths.sh
+python3 ./tools/ci/validate_renderer_fixtures.py
 ```
 
 When the checked-out branch uses `pytest` for this lane, the documented thin slice should remain runnable locally as well as in CI:
 
 ```bash
-pytest -q tests/ci/test_render_diff_summary.py
-pytest -q tests/ci/test_render_bundle_diff_policy_summary.py
-pytest -q tests/ci/test_render_promotion_review_handoff.py
+pytest -q tests/ci
 ```
 
 [Back to top](#top)

--- a/tools/ci/check_readme_paths.sh
+++ b/tools/ci/check_readme_paths.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -eu
+
+repo_root="."
+manifest_path="tools/ci/readme_required_paths.txt"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --root" >&2
+        exit 2
+      fi
+      repo_root="$2"
+      shift 2
+      ;;
+    --manifest)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --manifest" >&2
+        exit 2
+      fi
+      manifest_path="$2"
+      shift 2
+      ;;
+    --help|-h)
+      echo "usage: $0 [--root <repo_root>] [--manifest <path>]"
+      exit 0
+      ;;
+    --*)
+      echo "unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      echo "unexpected argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$repo_root"
+
+if [ ! -f "$manifest_path" ]; then
+  echo "manifest not found: $manifest_path" >&2
+  exit 2
+fi
+
+missing_count=0
+checked_count=0
+
+while IFS= read -r line || [ -n "$line" ]; do
+  path="$(printf '%s' "$line" | sed 's/[[:space:]]*$//')"
+  case "$path" in
+    ''|\#*)
+      continue
+      ;;
+  esac
+
+  checked_count=$((checked_count + 1))
+  if [ ! -f "$path" ]; then
+    echo "missing: $path" >&2
+    missing_count=$((missing_count + 1))
+  fi
+done < "$manifest_path"
+
+if [ "$checked_count" -eq 0 ]; then
+  echo "manifest has no paths: $manifest_path" >&2
+  exit 2
+fi
+
+if [ "$missing_count" -ne 0 ]; then
+  echo "check_readme_paths: failed ($missing_count missing path(s))" >&2
+  exit 1
+fi
+
+echo "check_readme_paths: ok ($checked_count paths checked)"

--- a/tools/ci/readme_required_paths.txt
+++ b/tools/ci/readme_required_paths.txt
@@ -1,0 +1,26 @@
+# Required paths surfaced as "current" in README thin-slice docs.
+scripts/README.md
+scripts/bootstrap.sh
+scripts/dev_up.sh
+scripts/sample_ingest.sh
+scripts/validate_schemas.py
+scripts/catalog_validate.py
+tools/ci/README.md
+tools/ci/verify_baseline.sh
+tools/ci/test_verify_baseline.sh
+tools/ci/render_promotion_summary.py
+tools/ci/render_promotion_bundle_summary.py
+tools/ci/render_diff_summary.py
+tools/ci/render_bundle_diff_policy_summary.py
+tools/ci/render_promotion_review_handoff.py
+tools/ci/validate_renderer_fixtures.py
+tests/ci/README.md
+tests/ci/test_render_diff_summary.py
+tests/ci/test_render_bundle_diff_policy_summary.py
+tests/ci/test_render_promotion_review_handoff.py
+tests/ci/test_validate_renderer_fixtures.py
+schemas/contracts/v1/runtime/renderers/diff_summary_input.schema.json
+schemas/contracts/v1/runtime/renderers/diff_policy_summary_input.schema.json
+schemas/contracts/v1/runtime/renderers/promotion_summary_input.schema.json
+schemas/contracts/v1/runtime/renderers/promotion_bundle_summary_input.schema.json
+schemas/contracts/v1/runtime/renderers/review_handoff_inputs.schema.json

--- a/tools/ci/render_bundle_diff_policy_summary.py
+++ b/tools/ci/render_bundle_diff_policy_summary.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def read_json(path: str) -> dict:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"render_bundle_diff_policy_summary: input not found: {path}", file=sys.stderr)
+        raise SystemExit(2)
+    except json.JSONDecodeError as exc:
+        print(f"render_bundle_diff_policy_summary: invalid JSON in {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render markdown summary for bundle diff-policy report.")
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    payload = read_json(args.input)
+    if "decision" not in payload or not isinstance(payload["decision"], str):
+        print("render_bundle_diff_policy_summary: missing required string key: decision", file=sys.stderr)
+        return 2
+
+    reasons = payload.get("reasons", [])
+    if not isinstance(reasons, list):
+        print("render_bundle_diff_policy_summary: reasons must be a list when provided", file=sys.stderr)
+        return 2
+
+    lines = ["# Bundle Diff Policy Summary", "", f"- Decision: **{payload['decision']}**"]
+    if reasons:
+        lines.append("- Reasons:")
+        lines.extend([f"  - {reason}" for reason in reasons])
+
+    md = "\n".join(lines)
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_diff_summary.py
+++ b/tools/ci/render_diff_summary.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REQUIRED_KEYS = ("added", "changed", "removed")
+
+
+def read_json(path: str) -> dict:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"render_diff_summary: input not found: {path}", file=sys.stderr)
+        raise SystemExit(2)
+    except json.JSONDecodeError as exc:
+        print(f"render_diff_summary: invalid JSON in {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render a markdown summary for a diff report.")
+    parser.add_argument("--input", required=True, help="Path to JSON diff report")
+    parser.add_argument("--output", help="Optional output markdown path")
+    args = parser.parse_args()
+
+    payload = read_json(args.input)
+    missing = [k for k in REQUIRED_KEYS if k not in payload]
+    if missing:
+        print(f"render_diff_summary: missing required key(s): {', '.join(missing)}", file=sys.stderr)
+        return 2
+
+    if not all(isinstance(payload[k], int) for k in REQUIRED_KEYS):
+        print("render_diff_summary: required keys must be integers", file=sys.stderr)
+        return 2
+
+    md = "\n".join(
+        [
+            "# Diff Summary",
+            "",
+            f"- Added: **{payload['added']}**",
+            f"- Changed: **{payload['changed']}**",
+            f"- Removed: **{payload['removed']}**",
+        ]
+    )
+
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_promotion_bundle_summary.py
+++ b/tools/ci/render_promotion_bundle_summary.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def read_json(path: str) -> dict:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"render_promotion_bundle_summary: input not found: {path}", file=sys.stderr)
+        raise SystemExit(2)
+    except json.JSONDecodeError as exc:
+        print(f"render_promotion_bundle_summary: invalid JSON in {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render markdown summary for promotion bundle.")
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    payload = read_json(args.input)
+    if "bundle_id" not in payload or not isinstance(payload["bundle_id"], str):
+        print("render_promotion_bundle_summary: missing required string key: bundle_id", file=sys.stderr)
+        return 2
+
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        print("render_promotion_bundle_summary: missing required list key: artifacts", file=sys.stderr)
+        return 2
+
+    md = "\n".join([
+        "# Promotion Bundle Summary",
+        "",
+        f"- Bundle: **{payload['bundle_id']}**",
+        f"- Artifacts: **{len(artifacts)}**",
+    ])
+
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_promotion_review_handoff.py
+++ b/tools/ci/render_promotion_review_handoff.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def read_json(path: str, label: str) -> dict:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"render_promotion_review_handoff: {label} input not found: {path}", file=sys.stderr)
+        raise SystemExit(2)
+    except json.JSONDecodeError as exc:
+        print(f"render_promotion_review_handoff: invalid JSON in {label} input {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compose promotion review handoff markdown.")
+    parser.add_argument("--promotion", required=True)
+    parser.add_argument("--bundle", required=True)
+    parser.add_argument("--diff", required=True)
+    parser.add_argument("--diff-policy", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    promotion = read_json(args.promotion, "promotion")
+    bundle = read_json(args.bundle, "bundle")
+    diff = read_json(args.diff, "diff")
+    diff_policy = read_json(args.diff_policy, "diff-policy")
+
+    required = [
+        (promotion, "release_id", str),
+        (promotion, "state", str),
+        (bundle, "bundle_id", str),
+        (diff, "added", int),
+        (diff, "changed", int),
+        (diff, "removed", int),
+        (diff_policy, "decision", str),
+    ]
+
+    for payload, key, typ in required:
+        if key not in payload or not isinstance(payload[key], typ):
+            print(f"render_promotion_review_handoff: missing required {typ.__name__} key: {key}", file=sys.stderr)
+            return 2
+
+    md = "\n".join([
+        "# Promotion Review Handoff",
+        "",
+        f"- Release: **{promotion['release_id']}**",
+        f"- Promotion state: **{promotion['state']}**",
+        f"- Bundle id: **{bundle['bundle_id']}**",
+        f"- Diff totals: added={diff['added']}, changed={diff['changed']}, removed={diff['removed']}",
+        f"- Diff policy decision: **{diff_policy['decision']}**",
+    ])
+
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_promotion_summary.py
+++ b/tools/ci/render_promotion_summary.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def read_json(path: str) -> dict:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"render_promotion_summary: input not found: {path}", file=sys.stderr)
+        raise SystemExit(2)
+    except json.JSONDecodeError as exc:
+        print(f"render_promotion_summary: invalid JSON in {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render markdown summary for promotion decision.")
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    payload = read_json(args.input)
+    for key in ("release_id", "state"):
+        if key not in payload or not isinstance(payload[key], str):
+            print(f"render_promotion_summary: missing required string key: {key}", file=sys.stderr)
+            return 2
+
+    md = "\n".join([
+        "# Promotion Summary",
+        "",
+        f"- Release: **{payload['release_id']}**",
+        f"- State: **{payload['state']}**",
+    ])
+
+    if args.output:
+        Path(args.output).write_text(md + "\n", encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_check_readme_paths.sh
+++ b/tools/ci/test_check_readme_paths.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+checker="${script_dir}/check_readme_paths.sh"
+manifest="${script_dir}/readme_required_paths.txt"
+
+"${checker}" --root . --manifest "${manifest}" >/dev/null
+
+# unknown option should fail
+if "${checker}" --unknown >/dev/null 2>&1; then
+  echo "expected checker to fail on unknown option"
+  exit 1
+fi
+
+# incomplete root should fail
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+if "${checker}" --root "${tmpdir}" --manifest "${manifest}" >/dev/null 2>&1; then
+  echo "expected checker to fail on incomplete root"
+  exit 1
+fi
+
+# missing manifest should fail
+if "${checker}" --manifest "${script_dir}/does-not-exist.txt" >/dev/null 2>&1; then
+  echo "expected checker to fail on missing manifest"
+  exit 1
+fi
+
+# empty/comment-only manifest should fail
+empty_manifest="${tmpdir}/empty-manifest.txt"
+printf '# comment only\n\n' > "${empty_manifest}"
+if "${checker}" --manifest "${empty_manifest}" >/dev/null 2>&1; then
+  echo "expected checker to fail on empty manifest"
+  exit 1
+fi
+
+echo "check_readme_paths tests passed"

--- a/tools/ci/validate_renderer_fixtures.py
+++ b/tools/ci/validate_renderer_fixtures.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+TYPE_MAP = {
+    "object": dict,
+    "array": list,
+    "string": str,
+    "integer": int,
+}
+
+
+def validate(payload: Any, schema: dict[str, Any], context: str, errors: list[str]) -> None:
+    schema_type = schema.get("type")
+    if schema_type in TYPE_MAP and not isinstance(payload, TYPE_MAP[schema_type]):
+        errors.append(f"{context}: expected {schema_type}, got {type(payload).__name__}")
+        return
+
+    if schema_type == "object":
+        required = schema.get("required", [])
+        for key in required:
+            if key not in payload:
+                errors.append(f"{context}: missing required key '{key}'")
+
+        props = schema.get("properties", {})
+        for key, sub_schema in props.items():
+            if key in payload:
+                validate(payload[key], sub_schema, f"{context}.{key}", errors)
+
+    if schema_type == "array" and "items" in schema:
+        for i, item in enumerate(payload):
+            validate(item, schema["items"], f"{context}[{i}]", errors)
+
+
+def load_json(path: Path, errors: list[str]) -> Any | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        errors.append(f"missing file: {path}")
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid JSON in {path}: {exc}")
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate renderer fixtures against schema contracts.")
+    parser.add_argument("--root", default=".", help="Repository root path")
+    args = parser.parse_args()
+
+    root = Path(args.root)
+
+    pairs: list[tuple[Path, Path, str]] = [
+        (
+            Path("tests/ci/fixtures/diff_summary/diff.json"),
+            Path("schemas/contracts/v1/runtime/renderers/diff_summary_input.schema.json"),
+            "diff_summary",
+        ),
+        (
+            Path("tests/ci/fixtures/diff_policy/diff_policy.json"),
+            Path("schemas/contracts/v1/runtime/renderers/diff_policy_summary_input.schema.json"),
+            "diff_policy_summary",
+        ),
+        (
+            Path("tests/ci/fixtures/promotion_summary/promotion.json"),
+            Path("schemas/contracts/v1/runtime/renderers/promotion_summary_input.schema.json"),
+            "promotion_summary",
+        ),
+        (
+            Path("tests/ci/fixtures/promotion_bundle/bundle.json"),
+            Path("schemas/contracts/v1/runtime/renderers/promotion_bundle_summary_input.schema.json"),
+            "promotion_bundle_summary",
+        ),
+    ]
+
+    errors: list[str] = []
+    for payload_rel, schema_rel, label in pairs:
+        payload = load_json(root / payload_rel, errors)
+        schema = load_json(root / schema_rel, errors)
+        if payload is None or schema is None:
+            continue
+        validate(payload, schema, label, errors)
+
+    review_schema = load_json(root / Path("schemas/contracts/v1/runtime/renderers/review_handoff_inputs.schema.json"), errors)
+    review_payload = {
+        "promotion": load_json(root / Path("tests/ci/fixtures/review_handoff/promotion.json"), errors),
+        "bundle": load_json(root / Path("tests/ci/fixtures/review_handoff/bundle.json"), errors),
+        "diff": load_json(root / Path("tests/ci/fixtures/review_handoff/diff.json"), errors),
+        "diff_policy": load_json(root / Path("tests/ci/fixtures/review_handoff/diff_policy.json"), errors),
+    }
+    if review_schema is not None and all(v is not None for v in review_payload.values()):
+        validate(review_payload, review_schema, "review_handoff", errors)
+
+    if errors:
+        print("validate_renderer_fixtures: failed", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        return 1
+
+    print("validate_renderer_fixtures: all renderer fixtures satisfy schema contracts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Reduce documentation drift and provide a runnable thin-slice CI for renderer helpers and README-path claims. 
- Introduce small, auditable renderer programs and corresponding schemas/fixtures so renderers can be validated automatically. 
- Strengthen the repository baseline verification job to include README path checks, schema validation, and renderer test execution.

### Description

- Added renderer CLI scripts under `tools/ci/` (`render_diff_summary.py`, `render_bundle_diff_policy_summary.py`, `render_promotion_summary.py`, `render_promotion_bundle_summary.py`, `render_promotion_review_handoff.py`) that accept JSON inputs and render markdown outputs. 
- Added renderer input JSON Schema contracts under `schemas/contracts/v1/runtime/renderers/` and implemented `tools/ci/validate_renderer_fixtures.py` to validate fixtures against those schemas. 
- Added test fixtures and golden outputs under `tests/ci/fixtures/` and `tests/ci/golden/` plus a comprehensive test suite in `tests/ci/` exercising rendering and end-to-end golden comparisons. 
- Added README-path manifest and checker `tools/ci/check_readme_paths.sh` with its test harness and a set of lightweight repository scripts (`scripts/bootstrap.sh`, `scripts/dev_up.sh`, `scripts/sample_ingest.sh`, `scripts/validate_schemas.py`, `scripts/catalog_validate.py`). 
- Updated `.github/workflows/verification-baseline.yml` and `.github/workflows/README.md` to run the new checks and to document the `verification-baseline` job as the current required-check baseline, and added a runbook `docs/runbooks/repository-next-steps.md` with next-step guidance.

### Testing

- Ran shell syntax and verifier self-tests via `sh -n ./tools/ci/verify_baseline.sh ./tools/ci/test_verify_baseline.sh ...` and executed `sh ./tools/ci/test_verify_baseline.sh`, which completed successfully. 
- Executed README-path tests and checks using `sh ./tools/ci/test_check_readme_paths.sh` and `sh ./tools/ci/check_readme_paths.sh`, which passed. 
- Ran scripts thin-slice checks including `./scripts/bootstrap.sh`, `python3 ./scripts/validate_schemas.py`, and `python3 ./scripts/catalog_validate.py`, which reported success. 
- Validated renderer fixtures with `python3 ./tools/ci/validate_renderer_fixtures.py` and ran the renderer test suite with `python3 -m pytest -q tests/ci`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8480dd18832aa23c8d4bc69437ab)