### PR TITLE
Rewrite root README to reflect verified baseline and update repository next-steps runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,391 +1,97 @@
-<!-- [KFM_META_BLOCK_V2]
-doc_id: kfm://doc/NEEDS-VERIFICATION
-title: Kansas Frontier Matrix
-type: standard
-version: v1
-status: draft
-owners: @bartytime4life
-created: NEEDS-VERIFICATION
-updated: 2026-04-23
-policy_label: NEEDS-VERIFICATION
-related: [NEEDS-VERIFICATION]
-tags: [kfm, readme, spatial-evidence, governance, map-first, time-aware]
-notes: [Root README revision prepared from the uploaded KFM README draft, attached KFM doctrine, and current-session workspace scan. Repository is mounted in this session and basic path inventory is now verified; implementation behavior and platform state still require deeper verification. Confirm doc_id, owners, created date, policy label, related links, package manager, workflows, schemas, contracts, tests, source registries, release artifacts, and runtime behavior before merge.]
-[/KFM_META_BLOCK_V2] -->
-
-<a id="top"></a>
-
 # Kansas Frontier Matrix
 
-A governed, evidence-first, map-first, time-aware spatial knowledge system for producing inspectable public claims from spatial evidence.
+Kansas Frontier Matrix (KFM) is a governed, evidence-first workspace for building inspectable claims from spatial and policy-aware artifacts.
 
