### PR TITLE
docs(agriculture): build out companion domain documentation pack

### DIFF
--- a/docs/domains/agriculture/CHANGELOG.md
+++ b/docs/domains/agriculture/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Agriculture Lane Changelog
+
+## 2026-04-27
+
+- Added complete agriculture documentation companion set:
+  - `STATE_OF_LANE.md`
+  - `FILE_INDEX.md`
+  - `SOURCE_COVERAGE_MATRIX.md`
+  - `SOURCE_REGISTRY.md`
+  - `DATA_CONTRACTS.md`
+  - `VALIDATION_PLAN.md`
+  - `EVIDENCE_AND_PROVENANCE.md`
+  - `PIPELINE_RUNBOOK.md`
+  - `SUPERSESSION_MAP.md`
+  - `archive/README.md`
+- Updated `README.md` quick-jump and directory-tree assumptions to match the implemented documentation set.

--- a/docs/domains/agriculture/DATA_CONTRACTS.md
+++ b/docs/domains/agriculture/DATA_CONTRACTS.md
@@ -1,0 +1,29 @@
+# Agriculture Data Contracts
+
+This document defines the minimum object families expected for agriculture lane contracts.
+
+## Schema home
+
+Canonical schema home is currently **NEEDS VERIFICATION**. Use one canonical location only:
+
+- `schemas/contracts/v1/agriculture/` **or**
+- `contracts/agriculture/`
+
+## Core object families
+
+| Object | Purpose | Required identity |
+|---|---|---|
+| `AgricultureObservation` | Station-like or measured agriculture variable record | source ID + station/grid key + timestamp + variable |
+| `AgricultureAggregateStat` | County/state/region aggregate statistic | source ID + geography + period + statistic |
+| `AgricultureGridProduct` | Remote-sensing/gridded product slice | source ID + product/version + grid/time window |
+| `AgricultureDerivedIndicator` | Derived stress/index product built from validated sources | indicator ID + source refs + processing version |
+| `EvidenceBundle` | Claim support payload for API/UI consumption | bundle ID + evidence refs + policy/review status |
+| `DecisionEnvelope` | Promotion/publication result object | decision ID + outcome + reasons + obligations |
+| `ReleaseManifest` | Published release linkage | release ID + artifact digests + rollback reference |
+
+## Contract rules
+
+- Aggregate records cannot carry field-level claim affordances.
+- Remote-sensing and derived products must expose product/version lineage.
+- Public DTOs must include claim scope and uncertainty affordances.
+- Corrections must supersede; never mutate historical canonical rows in place.

--- a/docs/domains/agriculture/EVIDENCE_AND_PROVENANCE.md
+++ b/docs/domains/agriculture/EVIDENCE_AND_PROVENANCE.md
@@ -1,0 +1,26 @@
+# Agriculture Evidence and Provenance
+
+Agriculture claims must be reproducible to source-aligned evidence.
+
+## EvidenceBundle requirements
+
+Each bundle should include:
+
+- claim target and claim scope (spatial + temporal + semantic);
+- supporting evidence references and source roles;
+- policy outcome and review status;
+- uncertainty statement;
+- generation metadata (run ID, contract version, policy version).
+
+## Provenance requirements
+
+- Preserve source keys through normalization and publication.
+- Record product/version metadata for grid and derived products.
+- Include immutable digests for publishable artifacts.
+- Preserve correction lineage using supersession references.
+
+## Public trust guardrails
+
+- API/UI must resolve EvidenceBundle data before rendering consequential claims.
+- Evidence Drawer payloads must expose source role and support class.
+- Focus responses must abstain where evidence is missing or policy blocks disclosure.

--- a/docs/domains/agriculture/FILE_INDEX.md
+++ b/docs/domains/agriculture/FILE_INDEX.md
@@ -1,0 +1,18 @@
+# Agriculture Lane File Index
+
+This index tracks the agriculture domain documentation package.
+
+| File | Purpose |
+|---|---|
+| `README.md` | Domain landing page, scope, lifecycle, and governance posture. |
+| `STATE_OF_LANE.md` | Current lane maturity snapshot and next actions. |
+| `FILE_INDEX.md` | Inventory of lane docs and companion surfaces. |
+| `SOURCE_COVERAGE_MATRIX.md` | Source-family readiness, role, and activation posture. |
+| `SOURCE_REGISTRY.md` | Human-readable source descriptor requirements and admission checklist. |
+| `DATA_CONTRACTS.md` | Contract object inventory and schema-version expectations. |
+| `VALIDATION_PLAN.md` | Required validators, fixtures, and release gates. |
+| `EVIDENCE_AND_PROVENANCE.md` | EvidenceBundle, provenance, proof, and release lineage expectations. |
+| `PIPELINE_RUNBOOK.md` | Fixture-first lifecycle and operations guidance. |
+| `CHANGELOG.md` | Human-readable lane documentation change history. |
+| `SUPERSESSION_MAP.md` | Mapping from earlier placeholders to the current doc set. |
+| `archive/README.md` | Rules for archiving superseded agriculture docs. |

