### PR TITLE
docs: complete the registers documentation surface

### DIFF
--- a/docs/registers/AUTHORITY_LADDER.md
+++ b/docs/registers/AUTHORITY_LADDER.md
@@ -1,0 +1,56 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/NEEDS-VERIFICATION/authority-ladder
+title: Authority Ladder
+type: standard
+version: v1
+status: draft
+owners: NEEDS_VERIFICATION
+created: NEEDS_VERIFICATION
+updated: 2026-04-27
+policy_label: NEEDS_VERIFICATION
+related: [README.md, CANONICAL_LINEAGE_EXPLORATORY.md, DRIFT_REGISTER.md, VERIFICATION_BACKLOG.md, ../README.md, ../../README.md]
+tags: [kfm, registers, authority, governance, doctrine]
+notes: [Initial register stub expanded into a working authority ladder; owner, policy label, and enforcement integration require verification in active branch.]
+[/KFM_META_BLOCK_V2] -->
+
+# Authority Ladder
+
+Defines how to resolve conflicts between KFM materials and evidence classes.
+
+## Ladder (highest to lowest)
+
+1. **Safety/legal/policy hard-stops** in `policy/` and approved governance doctrine.
+2. **Versioned machine contracts and schemas** in canonical schema homes.
+3. **ADR decisions** marked accepted/current and not superseded.
+4. **Current canonical documentation** under `docs/`.
+5. **Implementation evidence** (tests, fixtures, generated receipts, proofs, release manifests).
+6. **Lineage docs** (historical manuals and superseded guidance).
+7. **Exploratory material** (idea packets, drafts, analysis notes).
+8. **External references** (papers, standards, vendor docs) when not explicitly adopted.
+
+> If two sources conflict, the higher rung wins unless an accepted ADR explicitly redefines scope.
+
+## Conflict resolution protocol
+
+1. Record the conflict in `DRIFT_REGISTER.md`.
+2. Mark each competing claim with a truth label (`CONFIRMED`, `PROPOSED`, `UNKNOWN`, `CONFLICTED`).
+3. Open/update a `VERIFICATION_BACKLOG.md` item for required evidence.
+4. If authority order itself is ambiguous, raise an ADR.
+5. Only promote state once evidence is attached and reviewed.
+
+## Allowed citations by claim type
+
+| Claim type | Minimum authority class |
+|---|---|
+| "Policy requires/forbids X" | Policy rule + fixture/test evidence |
+| "Schema/contract defines X" | Canonical schema/contract file |
+| "Architecture intends X" | Current architecture doc or accepted ADR |
+| "System currently does X" | Runtime/test/release evidence |
+| "Historical/manual states X" | Lineage source with non-authoritative marker |
+
+## Anti-patterns
+
+- Treating repeated prose as stronger than machine-validated evidence.
+- Letting generated artifacts silently override doctrine without ADR/policy update.
+- Using exploratory notes as implementation proof.
+- Using external references as implicit policy.

--- a/docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md
+++ b/docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md
@@ -1,0 +1,53 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/NEEDS-VERIFICATION/canonical-lineage-exploratory
+title: Canonical / Lineage / Exploratory Register
+type: register
+version: v1
+status: draft
+owners: NEEDS_VERIFICATION
+created: NEEDS_VERIFICATION
+updated: 2026-04-27
+policy_label: NEEDS_VERIFICATION
+related: [README.md, AUTHORITY_LADDER.md, DRIFT_REGISTER.md, VERIFICATION_BACKLOG.md]
+tags: [kfm, registers, canon, lineage, exploratory, classification]
+notes: [Initial classification register scaffold; entries should be updated as directories are reviewed and ADRs are accepted.]
+[/KFM_META_BLOCK_V2] -->
+
+# Canonical / Lineage / Exploratory Register
+
+Tracks documentation/source families by authority class so maintainers can classify before citing.
+
+## Status classes
+
+- **Canonical**: current governing source for a concern.
+- **Lineage**: historical/superseded context worth preserving.
+- **Exploratory**: useful but non-governing, non-proving material.
+- **Reference**: external context not adopted as doctrine.
+- **Superseded**: replaced by newer canonical source.
+
+## Register entries
+
+| Scope | Current class | Why | Promotion/demotion trigger | Owner |
+|---|---|---|---|---|
+| `policy/` rules + policy tests | Canonical | Defines allow/deny behavior and obligations. | ADR/policy update accepted and validated. | NEEDS_VERIFICATION |
+| Versioned schemas/contracts | Canonical | Machine-checkable definitions for payloads and artifacts. | Schema-home decision or version supersession. | NEEDS_VERIFICATION |
+| Accepted ADRs | Canonical | Governing decisions on boundaries and file homes. | Superseding ADR accepted. | NEEDS_VERIFICATION |
+| `docs/` current standards/runbooks/architecture | Canonical | Human-governed doctrine and operating guidance. | Superseded by accepted ADR + doc update. | NEEDS_VERIFICATION |
+| Historic manuals / old architecture packets | Lineage | Useful context but not current authority. | Explicit promotion via ADR + verification. | NEEDS_VERIFICATION |
+| Intake ideas / exploratory packets | Exploratory | Candidate guidance lacking implementation proof. | Verified implementation + review + migration. | NEEDS_VERIFICATION |
+| External standards and vendor references | Reference | Contextual technical input. | Explicit adoption into policy/schema/ADR. | NEEDS_VERIFICATION |
+| Deprecated docs with successor path | Superseded | Kept for audit trail and traceability. | Removal only per retention policy. | NEEDS_VERIFICATION |
+
+## Entry template
+
+Use this snippet for new classifications:
+
+```markdown
+| <path or family> | <class> | <justification> | <promotion/demotion trigger> | <owner> |
+```
+
+## Rules
+
+1. A file/family is not canonical unless there is a clear current owner and non-conflicting authority path.
+2. Repetition across sources does not increase authority class.
+3. Promotion from exploratory/lineage to canonical requires explicit evidence and review.