-> [!IMPORTANT]
-> **Status:** `experimental` · **Document status:** `draft` · **Owners:** `@bartytime4life`
-> **Target path:** `README.md` / `readme.md` — `NEEDS VERIFICATION`  
-> **Evidence posture:** `CONFIRMED doctrine` · `PROPOSED implementation plan` · `UNKNOWN mounted repo implementation`  
-> **Operating posture:** artifactization and verification before broad live-source ingestion, UI expansion, model integration, or public release.
->
-> ![status](https://img.shields.io/badge/status-experimental-orange)
-> ![doc](https://img.shields.io/badge/doc-draft-lightgrey)
-> ![posture](https://img.shields.io/badge/posture-evidence--first-blue)
-> ![surface](https://img.shields.io/badge/surface-root%20README-0b7285)
-> ![repo](https://img.shields.io/badge/repo-needs%20verification-lightgrey)
-> ![lifecycle](https://img.shields.io/badge/lifecycle-governed-6f42c1)
->
-> **Quick jumps:** [Scope](#scope) · [Evidence basis](#evidence-basis) · [Repo fit](#repo-fit) · [Inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Architecture](#architecture-at-a-glance) · [Directory tree](#target-directory-tree) · [Quickstart](#verification-first-quickstart) · [Done](#definition-of-done) · [FAQ](#faq)
+## Current repository status (verified 2026-04-25)
 
----
+- Repository type: docs-first with executable validation tooling.
+- Baseline local verification command: `tools/ci/run_repo_baseline_local.sh`.
+- Baseline CI workflow: `.github/workflows/verification-baseline.yml`.
+- Current baseline test result from local run on 2026-04-25: `89 passed` in `tests/ci`.
 
-## Scope
+## What this repository contains
 
-Kansas Frontier Matrix (**KFM**) is not a generic GIS portal, a map tile project, a graph demo, or an AI chatbot.
+### Governance and contracts
 
-**CONFIRMED doctrine:** KFM’s durable public value is the **inspectable claim**: a statement reconstructable to admissible evidence, spatial and temporal scope, source role, policy posture, review state, release state, and correction lineage.
+- `contracts/`: runtime and interface contract documentation.
+- `schemas/contracts/v1/`: JSON schemas used by validation tooling.
+- `policy/`: policy bundles and runtime policy tests.
 
-**PROPOSED implementation posture:** move the repository through small, reversible, proof-bearing thin slices before broad live-source ingestion, public map layers, UI polish, model-provider integration, or publication workflows.
+### Tooling and validation
 
-**UNKNOWN until repo inspection:** current package manager, root directory conventions, checked-in schemas, APIs, route names, workflows, tests, dashboards, runtime logs, branch protections, source registries, emitted receipts, and release artifacts.
+- `tools/ci/`: baseline verifiers, rendering helpers, and fixture validators.
+- `tools/validators/`: contract/policy-oriented validators.
+- `tools/receipts/`, `tools/proofs/`, `tools/registry/`: helper CLIs and proof/receipt/registry utilities.
 
-> [!WARNING]
-> This README is written from attached KFM doctrine, the uploaded README draft, and a current-session workspace scan. The authoring session did **not** expose a mounted KFM Git checkout. Any implementation-shaped path, command, route, workflow, schema, test, or file below is either `PROPOSED`, `UNKNOWN`, or `NEEDS VERIFICATION` until a maintainer confirms it in the real repository.
+### Applications
 
-[Back to top](#top)
+- `apps/governed-api/`: API-side runtime and route adapters.
+- `apps/ui/`: UI-side mapping and adapter logic.
+- `apps/web/`, `ui/`, `web/`: web and UI documentation surfaces.
 
----
+### Documentation
 
-## Evidence basis
+- `docs/architecture/`: architecture references.
+- `docs/adr/`: architecture decision records.
+- `docs/runbooks/`: operational runbooks (including repository next-step planning).
+- `docs/domains/`: domain-focused documentation lanes.
 
-This file is intentionally truth-labeled because README language can otherwise create false implementation confidence.
+## Baseline workflow
 
-| Evidence class | Status in this revision | How it is used |
-|---|---|---|
-| Attached KFM doctrine and synthesis PDFs | `CONFIRMED as supplied documents` | Establish KFM identity, trust posture, lifecycle, object families, UI/AI boundaries, and publication discipline |
-| Uploaded root README draft | `CONFIRMED as source text` | Preserved as the baseline structure and wording where strong |
-| Current-session workspace scan | `CONFIRMED` | Confirms `/mnt/data` is not a Git repository and visible files are uploaded PDFs / prompts, not a mounted source tree |
-| Target repository implementation | `UNKNOWN` | Not used to claim existing files, routes, workflows, tests, source registries, dashboards, branch rules, or runtime behavior |
-| External standards and sources | `DEFERRED` | Not needed for this root README revision; recheck separately for source activation, standards versions, API behavior, licensing, or security facts |
+The baseline workflow currently checks the following thin-slice path:
 
-### Truth labels used here
+1. Repository and README path integrity checks.
+2. Baseline verifier checks.
+3. Script-level schema and catalog checks.
+4. Runtime policy fixture validation.
+5. Renderer fixture validation.
+6. `tests/ci` pytest suite.
 
-| Label | Meaning |
-|---|---|
-| `CONFIRMED` | Verified in this session from attached documents, uploaded Markdown, command output, or visible workspace evidence |
-| `PROPOSED` | Recommended design, file home, sequence, or implementation shape not verified as present in the repo |
-| `UNKNOWN` | Not verifiable because the repository, runtime, logs, workflows, dashboards, or platform settings were not mounted |
-| `NEEDS VERIFICATION` | Specific check required before merge, source activation, release, or public claim |
-| `CONFLICTED` | Evidence suggests unresolved authority, naming, or file-home ambiguity; no current repo conflict is proven without repo access |
+This establishes a reliable minimum merge gate for repository integrity and fixture-level policy/rendering behavior.
 
-[Back to top](#top)
+## Local verification quickstart
 
----
-
-## Repo fit
-
-This README is the root orientation layer. It should help maintainers and reviewers decide whether a change preserves KFM’s trust membrane before they inspect lower-level docs, contracts, tests, and release artifacts.
-
-| Field | Value |
-|---|---|
-| **Target file** | `README.md` or `readme.md` — `NEEDS VERIFICATION`; the uploaded draft used `readme.md` |
-| **Role** | Root orientation, trust posture, navigation, contributor guardrails, and verification-first onboarding |
-| **Primary upstream doctrine** | `docs/architecture/`, `docs/registers/`, `docs/adr/` — `PROPOSED / NEEDS VERIFICATION` |
-| **Machine contracts** | `schemas/contracts/v1/` and/or `contracts/` — `CONFLICTED / ADR REQUIRED` |
-| **Policy boundary** | `policy/`, `tools/validators/`, `.github/workflows/` — `PROPOSED / NEEDS VERIFICATION` |
-| **Downstream consumers** | governed API, MapLibre shell, Evidence Drawer, Focus Mode, exports, release review — `PROPOSED until code is inspected` |
-| **Primary reviewer question** | “Does this change preserve the trust membrane and make claims more inspectable?” |
-
-This file should stay high-level. Domain details, source-specific rules, validator behavior, schema definitions, policy code, and release proof formats belong in their own verified repo homes and should be linked here only after their paths are confirmed.
-
----
-
-## Accepted inputs
-
-Use this README to orient maintainers, contributors, reviewers, and stewards around KFM’s governed shape.
-
-| Accepted input | Belongs here when… | Typical downstream home |
-|---|---|---|
-| Project identity | It explains what KFM is and is not | `docs/architecture/` — `NEEDS VERIFICATION` |
-| Trust posture | It names rules contributors must preserve | `docs/registers/`, `policy/` — `NEEDS VERIFICATION` |
-| Lifecycle overview | It clarifies RAW → PUBLISHED movement | `data/`, `release/`, `docs/runbooks/` — `NEEDS VERIFICATION` |
-| First-slice guidance | It describes safe next work without claiming implementation | `docs/adr/`, `tests/`, `tools/validators/` — `NEEDS VERIFICATION` |
-| Contributor gates | It tells reviewers what must pass before merge | `.github/`, `tests/`, `policy/` — `NEEDS VERIFICATION` |
-| Navigation | It points to verified repo paths | Root and directory READMEs after path verification |
-
----
-
-## Exclusions
-
-Do **not** use this README as a dumping ground for raw material, unstable operational facts, or unreviewed public claims.
-
-| Excluded item | Why it does not belong here | Put it here instead |
-|---|---|---|
-| Raw source files, scraped data, private records | Root README is not a lifecycle store | `data/raw/`, `data/work/`, or `data/quarantine/` after source intake — `NEEDS VERIFICATION` |
-| Secrets, API keys, tokens, credentials | Public docs and receipts must not leak secrets | Local secret manager / deployment config outside repo |
-| Exact sensitive locations | Archaeology, rare species, cultural, critical-infrastructure, living-person, and DNA contexts fail closed | Restricted steward workflow with redaction/generalization receipts |
-| Direct model output | AI is interpretive, not root truth | Governed runtime envelope + EvidenceBundle + citation validation |
-| Unverified source terms or current endpoint claims | Rights, quotas, schemas, and APIs change | Source registry with `NEEDS VERIFICATION` |
-| Broad route/API claims | Current route tree was not inspected | API contracts after repo verification |
-| Emergency or medical instructions | KFM contextualizes evidence; it is not an alerting or medical system | Official emergency, public-health, or life-safety authorities |
-
-[Back to top](#top)
-
----
-
-## Architecture at a glance
-
-```mermaid
-flowchart LR
-  A[SourceDescriptor<br/>source role, rights, sensitivity] --> B[RAW<br/>immutable bytes or references]
-  B --> C{Intake checks}
-  C -->|valid enough to work| D[WORK<br/>normalization + review]
-  C -->|invalid / sensitive / unclear rights| Q[QUARANTINE<br/>fail closed]
-  D --> E[PROCESSED<br/>validated normalized artifacts]
-  E --> F[CATALOG / TRIPLET<br/>discoverable evidence + relations]
-  F --> G{Promotion gates}
-  G -->|pass policy + review + proof| H[PUBLISHED<br/>released public-safe artifacts]
-  G -->|fail or uncertain| Q
-
-  H --> I[Governed API<br/>finite outcomes]
-  I --> J[MapLibre shell<br/>map + time + trust cues]
-  I --> K[Evidence Drawer<br/>EvidenceRef → EvidenceBundle]
-  I --> L[Focus Mode<br/>ANSWER / ABSTAIN / DENY / ERROR]
-  J --> M[Inspectable claim]
-  K --> M
-  L --> M
-
-  H --> N[Exports / stories<br/>trust cues preserved]
-  M --> O[Correction / rollback lineage]
-```
-
-### Non-negotiable trust rules
-
-| Rule | README-level meaning |
-|---|---|
-| **Lifecycle is law** | Public surfaces do not read RAW, WORK, QUARANTINE, or canonical/internal stores directly. |
-| **Evidence outranks fluency** | An EvidenceBundle beats generated prose. Focus Mode cites, abstains, denies, or errors. |
-| **Renderer is not truth** | MapLibre renders governed outputs; it does not decide source authority. |
-| **AI is an adapter** | Model runtimes stay behind governed APIs, after evidence resolution and policy checks. |
-| **Promotion is a state transition** | Publication requires validation, policy, review, proof, and rollback memory. |
-| **Negative states are first class** | Unsupported, restricted, stale, generalized, embargoed, and unresolved are valid outcomes. |
-| **Rights and sensitivity fail closed** | Unknown rights, unclear sensitivity, or exact sensitive geometry blocks public release. |
-
----
-
-## Target directory tree
-
-`NEEDS VERIFICATION`: this tree reflects the target architecture repeatedly described in the attached implementation manuals and the uploaded draft. Verify the real checkout before creating, moving, renaming, or linking files.
-
-```text
-.
-├── README.md                       # or readme.md — confirm repo convention
-├── docs/
-│   ├── README.md
-│   ├── adr/
-│   ├── architecture/
-│   ├── domains/
-│   ├── registers/
-│   └── runbooks/
-├── schemas/
-│   └── contracts/
-│       └── v1/
-├── contracts/
-│   ├── api/
-│   └── runtime/
-├── policy/
-├── tools/
-│   ├── validators/
-│   └── ingest/
-├── pipelines/
-├── data/
-│   ├── registry/
-│   ├── fixtures/
-│   ├── raw/
-│   ├── work/
-│   ├── quarantine/
-│   ├── processed/
-│   ├── catalog/
-│   ├── triplets/
-│   ├── receipts/
-│   ├── proofs/
-│   └── published/
-├── release/
-├── apps/
-│   ├── governed-api/
-│   └── web/
-├── packages/
-├── tests/
-├── .github/
-│   └── workflows/
-├── infra/
-└── configs/
-```
-
-> [!CAUTION]
-> The schema home is not safe to assume. Do not maintain divergent machine contracts in both `schemas/` and `contracts/` without an ADR that names the canonical home, compatibility aliases, validators, and migration plan.
-
-[Back to top](#top)
-
----
-
-## Verification-first quickstart
-
-Start with evidence inventory, not build assumptions.
+From repository root:
 
 ```bash
-git status --short
-git branch --show-current
-git rev-parse --show-toplevel
+# run full baseline verification locally
+tools/ci/run_repo_baseline_local.sh
 
-find . -maxdepth 2 -type f \
-  \( -iname 'readme.md' -o -iname 'README.md' -o -name 'package.json' -o -name 'pyproject.toml' -o -name 'go.mod' -o -name 'Cargo.toml' -o -name 'Makefile' \) \
-  | sort
-
-find .github docs contracts schemas policy data tools tests apps packages pipelines infra configs release \
-  -maxdepth 3 -type f 2>/dev/null \
-  | sort \
-  | sed -n '1,250p'
+# run CI pytest slice directly
+python3 -m pytest -q tests/ci
 ```
 
-Record the result in a small repo-evidence note before changing architecture-significant files.
+## Development priorities
 
-### First safe PR shape
+The current priorities are tracked in:
 
-| Step | Target | Why this comes first |
-|---:|---|---|
-| 1 | Repo inventory + README/meta-block verification | Avoids false implementation confidence |
-| 2 | Schema-home ADR | Prevents contracts-vs-schemas drift |
-| 3 | Source registry skeleton | Makes source roles, rights, and sensitivity explicit |
-| 4 | Core schema wave | Makes EvidenceBundle, DecisionEnvelope, receipts, manifests, and layer payloads testable |
-| 5 | Offline fixtures | Allows valid/invalid proof without live source risk |
-| 6 | Validators + policy stubs | Converts doctrine into fail-closed checks |
-| 7 | No-network hydrology dry run | Proves a lower-sensitivity end-to-end lane before higher-risk domains |
-| 8 | Evidence Drawer + Focus payload contracts | Keeps UI and AI downstream of evidence |
+- `docs/runbooks/repository-next-steps.md`
 
-`PROPOSED`: hydrology remains the preferred first proof lane because it exercises source identity, geometry, time, catalog, API, UI, and evidence resolution without starting from the highest-sensitivity domains.
+As of 2026-04-25, the highest-value sequence is:
 
----
+1. Reduce ambiguity in root-level documentation claims.
+2. Expand boundary-level contract tests for API/UI adapters.
+3. Build one deterministic end-to-end governed artifact path in CI.
+4. Systematically reduce unresolved documentation markers.
 
-## Core object families
+## Contribution expectations
 
-These object families are a contract and verification backlog unless the real repository proves they already exist.
+When submitting changes:
 
-| Object family | Purpose | Public-release pressure |
-|---|---|---|
-| `SourceDescriptor` | Names source role, authority limits, rights, sensitivity, cadence, and activation state | Blocks promotion when rights/source role are unknown |
-| `EvidenceRef` | Stable reference to support material | Must resolve before consequential claims |
-| `EvidenceBundle` | Inspectable support package with source, scope, lineage, rights, and review posture | Outranks generated language |
-| `PolicyDecision` | Records allow/deny/abstain obligations | Must be visible to release and UI gates |
-| `ValidationReport` | Explains what passed, failed, or quarantined | Required for reviewable promotion |
-| `RuntimeResponseEnvelope` | Finite outward answer shape | Prevents free-form unsupported responses |
-| `RunReceipt` / `AIReceipt` | Process memory for pipelines and model-assisted outputs | Receipts are not proof by themselves |
-| `ReleaseManifest` | Names released artifacts and integrity metadata | Required for publication and rollback |
-| `LayerManifest` | Binds map layers to governed sources and evidence routes | Map layer must not point to raw/work/quarantine |
-| `CatalogMatrix` | Tracks catalog closure and discoverability | Prevents orphaned artifacts |
-| `RollbackReference` | Identifies prior release or rebuild target | Required for correction-forward publication |
+- Keep claims in docs aligned with files, scripts, and tests that exist in this checkout.
+- Prefer small, verifiable slices with explicit tests.
+- Extend existing validators/tests instead of introducing parallel one-off checks.
+- Update runbooks when operational expectations change.
+
+## Useful paths
+
+- Baseline workflow: `.github/workflows/verification-baseline.yml`
+- Baseline local runner: `tools/ci/run_repo_baseline_local.sh`
+- Baseline verifier: `tools/ci/verify_baseline.sh`
+- CI tests: `tests/ci/`
+- Policy runtime fixtures: `policy/fixtures/runtime/`
+- Next-step runbook: `docs/runbooks/repository-next-steps.md`
 
 ---
 
-## UI and AI boundary
-
-KFM’s UI is part of the trust system, not decorative chrome. KFM’s AI layer is interpretive, bounded, and subordinate to evidence, policy, review, and release state.
-
-| Surface | Must do | Must never do |
-|---|---|---|
-| MapLibre shell | Render governed layers with time, trust, evidence, review, and policy cues | Become a sovereign source of truth |
-| Evidence Drawer | Resolve EvidenceRef into EvidenceBundle details | Behave like an optional tooltip |
-| Focus Mode | Synthesize only over released, policy-safe evidence with finite outcomes | Act as a free-form chatbot or direct model client |
-| Review surface | Show diffs, obligations, approvals, denials, and correction state | Become a hidden alternate truth system |
-| Export / story | Preserve trust cues, provenance, generalization, and correction state | Strip evidence context for polish |
-| Controlled 3D | Answer burden-bearing questions only when 2D cannot carry the burden | Turn KFM into spectacle-first visualization |
-
----
-
-## Definition of done
-
-A KFM change is not done because it renders, summarizes, or passes a happy-path demo. It is done when it strengthens inspectability without weakening governance.
-
-- [ ] Repository path, owner, and adjacent docs verified.
-- [ ] KFM meta block present and reviewable for every governed Markdown file touched.
-- [ ] Source roles, rights, sensitivity, and activation state declared.
-- [ ] EvidenceRef resolves to EvidenceBundle for consequential claims.
-- [ ] Lifecycle state is explicit: RAW, WORK, QUARANTINE, PROCESSED, CATALOG/TRIPLET, or PUBLISHED.
-- [ ] No public route, UI layer, export, story, or Focus result reads RAW, WORK, QUARANTINE, or canonical stores directly.
-- [ ] Valid and invalid fixtures exist for changed contracts.
-- [ ] Validators fail closed for unknown rights, unknown sensitivity, missing citation, unsupported source role, and unresolved evidence.
-- [ ] Decision envelope supports `ANSWER`, `ABSTAIN`, `DENY`, and `ERROR`.
-- [ ] Receipts and proofs remain separate.
-- [ ] Release path includes review state, promotion decision, rollback reference, and correction route.
-- [ ] Docs updated where behavior, contract, lifecycle, or public meaning changed.
-- [ ] Rollback is described before publication.
-
-[Back to top](#top)
-
----
-
-## Current verification backlog
-
-| Item | Status | Next check |
-|---|---|---|
-| Root file casing: `README.md` vs `readme.md` | `CONFIRMED` (`README.md` present, `readme.md` absent) | Keep root filename stable as `README.md` |
-| Owner / CODEOWNERS coverage | `NEEDS VERIFICATION` | Confirm steward ownership model and CODEOWNERS intent with maintainers |
-| Package manager and test runner | `UNKNOWN` | Confirm authoritative runtime/toolchain and executable verification commands |
-| Schema home | `CONFLICTED / NEEDS ADR` | Decide `schemas/contracts/v1/` vs `contracts/` authority |
-| Existing governed API | `UNKNOWN` | Inspect `apps/`, `packages/`, and route contracts |
-| Existing MapLibre shell | `UNKNOWN` | Inspect web app and layer registry |
-| Existing Evidence Drawer / Focus Mode | `UNKNOWN` | Inspect UI contracts and runtime envelopes |
-| CI gates | `PARTIALLY VERIFIED` (`.github/workflows/verification-baseline.yml` now enforces baseline path checks) | Add contract/policy/runtime-proof gates and required-check settings |
-| Source registry | `UNKNOWN` | Inspect `data/registry/` and source descriptor conventions |
-| Release artifacts | `UNKNOWN` | Inspect `release/`, `data/proofs/`, `data/receipts/`, and `data/published/` |
-| Public exposure posture | `NEEDS VERIFICATION` | Verify firewall, reverse proxy, VPN, auth, audit logging, secrets, and least-privilege boundaries before semi-public access |
-
----
-
-## FAQ
-
-### Is KFM a GIS portal?
-
-No. KFM may use GIS, MapLibre, catalogs, graph relations, AI, tiles, and APIs, but those are mechanisms. The public unit of value is the inspectable claim.
-
-### Can a map popup make a claim without evidence?
-
-No. A consequential popup should be able to route to an EvidenceBundle or clearly mark that evidence is unavailable, partial, restricted, stale, generalized, or under review.
-
-### Can Focus Mode answer from the model’s memory?
-
-No. Focus Mode is bounded synthesis over released, policy-safe evidence. It should return `ABSTAIN`, `DENY`, or `ERROR` rather than unsupported prose when evidence, rights, policy, or identity are insufficient.
-
-### Are receipts the same as proofs?
-
-No. Receipts are process memory: what ran, when, with which inputs, checks, and outputs. Proofs are release evidence that supports promotion and later inspection.
-
-### Why so many `UNKNOWN` labels?
-
-Because implementation evidence matters. Attached doctrine can confirm KFM’s intended architecture; it cannot prove the current repository’s route tree, tests, workflows, runtime behavior, or deployment posture without a mounted checkout.
-
----
-
-<details>
-<summary>Glossary</summary>
-
-| Term | Working meaning |
-|---|---|
-| **Inspectable claim** | A public-facing statement reconstructable to evidence, scope, source role, policy, review, release, and correction lineage |
-| **Trust membrane** | Boundary preventing internal/canonical/raw paths from becoming normal public truth paths |
-| **EvidenceRef** | Stable reference to evidence that must resolve into an EvidenceBundle |
-| **EvidenceBundle** | Human- and machine-inspectable support package |
-| **DecisionEnvelope** | Finite response object carrying outcome, evidence refs, policy, reason codes, and obligations |
-| **SourceDescriptor** | Source identity and governance record |
-| **spec_hash** | Deterministic identity for a specification or run input, not a claim of correctness |
-| **RunReceipt** | Process-memory record for pipeline execution |
-| **AIReceipt** | Process-memory record for material model participation |
-| **ReleaseManifest** | Integrity and publication manifest for released artifacts |
-| **CatalogMatrix** | Catalog closure surface for datasets, distributions, evidence, and release objects |
-| **LayerManifest** | Map-layer governance record binding renderer inputs to source/evidence/policy state |
-| **Quarantine** | Lifecycle state for invalid, unresolved, rights-conflicted, sensitive, or unfit material |
-| **Promotion** | Governed state transition into public-safe release, not a file move |
-| **RollbackReference** | Explicit path back to prior release or rebuild target |
-| **Focus Mode** | Evidence-bounded synthesis surface with finite outcomes |
-| **Evidence Drawer** | Trust-visible UI object that explains what backs a claim |
-
-</details>
-
-[Back to top](#top)
+If you are looking for the immediate execution plan, start with `docs/runbooks/repository-next-steps.md`.

--- a/docs/runbooks/repository-next-steps.md
+++ b/docs/runbooks/repository-next-steps.md
@@ -1,128 +1,108 @@
 # Repository Next Steps (2026-04-25)
 
-This runbook captures the most practical next actions after a repository scan on 2026-04-25.
+This runbook captures the most important next actions after a fresh repository scan and baseline verification run on **2026-04-25**.
 
-## Current snapshot
+## Evidence snapshot
 
-- The repository is documentation-heavy: 200 files total, with 130 Markdown files and only a small set of executable artifacts (shell, Rego, JSON schemas).  
-- The currently executable CI baseline path is narrow but healthy: `.github/workflows/verification-baseline.yml` runs shell syntax checks, self-tests, and `tools/ci/verify_baseline.sh`.  
-- `tools/ci/test_verify_baseline.sh` passes locally and validates both pass/fail behavior for the baseline verifier.
+- Baseline local verification is green via `tools/ci/run_repo_baseline_local.sh`, including schema checks, runtime policy fixture checks, renderer fixture checks, and CI tests (`89 passed`).
+- The baseline GitHub workflow (`.github/workflows/verification-baseline.yml`) already executes thin-slice checks for baseline integrity, script validation, policy fixture validation, renderer fixture validation, and `tests/ci`.
+- The repo remains documentation-heavy (190 Markdown files out of 361 files), which means governance quality is currently constrained more by documentation clarity than by missing baseline test scaffolding.
+- Placeholder and uncertainty markers are still high:
+  - `TODO`: 423
+  - `UNKNOWN`: 469
+  - `NEEDS VERIFICATION`: 1,815
 
-## Progress update (2026-04-25)
+## Why the priorities changed
 
-- Baseline checks are now listed explicitly in `.github/workflows/verification-baseline.yml` (shell checks, script checks, fixture validation, and `tests/ci`) for clearer CI job visibility.
-- Local baseline execution remains green (`89 passed` in `tests/ci` as of 2026-04-25).
-- Runtime policy smoke checks are enforced through `tools/ci/validate_policy_runtime_fixtures.py`, including finite outcome coverage over `policy/fixtures/runtime/*.json`.
-- The baseline workflow has been consolidated so that shared steps are not duplicated, using `tools/ci/run_repo_baseline_local.sh` for the local wrapper path where appropriate.
-- This keeps CI behavior stable while reducing redundant runtime and maintenance surface.
+Earlier next-step guidance focused on adding baseline and smoke checks. That work is now in place. The highest-value work has shifted to **reducing ambiguity in authoritative docs**, **turning thin-slice checks into enforceable contract tests at additional boundaries**, and **proving one governed end-to-end runtime path beyond fixture-level smoke validation**.
 
-## Key gaps discovered
+## Priority plan
 
-1. **Documentation-to-repo drift is high.**
-   - Several READMEs describe scripts or helpers that are not present in the current tree.
-   - Example drift:
-     - `scripts/README.md` lists helper files that do not exist.
-2. **Placeholder density is very high.**
-   - A scan found ~1,875 `TODO`, `UNKNOWN`, and `NEEDS VERIFICATION` markers across core documentation lanes.
-3. **Machine-enforced governance is minimal today.**
-   - Current CI checks structural baseline only.
-   - Contract, schema, and policy gates are represented in docs but are not yet wired into runnable enforcement from this checkout.
+### P0 — Reduce trust-surface ambiguity in top-level docs (1–2 days)
 
-## Recommended next steps (priority order)
+1. Rewrite the root `README.md` from “unknown/doctrine-first” language to “repo-evidenced” language.
+2. Keep the doctrine framing, but move speculative/legacy claims into a clearly labeled appendix.
+3. Set a target to reduce root-README `NEEDS VERIFICATION` markers by at least **50%**.
 
-### P0 — Stabilize truth of repository documentation
+**Definition of done:**
+- Root README claims only behaviors that are directly backed by existing paths, scripts, tests, or workflow jobs.
+- Remaining uncertain claims are isolated and explicitly labeled as future work.
 
-1. Align README claims to currently mounted files (or create the referenced files).
-2. Start with top drift surfaces:
-   - `scripts/README.md`
-   - `tools/ci/README.md`
-3. Introduce one explicit status marker in each README section:
-   - `Present in repo`
-   - `Planned`
-   - `Archived`
+### P1 — Add mandatory contract gate coverage beyond current fixtures (2–4 days)
 
-**Definition of done:** no README claims file paths that do not exist without explicitly marking them as planned.
+1. Extend CI from fixture validity checks to explicit **contract boundary checks**:
+   - API route payload contracts (`apps/governed-api/ecology/*`)
+   - UI payload mapping contracts (`apps/ui/ecology/evidence_drawer_mapper.py`)
+2. Add at least one negative test per boundary for malformed payloads and missing required fields.
+3. Ensure failure messages are deterministic and actionable.
 
-### P1 — Expand thin-slice CI beyond baseline
+**Definition of done:**
+- CI fails when contract-breaking payload changes are introduced at API or UI adapter boundaries.
+- New tests document expected failure behavior for malformed evidence/claim payloads.
 
-1. Add a lightweight docs consistency check script (for example, verify referenced local file paths exist).
-2. Add JSON schema validation smoke tests using existing `schemas/contracts/v1/*.schema.json` files and fixture payloads.
-3. Add policy smoke checks for `policy/bundles/runtime/*.rego` using existing fixtures.
+### P2 — Build one governed E2E proof path in CI artifacts (3–5 days)
 
-**Definition of done:** CI fails on broken local doc links/path claims, invalid schema fixtures, and broken runtime policy tests.
+1. Promote one deterministic end-to-end path from fixture input to rendered output artifact:
+   - runtime fixture → policy decision → renderer summary artifact
+2. Publish the output as a CI artifact and validate checksum/structure in tests.
+3. Document the path in a short operator runbook.
 
-### P2 — Build one end-to-end governed proof slice
+**Definition of done:**
+- One command path can reproducibly generate a governed output artifact from fixed fixtures.
+- CI verifies both semantic content and structural stability of that artifact.
 
-1. Select one claim type (recommended: runtime finite outcomes).
-2. Produce a minimal fixture-to-decision path:
-   - fixture input
-   - policy decision
-   - envelope validation
-   - receipt/proof artifact
-3. Document this in `docs/runbooks/` as the canonical “first governed release slice.”
+### P3 — Systematically burn down placeholder debt in high-impact docs (ongoing)
 
-**Definition of done:** a single command path can reproduce a governed decision artifact from fixture input with deterministic output.
+1. Rank files by marker density and start with root/architecture/runbook docs.
+2. For each file, resolve markers by either:
+   - replacing with verified facts,
+   - moving to a planned-work section, or
+   - deleting stale claims.
+3. Track weekly marker counts in this runbook.
 
-### P3 — Reduce placeholder debt deliberately
+**Definition of done:**
+- Marker count trend is consistently down week-over-week.
+- Documentation uncertainty no longer blocks implementation or review decisions.
 
-1. Triage top 20 files by unresolved marker count.
-2. For each file, choose one action:
-   - resolve now,
-   - downgrade claim scope,
-   - split into `planned` appendix.
-3. Track marker burn-down weekly.
+## 7-day execution packet (recommended)
 
-**Definition of done:** 30% reduction in unresolved markers in the top 20 files without introducing unverified implementation claims.
+1. **Day 1:** Root README truth pass (P0).
+2. **Day 2–3:** Add API/UI negative boundary tests (P1).
+3. **Day 4–5:** Add one deterministic E2E governed artifact test + CI artifact publish (P2).
+4. **Day 6:** Run placeholder triage on top 10 docs (P3).
+5. **Day 7:** Publish progress update in this file with new metrics and remaining blockers.
 
-## Suggested first sprint backlog (1 week)
+## Weekly scorecard template
 
-- Fix drift in `scripts/README.md` and `tools/ci/README.md`.
-- Add `tools/ci/check_readme_paths.sh`.
-- Add workflow job to run:
-  - baseline verifier
-  - README path check
-  - schema smoke check
-  - runtime policy smoke check
-- Add one concise runbook for “baseline + smoke CI failure triage”.
+Update this section each week.
 
+- Baseline run status: `PASS/FAIL`
+- `tests/ci` pass count:
+- Marker counts:
+  - `TODO`:
+  - `UNKNOWN`:
+  - `NEEDS VERIFICATION`:
+- Root README verification marker count:
+- New boundary tests added this week:
+- E2E governed artifact status:
+- Top blocker:
 
-## Immediate next (post baseline workflow cleanup)
+## Commands used for this analysis
 
-Now that baseline scripts and renderer tests exist, the next highest-value moves are:
-
-1. **Lock input contracts for renderer scripts**
-   - Add JSON Schema files for renderer input reports.
-   - Validate inputs before rendering so CI fails with clear contract errors.
-
-2. **Add negative-path CI tests**
-   - Add tests for malformed JSON, missing required keys, and empty report files.
-   - Ensure each renderer exits non-zero with deterministic error messaging.
-
-3. **Wire documentation drift checks**
-   - Add `tools/ci/check_readme_paths.sh` that validates declared “current” file trees in READMEs.
-   - Gate pull requests on this check to prevent docs/repo divergence.
-
-4. **Promote one governed end-to-end fixture**
-   - Add a single fixture set under `tests/contracts/fixtures/runtime/`.
-   - Validate fixture -> policy decision -> envelope -> rendered summary in one deterministic test path.
-
-5. **Define merge gates explicitly**
-   - Document required checks in `.github/workflows/README.md` and align branch protection expectations.
-   - Keep `verification-baseline` as the minimum required status while expanding gates incrementally.
-
-
-## Next execution packet (recommended order)
-
-Use this as the concrete next implementation sequence:
-
-1. Add renderer input schemas under `schemas/contracts/v1/runtime/` and reject invalid payloads in each `tools/ci/render_*.py` entrypoint.
-2. Add failing-path tests in `tests/ci/` for malformed JSON and missing required keys.
-3. Add one integration test that runs: fixture -> policy output -> renderer handoff markdown.
-4. Document required status checks in `.github/workflows/README.md` and mirror them in branch protection settings.
-
-### Exit criteria for this packet
-
-- Every renderer has at least one negative-path test.
-- Invalid renderer input fails before markdown generation.
-- One deterministic end-to-end CI artifact is produced from fixture data.
-- Required checks are documented in-repo and enforced in GitHub settings.
+```bash
+tools/ci/run_repo_baseline_local.sh
+python - <<'PY'
+from pathlib import Path
+root=Path('.')
+files=[p for p in root.rglob('*') if p.is_file() and '.git' not in p.parts]
+print('files',len(files))
+print('markdown',sum(1 for p in files if p.suffix.lower()=='.md'))
+PY
+python - <<'PY'
+import subprocess
+for pat in ['TODO','UNKNOWN','NEEDS VERIFICATION']:
+    out=subprocess.run(['rg','-n',pat,'.'],capture_output=True,text=True)
+    count=0 if out.returncode==1 else len(out.stdout.strip().splitlines())
+    print(pat,count)
+PY
+```


### PR DESCRIPTION
### Motivation

- Align top-level documentation with what is actually present and verified in the repository instead of doctrine-first, speculative language. 
- Provide a clearer, evidence-backed onboarding and next-step plan that reflects the current baseline verification infrastructure. 

### Description

- Replace a large doctrine-heavy root `README.md` with a concise, repo-evidenced README that documents the baseline verification commands, repository layout highlights, and useful entry points. 
- Update `docs/runbooks/repository-next-steps.md` to capture a focused evidence snapshot, re-prioritized next steps (P0..P3), and a 7-day execution packet informed by a live baseline run. 
- Surface the baseline tooling and workflow entries such as `tools/ci/run_repo_baseline_local.sh`, `.github/workflows/verification-baseline.yml`, and `tests/ci` as authoritative verification paths. 

### Testing

- Ran the baseline local verifier with `tools/ci/run_repo_baseline_local.sh`, which includes schema, policy fixture, renderer fixture checks, and CI tests, and verified it succeeded. 
- Executed the CI pytest slice with `python3 -m pytest -q tests/ci`, which reported `89 passed` tests. 
- Confirmed the repository baseline GitHub workflow (`.github/workflows/verification-baseline.yml`) is configured to run the thin-slice checks used by the local baseline verifier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0a68b970832aa1db48ea2ee75f80)