--- a/docs/domains/agriculture/PIPELINE_RUNBOOK.md
+++ b/docs/domains/agriculture/PIPELINE_RUNBOOK.md
@@ -1,0 +1,20 @@
+# Agriculture Pipeline Runbook
+
+This runbook covers a fixture-first pipeline flow for the agriculture lane.
+
+## Lifecycle sequence
+
+1. Register or update source descriptor.
+2. Ingest RAW fixture/live payload with immutable receipt.
+3. Normalize into WORK with source IDs, units, CRS, and time semantics preserved.
+4. Validate with schema, role, rights, and policy checks.
+5. Promote valid candidates to PROCESSED and emit catalog/provenance objects.
+6. Evaluate publication gate and produce DecisionEnvelope.
+7. Publish release manifest + rollback card for approved artifacts.
+
+## Standard incident responses
+
+- **Malformed source payload**: quarantine with reason code and do not publish.
+- **Rights/sensitivity ambiguity**: force deny/abstain until steward review.
+- **Catalog closure failure**: block publication and record obligation to repair references.
+- **Regression in negative fixture**: rollback candidate release and reopen validation.

--- a/docs/domains/agriculture/README.md
+++ b/docs/domains/agriculture/README.md
@@ -6,11 +6,11 @@ version: v1
 status: draft
 owners: TODO-agriculture-domain-steward
 created: 2026-04-22
-updated: 2026-04-22
+updated: 2026-04-27
 policy_label: TODO-policy-label
 related: [TODO-verify-docs-domains-index, TODO-verify-agriculture-schema-home, TODO-verify-source-registry]
 tags: [kfm, agriculture, domain-readme, evidence-first, map-first, time-aware]
