### PR TITLE
Add catalog crosslink helper, fixtures, and tests

### DIFF
--- a/tests/catalog/fixtures/promotion-record-mismatch.json
+++ b/tests/catalog/fixtures/promotion-record-mismatch.json
@@ -1,0 +1,20 @@
+{
+  "release_ref": "kfm:release:floodplain-kansas:v2",
+  "catalog_refs": {
+    "stac": {
+      "subject_id": "kfm:subject:floodplain-kansas",
+      "version": "v1",
+      "release_ref": "kfm:release:floodplain-kansas:v1"
+    },
+    "dcat": {
+      "subject_id": "kfm:subject:floodplain-kansas",
+      "version": "v1",
+      "release_ref": "kfm:release:floodplain-kansas:v1"
+    },
+    "prov": {
+      "subject_id": "kfm:subject:floodplain-kansas",
+      "version": "v1",
+      "release_ref": "kfm:release:floodplain-kansas:v1"
+    }
+  }
+}

--- a/tests/catalog/fixtures/prov-mismatch.json
+++ b/tests/catalog/fixtures/prov-mismatch.json
@@ -1,0 +1,19 @@
+{
+  "catalog_refs": {
+    "stac": {
+      "subject_id": "kfm:subject:floodplain-kansas",
+      "version": "v1",
+      "release_ref": "kfm:release:floodplain-kansas:v1"
+    },
+    "dcat": {
+      "subject_id": "kfm:subject:floodplain-kansas",
+      "version": "v1",
+      "release_ref": "kfm:release:floodplain-kansas:v1"
+    },
+    "prov": {
+      "subject_id": "kfm:subject:other",
+      "version": "v1",
+      "release_ref": "kfm:release:floodplain-kansas:v1"
+    }
+  }
+}

