### PR TITLE
Scaffold remaining .github control-surface files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report a defect in behavior, validation, or automation
+title: "[bug] "
+labels: [bug]
+assignees: []
+---
+
+## Summary
+
+## Expected behavior
+
+## Actual behavior
+
+## Reproduction steps
+1.
+2.
+3.
+
+## Affected paths
+
+## Evidence
+
+## Environment
+- Branch:
+- Commit:
+- Runtime/tool versions:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: ../SECURITY.md
+    about: Please use private vulnerability reporting instructions.

--- a/.github/ISSUE_TEMPLATE/documentation_drift.md
+++ b/.github/ISSUE_TEMPLATE/documentation_drift.md
@@ -1,0 +1,17 @@
+---
+name: Documentation drift
+about: Report docs that no longer match implementation
+title: "[docs-drift] "
+labels: [documentation]
+assignees: []
+---
+
+## Drift summary
+
+## Source of truth path(s)
+
+## Drifted doc path(s)
+
+## Proposed correction
+
+## Verification commands

--- a/.github/ISSUE_TEMPLATE/policy_or_release_gap.md
+++ b/.github/ISSUE_TEMPLATE/policy_or_release_gap.md
@@ -1,0 +1,17 @@
+---
+name: Policy or release gap
+about: Report missing policy controls or release evidence gates
+title: "[policy-release-gap] "
+labels: [policy]
+assignees: []
+---
+
+## Gap summary
+
+## Affected workflow/policy path(s)
+
+## Risk if unresolved
+
+## Proposed guardrail
+
+## Validation or fixture updates needed

--- a/.github/ISSUE_TEMPLATE/source_intake.md
+++ b/.github/ISSUE_TEMPLATE/source_intake.md
@@ -1,0 +1,19 @@
+---
+name: Source intake
+about: Propose onboarding a new source or updating source terms
+title: "[source-intake] "
+labels: [source-intake]
+assignees: []
+---
+
+## Source summary
+
+## Source role
+
+## Rights and usage terms
+
+## Sensitivity considerations
+
+## Expected cadence
+
+## Proposed target paths

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,50 @@
-# .github/PULL_REQUEST_TEMPLATE
+# Pull Request
 
-Skeletal placeholder created to satisfy repository documentation links.
+## Summary
+<!-- What changed and why? Keep this concise and link issues/docs. -->
 
-## Status
+## Change type
+- [ ] docs
+- [ ] ci/workflows
+- [ ] contracts/schemas
+- [ ] policy
+- [ ] runtime/app code
+- [ ] data/catalog/receipts/proofs
+- [ ] other (describe)
 
-Draft placeholder; expand with scoped ownership, contracts, and usage guidance.
+## Affected surfaces
+- [ ] `.github/`
+- [ ] `docs/`
+- [ ] `contracts/`
+- [ ] `schemas/`
+- [ ] `policy/`
+- [ ] `tools/`
+- [ ] `tests/`
+- [ ] `data/`
+- [ ] `apps/` / `packages/`
+
+## Truth labels used in this PR
+- [ ] `CONFIRMED`
+- [ ] `INFERRED`
+- [ ] `PROPOSED`
+- [ ] `UNKNOWN`
+- [ ] `NEEDS_VERIFICATION`
+
+## Evidence and references
+<!-- Link the files, fixtures, run logs, ADRs, and docs this PR relies on. -->
+- 
+
+## Validation run
+<!-- Paste exact commands and a short result summary. -->
+```bash
+# example
+# sh ./tools/ci/verify_baseline.sh baseline-report.txt
+```
+
+## Risk and rollback
+- Risk level: low / medium / high
+- Rollback plan:
+- Follow-up tasks:
+
+## Reviewer notes
+<!-- Anything you want reviewers to focus on first. -->

--- a/.github/README.md
+++ b/.github/README.md
@@ -173,29 +173,35 @@ They should answer **when** and **why** GitHub calls a check. The check itself s
 
 ## Directory map
 