--- a/docs/registers/DRIFT_REGISTER.md
+++ b/docs/registers/DRIFT_REGISTER.md
@@ -1,0 +1,37 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/NEEDS-VERIFICATION/drift-register
+title: Drift Register
+type: register
+version: v1
+status: draft
+owners: NEEDS_VERIFICATION
+created: NEEDS_VERIFICATION
+updated: 2026-04-27
+policy_label: NEEDS_VERIFICATION
+related: [README.md, AUTHORITY_LADDER.md, CANONICAL_LINEAGE_EXPLORATORY.md, VERIFICATION_BACKLOG.md]
+tags: [kfm, registers, drift, contradictions, governance]
+notes: [Initial drift register with starter entries and a template for ongoing conflict tracking.]
+[/KFM_META_BLOCK_V2] -->
+
+# Drift Register
+
+Tracks contradictions, naming splits, overclaims, and authority ambiguity across documentation and implementation surfaces.
+
+## Open drift items
+
+| Drift ID | Date opened | Area | Conflict summary | Current truth | Risk if ignored | Owner | Next action |
+|---|---|---|---|---|---|---|---|
+| DRIFT-001 | 2026-04-27 | Register coverage | `docs/registers/README.md` listed four sibling register files that were missing from tree. | CONFIRMED | Maintainers cannot record authority/drift decisions consistently. | NEEDS_VERIFICATION | Closed by adding initial register files in this branch. |
+| DRIFT-002 | 2026-04-27 | Metadata quality | Multiple register docs still contain `NEEDS_VERIFICATION` placeholders for owner/policy labels. | CONFIRMED | Ownership ambiguity delays review and escalation. | NEEDS_VERIFICATION | Resolve after CODEOWNERS/policy label confirmation. |
+
+## Workflow
+
+1. Add an entry for every meaningful contradiction or overclaim.
+2. Link each entry to verification work in `VERIFICATION_BACKLOG.md`.
+3. Close an entry only when evidence and review show convergence.
+
+## Entry template
+
+```markdown
+| DRIFT-### | YYYY-MM-DD | <area> | <conflict summary> | <truth label> | <risk> | <owner> | <next action> |
+```

--- a/docs/registers/README.md
+++ b/docs/registers/README.md
@@ -127,15 +127,15 @@ The registers may accept concise entries that improve authority clarity, verific
 
 ## Directory tree
 
-Current sibling file presence is **NEEDS VERIFICATION** until the live repository is inspected.
+Current sibling file presence is **CONFIRMED in this branch**.
 
 ```text
 docs/registers/
 ├── README.md                             # this directory landing page
-├── AUTHORITY_LADDER.md                   # PROPOSED P0: source hierarchy and conflict-resolution rules
-├── CANONICAL_LINEAGE_EXPLORATORY.md      # PROPOSED P0: canon, lineage, exploratory, reference, superseded classes
-├── DRIFT_REGISTER.md                     # PROPOSED P1: contradictions, overclaims, naming drift, authority gaps
-└── VERIFICATION_BACKLOG.md               # PROPOSED P1: exact evidence needed before stronger claims
+├── AUTHORITY_LADDER.md                   # P0: source hierarchy and conflict-resolution rules
+├── CANONICAL_LINEAGE_EXPLORATORY.md      # P0: canon, lineage, exploratory, reference, superseded classes
+├── DRIFT_REGISTER.md                     # P1: contradictions, overclaims, naming drift, authority gaps
+└── VERIFICATION_BACKLOG.md               # P1: exact evidence needed before stronger claims
 ```
 
 > [!TIP]

