### PR TITLE
Complete flora domain documentation set

### DIFF
--- a/docs/domains/flora/ARCHITECTURE.md
+++ b/docs/domains/flora/ARCHITECTURE.md
@@ -1,0 +1,45 @@
+# Flora Domain Architecture
+
+## Purpose
+The flora lane turns plant-related evidence into governed, public-safe artifacts for maps and evidence surfaces.
+
+## Architectural boundaries
+- **In scope:** taxon identity, occurrence/specimen evidence, source roles, sensitivity transforms, publication decisions, and evidence payloads.
+- **Out of scope:** raw source snapshots, secrets, and direct public exposure of restricted precise locations.
+
+## Flow
+1. Source descriptors define rights, role, cadence, and sensitivity.
+2. Intake enters RAW/controlled staging.
+3. Normalization reconciles taxon identity and geometry support.
+4. Validation enforces schema, rights, sensitivity, and provenance.
+5. Promotion publishes only approved, public-safe derivatives.
+6. Governed API serves evidence-resolving payloads for UI surfaces.
+
+```mermaid
+flowchart LR
+  SD[SourceDescriptor] --> RAW[RAW / controlled intake]
+  RAW --> NORM[Normalization + reconciliation]
+  NORM --> VAL{Validation gates}
+  VAL -->|fail| QUAR[Quarantine / hold]
+  VAL -->|pass| PROC[Processed flora objects]
+  PROC --> CAT[Catalog + proof objects]
+  CAT --> REL{Promotion decision}
+  REL -->|approve| PUB[Published public-safe artifacts]
+  REL -->|deny/hold| QUAR
+  PUB --> API[Governed API]
+  API --> UI[Map + Evidence Drawer + Focus]
+```
+
+## Core invariants
+- Source role is part of meaning, not optional metadata.
+- Rights and sensitivity checks fail closed.
+- Derived layers are rebuildable and never replace canonical evidence.
+- Every public claim must resolve to an EvidenceBundle.
+
+## Companion docs
+- `CURRENT_STATE.md` for verified repository facts.
+- `SOURCE_REGISTRY.md` for source-role and descriptor expectations.
+- `DATA_MODEL.md` for domain objects.
+- `PIPELINES_AND_LIFECYCLE.md` for run-time lifecycle.
+- `PUBLICATION_AND_POLICY.md` for release controls.
+- `UI_AND_EVIDENCE_DRAWER.md` for payload contracts and UX boundaries.

--- a/docs/domains/flora/CHANGELOG.md
+++ b/docs/domains/flora/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Flora Domain Changelog
+
+## 2026-04-27
+- Added companion documentation set for `docs/domains/flora/`:
+  - `ARCHITECTURE.md`
+  - `CURRENT_STATE.md`
+  - `SOURCE_REGISTRY.md`
+  - `DATA_MODEL.md`
+  - `PIPELINES_AND_LIFECYCLE.md`
+  - `PUBLICATION_AND_POLICY.md`
+  - `UI_AND_EVIDENCE_DRAWER.md`
+  - `VERIFICATION_BACKLOG.md`
+  - `ROADMAP.md`
+  - `FILE_MANIFEST.md`
+  - `GLOSSARY.md`
+  - `IDEA_INTAKE.md`
+- Established baseline governance, lifecycle, policy, and verification guidance.