-notes: [Created from attached KFM agriculture and pipeline doctrine; repo checkout was not mounted during authoring; replace TODO values after repository verification.]
+notes: [Expanded in-repo with companion agriculture lane docs on 2026-04-27; TODO owner/policy metadata still requires steward verification.]
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
@@ -32,7 +32,7 @@ notes: [Created from attached KFM agriculture and pipeline doctrine; repo checko
 > **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Accepted inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Directory tree](#directory-tree) · [Source-role guardrails](#source-role-guardrails) · [Lifecycle](#lifecycle) · [Quickstart](#quickstart) · [Definition of done](#definition-of-done) · [FAQ](#faq)
 
 > [!NOTE]
-> **Authoring boundary — CONFIRMED:** this README was prepared from the attached KFM corpus and workspace inspection. A mounted KFM Git checkout was not visible during authoring, so actual owners, package manager, schema home, CI workflow names, app paths, route names, and emitted proof objects remain **NEEDS VERIFICATION**.
+> **Authoring boundary — UPDATED:** this README now lives in a mounted repository and has a companion agriculture documentation set. Owner metadata, canonical schema home, and runtime/CI wiring still remain **NEEDS VERIFICATION** until steward confirmation.
 
 ---
 
@@ -123,7 +123,7 @@ This directory accepts documentation that helps maintainers understand, review, 
 
 ## Directory tree
 
-**PROPOSED directory shape** for this documentation lane. Create only the files that match actual repo conventions after Phase 0 inspection.
+**Current directory shape** for this documentation lane in this repository checkout.
 
 ```text
 docs/domains/agriculture/

--- a/docs/domains/agriculture/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/domains/agriculture/SOURCE_COVERAGE_MATRIX.md
@@ -1,0 +1,14 @@
+# Agriculture Source Coverage Matrix
+
+Status legend: `PLANNED`, `FIXTURE-READY`, `READY-FOR-LIVE-INTAKE`, `ACTIVE`, `BLOCKED`.
+
+| Source family | Role | Status | Public release default | Blocking condition |
+|---|---|---|---|---|
+| SSURGO / SDA | Authoritative soil survey context | PLANNED | Allowed after evidence + provenance validation | Schema home and source descriptor unresolved |
+| gSSURGO | Gridded soil companion context | PLANNED | Allowed with explicit gridded label | Must not be promoted as independent authority |
+| Kansas Mesonet | Station observation context | FIXTURE-READY | Allowed with station/depth/time caveats | Unit/QC normalization tests incomplete |
+| NRCS SCAN / NOAA USCRN | Station corroboration | PLANNED | Allowed after source-role and QC mapping | Source mapping not finalized |
+| NASA SMAP | Satellite grid soil moisture context | FIXTURE-READY | Allowed only as gridded remote-sensing context | Product/version + mask capture tests needed |
+| NASA HLS / HLS-VI | Remote-sensing vegetation context | FIXTURE-READY | Allowed as derived/remote-sensing layer only | Mask and cloud quality constraints pending |
+| USDA NASS QuickStats / Crop Progress | Aggregate agricultural context | PLANNED | Allowed at aggregate geography/time only | Field-level misuse guardrails must be tested |
+| Private/proprietary farm data | Restricted future class | BLOCKED | Deny by default | No restricted-data lane approved |

--- a/docs/domains/agriculture/SOURCE_REGISTRY.md
+++ b/docs/domains/agriculture/SOURCE_REGISTRY.md
@@ -1,0 +1,27 @@
+# Agriculture Source Registry Guidance
+
+This file documents what each agriculture source descriptor must contain before activation.
+
+## Required fields
+
+- `source_id`: immutable unique source key.
+- `source_name`: human-friendly name.
+- `owner` and `steward`: accountable parties.
+- `source_role`: one of `authority`, `observation`, `aggregate`, `remote_sensing`, `derived`, `mirror`, `documentary`.
+- `rights`: license/terms, redistribution constraints, and citation requirements.
+- `sensitivity`: `public`, `review_required`, or `restricted`.
+- `spatial_support`: geometry type and precision class.
+- `temporal_support`: cadence, timestamp semantics, and staleness rule.
+- `stable_keys`: source identifiers that must survive normalization.
+- `ingest_mode`: `fixture_only` or `live`.
+- `activation_state`: `planned`, `approved`, `active`, or `blocked`.
+
+## Admission checklist
+
+A source is admissible only when all checks pass:
+
+1. Rights and sensitivity are explicit and reviewed.
+2. Source role is non-ambiguous and claim-scope compatible.
+3. Stable keys and timestamps are demonstrably preserved.
+4. Required negative fixtures exist.
+5. Policy checks enforce fail-closed outcomes.

--- a/docs/domains/agriculture/STATE_OF_LANE.md
+++ b/docs/domains/agriculture/STATE_OF_LANE.md
@@ -1,0 +1,29 @@
+# Agriculture Lane State of Lane
+
+Last reviewed: 2026-04-27.
+
+## Snapshot
+
+The agriculture lane now has a full documentation control set in `docs/domains/agriculture/` for governance, source admission, contracts, validation, evidence, and operations.
+
+## Present in this lane
+
+- README landing page and lane scope.
+- Source coverage and source registry documentation.
+- Data contract overview and validation plan.
+- Evidence/provenance and pipeline runbook guidance.
+- Changelog, file index, and supersession map.
+
+## Gaps still marked for verification
+
+- Canonical schema home (`schemas/contracts/...` vs `contracts/...`).
+- Existing policy-as-code locations and command names.
+- Concrete validator script and CI workflow paths.
+- CODEOWNERS/steward confirmation for agriculture lane ownership.
+
+## Next actions
+
+1. Confirm schema home via ADR and update `DATA_CONTRACTS.md`.
+2. Add machine-readable source descriptors under the canonical registry path.
+3. Land fixture-first validators and wire CI checks.
+4. Record first release manifest and rollback card references.

--- a/docs/domains/agriculture/SUPERSESSION_MAP.md
+++ b/docs/domains/agriculture/SUPERSESSION_MAP.md
@@ -1,0 +1,16 @@
+# Agriculture Supersession Map
+
+This map links placeholder sections from the agriculture README to concrete companion docs.
+
+| Placeholder intent | Current doc |
+|---|---|
+| Lane health snapshot | `STATE_OF_LANE.md` |
+| File inventory and doc ownership | `FILE_INDEX.md` |
+| Source-family readiness and status | `SOURCE_COVERAGE_MATRIX.md` |
+| Source descriptor expectations | `SOURCE_REGISTRY.md` |
+| Contract and schema expectations | `DATA_CONTRACTS.md` |
+| Validation and fixture expectations | `VALIDATION_PLAN.md` |
+| Evidence/provenance publication burden | `EVIDENCE_AND_PROVENANCE.md` |
+| Lifecycle operations and incident handling | `PIPELINE_RUNBOOK.md` |
+| Change history | `CHANGELOG.md` |
+| Archive policy | `archive/README.md` |

--- a/docs/domains/agriculture/VALIDATION_PLAN.md
+++ b/docs/domains/agriculture/VALIDATION_PLAN.md
@@ -1,0 +1,29 @@
+# Agriculture Validation Plan
+
+Validation is fail-closed and fixture-first.
+
+## Validation classes
+
+1. **Schema validation**: required fields, enum values, formats, and object-shape compatibility.
+2. **Source-role validation**: claim type must be compatible with source role.
+3. **Rights/sensitivity validation**: unknown rights or missing sensitivity blocks release.
+4. **Temporal validation**: timestamp semantics, staleness window, and period consistency.
+5. **Unit/depth validation**: station variables preserve unit and depth context.
+6. **Geospatial validation**: CRS integrity, geometry validity, and precision controls.
+7. **Aggregate misuse validation**: prevent field-level claims from aggregate products.
+8. **Catalog closure validation**: each public claim resolves to an EvidenceBundle.
+
+## Minimum fixture set
+
+- Valid station observation fixture.
+- Invalid missing-rights fixture.
+- Invalid aggregate-as-field-claim fixture.
+- Valid gridded remote-sensing fixture with product metadata.
+- Invalid missing-provenance fixture.
+- Promotion-denied fixture with DecisionEnvelope reasons.
+
+## CI expectations
+
+- Run fixture validations on every PR touching agriculture lane docs/contracts/policy/tests.
+- Treat failing negative fixtures as a hard fail.
+- Publish validator summary artifacts with deterministic run IDs.

--- a/docs/domains/agriculture/archive/README.md
+++ b/docs/domains/agriculture/archive/README.md
@@ -1,0 +1,10 @@
+# Agriculture Archive
+
+Use this folder for superseded agriculture domain documents.
+
+## Archive rules
+
+- Keep archived docs read-only after supersession.
+- Add a header note stating replacement file and date superseded.
+- Do not remove prior policy/evidence context that is needed for audit.
+- Never store RAW/WORK/QUARANTINE data in this archive.


### PR DESCRIPTION
### Motivation

- Expand the Agriculture lane from a single README into a complete, governed documentation package to make source-admission, validation, provenance, and release expectations explicit. 
- Provide a fixture-first validation and CI-facing plan so the lane can be exercised without enabling live connectors or publishing data prematurely. 
- Record remaining verification gaps (canonical schema home, owner/policy metadata, validator/CI wiring) so maintainers know follow-up actions.

### Description

- Added a companion documentation set under `docs/domains/agriculture/` including `STATE_OF_LANE.md`, `FILE_INDEX.md`, `SOURCE_COVERAGE_MATRIX.md`, `SOURCE_REGISTRY.md`, `DATA_CONTRACTS.md`, `VALIDATION_PLAN.md`, `EVIDENCE_AND_PROVENANCE.md`, `PIPELINE_RUNBOOK.md`, `CHANGELOG.md`, `SUPERSESSION_MAP.md`, and `archive/README.md` to capture lane responsibilities, contracts, fixtures, runbook, and archival rules. 
- Updated `docs/domains/agriculture/README.md` metadata (updated date, notes) and adjusted the directory-tree wording to reflect the now-present companion files. 
- Documented concrete next actions and CI/fixture expectations (minimum fixture set, fail-closed validation classes, and catalog/evidence closure rules) to guide implementation and reviews.

### Testing

- Verified the new file inventory with `find docs/domains/agriculture -maxdepth 2 -type f | sort` and confirmed all expected files are present. 
- Performed content inspections of `README.md` and the newly added docs using repository file reads to ensure the metadata and directory references were updated as intended. 
- Created PR metadata for review and validated the repository diff for the `docs/domains/agriculture` directory to confirm the intended changes were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efce53b8dc832a899cefc69179531e)