### PR TITLE
Seed .github/actions with initial composite actions

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -6,11 +6,11 @@ version: v1
 status: draft
 owners: @bartytime4life
 created: NEEDS-VERIFICATION
-updated: 2026-04-26
+updated: 2026-04-27
 policy_label: public
 related: [../README.md, ../CODEOWNERS, ../PULL_REQUEST_TEMPLATE.md, ../workflows/README.md, ../watchers/README.md, ../../README.md, ../../contracts/README.md, ../../schemas/README.md, ../../policy/README.md, ../../tests/README.md, ../../tools/README.md, ../../tools/validators/README.md, ../../tools/attest/README.md, ../../tools/ci/README.md, ../../data/receipts/README.md, ../../data/proofs/README.md]
 tags: [kfm, github-actions, ci-cd, governance, local-actions]
-notes: [doc_id and created date need registry or git-history verification, owner is grounded in current CODEOWNERS fallback coverage for /.github/actions/, policy label is based on public repository exposure and still should be checked against any policy-label registry, current source check shows .github/actions/ as README-only with no composite actions checked in, mounted private branch state and GitHub platform settings remain NEEDS VERIFICATION]
+notes: [doc_id and created date need registry or git-history verification, owner is grounded in current CODEOWNERS fallback coverage for /.github/actions/, policy label is based on public repository exposure and still should be checked against any policy-label registry, current source check shows seeded composite-action scaffolds (metadata-validate, opa-gate, provenance-guard, sbom-produce-and-sign) checked in, mounted private branch state and GitHub platform settings remain NEEDS VERIFICATION]
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
@@ -23,13 +23,13 @@ Repo-local action boundary for thin, reviewable GitHub Action step wrappers in K
 > **Status:** `experimental`  
 > **Owners:** `@bartytime4life`  
 > **Path:** `.github/actions/README.md`  
