### PR TITLE
Scaffold missing test directories and skeletal fixtures

### DIFF
--- a/tests/accessibility/README.md
+++ b/tests/accessibility/README.md
@@ -1,0 +1,3 @@
+# Accessibility
+
+This directory is reserved for trust-visible UI and assistive-use checks.

--- a/tests/contracts/fixtures/evidence/kfm_geo_manifest.valid.json
+++ b/tests/contracts/fixtures/evidence/kfm_geo_manifest.valid.json
@@ -1,0 +1,5 @@
+{
+  "fixture": "kfm_geo_manifest",
+  "variant": "valid",
+  "status": "skeletal"
+}

--- a/tests/contracts/fixtures/runtime/geospatial_review_action_request.promote.json
+++ b/tests/contracts/fixtures/runtime/geospatial_review_action_request.promote.json
@@ -1,0 +1,5 @@
+{
+  "fixture": "geospatial_review_action_request",
+  "operation": "promote",
+  "status": "skeletal"
+}

--- a/tests/contracts/fixtures/runtime/geospatial_review_action_response.expected_mismatch.json
+++ b/tests/contracts/fixtures/runtime/geospatial_review_action_response.expected_mismatch.json
@@ -1,0 +1,6 @@
+{
+  "fixture": "geospatial_review_action_response",
+  "operation": "promote",
+  "outcome": "expected_mismatch",
+  "status": "skeletal"
+}

--- a/tests/contracts/fixtures/runtime/geospatial_review_action_response.promote.ok.json
+++ b/tests/contracts/fixtures/runtime/geospatial_review_action_response.promote.ok.json
@@ -1,0 +1,6 @@
+{
+  "fixture": "geospatial_review_action_response",
+  "operation": "promote",
+  "outcome": "ok",
+  "status": "skeletal"
+}

--- a/tests/e2e/correction/README.md
+++ b/tests/e2e/correction/README.md
@@ -1,0 +1,3 @@
+# Correction E2E
+
+This directory is reserved for whole-path correction lineage drills.

--- a/tests/e2e/release_assembly/README.md
+++ b/tests/e2e/release_assembly/README.md
@@ -1,0 +1,3 @@
+# Release Assembly E2E
+
+This directory is reserved for release and publish-path completeness drills.

--- a/tests/fixtures/soil_moisture/README.md
+++ b/tests/fixtures/soil_moisture/README.md
@@ -1,0 +1,3 @@
+# Soil Moisture Fixtures
+
+Skeletal fixture lane for soil-moisture test artifacts.

--- a/tests/fixtures/source/kansas_mesonet_source_descriptor/README.md
+++ b/tests/fixtures/source/kansas_mesonet_source_descriptor/README.md
@@ -1,0 +1,3 @@
+# Kansas Mesonet Source Descriptor Fixtures
+
+Skeletal fixture lane for source descriptor examples.

--- a/tests/fixtures/source/maplibre_source_meta/README.md
+++ b/tests/fixtures/source/maplibre_source_meta/README.md
@@ -1,0 +1,3 @@
+# MapLibre Source Meta Fixtures
+
+Skeletal fixture lane for source metadata examples.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,3 @@
+# Integration
+
+This directory is reserved for cross-boundary integration tests.

--- a/tests/reproducibility/README.md
+++ b/tests/reproducibility/README.md
@@ -1,0 +1,3 @@
+# Reproducibility
+
+This directory is reserved for deterministic replay and hash-stability checks.

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,0 +1,3 @@
+# Unit
+
+This directory is reserved for local deterministic unit tests.

--- a/tests/validators/README.md
+++ b/tests/validators/README.md
@@ -1,0 +1,3 @@
+# Validators
+
+This directory contains validator fail-closed behavior and report-shape tests.


### PR DESCRIPTION
### Motivation
- Bring the checked-out tree into alignment with the guidance in the `tests/*.md` documents by creating the missing test lane directories and placeholder fixtures.
- Provide minimal, reviewable fixture stubs for contract and runtime examples referenced by README guidance so future test work has the expected paths to extend.
- Reduce friction for reviewers and contributors by making referenced directories explicit and discoverable.

### Description
- Added README placeholders under `tests/` for the lanes: `accessibility`, `reproducibility`, `unit`, `integration`, `validators`, and `tests/e2e/correction` and `tests/e2e/release_assembly`.
- Added skeletal contract/runtime fixture files under `tests/contracts/fixtures/`, including `evidence/kfm_geo_manifest.valid.json` and the runtime request/response stubs `geospatial_review_action_request.promote.json`, `geospatial_review_action_response.promote.ok.json`, and `geospatial_review_action_response.expected_mismatch.json`.
- Added fixture subtree README placeholders under `tests/fixtures/source/` for `kansas_mesonet_source_descriptor` and `maplibre_source_meta`, and a `tests/fixtures/soil_moisture/README.md` to match the documented fixture layout.

### Testing
- Ran `pytest tests -q`; test collection failed with import errors due to missing third-party dependency `jsonschema` and unresolved import root `packages`, so the suite could not be executed in this environment.
- Verified the new files and directories were created and their contents inspected locally using repository inspection commands (e.g. `find` and file listing outputs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee90cbd68832a888f4b91d7ea2df4)