### PR TITLE
Finish hazards domain documentation directory

### DIFF
--- a/docs/domains/hazards/ARCHITECTURE.md
+++ b/docs/domains/hazards/ARCHITECTURE.md
@@ -1,0 +1,42 @@
+# Hazards Lane Architecture
+
+Status: **proposed architecture baseline** for the hazards lane.
+
+## Purpose
+
+Define the end-to-end trust path for hazards so that public claims are always evidence-backed, policy-checked, and reviewable.
+
+## System boundaries
+
+- **In scope:** source descriptors, ingestion, normalization, policy checks, promotion, governed API payloads, MapLibre layers, Evidence Drawer payloads, and Focus Mode outcomes.
+- **Out of scope:** emergency dispatch, life-safety instructions, direct client access to raw feeds.
+
+## Reference flow
+
+```text
+SourceDescriptor -> RAW -> WORK/QUARANTINE -> PROCESSED -> CATALOG/TRIPLET -> PROMOTION -> PUBLISHED
+                                                                                      -> Governed API
+                                                                                      -> MapLibre + Drawer + Focus
+```
+
+## Core architectural rules
+
+1. **Source-role first:** each hazard object has exactly one primary `source_role`.
+2. **Evidence mandatory:** public hazard claims resolve through `EvidenceRef` -> `EvidenceBundle`.
+3. **Fail-closed policy:** unresolved rights, role, sensitivity, or evidence blocks promotion.
+4. **No emergency masquerade:** operational warning/advisory/watch content is contextual only.
+5. **Derivative humility:** model outputs, detections, and resilience analysis cannot masquerade as observations.
+6. **Lineage required:** corrections, supersessions, and rollbacks append lineage; they do not delete history.
+
+## Runtime surfaces
+
+- **Governed API:** released artifacts only.
+- **MapLibre:** released layer descriptors only; no live raw source URLs.
+- **Evidence Drawer:** must explain what a claim is and is not.
+- **Focus Mode:** finite outcomes (`ANSWER`, `ABSTAIN`, `DENY`, `ERROR`) only.
+
+## Verification targets
+
+- Implemented schema locations and CI validation commands.
+- Actual route and package names used by the active repo.
+- Signature and attestation infrastructure state.

--- a/docs/domains/hazards/CANON_AND_LINEAGE_RULES.md
+++ b/docs/domains/hazards/CANON_AND_LINEAGE_RULES.md
@@ -1,0 +1,13 @@
+# Canon and Lineage Rules
+
+## Canon boundaries
+
+- Canonical truth for hazards is source-grounded and evidence-linked, not UI/render artifacts.
+- Derived artifacts (tiles, summaries, cached payloads) must point back to release and evidence ids.
+
+## Lineage rules
+
+- Every promoted object must carry stable identity and lineage metadata.
+- Corrections create successor objects linked by `supersedes` / `superseded_by`.
+- Rollbacks change active pointers, not historical records.
+- Unpublished work/quarantine artifacts must not appear as canonical public truth.

--- a/docs/domains/hazards/CHANGE_SURFACES_MATRIX.md
+++ b/docs/domains/hazards/CHANGE_SURFACES_MATRIX.md
@@ -1,0 +1,13 @@
+# Hazards Change Surfaces Matrix
+
+Use this matrix to determine which files/systems need updates for common hazard-lane changes.
+
+| Change type | Must review/update |
+| --- | --- |
+| New source descriptor | `SOURCE_INDEX.md`, source registry descriptor, fixtures, validators, policy allowlists/denylists |
+| New source role | `SOURCE_ROLES.md`, `TIME_SEMANTICS.md`, drawer labels, policy checks, fixtures |
+| New time field | `TIME_SEMANTICS.md`, contracts/schemas, fixtures, freshness UI |
+| Promotion logic update | `PROMOTION.md`, validator outputs, CI checks, runbook notes |
+| Drawer payload update | `UI_AND_EVIDENCE_DRAWER.md`, API payload contract, frontend mapping tests |
+| Correction process change | `ROLLBACK_AND_CORRECTION.md`, operational runbooks, audit references |
+| Naming/supersession change | `NAMING_AND_SUPERSESSION_RULES.md`, lineage validation tests |