--- a/docs/domains/flora/CURRENT_STATE.md
+++ b/docs/domains/flora/CURRENT_STATE.md
@@ -1,0 +1,37 @@
+# Flora Current State
+
+## Verified at
+- **Date:** 2026-04-27
+- **Path scanned:** `docs/domains/flora/`
+
+## Confirmed files present
+- `README.md`
+- `ARCHITECTURE.md`
+- `CURRENT_STATE.md`
+- `SOURCE_REGISTRY.md`
+- `DATA_MODEL.md`
+- `PIPELINES_AND_LIFECYCLE.md`
+- `PUBLICATION_AND_POLICY.md`
+- `UI_AND_EVIDENCE_DRAWER.md`
+- `VERIFICATION_BACKLOG.md`
+- `CHANGELOG.md`
+- `ROADMAP.md`
+- `FILE_MANIFEST.md`
+- `GLOSSARY.md`
+- `IDEA_INTAKE.md`
+
+## Confirmed implementation status
+- This directory now contains a complete flora documentation skeleton aligned to the Flora README companion map.
+- Presence of documentation does **not** prove runtime implementation in API, pipeline, schema, or UI code.
+
+## Unknowns still requiring verification
+- Canonical schema home for flora contracts.
+- Existing flora source descriptors and rights snapshots.
+- Policy engine/toolchain location and test harness.
+- Governed API route and DTO implementation paths.
+- UI layer registry and Evidence Drawer runtime contracts.
+
+## Next verification actions
+1. Inventory `schemas/`, `contracts/`, `policy/`, `tools/validators/`, `pipelines/`, and app directories.
+2. Resolve schema-home ambiguity with ADR if needed.
+3. Add fixture-driven validation checks for rights and sensitivity fail-closed behavior.

--- a/docs/domains/flora/DATA_MODEL.md
+++ b/docs/domains/flora/DATA_MODEL.md
@@ -1,0 +1,22 @@
+# Flora Data Model (Domain-Level)
+
+## Object families
+| Object | Purpose |
+| --- | --- |
+| `FloraSourceDescriptor` | Defines source role, rights, cadence, and sensitivity constraints. |
+| `FloraTaxon` | Stable taxon identity with accepted name and crosswalk references. |
+| `TaxonCrosswalk` | Links raw names/IDs to normalized taxon identifiers. |
+| `OccurrenceEvidenceObject` | Source-traceable plant occurrence support. |
+| `SpecimenRecord` | Herbarium/institutional specimen context and uncertainty. |
+| `StatusAssertion` | Jurisdiction-scoped status claims with as-of dates. |
+| `VegetationProduct` | Derived vegetation/phenology/index artifacts and uncertainty metadata. |
+| `SensitivityTransformReceipt` | Proof of redaction/generalization for public-safe output. |
+| `EvidenceBundle` | Resolved evidence package for claims and UI payloads. |
+| `DecisionEnvelope` | Finite decision outcomes (`ANSWER`, `ABSTAIN`, `DENY`, `ERROR`). |
+| `ReleaseManifest` | Promotion-time artifact inventory and rollback target. |
+
+## Modeling rules
+- Taxon identity, occurrence evidence, and derived products must remain distinct object families.
+- Time fields must separate event time, retrieval time, and publication time.
+- Geometry precision and uncertainty are explicit, never implied.
+- Public-safe derivatives require transform receipts when precision is reduced.

--- a/docs/domains/flora/FILE_MANIFEST.md
+++ b/docs/domains/flora/FILE_MANIFEST.md
@@ -1,0 +1,18 @@
+# Flora File Manifest
+
+| File | Purpose |
+| --- | --- |
+| `README.md` | Domain landing page and doctrine-aligned orientation. |
+| `ARCHITECTURE.md` | Lane-level architecture and invariants. |
+| `CURRENT_STATE.md` | Verified repository facts and remaining unknowns. |
+| `SOURCE_REGISTRY.md` | Source descriptor and source-role expectations. |
+| `DATA_MODEL.md` | Domain object families and modeling rules. |
+| `PIPELINES_AND_LIFECYCLE.md` | Stage gates from intake to publication. |
+| `PUBLICATION_AND_POLICY.md` | Publication controls and deny conditions. |
+| `UI_AND_EVIDENCE_DRAWER.md` | UI payload boundaries and evidence behavior. |
+| `VERIFICATION_BACKLOG.md` | Open verification tasks and priorities. |
+| `CHANGELOG.md` | Human-readable documentation change history. |
+| `ROADMAP.md` | Sequenced next steps for lane maturation. |
+| `FILE_MANIFEST.md` | This inventory file. |
+| `GLOSSARY.md` | Shared term definitions for flora lane docs. |
+| `IDEA_INTAKE.md` | Structured intake for unpromoted ideas. |

