### PR TITLE
Build out archaeology domain documentation directory

### DIFF
--- a/docs/domains/archaeology/API_AND_UI_SURFACES.md
+++ b/docs/domains/archaeology/API_AND_UI_SURFACES.md
@@ -1,0 +1,16 @@
+# API and UI Surfaces
+
+## API boundaries
+
+- Public and steward routes consume released artifacts only.
+- API responses must not expose RAW/WORK/QUARANTINE or restricted stores.
+
+## UI boundaries
+
+- MapLibre layers must be public-safe and release-bound.
+- Evidence Drawer must show source role, rights, sensitivity, review, and correction context.
+- Focus Mode must produce finite decision outcomes and deny exact-location requests for public users.
+
+## Anti-leak requirement
+
+No side channel (tiles, drawer payloads, graph edges, exports) may reintroduce restricted exact geometry.

--- a/docs/domains/archaeology/ARCHITECTURE.md
+++ b/docs/domains/archaeology/ARCHITECTURE.md
@@ -1,0 +1,30 @@
+# Archaeology Architecture
+
+This document defines the architecture boundary for the archaeology lane.
+
+## Layering
+
+1. **Source edge**: admitted source descriptors only.
+2. **Lifecycle stores**: RAW/WORK/QUARANTINE/PROCESSED/CATALOG/PUBLISHED.
+3. **Governance**: policy checks, sensitivity checks, rights checks, promotion checks.
+4. **Serving**: governed API DTOs only.
+5. **Experience**: MapLibre, Evidence Drawer, Focus Mode, Story/exports.
+
+## Non-negotiable constraints
+
+- Public exact site geometry is denied by default.
+- Derived products (tiles, summaries, vectors, search) are not canonical truth.
+- EvidenceRef must resolve to an EvidenceBundle for consequential claims.
+- Promotion must emit release/proof artifacts and rollback references.
+
+## Required companion docs
+
+- `DOMAIN_MODEL.md`
+- `SOURCE_REGISTRY.md`
+- `SENSITIVITY_AND_RIGHTS.md`
+- `VALIDATION_AND_POLICY.md`
+- `CATALOG_AND_PROOF_OBJECTS.md`
+- `API_AND_UI_SURFACES.md`
+- `DATA_LIFECYCLE.md`
+- `PROMOTION_AND_ROLLBACK.md`
+- `RUNBOOK.md`

--- a/docs/domains/archaeology/BACKLOG.md
+++ b/docs/domains/archaeology/BACKLOG.md
@@ -1,0 +1,19 @@
+# Backlog
+
+## P0
+
+- Confirm lane owner and CODEOWNERS mapping.
+- Resolve schema-home ADR.
+- Add source registry examples with disabled-by-default entries.
+- Add valid/invalid fixtures for public safety and evidence closure.
+
+## P1
+
+- Add policy parity tests (Rego/Python if both are used).
+- Add API contract tests proving restricted geometry omission.
+- Add Focus denial tests for exact-location prompts.
+
+## P2
+
+- Add CI workflow coverage and release verification automation.
+- Add correction/rollback dashboard checks.

--- a/docs/domains/archaeology/CATALOG_AND_PROOF_OBJECTS.md
+++ b/docs/domains/archaeology/CATALOG_AND_PROOF_OBJECTS.md
@@ -1,0 +1,18 @@
+# Catalog and Proof Objects
+
+## Closure set
+
+A releasable archaeology publication should provide a coherent closure set:
+
+- release manifest
+- EvidenceBundle references
+- STAC/DCAT/PROV catalog records
+- policy decision receipt
+- publication transform receipt (when geometry transformed)
+
+## Proof expectations
+
+- deterministic digests
+- cross-object reference integrity
+- correction lineage and supersession markers
+- rollback card availability

--- a/docs/domains/archaeology/CHANGELOG.md
+++ b/docs/domains/archaeology/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-04-27
+
+- Added archaeology companion documentation set to complete the `docs/domains/archaeology/` directory scaffold.
+- Added architecture, domain model, source registry, sensitivity/rights, validation/policy, catalog/proof, API/UI, lifecycle, promotion/rollback, file map, runbook, open questions, and backlog docs.

--- a/docs/domains/archaeology/DATA_LIFECYCLE.md
+++ b/docs/domains/archaeology/DATA_LIFECYCLE.md
@@ -1,0 +1,14 @@
+# Data Lifecycle
+
+## Truth path
+
+`RAW -> WORK/QUARANTINE -> PROCESSED -> CATALOG/TRIPLET -> PUBLISHED`
+
+## Lifecycle notes
+
+- RAW is immutable and auditable.
+- WORK is transform/normalization space.
+- QUARANTINE stores blocked artifacts with reason codes.
+- PROCESSED holds validated candidates.
+- CATALOG/TRIPLET captures discoverability and provenance.
+- PUBLISHED serves governed outputs with proofs.

