### PR TITLE
Scaffold remaining ui directory sections and add README stubs

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -167,7 +167,7 @@ The UI should consume prepared, governed, released, or review-authorized inputs 
 
 ## Directory tree
 
-The current session did **not** expose a mounted repo tree, so the shape below is a review scaffold, not a claim that these files exist.
+The tree below reflects the initialized `ui/` structure in this repository as of 2026-04-27. Child folders are scaffolded and ready for contract/implementation-specific expansion.
 
 ```text
 ui/

--- a/ui/__tests__/README.md
+++ b/ui/__tests__/README.md
@@ -1,0 +1,14 @@
+# UI Tests
+
+Test guidance for UI-facing fixtures and contract-alignment checks.
+
+## Scope
+- Snapshot/fixture expectations for UI payload rendering.
+- Negative-state coverage for drawer/focus/shell modes.
+- Contract drift checks for UI payload shape assumptions.
+
+## Out of scope
+- Backend integration test ownership.
+
+## Next steps
+- Add concrete test command references once UI package tooling is confirmed.

--- a/ui/accessibility/README.md
+++ b/ui/accessibility/README.md
@@ -1,0 +1,14 @@
+# Accessibility
+
+Accessibility guidance for trust-visible map-first interactions.
+
+## Scope
+- Keyboard/screen-reader behavior expectations.
+- Non-color trust cue requirements.
+- Motion/contrast/readability guardrails.
+
+## Out of scope
+- Framework-specific implementation details.
+
+## Next steps
+- Add component-level a11y checklists and fixtures.

--- a/ui/compare/README.md
+++ b/ui/compare/README.md
@@ -1,0 +1,14 @@
+# Compare
+
+Compare/split-view UI expectations for asymmetric evidence-aware analysis.
+
+## Scope
+- Side-by-side state synchronization rules.
+- Cross-pane evidence visibility requirements.
+- Time/place alignment behaviors.
+
+## Out of scope
+- Canonical comparison scoring logic.
+
+## Next steps
+- Add compare payload examples and test scenarios.

--- a/ui/evidence-drawer/README.md
+++ b/ui/evidence-drawer/README.md
@@ -1,0 +1,16 @@
+# Evidence Drawer
+
+UI-facing notes for rendering Evidence Drawer payloads.
+
+## Scope
+- Drawer field semantics and trust-cue display.
+- Support/provenance/freshness/review visibility.
+- Error/deny/abstain handling in drawer context.
+
+## Out of scope
+- EvidenceBundle storage/resolution logic.
+- Contract/schema ownership.
+
+## Next steps
+- Add payload mapping examples aligned to governed contracts.
+- Link to app-level mapper tests.

--- a/ui/export/README.md
+++ b/ui/export/README.md
@@ -1,0 +1,14 @@
+# Export
+
+Trust-preserving export and share-preview guidance.
+
+## Scope
+- Export-preview trust cue requirements.
+- Evidence and scope carry-through expectations.
+- Release/sensitivity visibility in export flows.
+
+## Out of scope
+- Long-term artifact storage policy.
+
+## Next steps
+- Add export payload examples and validation checklist.

--- a/ui/focus/README.md
+++ b/ui/focus/README.md
@@ -1,0 +1,16 @@
+# Focus
+
+Bounded Focus Mode UI behavior for governed runtime outcomes.
+
+## Scope
+- Rendering for `ANSWER`, `ABSTAIN`, `DENY`, and `ERROR`.
+- Scope echo and citation visibility expectations.
+- User-facing trust copy for finite outcomes.
+
+## Out of scope
+- Direct model/runtime integration.
+- Policy rule authoring.
+
+## Next steps
+- Add UI examples mapped to runtime envelope fields.
+- Add failure/negative-state fixtures.

--- a/ui/maplibre/README.md
+++ b/ui/maplibre/README.md
@@ -1,0 +1,16 @@
+# MapLibre
+
+Map renderer boundary for the governed UI.
+
+## Scope
+- Layer/source/style binding notes.
+- Runtime rendering constraints for approved layers.
+- Trust-visible map interaction expectations.
+
+## Out of scope
+- Source admission rules.
+- Canonical data model definitions.
+
+## Next steps
+- Add layer registry references and adapter notes.
+- Add rendering test fixture references.

--- a/ui/review/README.md
+++ b/ui/review/README.md
@@ -1,0 +1,15 @@
+# Review
+
+Role-gated review/steward UI conventions.
+
+## Scope
+- Review overlays and decision affordances.
+- Evidence-first correction workflows.
+- Role/sensitivity-visible UI cues.
+
+## Out of scope
+- Authoritative policy enforcement implementation.
+- Separate hidden admin truth systems.
+
+## Next steps
+- Add review state model notes once paths/contracts are verified.

--- a/ui/shell/README.md
+++ b/ui/shell/README.md
@@ -1,0 +1,16 @@
+# UI Shell
+
+Defines shell-level state and navigation conventions for the map-first UI surface.
+
+## Scope
+- Global shell state (place, time, mode, selected object).
+- Deep-link hydration expectations.
+- Cross-surface state handoff rules.
+
+## Out of scope
+- Backend/runtime policy decisions.
+- Canonical schema authority.
+
+## Next steps
+- Add concrete state contract references after schema paths are verified.
+- Document route/state examples once app routes are finalized.

--- a/ui/story/README.md
+++ b/ui/story/README.md
@@ -1,0 +1,15 @@
+# Story
+
+Story presentation patterns that preserve map/time/evidence context.
+
+## Scope
+- Story sequencing expectations.
+- Evidence-linked story card behavior.
+- Mode transitions back to explore/dossier/focus.
+
+## Out of scope
+- Raw content ingestion pipelines.
+- Detached storytelling truth models.
+
+## Next steps
+- Add structure for story segment payloads and interactions.


### PR DESCRIPTION
### Motivation
- Initialize the `ui/` surface using the existing README blueprint so downstream implementers have a clear scaffold for MapLibre, Evidence Drawer, Focus, and other UI responsibilities.
- Make the repository state explicit by updating the `ui/` directory-tree preface to reflect that the `ui/` structure is now initialized in-repo as of 2026-04-27.
- Provide lightweight guidance placeholders to avoid prematurely authoring authoritative schemas, policy, or runtime logic in the UI layer.

### Description
- Added README stubs under `ui/` for the sections `shell`, `maplibre`, `evidence-drawer`, `focus`, `story`, `review`, `compare`, `export`, `accessibility`, and `__tests__` to capture scope, out-of-scope, and next steps for each area.
- Updated `ui/README.md` to change the directory-tree preface to state the initialized `ui/` structure and to keep the governance guidance in place.
- This change is documentation scaffolding only and does not modify any runtime UI logic, components, or schemas.

### Testing
- Verified presence of the new files with `find ui -maxdepth 2 -type f | sort` which listed the added README files.
- Ran the existing app-level test suite with `python3 -m pytest -q apps/ui/ecology/tests` which completed successfully with `8 passed`.
- No runtime or UI integration tests were added because the change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeda5eb9d4832a8b72eb2c63c2bbf9)