### PR TITLE
Add tools/attest sign/verify CLIs, schema, and tests

### DIFF
--- a/tools/attest/README.md
+++ b/tools/attest/README.md
@@ -209,7 +209,10 @@ Do **not** silently convert visible lane presence into claims of mature, end-to-
 
 ```text
 tools/attest/
-└── README.md
+├── README.md
+├── receipt.schema.json
+├── sign_decision_envelope.py
+└── verify_decision_envelope.py
 ```
 
 ### Current documented thin-slice shape

--- a/tools/attest/receipt.schema.json
+++ b/tools/attest/receipt.schema.json
@@ -1,1 +1,82 @@
-
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/tools/attest/receipt.schema.json",
+  "title": "KFM Attest Helper Result",
+  "description": "Schema for sign/verify result artifacts emitted by tools/attest thin-slice helpers.",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "result_type",
+        "status",
+        "artifact_uri",
+        "decision_sha256",
+        "signature",
+        "signed_at",
+        "tool"
+      ],
+      "properties": {
+        "result_type": { "const": "kfm:DecisionEnvelopeSignResult" },
+        "status": { "const": "signed" },
+        "artifact_uri": { "type": "string", "minLength": 1 },
+        "decision_path": { "type": "string", "minLength": 1 },
+        "decision_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "signature": {
+          "type": "object",
+          "required": ["alg", "value", "signer", "key_source"],
+          "properties": {
+            "alg": { "const": "sha256" },
+            "value": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+            "signer": { "type": "string", "minLength": 1 },
+            "key_source": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "signed_at": { "type": "string", "format": "date-time" },
+        "tool": { "const": "tools/attest/sign_decision_envelope.py" }
+      },
+      "additionalProperties": true
+    },
+    {
+      "type": "object",
+      "required": [
+        "result_type",
+        "status",
+        "verified",
+        "artifact_uri",
+        "decision_sha256",
+        "checks",
+        "checked_at",
+        "tool"
+      ],
+      "properties": {
+        "result_type": { "const": "kfm:DecisionEnvelopeVerifyResult" },
+        "status": { "enum": ["verified", "verification_failed"] },
+        "verified": { "type": "boolean" },
+        "artifact_uri": { "type": "string", "minLength": 1 },
+        "decision_path": { "type": "string", "minLength": 1 },
+        "sign_result_path": { "type": "string", "minLength": 1 },
+        "decision_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "checks": {
+          "type": "object",
+          "required": [
+            "artifact_uri_match",
+            "decision_sha256_match",
+            "signature_match",
+            "result_type_match"
+          ],
+          "properties": {
+            "artifact_uri_match": { "type": "boolean" },
+            "decision_sha256_match": { "type": "boolean" },
+            "signature_match": { "type": "boolean" },
+            "result_type_match": { "type": "boolean" }
+          },
+          "additionalProperties": true
+        },
+        "checked_at": { "type": "string", "format": "date-time" },
+        "tool": { "const": "tools/attest/verify_decision_envelope.py" }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/tools/attest/sign_decision_envelope.py
+++ b/tools/attest/sign_decision_envelope.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+EXIT_PASS = 0
+EXIT_FAILURE = 1
+EXIT_MISSING_INPUT = 2
+EXIT_CONFIRM_REQUIRED = 4
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python tools/attest/sign_decision_envelope.py",
+        description="Create a deterministic KFM decision-envelope signing result artifact.",
+    )
+    parser.add_argument("decision", help="Path to decision envelope JSON.")
+    parser.add_argument("--artifact-uri", required=True, help="Artifact URI bound to this signature.")
+    parser.add_argument("--output", required=True, help="Output path for decision-sign-result JSON.")
+    parser.add_argument("--signer", default="local-dev-signer", help="Signer identifier recorded in the result.")
+    parser.add_argument(
+        "--key-env",
+        default="KFM_ATTEST_SIGNING_KEY",
+        help="Environment variable containing signing key material.",
+    )
+    parser.add_argument("--yes", action="store_true", help="Acknowledge explicit signing intent.")
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError("decision envelope must be a JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.yes:
+        print("explicit confirmation required: pass --yes", file=sys.stderr)
+        return EXIT_CONFIRM_REQUIRED
+
+    decision_path = Path(args.decision)
+    output_path = Path(args.output)
+
+    if not decision_path.exists():
+        print(f"missing decision: {decision_path}", file=sys.stderr)
+        return EXIT_MISSING_INPUT
+
+    try:
+        decision = load_json(decision_path)
+        decision_digest = sha256_hex(canonical_json(decision))
+        key_material = os.environ.get(args.key_env, "")
+        signature = sha256_hex(f"{args.artifact_uri}\n{decision_digest}\n{args.signer}\n{key_material}")
+
+        result = {
+            "result_type": "kfm:DecisionEnvelopeSignResult",
+            "status": "signed",
+            "artifact_uri": args.artifact_uri,
+            "decision_path": str(decision_path),
+            "decision_sha256": decision_digest,
+            "signature": {
+                "alg": "sha256",
+                "value": signature,
+                "signer": args.signer,
+                "key_source": f"env:{args.key_env}",
+            },
+            "signed_at": utc_now_iso(),
+            "tool": "tools/attest/sign_decision_envelope.py",
+        }
+        write_json(output_path, result)
+    except json.JSONDecodeError as exc:
+        print(f"invalid json: {exc}", file=sys.stderr)
+        return EXIT_FAILURE
+    except Exception as exc:
+        print(f"sign error: {exc}", file=sys.stderr)
+        return EXIT_FAILURE
+
+    print(f"decision signature: {output_path}")
+    print(f"decision sha256: {decision_digest}")
+    return EXIT_PASS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/attest/verify_decision_envelope.py
+++ b/tools/attest/verify_decision_envelope.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+EXIT_PASS = 0
+EXIT_FAILURE = 1
+EXIT_MISSING_INPUT = 2
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python tools/attest/verify_decision_envelope.py",
+        description="Verify a deterministic KFM decision-envelope signing result artifact.",
+    )
+    parser.add_argument("artifact_uri", help="Artifact URI expected to match the sign result.")
+    parser.add_argument("--decision", default="decision.json", help="Path to decision envelope JSON.")
+    parser.add_argument(
+        "--sign-result",
+        default="decision-sign-result.json",
+        help="Path to decision-sign-result JSON produced by sign_decision_envelope.py.",
+    )
+    parser.add_argument("--output", required=True, help="Output path for decision-verify-result JSON.")
+    parser.add_argument(
+        "--key-env",
+        default="KFM_ATTEST_SIGNING_KEY",
+        help="Environment variable containing signing key material.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError("expected JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    decision_path = Path(args.decision)
+    sign_result_path = Path(args.sign_result)
+    output_path = Path(args.output)
+
+    if not decision_path.exists():
+        print(f"missing decision: {decision_path}", file=sys.stderr)
+        return EXIT_MISSING_INPUT
+    if not sign_result_path.exists():
+        print(f"missing sign result: {sign_result_path}", file=sys.stderr)
+        return EXIT_MISSING_INPUT
+
+    try:
+        decision = load_json(decision_path)
+        sign_result = load_json(sign_result_path)
+
+        decision_digest = sha256_hex(canonical_json(decision))
+        signer = str(sign_result.get("signature", {}).get("signer", ""))
+        signature_value = str(sign_result.get("signature", {}).get("value", ""))
+        key_material = os.environ.get(args.key_env, "")
+
+        expected_signature = sha256_hex(f"{args.artifact_uri}\n{decision_digest}\n{signer}\n{key_material}")
+
+        checks = {
+            "artifact_uri_match": sign_result.get("artifact_uri") == args.artifact_uri,
+            "decision_sha256_match": sign_result.get("decision_sha256") == decision_digest,
+            "signature_match": signature_value == expected_signature,
+            "result_type_match": sign_result.get("result_type") == "kfm:DecisionEnvelopeSignResult",
+        }
+        verified = all(checks.values())
+
+        verify_result = {
+            "result_type": "kfm:DecisionEnvelopeVerifyResult",
+            "status": "verified" if verified else "verification_failed",
+            "verified": verified,
+            "artifact_uri": args.artifact_uri,
+            "decision_path": str(decision_path),
+            "sign_result_path": str(sign_result_path),
+            "decision_sha256": decision_digest,
+            "checks": checks,
+            "checked_at": utc_now_iso(),
+            "tool": "tools/attest/verify_decision_envelope.py",
+        }
+        write_json(output_path, verify_result)
+    except json.JSONDecodeError as exc:
+        print(f"invalid json: {exc}", file=sys.stderr)
+        return EXIT_FAILURE
+    except Exception as exc:
+        print(f"verify error: {exc}", file=sys.stderr)
+        return EXIT_FAILURE
+
+    if verify_result["verified"]:
+        print(f"decision verification: verified ({output_path})")
+        return EXIT_PASS
+
+    print(f"decision verification: failed ({output_path})", file=sys.stderr)
+    return EXIT_FAILURE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_attest_decision_envelope_cli.py
+++ b/tools/tests/test_attest_decision_envelope_cli.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_sign(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    run_env = dict(os.environ)
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        [sys.executable, "tools/attest/sign_decision_envelope.py", *args],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=run_env,
+    )
+
+
+def run_verify(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    run_env = dict(os.environ)
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        [sys.executable, "tools/attest/verify_decision_envelope.py", *args],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=run_env,
+    )
+
+
+def decision_fixture() -> dict[str, object]:
+    return {
+        "decision_id": "kfm://decision/example/1",
+        "candidate_ref": "kfm://candidate/ecology/example",
+        "status": "allow",
+        "spec_hash": "a" * 64,
+    }
+
+
+def test_sign_then_verify_success(tmp_path: Path) -> None:
+    decision_path = tmp_path / "decision.json"
+    sign_out = tmp_path / "decision-sign-result.json"
+    verify_out = tmp_path / "decision-verify-result.json"
+
+    write_json(decision_path, decision_fixture())
+
+    sign = run_sign(
+        str(decision_path),
+        "--artifact-uri",
+        "ghcr.io/example/promotion:overlay-floodplain-kansas-v1",
+        "--output",
+        str(sign_out),
+        "--yes",
+        env={"KFM_ATTEST_SIGNING_KEY": "unit-test-key"},
+    )
+
+    assert sign.returncode == 0
+    assert sign_out.exists()
+
+    verify = run_verify(
+        "ghcr.io/example/promotion:overlay-floodplain-kansas-v1",
+        "--decision",
+        str(decision_path),
+        "--sign-result",
+        str(sign_out),
+        "--output",
+        str(verify_out),
+        env={"KFM_ATTEST_SIGNING_KEY": "unit-test-key"},
+    )
+
+    assert verify.returncode == 0
+    assert "verified" in verify.stdout
+
+    result = json.loads(verify_out.read_text(encoding="utf-8"))
+    assert result["verified"] is True
+    assert result["status"] == "verified"
+
+
+def test_sign_requires_yes(tmp_path: Path) -> None:
+    decision_path = tmp_path / "decision.json"
+    sign_out = tmp_path / "decision-sign-result.json"
+
+    write_json(decision_path, decision_fixture())
+
+    sign = run_sign(
+        str(decision_path),
+        "--artifact-uri",
+        "ghcr.io/example/promotion:overlay-floodplain-kansas-v1",
+        "--output",
+        str(sign_out),
+    )
+
+    assert sign.returncode == 4
+    assert "pass --yes" in sign.stderr
+    assert not sign_out.exists()
+
+
+def test_verify_fails_on_artifact_mismatch(tmp_path: Path) -> None:
+    decision_path = tmp_path / "decision.json"
+    sign_out = tmp_path / "decision-sign-result.json"
+    verify_out = tmp_path / "decision-verify-result.json"
+
+    write_json(decision_path, decision_fixture())
+
+    sign = run_sign(
+        str(decision_path),
+        "--artifact-uri",
+        "ghcr.io/example/promotion:correct",
+        "--output",
+        str(sign_out),
+        "--yes",
+        env={"KFM_ATTEST_SIGNING_KEY": "unit-test-key"},
+    )
+    assert sign.returncode == 0
+
+    verify = run_verify(
+        "ghcr.io/example/promotion:wrong",
+        "--decision",
+        str(decision_path),
+        "--sign-result",
+        str(sign_out),
+        "--output",
+        str(verify_out),
+        env={"KFM_ATTEST_SIGNING_KEY": "unit-test-key"},
+    )
+
+    assert verify.returncode == 1
+    result = json.loads(verify_out.read_text(encoding="utf-8"))
+    assert result["verified"] is False
+    assert result["checks"]["artifact_uri_match"] is False


### PR DESCRIPTION
### Motivation
- Provide a small, reviewable thin-slice attestation surface that can create and verify deterministic sign results for DecisionEnvelope-style JSON used by downstream promotion/validator flows.
- Emit compact, machine-readable attest result artifacts and a schema so downstream lanes can consume deterministic sign/verify outputs without relying on hidden workflow logic.

### Description
- Add `tools/attest/sign_decision_envelope.py` which reads a decision JSON, requires explicit `--yes`, computes a deterministic `decision_sha256`, builds a deterministic `signature` from the `artifact_uri`, decision digest, `signer`, and environment key, and writes a `kfm:DecisionEnvelopeSignResult` JSON.
- Add `tools/attest/verify_decision_envelope.py` which reproduces the expected signature for a given `artifact_uri` and sign-result, runs a set of checks (`artifact_uri_match`, `decision_sha256_match`, `signature_match`, `result_type_match`), and writes a `kfm:DecisionEnvelopeVerifyResult` JSON with pass/fail state.
- Replace the empty `tools/attest/receipt.schema.json` with a Draft 2020-12 schema that validates both sign and verify result shapes and required check fields.
- Add CLI integration tests at `tools/tests/test_attest_decision_envelope_cli.py` that exercise a success path and two failure paths, and update `tools/attest/README.md` directory snapshot to reflect the new files.

### Testing
- Ran `python -m pytest -q tools/tests/test_attest_decision_envelope_cli.py` and `3` tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc6733100832abd0a87dd32ae53fe)