--- a/docs/domains/archaeology/DOMAIN_MODEL.md
+++ b/docs/domains/archaeology/DOMAIN_MODEL.md
@@ -1,0 +1,32 @@
+# Archaeology Domain Model
+
+## Core entities
+
+- `archaeology_site`
+- `archaeology_component`
+- `archaeological_feature`
+- `stratigraphic_unit`
+- `provenience_context`
+- `survey_project`
+- `survey_transect`
+- `survey_observation`
+- `excavation_unit`
+- `artifact_record`
+- `assemblage`
+- `sample_record`
+- `lab_result`
+- `chronometric_determination`
+- `report_bibliographic_source`
+- `historic_archival_source`
+- `geophysical_observation`
+
+## Relationship expectations
+
+- Site -> many components/features/contexts.
+- Survey and excavation objects support site-level claims.
+- Artifact/lab/chronometric objects require provenance links.
+- Candidate-feature objects cannot imply confirmed-site status without review.
+
+## Public-safe representation
+
+Public payloads must use approved generalized/suppressed geometry and include provenance and review context.

--- a/docs/domains/archaeology/FILE_MAP.md
+++ b/docs/domains/archaeology/FILE_MAP.md
@@ -1,0 +1,18 @@
+# Archaeology File Map
+
+| File | Purpose |
+|---|---|
+| `README.md` | Lane landing page and governance posture. |
+| `ARCHITECTURE.md` | Architecture layering and constraints. |
+| `DOMAIN_MODEL.md` | Entity families and relationship expectations. |
+| `SOURCE_REGISTRY.md` | Source descriptor rules and source-role classes. |
+| `SENSITIVITY_AND_RIGHTS.md` | Rights/sensitivity gates and denial triggers. |
+| `VALIDATION_AND_POLICY.md` | Validation gates and policy outcomes. |
+| `CATALOG_AND_PROOF_OBJECTS.md` | Catalog closure and release proof expectations. |
+| `API_AND_UI_SURFACES.md` | Governed API and UI contract boundaries. |
+| `DATA_LIFECYCLE.md` | State transitions and storage semantics. |
+| `PROMOTION_AND_ROLLBACK.md` | Release promotion and reversal process. |
+| `RUNBOOK.md` | Operator workflow checklist. |
+| `OPEN_QUESTIONS.md` | Unresolved governance and implementation decisions. |
+| `BACKLOG.md` | Prioritized lane build tasks. |
+| `CHANGELOG.md` | Human-readable documentation change history. |

--- a/docs/domains/archaeology/OPEN_QUESTIONS.md
+++ b/docs/domains/archaeology/OPEN_QUESTIONS.md
@@ -1,0 +1,8 @@
+# Open Questions
+
+- Who is the canonical archaeology lane owner?
+- What is the approved schema-home path for archaeology contracts?
+- Which policy-runtime stack is canonical in this repository?
+- What stewardship/tribal/cultural review protocol governs sensitive releases?
+- What public generalization thresholds are approved?
+- Which exact API and UI paths are canonical in this checkout?

--- a/docs/domains/archaeology/PROMOTION_AND_ROLLBACK.md
+++ b/docs/domains/archaeology/PROMOTION_AND_ROLLBACK.md
@@ -1,0 +1,15 @@
+# Promotion and Rollback
+
+## Promotion requirements
+
+- schema + policy pass
+- rights and sensitivity review completed
+- evidence and citation support complete
+- release manifest and proof objects emitted
+- rollback plan attached
+
+## Rollback requirements
+
+- rollback card published
+- release aliases retargeted or release disabled with clear notice
+- prior lineage retained (no silent deletion)

--- a/docs/domains/archaeology/RUNBOOK.md
+++ b/docs/domains/archaeology/RUNBOOK.md
@@ -1,0 +1,14 @@
+# Archaeology Runbook
+
+## Safe first-run sequence
+
+1. Verify docs and source-registry scaffolding.
+2. Confirm no live connectors are enabled.
+3. Run fixture-based validation and policy checks.
+4. Validate public DTO safety.
+5. Validate catalog/proof closure.
+6. Approve promotion only with completed review evidence.
+
+## Incident handling
+
+- If sensitivity leakage is detected: disable affected release, publish correction notice, execute rollback card, and re-run closure validation.