--- a/docs/domains/hazards/DOCUMENT_REGISTRY.v1.yaml
+++ b/docs/domains/hazards/DOCUMENT_REGISTRY.v1.yaml
@@ -1,0 +1,52 @@
+version: v1
+surface: docs/domains/hazards
+status: proposed
+owners:
+  - TODO-NEEDS-OWNER
+updated: 2026-04-27
+documents:
+  - path: docs/domains/hazards/README.md
+    role: landing
+    status: draft
+  - path: docs/domains/hazards/ARCHITECTURE.md
+    role: architecture
+    status: draft
+  - path: docs/domains/hazards/FILE_MAP.md
+    role: map
+    status: draft
+  - path: docs/domains/hazards/SOURCE_INDEX.md
+    role: source-index
+    status: draft
+  - path: docs/domains/hazards/SOURCE_ROLES.md
+    role: taxonomy
+    status: draft
+  - path: docs/domains/hazards/TIME_SEMANTICS.md
+    role: semantics
+    status: draft
+  - path: docs/domains/hazards/PROMOTION.md
+    role: governance
+    status: draft
+  - path: docs/domains/hazards/UI_AND_EVIDENCE_DRAWER.md
+    role: ui-contract
+    status: draft
+  - path: docs/domains/hazards/ROLLBACK_AND_CORRECTION.md
+    role: operations
+    status: draft
+  - path: docs/domains/hazards/CANON_AND_LINEAGE_RULES.md
+    role: canon-rules
+    status: draft
+  - path: docs/domains/hazards/GENERATED_ARTIFACT_RULES.md
+    role: generated-artifact-rules
+    status: draft
+  - path: docs/domains/hazards/NAMING_AND_SUPERSESSION_RULES.md
+    role: naming-rules
+    status: draft
+  - path: docs/domains/hazards/CHANGE_SURFACES_MATRIX.md
+    role: change-impact
+    status: draft
+  - path: docs/domains/hazards/VERIFICATION_BACKLOG.md
+    role: backlog
+    status: draft
+  - path: docs/domains/hazards/OPEN_QUESTIONS.md
+    role: questions
+    status: draft

--- a/docs/domains/hazards/FILE_MAP.md
+++ b/docs/domains/hazards/FILE_MAP.md
@@ -1,0 +1,21 @@
+# Hazards File Map
+
+This map classifies files in `docs/domains/hazards/` by purpose.
+
+| File | Class | Purpose |
+| --- | --- | --- |
+| `README.md` | Landing | Domain orientation and guardrails. |
+| `ARCHITECTURE.md` | Architecture | Trust path and boundary model. |
+| `SOURCE_ROLES.md` | Taxonomy | Role definitions and non-equivalence constraints. |
+| `TIME_SEMANTICS.md` | Semantics | Role-aware time and freshness rules. |
+| `PROMOTION.md` | Governance | Promotion gates and outcomes. |
+| `UI_AND_EVIDENCE_DRAWER.md` | UX contract | Drawer/map expectations and negative states. |
+| `ROLLBACK_AND_CORRECTION.md` | Operations | Correction and rollback workflow. |
+| `SOURCE_INDEX.md` | Index | Human index of planned source descriptors. |
+| `DOCUMENT_REGISTRY.v1.yaml` | Control record | Machine-readable doc registry. |
+| `CANON_AND_LINEAGE_RULES.md` | Canon rules | Canonical-vs-derived and lineage rules. |
+| `GENERATED_ARTIFACT_RULES.md` | Safety rules | Anti-masquerade for generated artifacts. |
+| `NAMING_AND_SUPERSESSION_RULES.md` | Naming rules | IDs, aliases, supersession semantics. |
+| `CHANGE_SURFACES_MATRIX.md` | Impact map | Change propagation checklist. |
+| `VERIFICATION_BACKLOG.md` | Backlog | Unverified items blocking stronger claims. |
+| `OPEN_QUESTIONS.md` | Design backlog | Unresolved domain decisions. |

--- a/docs/domains/hazards/GENERATED_ARTIFACT_RULES.md
+++ b/docs/domains/hazards/GENERATED_ARTIFACT_RULES.md
@@ -1,0 +1,21 @@
+# Generated Artifact Rules
+
+Generated artifacts are useful but never authoritative by themselves.
+
+## Anti-masquerade controls
+
+- Generated map/vector artifacts cannot replace canonical release records.
+- AI summaries cannot replace evidence objects.
+- Search indexes and embeddings cannot become source-of-truth fields.
+- Receipts cannot masquerade as proofs; proofs cannot masquerade as source truth.
+
+## Required provenance
+
+Each generated artifact should declare:
+
+- artifact type;
+- source release id(s);
+- generation method/spec version;
+- generation timestamp;
+- policy posture (public/restricted);
+- invalidation conditions.

