### PR TITLE
docs(habitat): add companion domain documentation and update README

### DIFF
--- a/docs/domains/habitat/API_AND_UI_SURFACES.md
+++ b/docs/domains/habitat/API_AND_UI_SURFACES.md
@@ -1,0 +1,46 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: TODO(kfm://doc/<uuid>)
+title: Habitat API and UI Surfaces
+type: standard
+version: v1
+status: draft
+owners: TODO(confirm habitat API owner and web/UI owner)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(confirm public|restricted)
+related: [docs/domains/habitat/README.md, docs/architecture/habitat/RUNTIME_EVIDENCE_MODEL.md]
+tags: [kfm, habitat, api, ui, evidence-drawer, maplibre]
+notes: [Path conventions for API and web apps remain NEEDS VERIFICATION in this repository.]
+[/KFM_META_BLOCK_V2] -->
+
+# Habitat API and UI Surfaces
+
+## API contract expectations
+Public habitat endpoints should:
+- return governed `DecisionEnvelope` responses;
+- include evidence references resolvable to an `EvidenceBundle`;
+- include freshness/review/limitation metadata;
+- expose denial/abstention reasons when policy blocks an answer.
+
+Public habitat endpoints must not:
+- expose RAW/WORK/QUARANTINE paths;
+- return restricted internal canonical-store objects;
+- infer legal authority from modeled/context-only sources.
+
+## UI surface expectations
+MapLibre, Evidence Drawer, and Focus Mode should render only governed API payloads.
+
+### Map behavior
+- Layers must identify source role and review state.
+- Popups should link to evidence metadata, not raw internal records.
+- Sensitive geometry should be generalized/withheld as required by policy.
+
+### Evidence Drawer behavior
+- Show claim summary, source-role labels, and policy posture.
+- Show limitation and confidence context.
+- Support correction/supersession visibility.
+
+### Focus Mode behavior
+- Summarize only released evidence-backed claims.
+- Use `ABSTAIN` for unsupported or incomplete evidence situations.
+- Never fabricate policy permissions or legal conclusions.

--- a/docs/domains/habitat/ARCHITECTURE.md
+++ b/docs/domains/habitat/ARCHITECTURE.md
@@ -1,0 +1,61 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: TODO(kfm://doc/<uuid>)
+title: Habitat Domain Architecture
+type: standard
+version: v1
+status: draft
+owners: TODO(confirm habitat lane steward and documentation-control owner)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(confirm public|restricted)
+related: [docs/domains/habitat/README.md, docs/architecture/habitat/HABITAT_CONTROL_PLANE_INDEX.md]
+tags: [kfm, habitat, architecture, evidence-first]
+notes: [Draft companion file created to complete docs/domains/habitat set; confirm links and owner metadata before promotion.]
+[/KFM_META_BLOCK_V2] -->
+
+# Habitat Architecture
+
+## Purpose
+This document defines the Habitat lane boundaries, object families, and trust boundaries that support the `RAW -> WORK/QUARANTINE -> PROCESSED -> CATALOG/TRIPLET -> PUBLISHED` lifecycle described in the Habitat README.
+
+## Bounded context
+Habitat owns environmental and habitat-support context products. It can depend on and link to fauna, flora, and other lane evidence, but does not absorb those domains into habitat truth.
+
+### In-bounds
+- regulatory critical habitat
+- state review/list context for habitat relevance
+- modeled habitat and range-support layers
+- occurrence-derived habitat assignments (derived artifacts only)
+- landscape/community/context layers
+- connectivity and corridor context
+- correction and supersession lineage for habitat releases
+
+### Out-of-bounds
+- raw source connectors and credentials
+- direct legal conclusions outside source-role scope
+- exact sensitive occurrence disclosure in public outputs
+- browser-side policy inference
+
+## Primary object families
+| Object family | Role | Notes |
+|---|---|---|
+| `SourceDescriptor` | Source admission and rights posture | Must exist before live fetch or publication. |
+| `HabitatFeature` | Normalized habitat geometry/object payload | Carries source-role and support scale metadata. |
+| `ValidationReport` | Fixture and schema gate result | Fail-closed on critical violations. |
+| `EvidenceBundle` | Claim-to-evidence resolution container | Runtime and UI claims must resolve through this surface. |
+| `ReleaseManifest` | Immutable release contract | Supports reproducibility, rollback, and alias updates. |
+| `DecisionEnvelope` | Runtime finite outcome wrapper | `ANSWER`, `ABSTAIN`, `DENY`, `ERROR`. |
+
+## Trust boundaries
+1. Public surfaces read from released artifacts only.
+2. No public consumer reads RAW/WORK/QUARANTINE or internal canonical stores directly.
+3. Source role must be preserved through derivation and publication.
+4. Sensitive locations default to deny, generalize, or abstain depending on policy.
+
+## Cross-lane dependencies
+Habitat can reference:
+- Fauna and Flora evidence for habitat-support context.
+- Hydrology and Soil layers for environmental covariates.
+- Hazards and Infrastructure for disturbance and barrier context.
+
+Cross-lane joins must preserve provenance edges and source-role meaning.

--- a/docs/domains/habitat/OPEN_QUESTIONS.md
+++ b/docs/domains/habitat/OPEN_QUESTIONS.md
@@ -1,0 +1,33 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: TODO(kfm://doc/<uuid>)
+title: Habitat Open Questions and Verification Backlog
+type: standard
+version: v1
+status: draft
+owners: TODO(confirm habitat lane steward)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(confirm public|restricted)
+related: [docs/domains/habitat/README.md]
+tags: [kfm, habitat, backlog, verification, open-questions]
+notes: [Tracks unresolved repository and governance questions blocking full habitat-lane promotion.]
+[/KFM_META_BLOCK_V2] -->
+
+# Habitat Open Questions
+
+## Priority verification backlog
+| Priority | Question | Why it matters |
+|---:|---|---|
+| P0 | Which schema home is canonical (`schemas/contracts/v1/habitat/` vs `contracts/habitat/`)? | Prevent split machine authority. |
+| P0 | Who are the authoritative lane/documentation/policy owners? | Establish review and merge accountability. |
+| P0 | Which source descriptors currently exist and are active? | Clarify admission status and rights risk. |
+| P1 | What are the canonical paths for governed API and web UI habitat surfaces? | Avoid duplicate or drifting contracts. |
+| P1 | Which validator toolchain is active in CI? | Ensure gate expectations map to executable checks. |
+| P1 | Are rollback/correction receipts already standardized in-repo? | Align with existing release lineage conventions. |
+| P2 | Which cross-domain habitat relationships are currently implemented? | Scope next documentation and contract updates. |
+
+## Evidence requests for closure
+- Confirm CODEOWNERS or stewardship references for Habitat files.
+- Confirm existing policy rule locations and naming conventions.
+- Confirm fixture inventory for regulatory, modeled, and occurrence cases.
+- Confirm if current README companion links are valid relative paths.

--- a/docs/domains/habitat/PROMOTION_AND_ROLLBACK.md
+++ b/docs/domains/habitat/PROMOTION_AND_ROLLBACK.md
@@ -1,0 +1,44 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: TODO(kfm://doc/<uuid>)
+title: Habitat Promotion and Rollback
+type: standard
+version: v1
+status: draft
+owners: TODO(confirm habitat release owner)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(confirm public|restricted)
+related: [docs/domains/habitat/README.md, data/manifests/habitat/, data/receipts/habitat/]
+tags: [kfm, habitat, release, rollback, correction]
+notes: [Promotion flow described for lane consistency; concrete scripts and command names require verification.]
+[/KFM_META_BLOCK_V2] -->
+
+# Habitat Promotion and Rollback
+
+## Promotion prerequisites
+A habitat release candidate should not be promoted until:
+- source descriptors are valid and approved;
+- validation and policy gates pass;
+- catalog closure (STAC/DCAT/PROV) is complete;
+- EvidenceBundle and ReleaseManifest references resolve;
+- reviewer approval is recorded.
+
+## Promotion flow
+1. Validate release candidate fixtures and generated artifacts.
+2. Generate/verify RunReceipt and EvidenceBundle.
+3. Build ReleaseManifest with immutable artifact digests.
+4. Record review decision and policy posture.
+5. Update current alias only after all checks pass.
+
+## Rollback flow
+Rollback is required when an active release is found invalid, superseded, or policy-incompatible.
+
+1. Create CorrectionNotice or RollbackReceipt referencing impacted release.
+2. Re-point current alias to last known good release.
+3. Preserve superseded release for lineage traceability.
+4. Publish runtime message indicating correction/rollback state.
+
+## Non-negotiables
+- No destructive overwrite of historical releases.
+- No alias change without auditable receipt.
+- No silent correction without evidence and policy references.

--- a/docs/domains/habitat/README.md
+++ b/docs/domains/habitat/README.md
@@ -8,7 +8,7 @@ owners: TODO(confirm habitat lane steward and documentation-control owner)
 created: TODO(verify initial creation date)
 updated: 2026-04-22
 policy_label: TODO(confirm public|restricted)
-related: [docs/architecture/habitat/HABITAT_CONTROL_PLANE_INDEX.md, docs/architecture/habitat/ADR-0001-habitat-schema-home.md, data/registry/habitat/MASTER_REGISTRY_INDEX.md]
+related: [docs/domains/habitat/ARCHITECTURE.md, docs/domains/habitat/SOURCE_REGISTRY.md, docs/domains/habitat/VALIDATION_AND_POLICY.md, docs/architecture/habitat/HABITAT_CONTROL_PLANE_INDEX.md, docs/architecture/habitat/ADR-0001-habitat-schema-home.md, data/registry/habitat/MASTER_REGISTRY_INDEX.md]
 tags: [kfm, habitat, domain, evidence, map-first, geoprivacy]
 notes: [Repository checkout was not mounted during authoring; owner, created date, policy label, badge targets, and companion-path links require verification before publication.]
 [/KFM_META_BLOCK_V2] -->
@@ -24,7 +24,7 @@ Governed orientation for the KFM Habitat lane: source-role-safe habitat evidence
 > **Owners:** `TODO(confirm habitat lane steward and documentation-control owner)`  
 > **Path:** `docs/domains/habitat/README.md`  
 > **Badges:** ![status](https://img.shields.io/badge/status-experimental-orange) ![doc](https://img.shields.io/badge/doc-README--like%20%2B%20standard-blue) ![truth](https://img.shields.io/badge/truth-evidence--bounded-2b6cb0) ![lane](https://img.shields.io/badge/lane-habitat-2ea043) ![repo](https://img.shields.io/badge/repo-needs%20verification-lightgrey) ![posture](https://img.shields.io/badge/posture-fail--closed-b60205)  
-> **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Accepted inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Directory tree](#directory-tree) · [Quickstart](#quickstart) · [Usage](#usage) · [Diagram](#diagram) · [Reference tables](#reference-tables) · [Definition of done](#definition-of-done) · [FAQ](#faq) · [Appendix](#appendix)
+> **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Companion docs](#companion-docs) · [Accepted inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Directory tree](#directory-tree) · [Quickstart](#quickstart) · [Usage](#usage) · [Diagram](#diagram) · [Reference tables](#reference-tables) · [Definition of done](#definition-of-done) · [FAQ](#faq) · [Appendix](#appendix)
 
 > [!NOTE]
 > This README is intentionally **evidence-bounded**. It states KFM Habitat doctrine confidently where the attached corpus supports it, but marks repo implementation, owners, exact paths, CI, routes, and live source behavior as `NEEDS VERIFICATION` until the real checkout is inspected.
@@ -86,6 +86,23 @@ Habitat outputs may support Fauna, Flora, Hydrology, Soils, Atmosphere, Hazards,
 
 ---
 
+## Companion docs
+
+The Habitat domain directory now includes companion documents for day-to-day maintenance:
+
+- [ARCHITECTURE.md](ARCHITECTURE.md): bounded context, object families, and trust boundaries.
+- [SOURCE_REGISTRY.md](SOURCE_REGISTRY.md): source-admission guide and source-role expectations.
+- [VALIDATION_AND_POLICY.md](VALIDATION_AND_POLICY.md): fail-closed gate categories and runtime outcomes.
+- [API_AND_UI_SURFACES.md](API_AND_UI_SURFACES.md): governed API and MapLibre/Evidence Drawer/Focus expectations.
+- [PROMOTION_AND_ROLLBACK.md](PROMOTION_AND_ROLLBACK.md): release prerequisites, promotion path, and rollback protocol.
+- [OPEN_QUESTIONS.md](OPEN_QUESTIONS.md): unresolved decisions and verification backlog.
+
+These files are documentation-control surfaces. They do not replace machine contracts, validators, policy code, or run receipts.
+
+[Back to top](#top)
+
+---
+
 ## Accepted inputs
 
 Use this directory and its companion Habitat control-plane files for materials that belong to the Habitat lane and can be governed through KFM’s evidence path.
@@ -131,7 +148,13 @@ Do not place these in the Habitat lane without an explicit ADR, source admission
 
 ```text
 docs/domains/habitat/
-└── README.md
+├── README.md
+├── ARCHITECTURE.md
+├── SOURCE_REGISTRY.md
+├── VALIDATION_AND_POLICY.md
+├── API_AND_UI_SURFACES.md
+├── PROMOTION_AND_ROLLBACK.md
+└── OPEN_QUESTIONS.md
 ```
 
 ### Expected companion surfaces

--- a/docs/domains/habitat/SOURCE_REGISTRY.md
+++ b/docs/domains/habitat/SOURCE_REGISTRY.md
@@ -1,0 +1,46 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: TODO(kfm://doc/<uuid>)
+title: Habitat Source Registry Guide
+type: standard
+version: v1
+status: draft
+owners: TODO(confirm habitat lane steward and source-governance owner)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(confirm public|restricted)
+related: [docs/domains/habitat/README.md, data/registry/habitat/MASTER_REGISTRY_INDEX.md]
+tags: [kfm, habitat, source-registry, rights, sensitivity]
+notes: [Human-readable guide; machine source descriptors remain under data/registry/habitat/.]
+[/KFM_META_BLOCK_V2] -->
+
+# Habitat Source Registry
+
+## Registry intent
+Habitat source descriptors define what may be ingested, why it is admissible, and under what rights/sensitivity posture it can be published.
+
+## Minimum descriptor fields
+Each source descriptor should provide:
+- source identifier and steward
+- source role (regulatory, modeled, occurrence, context, etc.)
+- rights/license and redistribution constraints
+- sensitivity handling requirements
+- update cadence and refresh policy
+- schema/version and validation expectations
+- default activation state (`inactive` until reviewed)
+
+## Source-role families
+| Role | Typical examples | Publication posture |
+|---|---|---|
+| `regulatory_critical_habitat` | USFWS official designations | Can support regulatory questions when release-approved. |
+| `state_review_context` | KDWP listed/review context | Supports state review context; not a permit decision by default. |
+| `modeled_habitat` | GAP/NatureServe model outputs | Contextual support only; cannot answer legal-designation questions. |
+| `occurrence_signal` | GBIF/iDigBio or local reviewed signals | Rights + precision + sensitivity checks required before publication. |
+| `landscape_context` | NLCD/LANDFIRE/NWI/PAD-US/HLS | Context layers; scope and uncertainty must be explicit. |
+
+## Admission checklist
+- Descriptor schema validates.
+- Rights and terms are documented and compatible.
+- Sensitivity policy is mapped.
+- Source role is unambiguous.
+- At least one valid and one invalid fixture exist.
+- Live fetch remains disabled until steward review is complete.

--- a/docs/domains/habitat/VALIDATION_AND_POLICY.md
+++ b/docs/domains/habitat/VALIDATION_AND_POLICY.md
@@ -1,0 +1,45 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: TODO(kfm://doc/<uuid>)
+title: Habitat Validation and Policy Gates
+type: standard
+version: v1
+status: draft
+owners: TODO(confirm habitat lane steward and policy owner)
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO(confirm public|restricted)
+related: [docs/domains/habitat/README.md, policy/habitat/, tools/validators/habitat/]
+tags: [kfm, habitat, validation, policy, fail-closed]
+notes: [Validation and policy are described at a lane level; concrete tools and rule files require checkout verification.]
+[/KFM_META_BLOCK_V2] -->
+
+# Habitat Validation and Policy
+
+## Validation posture
+Habitat validation is fail-closed. Missing rights, unresolved sensitivity, invalid source role, or incomplete catalog closure blocks promotion.
+
+## Required gate categories
+| Gate | Purpose | Block condition |
+|---|---|---|
+| Schema gate | Ensure descriptors and payloads match contract shape. | Missing required fields or invalid type/value constraints. |
+| Source-role gate | Prevent role mixing across regulatory/modeled/occurrence/context families. | Claim attempts unsupported role inference. |
+| Rights gate | Enforce license and redistribution constraints. | Rights absent, ambiguous, or incompatible with public release. |
+| Geoprivacy gate | Protect sensitive exact locations. | Public output contains exact restricted/sensitive geometry. |
+| Catalog-closure gate | Require STAC/DCAT/PROV resolution. | Missing or misaligned catalog references. |
+| Proof gate | Ensure EvidenceBundle/ReleaseManifest consistency. | Evidence or release references fail integrity checks. |
+
+## Runtime outcomes
+The governed runtime must return only finite outcomes:
+- `ANSWER`
+- `ABSTAIN`
+- `DENY`
+- `ERROR`
+
+## Fixture expectations
+At minimum, include fixtures for:
+- valid regulatory critical habitat sample
+- modeled habitat used correctly as context
+- modeled habitat incorrectly used as legal designation (must fail)
+- occurrence without rights (must quarantine/deny)
+- sensitive exact occurrence request (must deny or abstain)
+- missing PROV closure in release candidate (must fail)


### PR DESCRIPTION
### Motivation
- Provide a complete, opinionated documentation surface for the Habitat lane so maintainers have architecture, registry, validation/policy, API/UI, promotion/rollback, and verification backlog guidance adjacent to the README. 
- Make the README an accurate navigation and control-plane entry by linking and surfacing the new companion docs while preserving `TODO` / `NEEDS VERIFICATION` posture for repo-specific items.

### Description
- Added companion documents under `docs/domains/habitat/`: `ARCHITECTURE.md`, `SOURCE_REGISTRY.md`, `VALIDATION_AND_POLICY.md`, `API_AND_UI_SURFACES.md`, `PROMOTION_AND_ROLLBACK.md`, and `OPEN_QUESTIONS.md` which capture lane boundaries, source admission, fail-closed gates, API/UI expectations, promotion/rollback flow, and verification backlog. 
- Updated `docs/domains/habitat/README.md` to include the new companion docs in the meta `related` block, add a `Companion docs` section with local links, expand quick-jump navigation, and update the directory tree to reflect the new files. 
- All new files are draft/`TODO`-marked and intentionally preserve verification placeholders for owners, schema-home decisions, CI/tooling, and downstream paths.

### Testing
- Verified presence of the new files with `find docs/domains/habitat -maxdepth 1 -type f | sort`, which showed the added companion documents and succeeded. 
- Performed a repository state check with `git status --short` and inspected the current commit id with `git rev-parse --short HEAD` to confirm the working tree changes and head state, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe0f2bea8832a95d8399b2fbaa972)