### PR TITLE
ci: deduplicate verification-baseline workflow and record progress update

### DIFF
--- a/.github/workflows/verification-baseline.yml
+++ b/.github/workflows/verification-baseline.yml
@@ -21,16 +21,6 @@ jobs:
       - name: Run repo-baseline wrapper
         run: sh ./tools/ci/run_repo_baseline_local.sh
 
-      - name: Run scripts thin-slice checks
-        run: |
-          ./scripts/bootstrap.sh
-          python3 ./scripts/validate_schemas.py
-          python3 ./scripts/catalog_validate.py
-          python3 ./tools/ci/validate_renderer_fixtures.py --root .
-
-      - name: Run CI renderer tests
-        run: python3 -m pytest -q tests/ci
-
       - name: Upload baseline report
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/runbooks/repository-next-steps.md
+++ b/docs/runbooks/repository-next-steps.md
@@ -8,6 +8,12 @@ This runbook captures the most practical next actions after a repository scan on
 - The currently executable CI baseline path is narrow but healthy: `.github/workflows/verification-baseline.yml` runs shell syntax checks, self-tests, and `tools/ci/verify_baseline.sh`.  
 - `tools/ci/test_verify_baseline.sh` passes locally and validates both pass/fail behavior for the baseline verifier.
 
+## Progress update (2026-04-24)
+
+- The baseline workflow has now been de-duplicated so it executes only the `tools/ci/run_repo_baseline_local.sh` wrapper and does not rerun the same schema/fixture/pytest checks in separate steps.
+- Local baseline execution remains green after this cleanup (`14 passed` in `tests/ci`).
+- This keeps CI behavior unchanged while reducing redundant runtime and maintenance surface.
+
 ## Key gaps discovered
 
 1. **Documentation-to-repo drift is high.**
@@ -79,7 +85,7 @@ This runbook captures the most practical next actions after a repository scan on
 - Add one concise runbook for “baseline + smoke CI failure triage”.
 
 
-## Immediate next (post thin-slice implementation)
+## Immediate next (post baseline workflow cleanup)
 
 Now that baseline scripts and renderer tests exist, the next highest-value moves are:
 
@@ -119,4 +125,3 @@ Use this as the concrete next implementation sequence:
 - Invalid renderer input fails before markdown generation.
 - One deterministic end-to-end CI artifact is produced from fixture data.
 - Required checks are documented in-repo and enforced in GitHub settings.
-


### PR DESCRIPTION
### Motivation

- Reduce redundant CI runtime and maintenance by avoiding duplicate execution of the same schema/fixture/pytest checks in the `verification-baseline` job. 
- Record and communicate the outcome of the cleanup so reviewers and operators see the current baseline state in the runbook.

### Description

- Removed the duplicated inline steps from `.github/workflows/verification-baseline.yml` so the job now runs the single authoritative wrapper `tools/ci/run_repo_baseline_local.sh` only. 
- Added a dated `Progress update (2026-04-24)` section to `docs/runbooks/repository-next-steps.md` documenting the workflow cleanup and that the local baseline remains green. 
- Renamed the runbook subsection to reflect the new post-cleanup phrasing (`Immediate next (post baseline workflow cleanup)`).

### Testing

- Ran the baseline wrapper with `sh ./tools/ci/run_repo_baseline_local.sh`, which executes schema validation, README path checks, renderer fixture validation, and the `tests/ci` pytest suite; the run completed successfully. 
- The `tests/ci` suite executed via the wrapper and reported `14 passed` (all checks passed). 
- `python3 scripts/validate_schemas.py` and `python3 scripts/catalog_validate.py` were exercised as part of the baseline wrapper and reported successful validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb76de674832a8a0df0a805aa27e4)