--- a/docs/domains/hazards/NAMING_AND_SUPERSESSION_RULES.md
+++ b/docs/domains/hazards/NAMING_AND_SUPERSESSION_RULES.md
@@ -1,0 +1,14 @@
+# Naming and Supersession Rules
+
+## Naming guidance
+
+- Use stable, explicit ids with domain prefix: `hazards.<object-class>.<id>`.
+- Keep human labels mutable; ids should be immutable.
+- Avoid encoding temporary status in ids.
+
+## Supersession semantics
+
+- `supersedes`: points to directly replaced object(s).
+- `superseded_by`: backlink set by newer object.
+- Supersession requires reason code (correction, schema migration, policy fix, source update).
+- UI should surface latest active object while allowing lineage drill-through.

--- a/docs/domains/hazards/OPEN_QUESTIONS.md
+++ b/docs/domains/hazards/OPEN_QUESTIONS.md
@@ -1,0 +1,9 @@
+# Hazards Open Questions
+
+1. Which machine-contract home is canonical (`contracts/` vs `schemas/contracts/v1/`) for hazards?
+2. What exact evidence resolver contract is required by Focus and Drawer runtimes?
+3. Should operational warning context have separate publish TTL policies by source?
+4. What minimum geometry generalization thresholds are required for sensitive hazard layers?
+5. Which signatures/attestations are mandatory vs optional for promotion gate E?
+6. Do local-context sources require additional steward classes beyond default review roles?
+7. What is the expected correction SLA by release surface (API, map, exports, stories)?

--- a/docs/domains/hazards/PROMOTION.md
+++ b/docs/domains/hazards/PROMOTION.md
@@ -1,0 +1,33 @@
+# Hazards Promotion
+
+Promotion is a governed decision that controls whether hazard material can become a released public surface.
+
+## Gates
+
+| Gate | Condition |
+| --- | --- |
+| A `ownership_present` | Responsible steward/reviewer assigned. |
+| B `schema_valid` | Required hazard schemas and payload contracts validate. |
+| C `evidence_complete` | All public evidence references resolve successfully. |
+| D `catalog_linkage_closed` | Manifest/proof/catalog links are internally consistent. |
+| E `signatures_verified` | Sign/attest checks pass or explicit hold reason recorded. |
+| F `policy_compliant` | Rights/sensitivity/source-role/no-emergency posture passes. |
+| G `diff_clean` | Reviewable, bounded diffs with no unresolved migration risk. |
+
+## Outcomes
+
+- `PROMOTE`: all gates pass.
+- `HOLD`: outstanding fixable obligations.
+- `DENY`: policy/evidence/rights posture forbids release.
+- `ERROR`: validator/service/runtime fault prevents decision.
+
+## Required output shape
+
+Each decision should include:
+
+- decision id and timestamp;
+- candidate release id;
+- gate-by-gate status;
+- reason codes;
+- reviewer/steward attribution;
+- follow-up obligations when not promoted.

--- a/docs/domains/hazards/ROLLBACK_AND_CORRECTION.md
+++ b/docs/domains/hazards/ROLLBACK_AND_CORRECTION.md
@@ -1,0 +1,33 @@
+# Hazards Rollback and Correction
+
+Corrections and rollbacks preserve lineage; they do not erase history.
+
+## Correction triggers
+
+- Incorrect role assignment.
+- Incorrect time basis or freshness fields.
+- Rights/sensitivity misclassification.
+- Broken evidence reference resolution.
+- Misleading UI wording (especially emergency posture).
+
+## Correction workflow
+
+1. Open correction record with reason code.
+2. Link affected release/object ids.
+3. Produce replacement artifact(s).
+4. Re-run validation/policy/promotion checks.
+5. Publish correction notice and lineage links.
+
+## Rollback workflow
+
+1. Identify rollback target and scope.
+2. Declare rollback reason and impact summary.
+3. Re-point active release pointer to prior safe release.
+4. Emit rollback receipt.
+5. Ensure public surfaces reference corrected lineage.
+
+## Invariants
+
+- No destructive deletes of released evidence lineage.
+- Supersession chains stay traversable.
+- Public history remains auditable.

