### PR TITLE
Populate fauna domain docs with governance, geoprivacy, validation and runbooks

### DIFF
--- a/docs/domains/fauna/CONTROL_PLANE.md
+++ b/docs/domains/fauna/CONTROL_PLANE.md
@@ -1,0 +1,63 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/TODO-register-fauna-control-plane
+title: Fauna Control Plane
+type: standard
+version: v1
+status: draft
+owners: TODO(fauna-domain-stewards)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(verify-public-or-restricted)
+related: [docs/domains/fauna/README.md, docs/domains/fauna/SOURCE_ROLES.md, docs/domains/fauna/GEOPRIVACY.md, docs/domains/fauna/VALIDATION.md, docs/domains/fauna/MIGRATION_AND_CONTINUITY.md]
+tags: [kfm, fauna, control-plane, governance]
+notes: [Initialize fauna control-plane registry for repo-native stewardship and review workflows.]
+[/KFM_META_BLOCK_V2] -->
+
+# Fauna Control Plane
+
+Purpose: keep fauna-lane governance legible in one place (owners, review cadence, admission state, release posture, and active risks).
+
+## Operating posture
+
+- **Truth posture:** evidence-first; fail closed on unresolved rights/sensitivity/source-role.
+- **Publication posture:** public-safe derivatives only.
+- **Activation posture:** fixture-first; live-source enablement only after descriptor + rights + steward approval.
+
+## Stewardship matrix
+
+| Area | Default owner | Backup owner | Cadence | Current status |
+|---|---|---|---|---|
+| Domain documentation | TODO(fauna-doc-steward) | TODO | Weekly | ACTIVE |
+| Source descriptors | TODO(fauna-source-steward) | TODO | Weekly | NEEDS VERIFICATION |
+| Geoprivacy policy | TODO(fauna-policy-steward) | TODO | Per release | NEEDS VERIFICATION |
+| Validation fixtures | TODO(fauna-validation-steward) | TODO | Per PR | ACTIVE |
+| Release + rollback runbooks | TODO(fauna-ops-steward) | TODO | Per release | ACTIVE |
+
+## Change-control gates
+
+A fauna change is merge-ready when all apply:
+
+- [ ] Source role is explicit and appropriate for claim type.
+- [ ] Rights and redistribution posture is documented.
+- [ ] Public geometry class is assigned and validated.
+- [ ] Evidence references resolve to inspectable evidence bundles.
+- [ ] Validation results are attached (or linked) for touched surfaces.
+- [ ] Rollback path is documented for publish-affecting changes.
+
+## Active risk register
+
+| Risk | Severity | Trigger | Mitigation | Owner |
+|---|---:|---|---|---|
+| Sensitive location exposure | High | Exact protected coordinates in public payload | Fail-closed validation + redaction receipts | TODO |
+| Source-role collapse | High | Aggregator used as legal authority | Enforce role-specific validators | TODO |
+| Rights ambiguity | High | Unknown license/terms at promotion time | HOLD/QUARANTINE until rights resolved | TODO |
+| Taxonomy drift | Medium | Synonym changes or rank conflict | Deterministic taxon key + migration map | TODO |
+| Untracked public release | Medium | Manual artifact publish | Release manifest + rollback runbook required | TODO |
+
+## Review ritual (recommended)
+
+1. Weekly 30-minute fauna governance triage.
+2. Review new/changed source descriptors and unresolved risks.
+3. Confirm geoprivacy exceptions and steward decisions.
+4. Verify pending release items have rollback-ready evidence.
+