--- a/tests/catalog/test_catalog_crosslink.py
+++ b/tests/catalog/test_catalog_crosslink.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/catalog/catalog_crosslink.py"
+FIXTURES = ROOT / "tests/catalog/fixtures"
+
+
+def _run(decision_payload: dict, record_payload: dict, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    decision = tmp_path / "decision.json"
+    record = tmp_path / "record.json"
+    output = tmp_path / "report.json"
+
+    decision.write_text(json.dumps(decision_payload), encoding="utf-8")
+    record.write_text(json.dumps(record_payload), encoding="utf-8")
+
+    return subprocess.run(
+        [
+            "python3",
+            str(SCRIPT),
+            "--decision",
+            str(decision),
+            "--record",
+            str(record),
+            "--output",
+            str(output),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_catalog_crosslink_passes_for_aligned_triplet(tmp_path: Path) -> None:
+    decision = {
+        "release_ref": "kfm:release:floodplain-kansas:v1",
+        "catalog_refs": {
+            "stac": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+            "dcat": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+            "prov": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+        },
+    }
+
+    record = {
+        "release_ref": "kfm:release:floodplain-kansas:v1",
+        "catalog_refs": decision["catalog_refs"],
+    }
+
+    result = _run(decision, record, tmp_path)
+    assert result.returncode == 0
+
+    report = _read(tmp_path / "report.json")
+    assert report["status"] == "pass"
+    assert report["blocking"] is False
+    assert report["errors"] == []
+    assert len(report["checks"]) == 5
+
+
+def test_catalog_crosslink_fails_for_prov_subject_mismatch(tmp_path: Path) -> None:
+    decision = {
+        "release_ref": "kfm:release:floodplain-kansas:v1",
+        "catalog_refs": {
+            "stac": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+            "dcat": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+            "prov": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+        },
+    }
+    record = _read(FIXTURES / "prov-mismatch.json")
+
+    result = _run(decision, record, tmp_path)
+    assert result.returncode == 1
+
+    report = _read(tmp_path / "report.json")
+    assert report["status"] == "fail"
+    assert report["blocking"] is True
+    assert any(
+        "subject alignment failed" in e or "decision/record catalog triplet mismatch" in e
+        for e in report["errors"]
+    )
+
+
+def test_catalog_crosslink_fails_for_release_ref_mismatch(tmp_path: Path) -> None:
+    decision = {
+        "release_ref": "kfm:release:floodplain-kansas:v1",
+        "catalog_refs": {
+            "stac": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+            "dcat": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+            "prov": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+        },
+    }
+    record = _read(FIXTURES / "promotion-record-mismatch.json")
+
+    result = _run(decision, record, tmp_path)
+    assert result.returncode == 1
+
+    report = _read(tmp_path / "report.json")
+    assert report["status"] == "fail"
+    assert report["blocking"] is True
+    assert any("release-ref alignment failed" in e for e in report["errors"])
+
+
+def test_catalog_crosslink_fails_for_missing_triplet_ref(tmp_path: Path) -> None:
+    decision = {
+        "release_ref": "kfm:release:floodplain-kansas:v1",
+        "catalog_refs": {
+            "stac": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+            "dcat": {
+                "subject_id": "kfm:subject:floodplain-kansas",
+                "version": "v1",
+                "release_ref": "kfm:release:floodplain-kansas:v1",
+            },
+        },
+    }
+    record = {
+        "release_ref": "kfm:release:floodplain-kansas:v1",
+        "catalog_refs": decision["catalog_refs"],
+    }
+
+    result = _run(decision, record, tmp_path)
+    assert result.returncode == 1
+
+    report = _read(tmp_path / "report.json")
+    assert report["status"] == "fail"
+    assert any("missing catalog refs: prov" in e for e in report["errors"])

--- a/tools/catalog/catalog_crosslink.py
+++ b/tools/catalog/catalog_crosslink.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+TRIPLET_KEYS = ("stac", "dcat", "prov")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _extract_triplet(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    if isinstance(payload.get("catalog_refs"), dict):
+        refs = payload["catalog_refs"]
+    elif isinstance(payload.get("catalog"), dict) and isinstance(payload["catalog"].get("refs"), dict):
+        refs = payload["catalog"]["refs"]
+    else:
+        refs = {}
+
+    triplet: dict[str, dict[str, Any]] = {}
+    for key in TRIPLET_KEYS:
+        value = refs.get(key)
+        if isinstance(value, dict):
+            triplet[key] = value
+    return triplet
+
+
+def _extract_release_ref(payload: dict[str, Any]) -> str | None:
+    for candidate in (
+        payload.get("release_ref"),
+        payload.get("release", {}).get("ref") if isinstance(payload.get("release"), dict) else None,
+    ):
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def _field(value: dict[str, Any], name: str) -> str | None:
+    raw = value.get(name)
+    return raw if isinstance(raw, str) and raw else None
+
+
+def build_report(decision: dict[str, Any], record: dict[str, Any]) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    decision_triplet = _extract_triplet(decision)
+    record_triplet = _extract_triplet(record)
+    triplet = decision_triplet or record_triplet
+
+    decision_record_consistent = True
+    for key in TRIPLET_KEYS:
+        d_value = decision_triplet.get(key)
+        r_value = record_triplet.get(key)
+        if d_value and r_value:
+            for field_name in ("subject_id", "version", "release_ref"):
+                d_field = _field(d_value, field_name)
+                r_field = _field(r_value, field_name)
+                if d_field is not None and r_field is not None and d_field != r_field:
+                    decision_record_consistent = False
+
+    if not decision_record_consistent:
+        errors.append("decision/record catalog triplet mismatch detected")
+    checks.append(
+        {
+            "name": "decision_record_triplet_alignment",
+            "ok": decision_record_consistent,
+        }
+    )
+
+    missing_refs = [key for key in TRIPLET_KEYS if key not in triplet]
+    if missing_refs:
+        errors.append(f"missing catalog refs: {', '.join(missing_refs)}")
+    checks.append(
+        {
+            "name": "triplet_ref_presence",
+            "ok": not missing_refs,
+            "missing": missing_refs,
+        }
+    )
+
+    subjects = {_field(triplet.get(key, {}), "subject_id") for key in TRIPLET_KEYS if key in triplet}
+    subjects.discard(None)
+    subject_ok = len(subjects) == 1 and len(triplet) == 3
+    if not subject_ok:
+        errors.append("subject alignment failed across stac/dcat/prov")
+    checks.append({"name": "subject_alignment", "ok": subject_ok, "subjects": sorted(subjects)})
+
+    versions = {_field(triplet.get(key, {}), "version") for key in TRIPLET_KEYS if key in triplet}
+    versions.discard(None)
+    version_ok = len(versions) == 1 and len(triplet) == 3
+    if not version_ok:
+        errors.append("version alignment failed across stac/dcat/prov")
+    checks.append({"name": "version_alignment", "ok": version_ok, "versions": sorted(versions)})
+
+    decision_release_ref = _extract_release_ref(decision)
+    record_release_ref = _extract_release_ref(record)
+    triplet_release_refs = {
+        _field(triplet.get(key, {}), "release_ref") for key in TRIPLET_KEYS if key in triplet
+    }
+    triplet_release_refs.discard(None)
+
+    release_ok = (
+        decision_release_ref is not None
+        and record_release_ref is not None
+        and len(triplet_release_refs) == 1
+        and decision_release_ref == record_release_ref == next(iter(triplet_release_refs))
+    )
+
+    if not release_ok:
+        errors.append("release-ref alignment failed between decision, record, and catalog triplet")
+
+    checks.append(
+        {
+            "name": "release_ref_alignment",
+            "ok": release_ok,
+            "decision_release_ref": decision_release_ref,
+            "record_release_ref": record_release_ref,
+            "triplet_release_refs": sorted(triplet_release_refs),
+        }
+    )
+
+    status = "pass" if not errors else "fail"
+    return {
+        "status": status,
+        "blocking": status == "fail",
+        "checks": checks,
+        "errors": errors,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Cross-link STAC/DCAT/PROV refs for catalog closure.")
+    parser.add_argument("--decision", required=True, type=Path, help="Path to decision JSON")
+    parser.add_argument("--record", required=True, type=Path, help="Path to promotion record JSON")
+    parser.add_argument("--output", required=True, type=Path, help="Path to output report JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    decision = _read_json(args.decision)
+    record = _read_json(args.record)
+    report = build_report(decision, record)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a thin-slice, reviewable helper to validate STAC/DCAT/PROV triplet closure and surface clear blocking diagnostics for catalog cross-link issues.
- Land the documented proof surface referenced by `tools/catalog/README.md` and `tests/catalog/README.md` so catalog helper behavior is explicitly tested with small, public-safe fixtures.

### Description
- Add `tools/catalog/catalog_crosslink.py`, a CLI helper that compares `decision` and `record` payloads against catalog triplet refs and emits a stable JSON report with pass/fail and blocking exit codes.
- Add `tests/catalog/test_catalog_crosslink.py` covering aligned triplet success and three failure modes: PROV subject mismatch, release-ref mismatch, and missing triplet member.
- Add two small fixtures under `tests/catalog/fixtures/`: `prov-mismatch.json` and `promotion-record-mismatch.json` used by the negative-path tests.

### Testing
- Ran `pytest -q tests/catalog/test_catalog_crosslink.py` which executed the module's tests and reported `4 passed`.
- The added test asserts the helper writes a structured JSON report and returns non-zero exits for blocking failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee7466c14832a8321edd4e94d52e5)