--- a/docs/domains/flora/GLOSSARY.md
+++ b/docs/domains/flora/GLOSSARY.md
@@ -1,0 +1,11 @@
+# Flora Glossary
+
+- **EvidenceBundle:** Inspectable set of evidence references backing a claim.
+- **DecisionEnvelope:** Finite decision outcome and reason context.
+- **Source role:** Declared authority type and allowed claim usage of a source.
+- **Sensitivity class:** Policy label that controls precision and exposure.
+- **Public-safe artifact:** Output approved for public surfaces after policy checks.
+- **Transform receipt:** Record of geometry redaction/generalization operations.
+- **Promotion gate:** Final release decision checkpoint for publication.
+- **Quarantine:** State for records blocked by unresolved rights, sensitivity, or integrity.
+- **Rollback target:** Identified prior release that can be restored if needed.

--- a/docs/domains/flora/IDEA_INTAKE.md
+++ b/docs/domains/flora/IDEA_INTAKE.md
@@ -1,0 +1,18 @@
+# Flora Idea Intake
+
+Use this file to capture ideas without promoting them to implementation claims.
+
+## Intake template
+- **Title:**
+- **Problem being solved:**
+- **Proposed change:**
+- **Domain impact:** (taxon / occurrence / specimen / product / policy / UI)
+- **Evidence needed:**
+- **Policy or sensitivity concerns:**
+- **Dependencies:**
+- **Promotion criteria:**
+- **Owner:**
+- **Status:** (`proposed`, `reviewing`, `deferred`, `accepted`, `rejected`)
+
+## Active ideas
+- _None recorded yet._

--- a/docs/domains/flora/PIPELINES_AND_LIFECYCLE.md
+++ b/docs/domains/flora/PIPELINES_AND_LIFECYCLE.md
@@ -1,0 +1,22 @@
+# Flora Pipelines and Lifecycle
+
+## Lifecycle stages
+1. **Source descriptor ready** (role/rights/sensitivity resolved).
+2. **RAW intake** captured with immutable provenance.
+3. **WORK normalization** applies crosswalks and geometry handling.
+4. **Validation gates** enforce schema + policy.
+5. **PROCESSED** objects produced for eligible records.
+6. **Catalog/proof closure** for reproducibility.
+7. **Promotion decision** approves, holds, denies, or quarantines.
+8. **PUBLISHED** public-safe artifacts served via governed surfaces.
+
+## Gate outcomes
+- `PASS` -> continue.
+- `HOLD` -> pending steward or policy review.
+- `DENY` -> blocked until corrected.
+- `QUARANTINE` -> unresolved rights/sensitivity/integrity.
+
+## Non-negotiable controls
+- No direct publication from RAW/WORK.
+- All public payloads must trace to cataloged artifacts.
+- Rollback target required for each promoted bundle.

--- a/docs/domains/flora/PUBLICATION_AND_POLICY.md
+++ b/docs/domains/flora/PUBLICATION_AND_POLICY.md
@@ -1,0 +1,27 @@
+# Flora Publication and Policy
+
+## Policy posture
+Flora publication is fail-closed: unknown rights or unresolved sensitivity prevents public release.
+
+## Required checks before publication
+- Rights/license compatibility for intended exposure.
+- Sensitivity class and geometry precision policy.
+- Source role compatibility with claim type.
+- EvidenceBundle resolvability.
+- Review status and promotion authorization.
+- Release manifest completeness and rollback readiness.
+
+## Public geometry classes
+| Class | Public behavior |
+| --- | --- |
+| `public_exact_allowed` | Exact geometry permitted only with explicit approval. |
+| `public_generalized` | Publish generalized geometry with transform receipt. |
+| `restricted_precise` | Never expose exact coordinates publicly. |
+| `embargoed` | Delayed or suppressed until embargo conditions pass. |
+| `steward_review_required` | Hold until explicit steward review. |
+
+## Deny conditions
+- Missing rights metadata.
+- Unknown source role.
+- Sensitive exact geometry without approved policy path.
+- Broken provenance or evidence references.