--- a/docs/domains/fauna/GEOPRIVACY.md
+++ b/docs/domains/fauna/GEOPRIVACY.md
@@ -1,0 +1,60 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/TODO-register-fauna-geoprivacy
+title: Fauna Geoprivacy and Public Geometry
+type: standard
+version: v1
+status: draft
+owners: TODO(fauna-domain-stewards)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(verify-public-or-restricted)
+related: [docs/domains/fauna/README.md, docs/domains/fauna/VALIDATION.md]
+tags: [kfm, fauna, geoprivacy, sensitivity]
+notes: [Public geometry classes and fail-closed release rules for fauna lane.]
+[/KFM_META_BLOCK_V2] -->
+
+# Fauna Geoprivacy
+
+## Default rule
+
+If uncertainty exists around rights, species sensitivity, or publication policy, **do not publish exact geometry**.
+
+## Public geometry classes
+
+| Class | Description | Public exposure |
+|---|---|---|
+| `public_exact_allowed` | Exact coordinates permitted after full checks | Exact allowed |
+| `public_generalized` | Precision reduced to approved geography | Generalized only |
+| `restricted_precise` | Exact record held in restricted channels | No public geometry |
+| `embargoed` | Temporarily blocked until conditions met | No public geometry |
+| `steward_review_required` | Requires explicit steward decision | No publish until decision |
+| `quarantine` | Missing/conflicting policy inputs | No publish |
+
+## Mandatory redaction receipt fields
+
+- Subject record key/hash
+- Geometry transform class and parameters
+- Before/after digest
+- Policy version used
+- Actor/run id
+- Timestamp
+- Evidence reference(s)
+
+## Leak vectors to test
+
+- API payloads and downloadable exports
+- Vector/raster tiles and style expressions
+- Popup text and Evidence Drawer snippets
+- Search index and autocomplete payloads
+- Graph projections and relationship endpoints
+- Screenshots/docs/examples used in public channels
+
+## Decision outcomes
+
+| Condition | Outcome |
+|---|---|
+| Sensitive record + exact geometry requested | `DENY` |
+| Unknown rights/sensitivity | `HOLD` or `QUARANTINE` |
+| Safe generalized representation validated | `PASS` |
+| Evidence unresolved for requested claim | `ABSTAIN` |
+

--- a/docs/domains/fauna/MIGRATION_AND_CONTINUITY.md
+++ b/docs/domains/fauna/MIGRATION_AND_CONTINUITY.md
@@ -1,0 +1,43 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/TODO-register-fauna-migration-continuity
+title: Fauna Migration and Continuity
+type: standard
+version: v1
+status: draft
+owners: TODO(fauna-domain-stewards)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(verify-public-or-restricted)
+related: [docs/domains/fauna/README.md, docs/domains/fauna/CONTROL_PLANE.md]
+tags: [kfm, fauna, migration, continuity]
+notes: [Protect prior fauna/habitat-fauna lineage and prevent rewrite-style migrations.]
+[/KFM_META_BLOCK_V2] -->
+
+# Fauna Migration and Continuity
+
+## Continuity goals
+
+- Preserve prior fauna and habitat+fauna work instead of restarting.
+- Keep historical IDs and supersession lineage inspectable.
+- Make migrations reversible where feasible.
+
+## Migration protocol
+
+1. Inventory existing fauna-adjacent files, schemas, fixtures, and releases.
+2. Classify each item: retain, supersede, alias, retire, or quarantine.
+3. Record mapping from prior IDs/paths to successor IDs/paths.
+4. Run validation suite before and after migration.
+5. Publish migration notes with rollback instructions.
+
+## Supersession mapping template
+
+| Prior artifact | Successor artifact | Change type | Reason | Rollback path |
+|---|---|---|---|---|
+| TODO | TODO | retain/supersede/alias/retire | TODO | TODO |
+
+## Hard rules
+
+- Never silently delete canonical lineage.
+- Never repurpose identifiers without explicit mapping.
+- Never publish migration results without updated validation evidence.
+

--- a/docs/domains/fauna/README.md
+++ b/docs/domains/fauna/README.md
@@ -6,7 +6,7 @@ version: v1
 status: draft
 owners: TODO(fauna-domain-stewards)
 created: TODO(verify-original-created-date-or-set-on-first-commit)