--- a/docs/domains/archaeology/SENSITIVITY_AND_RIGHTS.md
+++ b/docs/domains/archaeology/SENSITIVITY_AND_RIGHTS.md
@@ -1,0 +1,27 @@
+# Sensitivity and Rights
+
+## Default posture
+
+Archaeology is fail-closed with exact public location denial by default.
+
+## High-sensitivity classes
+
+- burial/human remains
+- sacred/culturally sensitive locations
+- looting-prone site details
+- private landowner identity/access details
+- collection security/storage details
+
+## Public release requirements
+
+- explicit rights/redistribution eligibility
+- reviewed public publication profile
+- approved geometry treatment (generalized/redacted/suppressed)
+- transform receipt linking restricted -> public representation
+
+## Denial triggers
+
+- unknown rights
+- unresolved stewardship/consent
+- exact sensitive geometry in public payloads
+- unsupported claim lacking evidence references

--- a/docs/domains/archaeology/SOURCE_REGISTRY.md
+++ b/docs/domains/archaeology/SOURCE_REGISTRY.md
@@ -1,0 +1,27 @@
+# Archaeology Source Registry (Human Companion)
+
+This file is the human-readable companion for source descriptors.
+
+## Descriptor minimums
+
+- source_id and steward/owner
+- source role
+- rights and redistribution posture
+- sensitivity defaults
+- cadence/freshness
+- citation expectations
+- activation state (default: disabled)
+
+## Source-role classes
+
+- Field/survey/excavation
+- Lab/chronometric
+- Archival/report
+- Oral/steward knowledge
+- Regulatory/inventory
+- Remote sensing/geophysical
+- Derived public
+
+## Admission default
+
+If rights, sensitivity, role, or steward review are unresolved, source activation remains blocked.

--- a/docs/domains/archaeology/VALIDATION_AND_POLICY.md
+++ b/docs/domains/archaeology/VALIDATION_AND_POLICY.md
@@ -1,0 +1,24 @@
+# Validation and Policy
+
+## Validation gates
+
+- schema validity
+- rights completeness
+- sensitivity safety
+- evidence resolution (EvidenceRef -> EvidenceBundle)
+- citation support
+- catalog closure
+- public DTO safety (no restricted or lifecycle-internal references)
+
+## Policy outcomes
+
+- `ALLOW`
+- `DENY`
+- `ABSTAIN`
+- `ERROR`
+
+## Mandatory denials
+
+- public exact-site-location requests
+- uncited consequential Focus responses
+- candidate-feature promoted as confirmed without review


### PR DESCRIPTION
### Motivation

- Provide a complete companion documentation set for the Archaeology domain lane so maintainers have a clear, reviewable scaffold for governance, policy, and implementation work.  
- Make the lane's fail-closed safety posture explicit by documenting sensitivity, rights, and publication constraints (including default denial of exact public site geometry).  
- Surface operational guidance, an indexed file map, a changelog, and a prioritized backlog so follow-up implementation and testing tasks are discoverable.

### Description

- Add a full set of documentation files under `docs/domains/archaeology/` including `ARCHITECTURE.md`, `DOMAIN_MODEL.md`, `SOURCE_REGISTRY.md`, `SENSITIVITY_AND_RIGHTS.md`, `VALIDATION_AND_POLICY.md`, `CATALOG_AND_PROOF_OBJECTS.md`, `API_AND_UI_SURFACES.md`, `DATA_LIFECYCLE.md`, `PROMOTION_AND_ROLLBACK.md`, `FILE_MAP.md`, `RUNBOOK.md`, `OPEN_QUESTIONS.md`, `BACKLOG.md`, and `CHANGELOG.md`.  
- Codify non-negotiable lane constraints and lifecycle expectations such as `RAW -> WORK/QUARANTINE -> PROCESSED -> CATALOG/TRIPLET -> PUBLISHED`, EvidenceRef → EvidenceBundle resolution, and promotion/rollback proof artifacts.  
- Add operator-facing assets including `RUNBOOK.md`, a prioritized `BACKLOG.md`, and `FILE_MAP.md` to accelerate safe first-runs and follow-up engineering work.

### Testing

- Ran `find docs/domains/archaeology -maxdepth 1 -type f | sort` to confirm the expected files exist and the directory was populated as intended.  
- Inspected representative files via commands such as `nl -ba docs/domains/archaeology/FILE_MAP.md` to verify the presence of architecture, runbook, backlog, and changelog content.  
- Created PR metadata with a title and body via the repository tooling to open the change for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd44ae0e0832a99d0827ed01a44a1)