### PR TITLE
Complete atmosphere-air domain documentation set

### DIFF
--- a/docs/domains/atmosphere-air/ADR-0001-atmosphere-air-lane.md
+++ b/docs/domains/atmosphere-air/ADR-0001-atmosphere-air-lane.md
@@ -1,0 +1,11 @@
+# ADR-0001: Atmosphere-Air Lane Boundary
+
+## Status
+Proposed
+
+## Decision
+Use `docs/domains/atmosphere-air/` as the documentation lane while retaining machine schema slug compatibility under `atmosphere` until superseded.
+
+## Consequences
+- Allows immediate lane documentation without schema path churn.
+- Requires explicit compatibility tracking.

--- a/docs/domains/atmosphere-air/ADR-0002-atmosphere-schema-compatibility.md
+++ b/docs/domains/atmosphere-air/ADR-0002-atmosphere-schema-compatibility.md
@@ -1,0 +1,11 @@
+# ADR-0002: Atmosphere Schema Compatibility
+
+## Status
+Proposed
+
+## Decision
+Maintain compatibility between existing/expected `schemas/contracts/v1/atmosphere/*` families and atmosphere-air lane semantics.
+
+## Consequences
+- Documentation and machine contracts remain linked by mapping rules.
+- Any rename requires migration notes and fixture compatibility checks.

--- a/docs/domains/atmosphere-air/ADR-0003-atmosphere-source-role-boundaries.md
+++ b/docs/domains/atmosphere-air/ADR-0003-atmosphere-source-role-boundaries.md
@@ -1,0 +1,11 @@
+# ADR-0003: Atmosphere Source Role Boundaries
+
+## Status
+Proposed
+
+## Decision
+Enforce strict source-role separation (observed vs report vs model vs mask vs fusion) across API, layer, and evidence surfaces.
+
+## Consequences
+- Reduced semantic drift and false certainty.
+- Additional validator burden for anti-collapse rules.

--- a/docs/domains/atmosphere-air/API_CONTRACTS.md
+++ b/docs/domains/atmosphere-air/API_CONTRACTS.md
@@ -1,0 +1,19 @@
+# Atmosphere / Air API Contracts
+
+Contract expectations for governed atmosphere-air APIs.
+
+## Response envelope
+
+Finite outcomes only:
+
+- `ANSWER`
+- `ABSTAIN`
+- `DENY`
+- `ERROR`
+
+## Contract constraints
+
+- Include knowledge character and source role in payloads.
+- Include EvidenceRefs for consequential claims.
+- Include freshness and temporal support details.
+- Deny when rights/evidence/policy checks fail.

--- a/docs/domains/atmosphere-air/ARCHITECTURE.md
+++ b/docs/domains/atmosphere-air/ARCHITECTURE.md
@@ -1,0 +1,30 @@
+# Atmosphere / Air Architecture
+
+Defines the trust-preserving architecture for the atmosphere-air lane.
+
+## Core doctrine
+
+- Preserve source identity, source role, and knowledge character end-to-end.
+- Keep observed, modeled, reported, classified, and fused objects distinct.
+- Public delivery consumes released artifacts only.
+- Promotion is a governed decision, not a filesystem side effect.
+
+## Trust path
+
+```text
+RAW -> WORK / QUARANTINE -> PROCESSED -> CATALOG -> PROOF -> PUBLISHED -> API -> UI
+```
+
+## Bounded contexts
+
+- **Intake:** source descriptors, rights posture, activation gating.
+- **Normalization:** unit conversion, timestamp normalization, identity alignment.
+- **Validation:** schema + policy + evidence checks.
+- **Publication:** release manifests, rollback cards, immutable references.
+
+## Non-negotiables
+
+1. No direct UI access to RAW/WORK/QUARANTINE.
+2. No public object without rights and evidence closure.
+3. No modeled object labeled as observed.
+4. No AQI index presented as concentration.