--- a/docs/domains/hazards/SOURCE_INDEX.md
+++ b/docs/domains/hazards/SOURCE_INDEX.md
@@ -1,0 +1,23 @@
+# Hazards Source Index (Proposed)
+
+Human index of first-wave hazard sources and intended role mapping.
+
+| Source | Candidate descriptor path | Primary role | Notes |
+| --- | --- | --- | --- |
+| NOAA/NCEI Storm Events | `data/registry/hazards/sources/noaa-storm-events.v1.yaml` | `historical_event_record` | Historical records; not active alerts. |
+| NWS Alerts | `data/registry/hazards/sources/nws-alerts.v1.yaml` | `operational_warning` / `operational_advisory` / `operational_watch` | Contextual only; not life-safety replacement. |
+| FEMA Declarations | `data/registry/hazards/sources/fema-disaster-declarations.v1.yaml` | `administrative_declaration` | Administrative action, not observation. |
+| FEMA NFHL | `data/registry/hazards/sources/fema-nfhl.v1.yaml` | `regulatory_context` | Regulatory area context only. |
+| USGS Earthquake Catalog | `data/registry/hazards/sources/usgs-earthquake-catalog.v1.yaml` | `scientific_observation` | Observation feed with uncertainty and cadence rules. |
+| NOAA HMS Smoke/Fire | `data/registry/hazards/sources/noaa-hms-smoke.v1.yaml` | `remote_sensing_detection` | Detection product; latency and limits required. |
+| NASA FIRMS | `data/registry/hazards/sources/nasa-firms-active-fire.v1.yaml` | `remote_sensing_detection` | Detection feed; rights/rate limits must be confirmed. |
+| Kansas/local context | `data/registry/hazards/sources/kansas-local-em-context.v1.yaml` | `local_context` | Disabled by default until steward and rights review pass. |
+
+## Admission checklist
+
+- Rights and attribution confirmed.
+- Primary `source_role` assigned.
+- Time fields specified.
+- Freshness behavior specified.
+- Evidence resolver mapping provided.
+- Policy notes for restriction/generalization included.

--- a/docs/domains/hazards/SOURCE_ROLES.md
+++ b/docs/domains/hazards/SOURCE_ROLES.md
@@ -1,0 +1,27 @@
+# Hazards Source Roles
+
+This file defines source-role boundaries used by validation, UI labeling, and policy checks.
+
+## Role taxonomy
+
+| Role | Meaning | Must not be interpreted as |
+| --- | --- | --- |
+| `historical_event_record` | Published record of a past event. | Active warning or response instruction. |
+| `operational_warning` | Warning context with issue/expiry/freshness. | KFM emergency guidance. |
+| `operational_advisory` | Advisory context about conditions. | Verified event occurrence. |
+| `operational_watch` | Watch context for potential hazards. | Confirmed impacts. |
+| `administrative_declaration` | Governmental declaration context. | Direct physical evidence. |
+| `regulatory_context` | Regulatory hazard-zone context. | Observed on-the-ground condition. |
+| `scientific_observation` | Instrument/report-based observation. | Legal declaration. |
+| `remote_sensing_detection` | Detection product from remote sensing workflows. | Field confirmation by default. |
+| `modeled_derivative` | Model output with methods and inputs. | Observation truth. |
+| `resilience_analysis` | Planning-oriented interpretive derivative. | Damage truth/prediction certainty. |
+| `local_context` | Reviewed local context sources. | Automatically publishable public truth. |
+| `unknown_unclassified` | Unmapped role. | Publishable material. |
+
+## Enforcement rules
+
+- Role is required and single-valued for each primary hazard object.
+- `unknown_unclassified` cannot promote.
+- Role changes require explicit supersession/correction lineage.
+- UI badge text must match role semantics.

--- a/docs/domains/hazards/TIME_SEMANTICS.md
+++ b/docs/domains/hazards/TIME_SEMANTICS.md
@@ -1,0 +1,23 @@
+# Hazards Time Semantics
+
+Role-aware time semantics prevent stale or misleading hazard interpretations.
+
+## Time fields by role
+
+| Role family | Required fields |
+| --- | --- |
+| Historical events | `event_begin`, `event_end` (or source equivalent) |
+| Warnings/advisories/watches | `issue_time`, `expiry_time` or `valid_until`, `retrieval_time` |
+| Administrative declarations | `declaration_time`, optional incident period and amendment time |
+| Regulatory context | `effective_time`, layer version/revision time |
+| Scientific observations | `observed_time`, optional uncertainty interval |
+| Remote-sensing detections | `product_time`, `analysis_time`, `retrieval_time` |
+| Modeled derivatives | `model_run_time`, `input_release_refs`, `method_version` |
+| Resilience analysis | `analysis_period`, `input_refs`, `review_time` |
+
+## Freshness expectations
+
+- Operational context must expose freshness and expiry status prominently.
+- Historical records should not be rendered as active conditions.
+- Detections and model outputs must show latency and uncertainty posture.
+- Missing required time fields -> validation failure and non-promotion.