-Current `.github/` contents were **not** available in the workspace used to draft this file. Treat the tree below as a verification map, not an inventory claim.
+Current `.github/` contents are now partially scaffolded in-repo. The tree below is the current checked-in baseline and still uses placeholder files where implementation details are pending.
 
 ```text
 .github/
 ├── README.md                         # this file
 ├── CODEOWNERS                        # NEEDS_VERIFICATION
 ├── PULL_REQUEST_TEMPLATE.md          # NEEDS_VERIFICATION
-├── ISSUE_TEMPLATE/                   # NEEDS_VERIFICATION
-│   ├── bug_report.md                 # NEEDS_VERIFICATION
-│   ├── documentation_drift.md        # PROPOSED pattern
-│   ├── source_intake.md              # PROPOSED pattern
-│   └── policy_or_release_gap.md      # PROPOSED pattern
-├── workflows/                        # NEEDS_VERIFICATION
-│   ├── README.md                     # NEEDS_VERIFICATION
-│   ├── docs-lint.yml                 # NEEDS_VERIFICATION
-│   ├── contracts.yml                 # NEEDS_VERIFICATION
-│   ├── policy.yml                    # NEEDS_VERIFICATION
-│   ├── tests.yml                     # NEEDS_VERIFICATION
-│   └── release-dry-run.yml           # PROPOSED pattern
-├── dependabot.yml                    # NEEDS_VERIFICATION
-└── linters/                          # NEEDS_VERIFICATION
-    ├── markdownlint.json             # NEEDS_VERIFICATION
-    └── mlc.config.json               # NEEDS_VERIFICATION
+├── ISSUE_TEMPLATE/
+│   ├── bug_report.md
+│   ├── documentation_drift.md
+│   ├── source_intake.md
+│   └── policy_or_release_gap.md
+├── SECURITY.md
+├── dependabot.yml
+├── actions/
+│   └── README.md
+├── watchers/
+│   └── README.md
+├── workflows/
+│   ├── README.md
+│   ├── verification-baseline.yml
+│   ├── docs-lint.yml
+│   ├── contracts.yml
+│   ├── policy.yml
+│   ├── tests.yml
+│   └── release-dry-run.yml
+└── linters/
+    ├── markdownlint.json
+    └── mlc.config.json
 ```
 
 > [!TIP]

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+This repository follows a fail-closed posture for rights, sensitivity, and release safety.
+
+## Reporting a vulnerability
+
+Please do **not** open public issues for suspected vulnerabilities.
+
+1. Open a private security advisory through GitHub Security Advisories for this repo.
+2. Include reproduction steps, impacted paths, and suggested severity.
+3. If sensitive data exposure is involved, include exact objects/paths and time window.
+
+## Response expectations
+
+- Initial triage target: within 5 business days.
+- If accepted, a fix and disclosure plan will be coordinated with maintainers.
+- High-risk issues may require temporary feature disablement or release hold.
+
+## Scope highlights
+
+Security-sensitive areas include:
+- `.github/workflows/` (automation and artifact handling)
+- `policy/` (decision logic)
+- `contracts/` and `schemas/` (validation boundaries)
+- `apps/` and `tools/` (runtime/utility execution paths)
+- `data/` and `release/` (receipts, proofs, publishable artifacts)

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1,0 +1,5 @@
+# .github/actions
+
+Composite actions home for reusable GitHub Action steps.
+
+Current state: no composite actions checked in yet.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "python"

--- a/.github/linters/markdownlint.json
+++ b/.github/linters/markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false
+}

--- a/.github/linters/mlc.config.json
+++ b/.github/linters/mlc.config.json
@@ -1,0 +1,6 @@
+{
+  "no-hard-tabs": true,
+  "no-trailing-punctuation-in-headings": false,
+  "require-h1": true,
+  "allow-duplicate-heading-text": false
+}

--- a/.github/watchers/README.md
+++ b/.github/watchers/README.md
@@ -1,0 +1,5 @@
+# .github/watchers
+
+Placeholder directory for GitHub-facing watcher orchestration docs.
+
+Current state: watcher implementations live outside `.github/` unless specifically needed for Actions integration.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,7 @@ Governed GitHub Actions orchestration surface for validation, runtime proof, rec
 
 > [!NOTE]
 > **Status:** `experimental` · **Document status:** `draft` · **Owners:** `@bartytime4life` · **Path:** `.github/workflows/README.md`  