--- a/docs/domains/atmosphere-air/DATA_LIFECYCLE.md
+++ b/docs/domains/atmosphere-air/DATA_LIFECYCLE.md
@@ -1,0 +1,21 @@
+# Atmosphere / Air Data Lifecycle
+
+Lifecycle rules for atmosphere-air data and artifacts.
+
+## State model
+
+1. **RAW**: source-native payloads, not public.
+2. **WORK**: normalized candidates and QC staging.
+3. **QUARANTINE**: failed validation/policy/evidence items.
+4. **PROCESSED**: validated canonical candidates.
+5. **CATALOG**: discoverability and lineage objects.
+6. **PROOF**: EvidenceBundle and decision candidates.
+7. **PUBLISHED**: released artifacts only.
+
+## Promotion requirements
+
+- schema validity
+- evidence closure
+- policy compliance
+- reviewer sign-off
+- rollback target

--- a/docs/domains/atmosphere-air/EXPANSION_BACKLOG.md
+++ b/docs/domains/atmosphere-air/EXPANSION_BACKLOG.md
@@ -1,0 +1,20 @@
+# Atmosphere / Air Expansion Backlog
+
+Prioritized backlog for future PRs.
+
+## Near-term
+
+- Add machine schemas for core atmosphere objects.
+- Add valid/invalid fixtures for observations, AQI, masks, and model fields.
+- Add validation tooling for anti-collapse rules.
+
+## Mid-term
+
+- Add catalog and proof object templates.
+- Add API envelope examples with denial scenarios.
+- Add Map layer descriptor examples.
+
+## Long-term
+
+- Add release automation with rollback cards.
+- Add cross-lane interoperability notes (hazards, hydrology, agriculture).

--- a/docs/domains/atmosphere-air/FOCUS_DRAWER_PAYLOADS.md
+++ b/docs/domains/atmosphere-air/FOCUS_DRAWER_PAYLOADS.md
@@ -1,0 +1,17 @@
+# Atmosphere / Air Focus + Evidence Drawer Payloads
+
+Payload shape expectations for Focus Mode and Evidence Drawer.
+
+## Evidence Drawer must show
+
+- source role + knowledge character
+- freshness and temporal scope
+- review state and policy posture
+- transform and payload hashes (or references)
+- conflict/disagreement markers when present
+
+## Focus constraints
+
+- bounded outputs only (`ANSWER`, `ABSTAIN`, `DENY`, `ERROR`)
+- no bypass around EvidenceBundle resolution
+- no uncited free-form claims

--- a/docs/domains/atmosphere-air/KNOWLEDGE_CHARACTER.md
+++ b/docs/domains/atmosphere-air/KNOWLEDGE_CHARACTER.md
@@ -1,0 +1,23 @@
+# Atmosphere / Air Knowledge Character
+
+Taxonomy that prevents category collapse in atmosphere-air.
+
+## Canonical characters
+
+- `OBSERVED_SENSOR`
+- `PUBLIC_AQI_REPORT`
+- `REGULATORY_ARCHIVE`
+- `LOW_COST_SENSOR`
+- `ATMOSPHERIC_MODEL_FIELD`
+- `REMOTE_SENSING_MASK`
+- `DERIVED_FUSION`
+- `CLIMATE_ANOMALY_CONTEXT`
+- `METEOROLOGICAL_CONTEXT`
+- `ALERT_AND_ADVISORY_CONTEXT`
+
+## Anti-collapse rules
+
+- Never present AQI as raw concentration.
+- Never present AOD or smoke masks as PM2.5 exposure by default.
+- Never present model fields as observed measurements.
+- Never hide fused inputs behind a single opaque layer.

--- a/docs/domains/atmosphere-air/MAP_LAYERS.md
+++ b/docs/domains/atmosphere-air/MAP_LAYERS.md
@@ -1,0 +1,18 @@
+# Atmosphere / Air Map Layers
+
+Governance notes for public map layer descriptors.
+
+## Layer descriptor minimums
+
+- released source identifier
+- layer knowledge character
+- time support and freshness state
+- evidence route
+- review state
+- rights posture
+
+## UI safety requirements
+
+- Render status (CONFIRMED/PROPOSED/UNKNOWN) where relevant.
+- Provide Evidence Drawer links for consequential claims.
+- Do not expose internal lifecycle paths.

--- a/docs/domains/atmosphere-air/OPEN_QUESTIONS.md
+++ b/docs/domains/atmosphere-air/OPEN_QUESTIONS.md
@@ -1,0 +1,9 @@
+# Atmosphere / Air Open Questions
+
+Tracked uncertainties before full lane activation.
+
+1. Confirm canonical path relationship between `atmosphere-air` docs and schema slug `atmosphere`.
+2. Confirm owners and policy label values.
+3. Confirm schema home and versioning convention.
+4. Confirm validator runtime and test runner conventions.
+5. Confirm public UI/API release workflow and approval path.

