### PR TITLE
Initial apps/web scaffold: static shell, map/evidence/focus modules, and test placeholders

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KFM Governed Web Shell</title>
+    <link rel="stylesheet" href="./src/styles/app.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./src/main.js"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@kfm/web",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Governed web shell scaffold for Kansas Frontier Matrix",
+  "scripts": {
+    "dev": "python3 -m http.server 4173",
+    "check": "node --check src/main.js"
+  }
+}

--- a/apps/web/public/README.md
+++ b/apps/web/public/README.md
@@ -1,0 +1,3 @@
+# public assets
+
+Static browser assets for `apps/web`.

--- a/apps/web/src/compare/README.md
+++ b/apps/web/src/compare/README.md
@@ -1,0 +1,3 @@
+# Compare
+
+Scaffold module for future apps/web compare implementation.

--- a/apps/web/src/contracts/README.md
+++ b/apps/web/src/contracts/README.md
@@ -1,0 +1,3 @@
+# Contracts
+
+Scaffold module for future apps/web contracts implementation.

--- a/apps/web/src/dossier/README.md
+++ b/apps/web/src/dossier/README.md
@@ -1,0 +1,3 @@
+# Dossier
+
+Scaffold module for future apps/web dossier implementation.

--- a/apps/web/src/evidence/evidence-drawer.js
+++ b/apps/web/src/evidence/evidence-drawer.js
@@ -1,0 +1,14 @@
+export function createEvidenceDrawer() {
+  const panel = document.createElement("section");
+  panel.className = "panel";
+  panel.innerHTML = `
+    <h2>Evidence Drawer</h2>
+    <p>Status: <strong>Support available</strong></p>
+    <ul>
+      <li>Source role: state agency</li>
+      <li>EvidenceBundle: eb://placeholder/1</li>
+      <li>Policy: public-safe generalized geometry</li>
+    </ul>
+  `;
+  return panel;
+}

--- a/apps/web/src/export/README.md
+++ b/apps/web/src/export/README.md
@@ -1,0 +1,3 @@
+# Export
+
+Scaffold module for future apps/web export implementation.

--- a/apps/web/src/focus/focus-panel.js
+++ b/apps/web/src/focus/focus-panel.js
@@ -1,0 +1,10 @@
+export function createFocusPanel() {
+  const panel = document.createElement("section");
+  panel.className = "panel";
+  panel.innerHTML = `
+    <h2>Focus Mode</h2>
+    <p>Question runtime is delegated to the governed API.</p>
+    <div class="runtime-outcome">Latest outcome: <strong>ABSTAIN</strong> (insufficient released support).</div>
+  `;
+  return panel;
+}

--- a/apps/web/src/main.js
+++ b/apps/web/src/main.js
@@ -1,0 +1,9 @@
+import { createShellFrame } from "./shell/shell-frame.js";
+
+const appRoot = document.getElementById("app");
+
+if (!appRoot) {
+  throw new Error("Expected #app root to exist.");
+}
+
+appRoot.appendChild(createShellFrame());

--- a/apps/web/src/map/map-pane.js
+++ b/apps/web/src/map/map-pane.js
@@ -1,0 +1,10 @@
+export function createMapPane() {
+  const section = document.createElement("section");
+  section.className = "map-pane";
+  section.innerHTML = `
+    <h2>Map Canvas</h2>
+    <div class="map-surface">MapLibre adapter placeholder</div>
+    <p class="note">Render released layers only; no direct RAW/WORK/QUARANTINE access.</p>
+  `;
+  return section;
+}

--- a/apps/web/src/review/README.md
+++ b/apps/web/src/review/README.md
@@ -1,0 +1,3 @@
+# Review
+
+Scaffold module for future apps/web review implementation.