--- a/docs/domains/hazards/UI_AND_EVIDENCE_DRAWER.md
+++ b/docs/domains/hazards/UI_AND_EVIDENCE_DRAWER.md
@@ -1,0 +1,29 @@
+# Hazards UI and Evidence Drawer
+
+UI surfaces must preserve source-role semantics and policy posture.
+
+## Drawer minimums
+
+- Claim title and hazard type.
+- `source_role` badge.
+- “What this is” and “What this is not”.
+- Time basis + freshness signal.
+- Evidence links (`EvidenceBundle`/references).
+- Rights/sensitivity posture.
+- Review/correction/supersession state.
+- Operational disclaimer when role is warning/advisory/watch.
+
+## Map requirements
+
+- Layers read governed released artifacts only.
+- No browser-to-raw-source fetch paths.
+- Legends and chips are role-aware.
+- Hidden/blocked states show explicit denial or abstain messaging.
+
+## Negative states
+
+| State | User-visible behavior |
+| --- | --- |
+| `ABSTAIN` | Explain insufficient support and offer evidence drill-through. |
+| `DENY` | Show policy-safe denial category, no sensitive leakage. |
+| `ERROR` | Show stable error shell and audit reference. |

--- a/docs/domains/hazards/VERIFICATION_BACKLOG.md
+++ b/docs/domains/hazards/VERIFICATION_BACKLOG.md
@@ -1,0 +1,12 @@
+# Hazards Verification Backlog
+
+Open checks needed before upgrading this lane from draft/proposed posture.
+
+- [ ] Confirm owner/steward assignment for `docs/domains/hazards/*`.
+- [ ] Confirm active schema/contract directory conventions.
+- [ ] Confirm policy engine implementation and command paths.
+- [ ] Confirm validator package location and CI invocation.
+- [ ] Confirm governed API route locations for hazards payloads.
+- [ ] Confirm MapLibre integration paths and drawer component names.
+- [ ] Confirm source terms/rights/rate-limit/citation requirements for first-wave sources.
+- [ ] Confirm correction + rollback runbook command set.


### PR DESCRIPTION
### Motivation

- Complete the hazards domain documentation surface so the landing README has concrete downstream files and governance artifacts.
- Provide a conservative, evidence-first governance baseline that prevents the lane from becoming an emergency-alert surface and guides implementers on promotion, time semantics, and source roles.
- Surface verification items and open questions so maintainers can resolve machine-contract, policy, and CI integration before claiming implementation status.

### Description

- Added a full hazards docs suite under `docs/domains/hazards/` including `ARCHITECTURE.md`, `SOURCE_ROLES.md`, `TIME_SEMANTICS.md`, `PROMOTION.md`, `UI_AND_EVIDENCE_DRAWER.md`, `ROLLBACK_AND_CORRECTION.md`, `CANON_AND_LINEAGE_RULES.md`, `GENERATED_ARTIFACT_RULES.md`, `NAMING_AND_SUPERSESSION_RULES.md`, `CHANGE_SURFACES_MATRIX.md`, `VERIFICATION_BACKLOG.md`, and `OPEN_QUESTIONS.md` to provide lane-level policy and operational guidance.
- Added maintainability artifacts `FILE_MAP.md`, `SOURCE_INDEX.md`, and a machine-readable `DOCUMENT_REGISTRY.v1.yaml` to enumerate the new documents and proposed source descriptors.
- The files encode enforcement guidance (single primary `source_role`, required time fields by role, fail-closed promotion gates A–G, evidence→EvidenceBundle resolution, and lineage/correction invariants) as a concrete baseline for implementers. 
- No application code or runtime behavior was changed; this PR is documentation and scaffolding only.

### Testing

- Performed repository inventory and file-presence checks to confirm all new files exist in `docs/domains/hazards/` and are readable, and the workspace diff/stat was inspected; these checks completed successfully. 
- Queried the current branch/HEAD identifier to record the working state for follow-up verification and it returned a short hash successfully. 
- No unit or integration tests were required or run because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe26ca1e8832a9aee11ed6ce9a821)