-> **Current public inventory:** `README.md` + `verification-baseline.yml` (+ optional `.gitkeep` placeholder); checked-in workflow YAML now includes a baseline verification gate.
+> **Current public inventory:** `README.md`, `verification-baseline.yml`, and scaffold workflows (`docs-lint.yml`, `contracts.yml`, `policy.yml`, `tests.yml`, `release-dry-run.yml`).
 > **Badges:** ![status](https://img.shields.io/badge/status-experimental-orange) ![doc](https://img.shields.io/badge/doc-draft-8250df) ![owner](https://img.shields.io/badge/owner-%40bartytime4life-0969da) ![lane](https://img.shields.io/badge/lane-.github%2Fworkflows-6f42c1) ![posture](https://img.shields.io/badge/posture-governed%20automation-0a7d5a) ![inventory](https://img.shields.io/badge/current%20inventory-README%20%2B%20verification--baseline.yml-lightgrey)
 > **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Inputs](#inputs) · [Exclusions](#exclusions) · [Directory tree](#directory-tree) · [Quickstart](#quickstart) · [Usage](#usage) · [Diagram](#diagram) · [Workflow lanes](#workflow-lanes) · [Task list](#task-list--definition-of-done) · [FAQ](#faq) · [Appendix](#appendix)
 
@@ -250,7 +250,12 @@ The following do **not** belong here as canonical truth:
 .github/
 └── workflows/
     ├── README.md
-    └── verification-baseline.yml
+    ├── verification-baseline.yml
+    ├── docs-lint.yml
+    ├── contracts.yml
+    ├── policy.yml
+    ├── tests.yml
+    └── release-dry-run.yml
 ```
 
 > [!NOTE]

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,14 @@
+name: contracts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "contracts workflow is scaffolded and pending implementation."

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,14 @@
+name: docs-lint
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "docs-lint workflow is scaffolded and pending implementation."

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -1,0 +1,14 @@
+name: policy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "policy workflow is scaffolded and pending implementation."

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,14 @@
+name: release-dry-run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "release-dry-run workflow is scaffolded and pending implementation."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,14 @@
+name: tests
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "tests workflow is scaffolded and pending implementation."


### PR DESCRIPTION
### Motivation
- Bring the repository `.github/` control-surface into a checked-in, usable state by creating the missing skeletal files referenced by the `.github` docs so maintainers have concrete templates to iterate on.
- Provide safe placeholders for additional workflow lanes without changing the existing baseline gate behavior by making the new workflow files `workflow_dispatch`-only.

### Description
- Added issue templates under ` .github/ISSUE_TEMPLATE/` (`bug_report.md`, `documentation_drift.md`, `source_intake.md`, `policy_or_release_gap.md`) and the template `config.yml` for issue handling. 
- Added `SECURITY.md`, `dependabot.yml`, linter configs (`.github/linters/markdownlint.json`, `.github/linters/mlc.config.json`), and placeholder READMEs for ` .github/actions/` and ` .github/watchers/`.
- Added scaffold workflow YAMLs (`.github/workflows/docs-lint.yml`, `contracts.yml`, `policy.yml`, `tests.yml`, `release-dry-run.yml`) that are `workflow_dispatch` placeholders and do not alter the verified `verification-baseline.yml` gate.
- Updated ` .github/PULL_REQUEST_TEMPLATE.md`, ` .github/README.md`, and ` .github/workflows/README.md` to reflect the newly scaffolded file tree and provide a more structured PR intake template.

### Testing
- Ran `sh ./tools/ci/test_check_readme_paths.sh` and it completed successfully. 
- Ran `sh ./tools/ci/check_readme_paths.sh --manifest ./tools/ci/readme_required_paths.txt` and it completed successfully. 
- Ran `python3 ./tools/ci/report_placeholder_markers.py --root . --top 5` and it completed successfully (placeholder markers reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee43e28158832a9736d9c4abc879f5)