--- a/apps/web/src/shell/shell-frame.js
+++ b/apps/web/src/shell/shell-frame.js
@@ -1,0 +1,34 @@
+import { createMapPane } from "../map/map-pane.js";
+import { createEvidenceDrawer } from "../evidence/evidence-drawer.js";
+import { createFocusPanel } from "../focus/focus-panel.js";
+
+export function createShellFrame() {
+  const shell = document.createElement("main");
+  shell.className = "shell-frame";
+
+  shell.innerHTML = `
+    <header class="top-bar">
+      <h1>KFM Governed Web Shell</h1>
+      <p class="subtitle">Map-first · Evidence-first · Cite-or-abstain</p>
+    </header>
+    <section class="workspace">
+      <aside class="left-rail">
+        <h2>Layers</h2>
+        <ul>
+          <li>Hydrology (released)</li>
+          <li>Habitat suitability (reviewed)</li>
+          <li>Policy overlays (role-gated)</li>
+        </ul>
+      </aside>
+      <section class="map-column"></section>
+      <aside class="right-stack"></aside>
+    </section>
+  `;
+
+  shell.querySelector(".map-column")?.appendChild(createMapPane());
+  const rightStack = shell.querySelector(".right-stack");
+  rightStack?.appendChild(createEvidenceDrawer());
+  rightStack?.appendChild(createFocusPanel());
+
+  return shell;
+}

--- a/apps/web/src/state/README.md
+++ b/apps/web/src/state/README.md
@@ -1,0 +1,3 @@
+# State
+
+Scaffold module for future apps/web state implementation.

--- a/apps/web/src/story/README.md
+++ b/apps/web/src/story/README.md
@@ -1,0 +1,3 @@
+# Story
+
+Scaffold module for future apps/web story implementation.

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1,0 +1,63 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f5f7fa;
+  color: #1f2937;
+}
+
+.shell-frame {
+  min-height: 100vh;
+}
+
+.top-bar {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem 1.5rem;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: #cbd5e1;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: 240px 1fr 320px;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.left-rail,
+.panel,
+.map-pane {
+  background: white;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.right-stack {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.map-surface {
+  border: 1px dashed #94a3b8;
+  border-radius: 8px;
+  background: #e2e8f0;
+  min-height: 380px;
+  display: grid;
+  place-items: center;
+}
+
+.note,
+.runtime-outcome {
+  font-size: 0.9rem;
+  color: #334155;
+}

--- a/apps/web/tests/accessibility/README.md
+++ b/apps/web/tests/accessibility/README.md
@@ -1,0 +1,3 @@
+# accessibility
+
+Placeholder test suite directory for accessibility coverage.

--- a/apps/web/tests/fixtures/README.md
+++ b/apps/web/tests/fixtures/README.md
@@ -1,0 +1,3 @@
+# fixtures
+
+Placeholder test suite directory for fixtures coverage.

--- a/apps/web/tests/no-bypass/README.md
+++ b/apps/web/tests/no-bypass/README.md
@@ -1,0 +1,3 @@
+# no-bypass
+
+Placeholder test suite directory for no-bypass coverage.

--- a/apps/web/tests/trust-state/README.md
+++ b/apps/web/tests/trust-state/README.md
@@ -1,0 +1,3 @@
+# trust-state
+
+Placeholder test suite directory for trust-state coverage.


### PR DESCRIPTION
### Motivation
- Provide a minimal, framework-agnostic web shell scaffold so the repository can host a map-first, evidence-first browser surface without committing to a specific stack.
- Surface a runnable static entrypoint and minimal scripts to enable quick local smoke checks and early UI iteration.
- Reserve structured places for future features and tests (dossier, story, review, compare, export, state, contracts, plus trust-state/accessibility/no-bypass test suites).

### Description
- Add a lightweight static web app entrypoint with `apps/web/index.html` and `apps/web/package.json` containing `dev` and `check` scripts. 
- Implement basic module wiring and DOM bootstrap via `apps/web/src/main.js` and a shell frame in `apps/web/src/shell/shell-frame.js`. 
- Add simple placeholder UI modules `apps/web/src/map/map-pane.js`, `apps/web/src/evidence/evidence-drawer.js`, and `apps/web/src/focus/focus-panel.js` and base styles in `apps/web/src/styles/app.css`. 
- Create scaffold README placeholders for feature modules and test directories plus a `apps/web/public/README.md` to reserve public assets. 

### Testing
- Ran `node --check` against the authored JavaScript modules (`apps/web/src/*.js` and submodules) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef717c81dc832aa5c8e4de59da7e90)