--- a/docs/registers/VERIFICATION_BACKLOG.md
+++ b/docs/registers/VERIFICATION_BACKLOG.md
@@ -1,0 +1,40 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/NEEDS-VERIFICATION/verification-backlog
+title: Verification Backlog
+type: register
+version: v1
+status: draft
+owners: NEEDS_VERIFICATION
+created: NEEDS_VERIFICATION
+updated: 2026-04-27
+policy_label: NEEDS_VERIFICATION
+related: [README.md, AUTHORITY_LADDER.md, CANONICAL_LINEAGE_EXPLORATORY.md, DRIFT_REGISTER.md]
+tags: [kfm, registers, verification, evidence, backlog]
+notes: [Initial evidence backlog for register hardening; convert placeholders to concrete owners, labels, and checks as evidence is collected.]
+[/KFM_META_BLOCK_V2] -->
+
+# Verification Backlog
+
+Defines concrete evidence required before upgrading register claims from `PROPOSED` or `UNKNOWN` to `CONFIRMED`.
+
+## Active backlog
+
+| Backlog ID | Date opened | Claim to verify | Evidence required | Status | Owner | Linked drift |
+|---|---|---|---|---|---|---|
+| VB-001 | 2026-04-27 | Register ownership is known and enforceable. | Confirm owning team in `.github/CODEOWNERS` and replace placeholders in all `docs/registers/*.md`. | OPEN | NEEDS_VERIFICATION | DRIFT-002 |
+| VB-002 | 2026-04-27 | Policy label for register docs is settled. | Identify approved policy label source and update metadata blocks consistently. | OPEN | NEEDS_VERIFICATION | DRIFT-002 |
+| VB-003 | 2026-04-27 | Register maintenance checks are part of CI or documented local workflow. | Add/verify command(s) or workflow step that checks register links/placeholders. | OPEN | NEEDS_VERIFICATION | DRIFT-001 |
+
+## Completion criteria
+
+An item can be closed when all conditions are met:
+
+1. Evidence is linked to a concrete file, command output, or workflow run.
+2. A reviewer acknowledges the evidence in PR review or ADR notes.
+3. Related drift items are updated to `resolved` or narrowed.
+
+## Entry template
+
+```markdown
+| VB-### | YYYY-MM-DD | <claim> | <required evidence> | OPEN\|IN_PROGRESS\|DONE | <owner> | <drift id or n/a> |
+```


### PR DESCRIPTION
### Motivation

- Provide a complete, reviewable register surface under `docs/registers/` so authority, canon status, drift, and verification work can be recorded in-repo. 
- Replace the README's TODO-only state by landing starter register files and linking drift items to concrete verification work so maintainers can act on gaps.

### Description

- Add `docs/registers/AUTHORITY_LADDER.md` with a ranked authority ladder, conflict-resolution protocol, allowed citation rules, and anti-patterns. 
- Add `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md` with status-class definitions, a classification table, and an entry template for promotions/demotions. 
- Add `docs/registers/DRIFT_REGISTER.md` containing starter drift entries, a workflow for tracking contradictions, and an entry template. 
- Add `docs/registers/VERIFICATION_BACKLOG.md` with concrete backlog items tied to drift entries and completion criteria plus an entry template. 
- Update `docs/registers/README.md` to reflect that the sibling register files are present in-branch and to adjust the directory-tree status annotations.

### Testing

- Ran `find docs/registers -maxdepth 1 -type f | sort` to confirm the new files are present; command completed successfully. 
- Ran `rg -n '^# ' docs/registers/*.md` to verify each new file contains a top-level heading; command completed successfully. 
- Ran `rg -n 'TODO|NEEDS VERIFICATION|UNKNOWN|CONFLICTED|PROPOSED' docs/registers` to identify remaining placeholders and unresolved verification items; scan succeeded and returned expected placeholder occurrences which are captured in the new `VERIFICATION_BACKLOG.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efccadfef4832abc141650ff8e2c85)