--- a/docs/domains/atmosphere-air/PARAMETER_REGISTRY.md
+++ b/docs/domains/atmosphere-air/PARAMETER_REGISTRY.md
@@ -1,0 +1,19 @@
+# Atmosphere / Air Parameter Registry
+
+Registry contract for atmospheric parameters and unit discipline.
+
+## Required parameter fields
+
+- `parameter_id`
+- raw unit set
+- normalized unit
+- conversion rule reference
+- value bounds
+- caveats and interpretation notes
+- allowed knowledge characters
+
+## Guardrails
+
+- Conversions must be deterministic and test-covered.
+- Parameter semantics must not drift by source.
+- AQI-like indexes are not concentration parameters.

--- a/docs/domains/atmosphere-air/PRESERVATION_LEDGER.md
+++ b/docs/domains/atmosphere-air/PRESERVATION_LEDGER.md
@@ -1,0 +1,12 @@
+# Atmosphere / Air Preservation Ledger
+
+Record of retain/extend/migrate/quarantine decisions for lane documentation.
+
+| Date | Decision | Scope | Rationale |
+|---|---|---|---|
+| 2026-04-27 | Retain | `README.md` | Existing domain doctrine retained as landing contract. |
+| 2026-04-27 | Extend | new lane docs | Added companion docs to complete atmosphere-air documentation set. |
+
+## Usage
+
+Append one row per consequential lane-document change.

--- a/docs/domains/atmosphere-air/PROMOTION_AND_ROLLBACK.md
+++ b/docs/domains/atmosphere-air/PROMOTION_AND_ROLLBACK.md
@@ -1,0 +1,18 @@
+# Atmosphere / Air Promotion and Rollback
+
+Rules for release promotion and safe rollback.
+
+## Promotion checklist
+
+- validation pass
+- policy pass
+- reviewer approval
+- release manifest generated
+- rollback receipt prepared
+
+## Rollback expectations
+
+- reversible to last-known-good release
+- immutable record of rollback reason
+- downstream cache invalidation plan
+- post-rollback verification report

--- a/docs/domains/atmosphere-air/RUNBOOK.md
+++ b/docs/domains/atmosphere-air/RUNBOOK.md
@@ -1,0 +1,17 @@
+# Atmosphere / Air Runbook
+
+Execution checklist for safe offline atmosphere-air work.
+
+## Minimal flow
+
+1. Verify branch and working tree.
+2. Run lane-local docs checks (if configured).
+3. Run schema/fixture validators (when implemented).
+4. Run lane tests.
+5. Record receipts and validation outcomes.
+
+## Failure triage
+
+- Schema failures -> quarantine candidate and fix fixtures/schema.
+- Policy denials -> resolve rights/role/evidence issues.
+- Evidence gaps -> attach missing refs before promotion attempts.

--- a/docs/domains/atmosphere-air/SECURITY_AND_RIGHTS.md
+++ b/docs/domains/atmosphere-air/SECURITY_AND_RIGHTS.md
@@ -1,0 +1,15 @@
+# Atmosphere / Air Security and Rights
+
+Rights and access posture for atmosphere-air sources and outputs.
+
+## Rights rules
+
+- Unknown rights block public release.
+- Redistribution terms must be explicit.
+- Source terms must be recorded in descriptor metadata.
+
+## Security rules
+
+- No secrets in docs or public artifacts.
+- Public APIs must not expose internal stores.
+- Restricted/steward workflows require explicit policy gates.

--- a/docs/domains/atmosphere-air/SOURCE_REGISTRY.md
+++ b/docs/domains/atmosphere-air/SOURCE_REGISTRY.md
@@ -1,0 +1,26 @@
+# Atmosphere / Air Source Registry
+
+Human-readable source registry posture for atmosphere-air.
+
+## Required fields
+
+- `source_id`
+- `source_role`
+- `knowledge_character`
+- `publisher`
+- `rights_spdx`
+- `verification_status`
+- `public_release_allowed`
+- `last_verified_at`
+
+## Activation rule
+
+A source remains inactive for public release when rights, terms, verification status, or source role are unresolved.
+
+## Role expectations
+
+- **Observed sensor:** measured values with site/instrument context.
+- **Public AQI report:** index/report semantics only.
+- **Model field:** modeled outputs with uncertainty.
+- **Remote sensing mask:** classification context.
+- **Derived fusion:** explicit multi-source method and uncertainty.

