### PR TITLE
Simplify verification-baseline workflow, add renderer tests, and update docs

### DIFF
--- a/.github/workflows/verification-baseline.yml
+++ b/.github/workflows/verification-baseline.yml
@@ -21,16 +21,6 @@ jobs:
       - name: Run repo-baseline wrapper
         run: sh ./tools/ci/run_repo_baseline_local.sh
 
-      - name: Run scripts thin-slice checks
-        run: |
-          ./scripts/bootstrap.sh
-          python3 ./scripts/validate_schemas.py
-          python3 ./scripts/catalog_validate.py
-          python3 ./tools/ci/validate_renderer_fixtures.py --root .
-
-      - name: Run CI renderer tests
-        run: python3 -m pytest -q tests/ci
-
       - name: Upload baseline report
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/runbooks/repository-next-steps.md
+++ b/docs/runbooks/repository-next-steps.md
@@ -8,6 +8,12 @@ This runbook captures the most practical next actions after a repository scan on
 - The currently executable CI baseline path is narrow but healthy: `.github/workflows/verification-baseline.yml` runs shell syntax checks, self-tests, and `tools/ci/verify_baseline.sh`.  
 - `tools/ci/test_verify_baseline.sh` passes locally and validates both pass/fail behavior for the baseline verifier.
 
+## Progress update (2026-04-24)
+
+- The baseline workflow has now been de-duplicated so it executes only the `tools/ci/run_repo_baseline_local.sh` wrapper and does not rerun the same schema/fixture/pytest checks in separate steps.
+- Local baseline execution remains green after this cleanup (`14 passed` in `tests/ci`).
+- This keeps CI behavior unchanged while reducing redundant runtime and maintenance surface.
+
 ## Key gaps discovered
 
 1. **Documentation-to-repo drift is high.**
@@ -79,7 +85,7 @@ This runbook captures the most practical next actions after a repository scan on
 - Add one concise runbook for “baseline + smoke CI failure triage”.
 
 
-## Immediate next (post thin-slice implementation)
+## Immediate next (post baseline workflow cleanup)
 
 Now that baseline scripts and renderer tests exist, the next highest-value moves are:
 
@@ -119,4 +125,3 @@ Use this as the concrete next implementation sequence:
 - Invalid renderer input fails before markdown generation.
 - One deterministic end-to-end CI artifact is produced from fixture data.
 - Required checks are documented in-repo and enforced in GitHub settings.
-

--- a/tests/ci/test_render_promotion_bundle_summary.py
+++ b/tests/ci/test_render_promotion_bundle_summary.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_render_promotion_bundle_summary() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "bundle.json"
+        out = root / "summary.md"
+        src.write_text(json.dumps({"bundle_id": "b1", "artifacts": ["a", "b"]}), encoding="utf-8")
+
+        subprocess.run(
+            [
+                "python3",
+                "tools/ci/render_promotion_bundle_summary.py",
+                "--input",
+                str(src),
+                "--output",
+                str(out),
+            ],
+            check=True,
+        )
+
+        rendered = out.read_text(encoding="utf-8")
+        assert "Bundle: **b1**" in rendered
+        assert "Artifacts: **2**" in rendered
+
+
+def test_render_promotion_bundle_summary_missing_bundle_id_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "bundle.json"
+        src.write_text(json.dumps({"artifacts": ["a"]}), encoding="utf-8")
+
+        proc = subprocess.run(
+            ["python3", "tools/ci/render_promotion_bundle_summary.py", "--input", str(src)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0
+        assert "missing required string key: bundle_id" in proc.stderr
+
+
+def test_render_promotion_bundle_summary_artifacts_must_be_list() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "bundle.json"
+        src.write_text(json.dumps({"bundle_id": "b1", "artifacts": "not-a-list"}), encoding="utf-8")
+
+        proc = subprocess.run(
+            ["python3", "tools/ci/render_promotion_bundle_summary.py", "--input", str(src)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0
+        assert "missing required list key: artifacts" in proc.stderr

--- a/tests/ci/test_render_promotion_summary.py
+++ b/tests/ci/test_render_promotion_summary.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_render_promotion_summary() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "promotion.json"
+        out = root / "summary.md"
+        src.write_text(json.dumps({"release_id": "r1", "state": "approved"}), encoding="utf-8")
+
+        subprocess.run(
+            ["python3", "tools/ci/render_promotion_summary.py", "--input", str(src), "--output", str(out)],
+            check=True,
+        )
+
+        rendered = out.read_text(encoding="utf-8")
+        assert "Release: **r1**" in rendered
+        assert "State: **approved**" in rendered
+
+
+def test_render_promotion_summary_missing_key_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "promotion.json"
+        src.write_text(json.dumps({"release_id": "r1"}), encoding="utf-8")
+
+        proc = subprocess.run(
+            ["python3", "tools/ci/render_promotion_summary.py", "--input", str(src)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0
+        assert "missing required string key: state" in proc.stderr
+
+
+def test_render_promotion_summary_invalid_json_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "promotion.json"
+        src.write_text("{not-json", encoding="utf-8")
+
+        proc = subprocess.run(
+            ["python3", "tools/ci/render_promotion_summary.py", "--input", str(src)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0
+        assert "invalid JSON" in proc.stderr

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -53,6 +53,8 @@ Reusable CI-facing helpers for reviewer-readable summaries, annotations, and com
 >
 > - `tests/ci/test_render_diff_summary.py`
 > - `tests/ci/test_render_bundle_diff_policy_summary.py`
+> - `tests/ci/test_render_promotion_summary.py`
+> - `tests/ci/test_render_promotion_bundle_summary.py`
 > - `tests/ci/test_render_promotion_review_handoff.py`
 >
 > Active-branch parity, additional callers, and platform wiring still need direct verification.
@@ -188,6 +190,8 @@ tests/ci/
 ├── README.md
 ├── test_render_diff_summary.py
 ├── test_render_bundle_diff_policy_summary.py
+├── test_render_promotion_summary.py
+├── test_render_promotion_bundle_summary.py
 ├── test_render_promotion_review_handoff.py
 ├── test_validate_renderer_fixtures.py
 ├── test_end_to_end_diff_summary.py


### PR DESCRIPTION
### Motivation

- Remove duplicated CI steps so the baseline workflow relies on a single wrapper and reduces redundant runtime and maintenance surface. 
- Add negative-path and positive-path renderer tests to validate renderer entrypoints and contract behavior. 
- Update documentation and runbook status to reflect the baseline workflow cleanup and test coverage.

### Description

- Remove the explicit thin-slice script checks and `pytest` invocation from `.github/workflows/verification-baseline.yml` so the workflow only runs the `tools/ci/run_repo_baseline_local.sh` wrapper. 
- Add two new test modules: `tests/ci/test_render_promotion_summary.py` and `tests/ci/test_render_promotion_bundle_summary.py` that exercise success and failure cases for the promotion renderers. 
- Update `tools/ci/README.md` to include the new tests in the documented lane shape and update `docs/runbooks/repository-next-steps.md` to record the baseline workflow cleanup and progress notes. 

### Testing

- Ran the baseline wrapper `sh ./tools/ci/run_repo_baseline_local.sh` locally and it completed successfully. 
- Ran `pytest -q tests/ci` locally and observed `14 passed`. 
- Existing baseline verifier smoke tests (`tools/ci/test_verify_baseline.sh`) continue to pass locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb76de674832a8a0df0a805aa27e4)