-updated: 2026-04-22
+updated: 2026-04-27
 policy_label: TODO(verify-public-or-restricted)
 related: ["source:KFM_Fauna_Architecture_PDF_Only_Report.pdf", "source:KFM_Habitat_Fauna_Thin_Slice_Extended_Pro_Blueprint.pdf", "source:KFM_MapLibre_UI_Architecture_and_Governed_Interaction_Design.pdf", "source:Kansas_Frontier_Matrix_Pipeline_Living_Implementation_Manual_v0.2.pdf"]
 tags: [kfm, fauna, wildlife, geoprivacy, evidence, domain-readme]
@@ -133,22 +133,22 @@ The fauna documentation directory must not become a dumping ground for data, sec
 
 ## Directory tree
 
-**PROPOSED companion layout — NEEDS VERIFICATION before creating files.**
+**Current companion layout.**
 
 ```text
 docs/domains/fauna/
 ├── README.md                         # this file
-├── CONTROL_PLANE.md                  # PROPOSED: domain doc registry, owners, source status
-├── SOURCE_ROLES.md                   # PROPOSED: fauna source-role taxonomy and examples
-├── GEOPRIVACY.md                     # PROPOSED: public geometry and sensitive-location rules
-├── VALIDATION.md                     # PROPOSED: human-readable validator and gate guide
-├── MIGRATION_AND_CONTINUITY.md       # PROPOSED: prior-gain preservation and old-to-new mappings
+├── CONTROL_PLANE.md                  # domain governance, ownership, cadence, and active risks
+├── SOURCE_ROLES.md                   # fauna source-role taxonomy and compatibility guardrails
+├── GEOPRIVACY.md                     # public geometry classes and sensitive-location rules
+├── VALIDATION.md                     # human-readable validator and gate expectations
+├── MIGRATION_AND_CONTINUITY.md       # prior-gain preservation and old-to-new mappings
 └── runbooks/
-    ├── release-dry-run.md            # PROPOSED: fixture-only promotion rehearsal
-    └── rollback.md                   # PROPOSED: release rollback and correction workflow
+    ├── release-dry-run.md            # fixture-first promotion rehearsal
+    └── rollback.md                   # release rollback and correction workflow
 ```
 