-> **Current source-check state:** `README.md` only; no composite actions are checked in on the public `main` snapshot.  
+> **Current source-check state:** seeded local composite-action scaffolds are checked in (`metadata-validate`, `opa-gate`, `provenance-guard`, `sbom-produce-and-sign`), with no caller workflow wiring claimed here.  
 > **Repo fit:** local action seam inside the [`.github/`](../README.md) gatehouse; shaped by [`../CODEOWNERS`](../CODEOWNERS), [`../PULL_REQUEST_TEMPLATE.md`](../PULL_REQUEST_TEMPLATE.md), [`../workflows/README.md`](../workflows/README.md), and [`../watchers/README.md`](../watchers/README.md); subordinate to canonical authority surfaces in [`../../contracts/`](../../contracts/), [`../../schemas/`](../../schemas/), [`../../policy/`](../../policy/), [`../../tests/`](../../tests/), [`../../tools/`](../../tools/), [`../../data/receipts/`](../../data/receipts/), and [`../../data/proofs/`](../../data/proofs/).
 
 ![status](https://img.shields.io/badge/status-experimental-orange)
 ![owner](https://img.shields.io/badge/owner-%40bartytime4life-0969da)
 ![surface](https://img.shields.io/badge/surface-.github%2Factions-6f42c1)
-![inventory](https://img.shields.io/badge/inventory-README--only-lightgrey)
+![inventory](https://img.shields.io/badge/inventory-seeded%20local%20actions-2ea043)
 ![posture](https://img.shields.io/badge/posture-thin%20%7C%20fail--closed-0a7d5a)
 ![truth](https://img.shields.io/badge/truth-CONFIRMED%20%7C%20PROPOSED%20%7C%20UNKNOWN-2ea043)
 
@@ -142,16 +142,7 @@ Keep these out of `.github/actions/` unless there is a narrow wrapper reason and
 
 ## Directory tree
 
-### Current public `main` snapshot (**CONFIRMED by source check**)
-
-```text
-.github/actions/
-└── README.md
-```
-
-Current state is intentionally narrow: this directory is a README-only surface. Do not claim implemented composite actions until action metadata, tests or fixtures, and caller workflows are present.
-
-### Graduated target shape (**PROPOSED**)
+### Current snapshot (**CONFIRMED by source check**)
 
 ```text
 .github/actions/
@@ -159,21 +150,38 @@ Current state is intentionally narrow: this directory is a README-only surface. 
 ├── metadata-validate/
 │   ├── action.yml
 │   ├── README.md
-│   ├── src/
-│   └── tests/fixtures/
+│   └── src/validate.sh
 ├── opa-gate/
 │   ├── action.yml
 │   ├── README.md
-│   ├── src/
-│   └── tests/fixtures/
+│   └── src/evaluate.sh
 ├── provenance-guard/
 │   ├── action.yml
 │   ├── README.md
-│   ├── templates/
-│   └── tests/fixtures/
+│   └── src/verify.sh
 ├── sbom-produce-and-sign/
 │   ├── action.yml
 │   ├── README.md
+│   └── src/build.sh
+└── src/
+    └── README.md
+```
+
+This directory now contains thin scaffolded local actions and a shared-helper placeholder. Treat them as composable wrappers until caller workflows and action-level tests are wired and verified.
+
+### Next target shape (**PROPOSED**)
+
+```text
+.github/actions/
+├── <existing seeded actions>/
+│   ├── action.yml
+│   ├── README.md
+│   ├── src/
+│   └── tests/fixtures/
+├── <future local actions>/
+│   ├── action.yml
+│   ├── README.md
+│   ├── src/
 │   ├── templates/
 │   └── tests/fixtures/
 └── src/
@@ -182,7 +190,7 @@ Current state is intentionally narrow: this directory is a README-only surface. 
 ```
 
 > [!NOTE]
-> The target shape is a reviewable landing pattern, not a claim that these directories exist today. Add each action only when there is a real repeated workflow step and a testable contract.
+> Keep each action single-purpose and fail-closed where it guards policy, provenance, or release transitions. Graduate heavy logic to durable tool lanes.
 
 [Back to top](#top)
 
@@ -390,7 +398,7 @@ flowchart LR
 | Directory-local `action.yml` files | Not visible under named action folders because no named action folders are currently checked in. | **UNKNOWN / not currently proven** |
 | Workflow callers | Must be verified from checked-in workflow YAML and platform settings. | **NEEDS VERIFICATION** |
 | Branch rules, required checks, OIDC, environments | Not derivable from this README. | **UNKNOWN** |
-| Receipt or proof emission from actions | Not proven by current README-only action inventory. | **UNKNOWN** |
+| Receipt or proof emission from actions | Not yet proven by workflow wiring from the current seeded action inventory. | **UNKNOWN** |
 
 ### Graduation gates
 
@@ -443,7 +451,7 @@ A directory-level README revision is ready when:
 
 ### Are composite actions currently checked in here?
 
-No, not from the current public source check. This directory is currently README-only.
+No, not yet from the current source check. This directory now has seeded actions, but workflow usage and runtime behavior still require verification.
 
 ### Can a local action enforce policy?
 
@@ -567,7 +575,7 @@ This action may call tools, validators, policy checks, or summary renderers. It 
 
 | Item | Status |
 |---|---|
-| Current public `.github/actions/` inventory | **CONFIRMED** as README-only during this revision source check. |
+| Current public `.github/actions/` inventory | **CONFIRMED** as seeded local actions plus directory docs during this revision source check. |
 | Owner fallback for `/.github/actions/` | **CONFIRMED** from current `CODEOWNERS`. |
 | Current composite action implementations | **UNKNOWN / not currently proven**. |
 | Current workflow callers | **NEEDS VERIFICATION** from checked-in workflow YAML and platform settings. |

--- a/.github/actions/metadata-validate/README.md
+++ b/.github/actions/metadata-validate/README.md
@@ -1,0 +1,22 @@
+# metadata-validate
+
+Composite action that verifies markdown files contain a required metadata token (defaults to `[KFM_META_BLOCK_V2]`).
+
+## Inputs
+
+- `files` (optional): newline-delimited list of files to validate. If omitted, scans all `*.md` files.
+- `required-token` (optional): token to require in each file.
+
+## Outputs
+
+- `checked-count`
+- `missing-count`
+
+## Example
+
+```yaml
+- name: Validate metadata blocks
+  uses: ./.github/actions/metadata-validate
+  with:
+    required-token: "[KFM_META_BLOCK_V2]"
+```

--- a/.github/actions/metadata-validate/action.yml
+++ b/.github/actions/metadata-validate/action.yml
@@ -1,0 +1,28 @@
+name: metadata-validate
+
+description: Validate KFM metadata blocks on markdown files.
+inputs:
+  files:
+    description: Newline-delimited list of files to validate.
+    required: false
+    default: ""
+  required-token:
+    description: Token that must appear in each file.
+    required: false
+    default: "[KFM_META_BLOCK_V2]"
+outputs:
+  checked-count:
+    description: Number of files checked.
+    value: ${{ steps.validate.outputs.checked_count }}
+  missing-count:
+    description: Number of files missing the required token.
+    value: ${{ steps.validate.outputs.missing_count }}
+runs:
+  using: composite
+  steps:
+    - id: validate
+      shell: bash
+      run: |
+        "${{ github.action_path }}/src/validate.sh" \
+          "${{ inputs.files }}" \
+          "${{ inputs.required-token }}"

--- a/.github/actions/metadata-validate/src/validate.sh
+++ b/.github/actions/metadata-validate/src/validate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILES_INPUT="${1:-}"
+REQUIRED_TOKEN="${2:-[KFM_META_BLOCK_V2]}"
+
+if [[ -z "${FILES_INPUT//$'\n'/}" ]]; then
+  mapfile -t FILES < <(find . -type f -name '*.md' -not -path './.git/*' | sort)
+else
+  mapfile -t FILES <<<"$FILES_INPUT"
+fi
+
+checked=0
+missing=0
+missing_files=()
+
+for file in "${FILES[@]}"; do
+  [[ -z "$file" ]] && continue
+  if [[ ! -f "$file" ]]; then
+    echo "::warning::Skipping missing file: $file"
+    continue
+  fi
+
+  checked=$((checked + 1))
+  if ! grep -qF "$REQUIRED_TOKEN" "$file"; then
+    missing=$((missing + 1))
+    missing_files+=("$file")
+  fi
+done
+
+{
+  echo "checked_count=$checked"
+  echo "missing_count=$missing"
+} >> "$GITHUB_OUTPUT"
+
+echo "Checked $checked markdown file(s)."
+
+if (( missing > 0 )); then
+  echo "::error::Missing '$REQUIRED_TOKEN' in ${missing} file(s): ${missing_files[*]}"
+  exit 1
+fi

--- a/.github/actions/opa-gate/README.md
+++ b/.github/actions/opa-gate/README.md
@@ -1,0 +1,21 @@
+# opa-gate
+
+Composite action wrapper for running an OPA (or equivalent policy) decision command and failing closed unless output matches an allow pattern.
+
+## Inputs
+
+- `command` (required): policy decision command.
+- `allow-pattern` (optional): regex that indicates success.
+
+## Output
+
+- `decision`: raw command output.
+
+## Example
+
+```yaml
+- name: Policy gate
+  uses: ./.github/actions/opa-gate
+  with:
+    command: "opa eval --format raw --data policy --input input.json 'data.kfm.allow'"
+```

--- a/.github/actions/opa-gate/action.yml
+++ b/.github/actions/opa-gate/action.yml
@@ -1,0 +1,24 @@
+name: opa-gate
+
+description: Run an OPA policy decision command and fail closed on non-allow output.
+inputs:
+  command:
+    description: Full command that evaluates policy and prints a decision.
+    required: true
+  allow-pattern:
+    description: Regex pattern treated as an allow result.
+    required: false
+    default: '(^|\s)(true|allow|allowed)(\s|$)'
+outputs:
+  decision:
+    description: Raw command output.
+    value: ${{ steps.opa.outputs.decision }}
+runs:
+  using: composite
+  steps:
+    - id: opa
+      shell: bash
+      run: |
+        "${{ github.action_path }}/src/evaluate.sh" \
+          "${{ inputs.command }}" \
+          "${{ inputs.allow-pattern }}"

--- a/.github/actions/opa-gate/src/evaluate.sh
+++ b/.github/actions/opa-gate/src/evaluate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMAND="${1:?command is required}"
+ALLOW_PATTERN="${2:-(^|\\s)(true|allow|allowed)(\\s|$)}"
+
+if ! command -v bash >/dev/null 2>&1; then
+  echo "::error::bash is required to execute policy command"
+  exit 1
+fi
+
+set +e
+DECISION=$(bash -lc "$COMMAND" 2>&1)
+STATUS=$?
+set -e
+
+echo "decision<<EOF" >> "$GITHUB_OUTPUT"
+echo "$DECISION" >> "$GITHUB_OUTPUT"
+echo "EOF" >> "$GITHUB_OUTPUT"
+
+if (( STATUS != 0 )); then
+  echo "::error::Policy command failed with exit code $STATUS"
+  echo "$DECISION"
+  exit "$STATUS"
+fi
+
+if ! grep -Eiq "$ALLOW_PATTERN" <<<"$DECISION"; then
+  echo "::error::Policy decision did not match allow pattern"
+  echo "$DECISION"
+  exit 1
+fi
+
+echo "Policy gate passed"

--- a/.github/actions/provenance-guard/README.md
+++ b/.github/actions/provenance-guard/README.md
@@ -1,0 +1,22 @@
+# provenance-guard
+
+Composite action that validates a file's SHA-256 checksum against an expected value.
+
+## Inputs
+
+- `file` (required)
+- `expected-sha256` (required)
+
+## Output
+
+- `actual-sha256`
+
+## Example
+
+```yaml
+- name: Verify artifact digest
+  uses: ./.github/actions/provenance-guard
+  with:
+    file: dist/build.tar.gz
+    expected-sha256: ${{ secrets.BUILD_SHA256 }}
+```

--- a/.github/actions/provenance-guard/action.yml
+++ b/.github/actions/provenance-guard/action.yml
@@ -1,0 +1,23 @@
+name: provenance-guard
+
+description: Verify file digests to enforce provenance checks before downstream promotion.
+inputs:
+  file:
+    description: File to hash.
+    required: true
+  expected-sha256:
+    description: Expected sha256 digest (hex).
+    required: true
+outputs:
+  actual-sha256:
+    description: Computed sha256 digest.
+    value: ${{ steps.provenance.outputs.actual_sha256 }}
+runs:
+  using: composite
+  steps:
+    - id: provenance
+      shell: bash
+      run: |
+        "${{ github.action_path }}/src/verify.sh" \
+          "${{ inputs.file }}" \
+          "${{ inputs.expected-sha256 }}"

--- a/.github/actions/provenance-guard/src/verify.sh
+++ b/.github/actions/provenance-guard/src/verify.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE="${1:?file is required}"
+EXPECTED="${2:?expected-sha256 is required}"
+
+if [[ ! -f "$FILE" ]]; then
+  echo "::error::File does not exist: $FILE"
+  exit 1
+fi
+
+ACTUAL=$(sha256sum "$FILE" | awk '{print $1}')
+echo "actual_sha256=$ACTUAL" >> "$GITHUB_OUTPUT"
+
+if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+  echo "::error::Digest mismatch for $FILE"
+  echo "expected=$EXPECTED"
+  echo "actual=$ACTUAL"
+  exit 1
+fi
+
+echo "Provenance digest verified for $FILE"

--- a/.github/actions/sbom-produce-and-sign/README.md
+++ b/.github/actions/sbom-produce-and-sign/README.md
@@ -1,0 +1,31 @@
+# sbom-produce-and-sign
+
+Composite action that emits a deterministic SHA-256 inventory manifest for an artifact path and can optionally produce a detached signature.
+
+## Inputs
+
+- `artifact-path` (required): file or directory to inventory.
+- `output-manifest` (optional): manifest output path.
+- `signature-path` (optional): detached signature output path.
+
+## Outputs
+
+- `manifest-path`
+- `signature-path` (only when generated)
+
+## Notes
+
+Signature generation requires:
+
+- `openssl` in PATH
+- `KFM_SIGNING_KEY_PEM` environment variable containing a PEM private key
+
+## Example
+
+```yaml
+- name: Build SBOM manifest
+  uses: ./.github/actions/sbom-produce-and-sign
+  with:
+    artifact-path: dist/
+    output-manifest: dist/sbom.sha256
+```

--- a/.github/actions/sbom-produce-and-sign/action.yml
+++ b/.github/actions/sbom-produce-and-sign/action.yml
@@ -1,0 +1,32 @@
+name: sbom-produce-and-sign
+
+description: Produce a lightweight SBOM-style manifest and optional detached signature.
+inputs:
+  artifact-path:
+    description: File or directory to inventory.
+    required: true
+  output-manifest:
+    description: Output manifest path.
+    required: false
+    default: sbom-manifest.sha256
+  signature-path:
+    description: Optional detached signature output path.
+    required: false
+    default: ""
+outputs:
+  manifest-path:
+    description: Path to manifest.
+    value: ${{ steps.sbom.outputs.manifest_path }}
+  signature-path:
+    description: Path to detached signature when requested.
+    value: ${{ steps.sbom.outputs.signature_path }}
+runs:
+  using: composite
+  steps:
+    - id: sbom
+      shell: bash
+      run: |
+        "${{ github.action_path }}/src/build.sh" \
+          "${{ inputs.artifact-path }}" \
+          "${{ inputs.output-manifest }}" \
+          "${{ inputs.signature-path }}"

--- a/.github/actions/sbom-produce-and-sign/src/build.sh
+++ b/.github/actions/sbom-produce-and-sign/src/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_PATH="${1:?artifact-path is required}"
+MANIFEST_PATH="${2:-sbom-manifest.sha256}"
+SIGNATURE_PATH="${3:-}"
+
+if [[ ! -e "$ARTIFACT_PATH" ]]; then
+  echo "::error::artifact-path does not exist: $ARTIFACT_PATH"
+  exit 1
+fi
+
+if [[ -d "$ARTIFACT_PATH" ]]; then
+  find "$ARTIFACT_PATH" -type f -print0 | sort -z | xargs -0 sha256sum > "$MANIFEST_PATH"
+else
+  sha256sum "$ARTIFACT_PATH" > "$MANIFEST_PATH"
+fi
+
+echo "manifest_path=$MANIFEST_PATH" >> "$GITHUB_OUTPUT"
+
+if [[ -n "$SIGNATURE_PATH" ]]; then
+  if command -v openssl >/dev/null 2>&1 && [[ -n "${KFM_SIGNING_KEY_PEM:-}" ]]; then
+    printf '%s' "$KFM_SIGNING_KEY_PEM" > /tmp/kfm-signing-key.pem
+    openssl dgst -sha256 -sign /tmp/kfm-signing-key.pem -out "$SIGNATURE_PATH" "$MANIFEST_PATH"
+    rm -f /tmp/kfm-signing-key.pem
+    echo "signature_path=$SIGNATURE_PATH" >> "$GITHUB_OUTPUT"
+  else
+    echo "::warning::Skipping signature generation; openssl or KFM_SIGNING_KEY_PEM is unavailable"
+  fi
+fi
+
+echo "Created manifest at $MANIFEST_PATH"

--- a/.github/actions/src/README.md
+++ b/.github/actions/src/README.md
@@ -1,0 +1,3 @@
+# Shared local-action helpers
+
+Use this folder only for tiny helpers shared by multiple local actions. If logic becomes substantial, graduate it to `tools/` with dedicated tests and docs.


### PR DESCRIPTION
### Motivation

- Provide a reviewed, repo-local seam for repeatable workflow step wrappers by seeding `.github/actions/` with actionable composites for common governance and CI tasks.
- Enable fail-closed, reviewable primitives for metadata validation, policy gating, provenance checks, and lightweight SBOM/signing so workflows can later wire them without embedding heavy logic in workflows or tools.

### Description

- Added four repo-local composite actions under `.github/actions/`: `metadata-validate`, `opa-gate`, `provenance-guard`, and `sbom-produce-and-sign`, each with an `action.yml` declaring inputs/outputs and a local `src/` helper script implementing the step logic.
- Implemented `metadata-validate/src/validate.sh` to scan markdown files (or an explicit file list) and fail if the required metadata token is missing while emitting `checked_count`/`missing_count` via `GITHUB_OUTPUT`.
- Implemented `opa-gate/src/evaluate.sh` to run an arbitrary policy command, capture raw output to `GITHUB_OUTPUT`, and fail unless output matches an allow regex.
- Implemented `provenance-guard/src/verify.sh` to compute SHA-256 digests, emit `actual_sha256` via `GITHUB_OUTPUT`, and fail on mismatch.
- Implemented `sbom-produce-and-sign/src/build.sh` to produce deterministic SHA-256 manifests for files or directories and optionally produce a detached signature when `openssl` and `KFM_SIGNING_KEY_PEM` are available, emitting `manifest_path` and `signature_path` to `GITHUB_OUTPUT` when appropriate.
- Added per-action `README.md` docs and a `.github/actions/src/README.md` placeholder for tiny shared helpers, and updated the top-level `.github/actions/README.md` to reflect the seeded action inventory and current snapshot details.

### Testing

- Ran shell syntax checks with `bash -n` across all new helper scripts which completed successfully. 
- Performed a smoke run of the metadata validator by exporting a temporary `GITHUB_OUTPUT`, creating a test markdown with the `[KFM_META_BLOCK_V2]` token, and executing `metadata-validate/src/validate.sh`, which returned `checked_count=1` and `missing_count=0` successfully. 
- Verified file layout with `find .github/actions -maxdepth 3 -type f | sort` to confirm expected artifacts and structure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6f50ae84832a8e2a0ade0fba5f4e)