--- a/docs/domains/flora/README.md
+++ b/docs/domains/flora/README.md
@@ -150,7 +150,7 @@ Do **not** put these in `docs/domains/flora/`:
 
 ## Directory tree
 
-The tree below is a **PROPOSED starter map** for the Flora lane. It should be reconciled with the real repo after a mounted checkout is inspected.
+The tree below reflects the current Flora documentation set in this repository. Keep `FILE_MANIFEST.md` aligned when files are added or removed.
 
 ```text
 docs/

--- a/docs/domains/flora/ROADMAP.md
+++ b/docs/domains/flora/ROADMAP.md
@@ -1,0 +1,20 @@
+# Flora Roadmap
+
+## Phase 1 — Documentation baseline (done)
+- Establish companion docs and domain guardrails.
+- Record verified-vs-proposed boundaries.
+
+## Phase 2 — Contract and policy resolution
+- Resolve schema home and publish contract skeletons.
+- Define policy checks for rights/sensitivity/source-role compatibility.
+- Add fixture packs for positive and negative cases.
+
+## Phase 3 — Validation and dry-run promotion
+- Implement flora validator coverage and CI hooks.
+- Run no-network promotion dry run with receipts and manifests.
+- Validate rollback path.
+
+## Phase 4 — Governed surfaces
+- Wire governed API payloads for flora claims.
+- Integrate Evidence Drawer and Focus finite outcomes.
+- Publish first public-safe layer manifest.

--- a/docs/domains/flora/SOURCE_REGISTRY.md
+++ b/docs/domains/flora/SOURCE_REGISTRY.md
@@ -1,0 +1,31 @@
+# Flora Source Registry Guide
+
+## Goal
+Define how flora sources are classified before they are eligible for processing or publication.
+
+## Required descriptor fields
+- Source ID and human-readable name
+- Source role (authority vs support vs derived)
+- Rights/license and redistribution posture
+- Sensitivity/geoprivacy posture
+- Cadence and freshness expectations
+- Spatial/temporal support
+- Steward owner and review requirements
+
+## Source roles
+| Role | Allowed use | Not allowed |
+| --- | --- | --- |
+| `official` | Authority-backed status or canonical program layer | Community observations as legal truth |
+| `institutional` | Specimen/collection support with provenance | Public exact geometry without clearance |
+| `steward_reviewed` | Curated and reviewed flora support | Automatic public publication |
+| `community_observation` | Corroborative evidence with quality checks | Sole authority for legal status |
+| `derived_model` | Condition/suitability context with uncertainty | Direct observation truth |
+| `controlled_access` | Restricted internal analysis | Public exact publication by default |
+
+## Admission rule
+Unknown source role, unknown rights, or unresolved sensitivity blocks promotion.
+
+## Minimum fixture expectation per source
+- 1 valid descriptor fixture.
+- 1 invalid rights fixture.
+- 1 invalid sensitivity/publication fixture.

--- a/docs/domains/flora/UI_AND_EVIDENCE_DRAWER.md
+++ b/docs/domains/flora/UI_AND_EVIDENCE_DRAWER.md
@@ -1,0 +1,29 @@
+# Flora UI and Evidence Drawer
+
+## Scope
+Defines behavior expectations for map layers, evidence drawers, and Focus-like synthesis surfaces.
+
+## Map layer expectations
+- Show public-safe geometry only.
+- Include trust metadata: source role, freshness, review state, and sensitivity class.
+- Never treat style configuration as source truth.
+
+## Evidence Drawer contract (human-level)
+Each consequential claim should present:
+- Claim summary.
+- Linked EvidenceBundle references.
+- Source role and rights posture.
+- Sensitivity/redaction notes (if any).
+- Decision outcome and reason code.
+
+## Focus outcome contract
+Focus responses should use finite outcomes:
+- `ANSWER` when admissible evidence supports the response.
+- `ABSTAIN` when scope/evidence is insufficient.
+- `DENY` when policy disallows disclosure.
+- `ERROR` when retrieval/validation fails.
+
+## Prohibitions
+- No direct RAW/WORK reads from UI runtime.
+- No disclosure of restricted precise locations in public surfaces.
+- No unsupported claims without evidence resolution.

--- a/docs/domains/flora/VERIFICATION_BACKLOG.md
+++ b/docs/domains/flora/VERIFICATION_BACKLOG.md
@@ -1,0 +1,19 @@
+# Flora Verification Backlog
+
+## High priority
+- [ ] Confirm schema home and add/align ADR.
+- [ ] Verify source registry location and existing flora descriptors.
+- [ ] Identify policy engine path and current flora policies.
+- [ ] Inventory validators and add flora-specific negative tests.
+- [ ] Confirm governed API endpoint locations for flora payloads.
+- [ ] Confirm UI layer registry and Evidence Drawer integration points.
+
+## Medium priority
+- [ ] Add no-network fixtures for taxon, occurrence, specimen, and denied publication cases.
+- [ ] Define canonical reason code set for HOLD/DENY/ABSTAIN/ERROR.
+- [ ] Establish transform receipt schema for generalized public geometry.
+- [ ] Confirm catalog/proof artifact directories used by flora releases.
+
+## Low priority
+- [ ] Add glossary refinements after implementation vocabulary stabilizes.
+- [ ] Add cross-domain join notes with habitat, soil, and hydrology lanes.


### PR DESCRIPTION
### Motivation
- Provide a complete, reviewable documentation surface for the Flora domain so contributors have a consistent set of companion docs aligned to the Flora README. 
- Capture architecture, lifecycle, source-role discipline, data model, publication rules, UI contract, and verification tasks so the lane can be progressed with minimal ambiguity. 
- Preserve a clear separation between documented doctrine and unverified runtime/schema implementation by recording unknowns and next verification actions. 

### Description
- Added a companion documentation set under `docs/domains/flora/` including `ARCHITECTURE.md`, `CURRENT_STATE.md`, `SOURCE_REGISTRY.md`, `DATA_MODEL.md`, `PIPELINES_AND_LIFECYCLE.md`, `PUBLICATION_AND_POLICY.md`, `UI_AND_EVIDENCE_DRAWER.md`, `VERIFICATION_BACKLOG.md`, `ROADMAP.md`, `FILE_MANIFEST.md`, `GLOSSARY.md`, `IDEA_INTAKE.md`, and `CHANGELOG.md`. 
- Updated `docs/domains/flora/README.md` to reflect that the listed companion doc set now exists and to recommend keeping `FILE_MANIFEST.md` aligned when files change. 
- Established fail-closed publication rules, object-family definitions, gate outcomes, and a prioritized verification backlog to guide next implementation steps without asserting runtime changes. 

### Testing
- Verified the new files are present with `find docs/domains/flora -maxdepth 1 -type f | sort` and confirmed the expected set was listed successfully. 
- Sanity-checked headings and key markers with `rg -n "^#|TODO|PROPOSED" docs/domains/flora` which returned the expected coverage across the new documents. 
- Inspected representative file content snippets with `nl`/`sed` to confirm the README update and the presence of `ARCHITECTURE.md` and `CURRENT_STATE.md`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdd35112c832a8cb0e3f1c8b06ff9)