--- a/docs/domains/atmosphere-air/UNIT_CONVERSIONS.md
+++ b/docs/domains/atmosphere-air/UNIT_CONVERSIONS.md
@@ -1,0 +1,22 @@
+# Atmosphere / Air Unit Conversions
+
+Unit handling requirements for atmospheric values.
+
+## Required practices
+
+- Preserve `raw_value`/`raw_unit` and `normalized_value`/`normalized_unit`.
+- Attach conversion rule/version metadata.
+- Validate bounds pre/post conversion.
+
+## Priority conversions
+
+- particulate concentration units
+- gas concentration units
+- meteorological unit harmonization
+- visibility and optical context units
+
+## Validation expectations
+
+- deterministic conversion tests
+- precision/rounding policy checks
+- invalid-unit denial cases

--- a/docs/domains/atmosphere-air/VALIDATION_STATUS.md
+++ b/docs/domains/atmosphere-air/VALIDATION_STATUS.md
@@ -1,0 +1,17 @@
+# Atmosphere / Air Validation Status
+
+Current validation inventory for the lane.
+
+## Present state
+
+- Documentation baseline complete.
+- Schema, fixture, validator, and policy implementation: pending verification.
+
+## Planned validation families
+
+- schema validity
+- source registry validity
+- unit conversion invariants
+- knowledge-character anti-collapse checks
+- policy denial coverage
+- catalog closure checks


### PR DESCRIPTION
### Motivation
- Flesh out the Atmosphere / Air lane so it is no longer README-only and provides a full governance, lifecycle, and rollout scaffold. 
- Capture lane-level contracts for source/parameter registries, unit discipline, evidence handling, API/UI envelopes, and promotion/rollback guidance to reduce ambiguity for future implementations. 
- Record open questions, backlog, preservation history, and ADRs to make follow-on implementation PRs small and reviewable.

### Description
- Added a companion documentation suite under `docs/domains/atmosphere-air/` including `ARCHITECTURE.md`, `DATA_LIFECYCLE.md`, `SOURCE_REGISTRY.md`, `PARAMETER_REGISTRY.md`, `UNIT_CONVERSIONS.md`, `KNOWLEDGE_CHARACTER.md`, `MAP_LAYERS.md`, `API_CONTRACTS.md`, `FOCUS_DRAWER_PAYLOADS.md`, `PROMOTION_AND_ROLLBACK.md`, `SECURITY_AND_RIGHTS.md`, `RUNBOOK.md`, `VALIDATION_STATUS.md`, `EXPANSION_BACKLOG.md`, `PRESERVATION_LEDGER.md`, and `OPEN_QUESTIONS.md`. 
- Added three ADR drafts: `ADR-0001-atmosphere-air-lane.md`, `ADR-0002-atmosphere-schema-compatibility.md`, and `ADR-0003-atmosphere-source-role-boundaries.md`. 
- The new docs define non-negotiables (e.g., no AQI-as-concentration, no modeled objects labeled as observed), required metadata (e.g., `source_id`, `knowledge_character`, `rights_spdx`, `parameter_id`), and promotion/gating expectations (schema validity, evidence closure, policy compliance, reviewer sign-off). 
- This change is documentation-only and does not add schemas, validators, policies, or runtime code.

### Testing
- Ran repository inspection commands including `find docs/domains -maxdepth 2 -type f | sort` and `sed`/`nl` to verify file content and presence, and these checks completed successfully. 
- Verified git staging and recorded the change with `git add docs/domains/atmosphere-air` and `git commit -m "Add companion docs for atmosphere-air domain lane"`, and the commit succeeded. 
- No schema validators, unit tests, or policy tests were executed as part of this PR (these are tracked in `EXPANSION_BACKLOG.md` and `VALIDATION_STATUS.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd7aa5f3c832a8a98815fb6630294)