-Directory creation should wait until the repo’s existing documentation pattern, ADR convention, and source registry home are verified.
+Companion documents are now present in this directory and should be maintained together as a single fauna documentation set.
 
 [Back to top](#top)
 
@@ -308,7 +308,7 @@ Expected result: actual repo conventions are visible before adding or editing fi
 ### 2. Inventory existing fauna and adjacent work
 
 ```bash
-grep -RInE "fauna|wildlife|species|taxon|occurrence|sensitivity|geoprivacy|EvidenceBundle|DecisionEnvelope|LayerManifest" \
+rg -n --no-heading "fauna|wildlife|species|taxon|occurrence|sensitivity|geoprivacy|EvidenceBundle|DecisionEnvelope|LayerManifest" \
   docs contracts schemas policy data apps packages tools tests 2>/dev/null | sed -n '1,200p'
 ```
 

--- a/docs/domains/fauna/SOURCE_ROLES.md
+++ b/docs/domains/fauna/SOURCE_ROLES.md
@@ -1,0 +1,56 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/TODO-register-fauna-source-roles
+title: Fauna Source Roles
+type: standard
+version: v1
+status: draft
+owners: TODO(fauna-domain-stewards)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(verify-public-or-restricted)
+related: [docs/domains/fauna/README.md, docs/domains/fauna/CONTROL_PLANE.md]
+tags: [kfm, fauna, source-role, governance]
+notes: [Companion role taxonomy for source admission and claim safety checks.]
+[/KFM_META_BLOCK_V2] -->
+
+# Fauna Source Roles
+
+Source roles are mandatory semantics, not optional labels. Claims that cross role boundaries without explicit policy approval should fail closed.
+
+## Canonical role table
+
+| Role | Allows | Never implies |
+|---|---|---|
+| `legal_status_authority` | Jurisdiction-specific listing/status context | Occurrence truth |
+| `taxonomic_authority` | Accepted names, synonymy, rank, authority lineage | Legal status or location permission |
+| `occurrence_source` | Observation/specimen/survey support with context | Legal authority |
+| `occurrence_aggregator` | Discovery and supporting occurrence context | Sovereign truth or exact public release |
+| `monitoring_source` | Detection/non-detection and protocol evidence | Public precision entitlement |
+| `habitat_context` | Environmental support for interpretation | Presence proof |
+| `derived_model` | Suitability/richness/corridor interpretation | Canonical fauna truth |
+| `documentary_source` | Historical or narrative support with citation | Unreviewed precise geometry |
+
+## Admission checklist
+
+- [ ] Source has stable identity and version/cadence notes.
+- [ ] Rights and redistribution posture documented.
+- [ ] Source role selected from canonical table.
+- [ ] Sensitivity expectations captured.
+- [ ] Citation/attribution requirements captured.
+
+## Claim-role compatibility
+
+| Claim type | Minimum role | Additional required support |
+|---|---|---|
+| Legal listing/status statement | `legal_status_authority` | jurisdiction + effective date |
+| Taxon canonical name | `taxonomic_authority` | synonym handling note |
+| Presence/occurrence statement | `occurrence_source` or `monitoring_source` | uncertainty + time window |
+| Habitat-only statement | `habitat_context` | explicit non-occurrence disclaimer |
+| Modeled suitability statement | `derived_model` | method/version + uncertainty note |
+
+## Guardrails
+
+- Unknown role => `HOLD`.
+- Conflicting role evidence => `ABSTAIN` until steward review.
+- Missing rights for public use => `DENY` or `QUARANTINE`.
+

--- a/docs/domains/fauna/VALIDATION.md
+++ b/docs/domains/fauna/VALIDATION.md
@@ -1,0 +1,51 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/TODO-register-fauna-validation
+title: Fauna Validation and Gates
+type: standard
+version: v1
+status: draft
+owners: TODO(fauna-domain-stewards)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(verify-public-or-restricted)
+related: [docs/domains/fauna/README.md, docs/domains/fauna/GEOPRIVACY.md, docs/domains/fauna/runbooks/release-dry-run.md]
+tags: [kfm, fauna, validation, policy]
+notes: [Human-readable validation contract for fixture-first fauna lane development.]
+[/KFM_META_BLOCK_V2] -->
+
+# Fauna Validation
+
+## Validation layers
+
+1. **Schema checks** — required fields/types and enum boundaries.
+2. **Policy checks** — source role, rights, sensitivity, and release posture.
+3. **Evidence checks** — claim support must resolve to admissible evidence.
+4. **Publication checks** — public payloads/layers must be geoprivacy-safe.
+
+## Minimum fixture set
+
+| Fixture | Purpose | Expected outcome |
+|---|---|---|
+| Valid public-safe occurrence | Happy path for governed publication | `PASS` |
+| Protected species exact geometry | Confirm fail-closed posture | `DENY` |
+| Unknown source role | Enforce role requirement | `HOLD` |
+| Missing rights metadata | Prevent unsafe promotion | `QUARANTINE` |
+| Habitat-only support for occurrence claim | Prevent role collapse | `ABSTAIN` |
+
+## Required PR evidence
+
+- Validation command output (or CI link)
+- Changed fixture list (if validators changed)
+- Notes for any expected HOLD/ABSTAIN/DENY scenarios
+- Rollback implications if publish-facing behavior changed
+
+## Suggested command placeholders
+
+Use repo-native tooling once finalized:
+
+```bash
+# Example placeholders; replace with canonical repo commands.
+python tools/validators/fauna/run_all.py --fixtures tests/fixtures/fauna
+conftest test policy/fauna tests/fixtures/fauna
+```
+

--- a/docs/domains/fauna/runbooks/release-dry-run.md
+++ b/docs/domains/fauna/runbooks/release-dry-run.md
@@ -1,0 +1,25 @@
+# Fauna Release Dry-Run Runbook
+
+Purpose: rehearse fauna publication safely with synthetic or previously approved public-safe fixtures.
+
+## Preconditions
+
+- Validation suite passes for touched fauna surfaces.
+- No unresolved high-severity geoprivacy risks.
+- Release candidate includes evidence and policy references.
+
+## Steps
+
+1. Build candidate artifacts from fixture or approved input set.
+2. Execute schema, policy, and publication validators.
+3. Verify no restricted geometry appears in public payloads/artifacts.
+4. Produce release manifest and attach validation evidence.
+5. Stage publish to non-public target and verify API/UI behavior.
+6. Approve or hold release with explicit decision record.
+
+## Exit criteria
+
+- `PASS`: candidate may proceed to governed publish.
+- `HOLD`: missing evidence, unresolved rights, or policy drift.
+- `DENY`: geoprivacy/safety violation detected.
+

--- a/docs/domains/fauna/runbooks/rollback.md
+++ b/docs/domains/fauna/runbooks/rollback.md
@@ -1,0 +1,26 @@
+# Fauna Rollback Runbook
+
+Purpose: quickly and safely withdraw or revert a fauna release when policy, evidence, rights, or quality issues are discovered.
+
+## Rollback triggers
+
+- Sensitive location exposure risk.
+- Incorrect legal/status claim in released outputs.
+- Evidence reference broken or non-resolving.
+- Corrupt or incomplete release manifest.
+
+## Immediate actions
+
+1. Stop new publication/promotions for fauna lane.
+2. Repoint public aliases to prior known-good release.
+3. Invalidate affected caches and public artifacts.
+4. Publish correction notice with scope and user impact.
+
+## Recovery checklist
+
+- [ ] Incident ticket opened with timestamp and owner.
+- [ ] Impacted artifacts/layers/endpoints enumerated.
+- [ ] Known-good release confirmed and restored.
+- [ ] Correction lineage recorded in release notes.
+- [ ] Follow-up validation and prevention action assigned.
+


### PR DESCRIPTION
### Motivation

- Finish and operationalize the `docs/domains/fauna` landing area so contributors have governance, source-role, geoprivacy, validation, and migration guidance rather than only a proposed layout. 
- Provide explicit, fixture-first runbooks and control-plane guidance to enforce fail-closed public-safety and release/rollback behavior for fauna artifacts. 

### Description

- Added companion governance and guidance files: `docs/domains/fauna/CONTROL_PLANE.md`, `docs/domains/fauna/SOURCE_ROLES.md`, `docs/domains/fauna/GEOPRIVACY.md`, `docs/domains/fauna/VALIDATION.md`, and `docs/domains/fauna/MIGRATION_AND_CONTINUITY.md`. 
- Added operational runbooks: `docs/domains/fauna/runbooks/release-dry-run.md` and `docs/domains/fauna/runbooks/rollback.md`. 
- Updated `docs/domains/fauna/README.md` to reflect the directory as populated, refreshed the companion tree descriptions, updated the meta `updated` timestamp, and replaced the recursive `grep` example with an `rg`-based inventory command. 
- Committed the new files and README changes as a single change set to keep the fauna documentation set consistent. 

### Testing

- Ran `git status --short` to confirm working tree and observed updated/created files, which completed successfully. 
- Verified file layout with `find docs/domains/fauna -maxdepth 3 -type f | sort` and confirmed the new files are present. 
- Created the change commit with `git add docs/domains/fauna && git commit -m "Expand fauna domain documentation set"`, which succeeded and produced a commit containing the new files and README update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdc489640832a946e9f6ac55f45ab)