### PR TITLE
docs: scaffold roads-rail-trade-routes domain companion docs

### DIFF
--- a/docs/domains/roads-rail-trade-routes/README.md
+++ b/docs/domains/roads-rail-trade-routes/README.md
@@ -299,6 +299,34 @@ apps/governed-api/
 
 ---
 
+## Companion docs in this directory
+
+The files listed in the directory-tree section are now scaffolded and ready for iterative hardening:
+
+- [architecture.md](./architecture.md)
+- [data_model.md](./data_model.md)
+- [source_registry.md](./source_registry.md)
+- [schema_index.md](./schema_index.md)
+- [pipeline_inventory.md](./pipeline_inventory.md)
+- [lifecycle_and_promotion.md](./lifecycle_and_promotion.md)
+- [catalog_and_proof_objects.md](./catalog_and_proof_objects.md)
+- [api_surface.md](./api_surface.md)
+- [ui_layer_inventory.md](./ui_layer_inventory.md)
+- [evidence_drawer_payloads.md](./evidence_drawer_payloads.md)
+- [focus_mode_behavior.md](./focus_mode_behavior.md)
+- [test_matrix.md](./test_matrix.md)
+- [fixture_inventory.md](./fixture_inventory.md)
+- [ci_gate_matrix.md](./ci_gate_matrix.md)
+- [rollback_and_corrections.md](./rollback_and_corrections.md)
+- [file_inventory.md](./file_inventory.md)
+- [change_log.md](./change_log.md)
+- [verification_backlog.md](./verification_backlog.md)
+- [extension_points.md](./extension_points.md)
+
+<p align="right"><a href="#top">Back to top ↑</a></p>
+
+---
+
 ## Quickstart
 
 Use this only after the real repository is mounted.

--- a/docs/domains/roads-rail-trade-routes/api_surface.md
+++ b/docs/domains/roads-rail-trade-routes/api_surface.md
@@ -1,0 +1,13 @@
+# API Surface
+
+Framework-neutral API notes for transport lane endpoints.
+
+## Candidate resources
+- Segments, routes, memberships, restrictions, facilities, crossings.
+- Evidence and proof objects.
+- Focus-mode bounded synthesis endpoints.
+
+## Contract posture
+- Public endpoints read released artifacts only.
+- No RAW/WORK/QUARANTINE leakage.
+- Responses use finite envelope outcomes where applicable.

--- a/docs/domains/roads-rail-trade-routes/architecture.md
+++ b/docs/domains/roads-rail-trade-routes/architecture.md
@@ -1,0 +1,21 @@
+# Architecture
+
+Defines domain boundaries, object families, and trust membranes for roads/rail/trade-routes.
+
+## Scope
+- Canonical records vs derived products.
+- Source-role and policy boundaries.
+- API/UI downstream posture.
+
+## Core boundaries
+- Physical alignment is not route designation.
+- Regulatory/administrative status is temporal and sourced.
+- Graph projections and map layers are derived artifacts.
+
+## Dependencies
+- `README.md` for lane posture.
+- ADRs for schema-home, generalization, and derived-graph policy.
+
+## Open verification tasks
+- Confirm runtime route names and package locations.
+- Confirm policy and validator path conventions.

--- a/docs/domains/roads-rail-trade-routes/catalog_and_proof_objects.md
+++ b/docs/domains/roads-rail-trade-routes/catalog_and_proof_objects.md
@@ -1,0 +1,15 @@
+# Catalog and Proof Objects
+
+Defines the proof closure expectations before publication.
+
+## Minimum objects
+- `run_receipt`
+- `evidence_bundle`
+- `decision_envelope`
+- `release_manifest`
+- `catalog_matrix`
+
+## Closure checks
+- Every public claim resolves to EvidenceBundle refs.
+- STAC/DCAT/PROV identifiers align with digests/spec hash.
+- Release alias and rollback reference are explicit.

--- a/docs/domains/roads-rail-trade-routes/change_log.md
+++ b/docs/domains/roads-rail-trade-routes/change_log.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## 2026-04-27
+- Added initial companion docs to complete the roads/rail/trade-routes domain directory skeleton.
+- Established placeholders for architecture, data model, source registry, schema index, lifecycle/promotion, API/UI, evidence/focus contracts, testing, CI, and rollback documentation.

--- a/docs/domains/roads-rail-trade-routes/ci_gate_matrix.md
+++ b/docs/domains/roads-rail-trade-routes/ci_gate_matrix.md
@@ -1,0 +1,13 @@
+# CI Gate Matrix
+
+CI gate plan for promotion safety.
+
+## Recommended gates
+- Lint and markdown checks.
+- Contract validation and fixture tests.
+- Policy checks for source role and sensitivity.
+- Catalog/proof closure checks.
+- Release dry-run checks with rollback reference.
+
+## Promotion gate
+- Block merge/release when any required lane gate fails.

--- a/docs/domains/roads-rail-trade-routes/data_model.md
+++ b/docs/domains/roads-rail-trade-routes/data_model.md
@@ -1,0 +1,17 @@
+# Data Model
+
+Canonical object-family summary for transport evidence.
+
+## Families
+- `RoadSegment`, `RailSegment`, `CorridorRoute`, `RouteMembership`.
+- `NetworkNode`, `Crossing`, `TransportFacility`.
+- `RestrictionEvent`, `StatusEvent`, `OperatorAssignment`.
+- `AlignmentVersion`, `HistoricRouteClaim`, `TradeRouteCorridor`.
+
+## Invariants
+- Identity and membership are time-scoped.
+- Legal authority claims require governing/authoritative source role.
+- Sensitive corridors default to generalized or denied public geometry.
+
+## Validation hooks
+- Schema, CRS/geometry, temporal consistency, and source-role checks.

--- a/docs/domains/roads-rail-trade-routes/evidence_drawer_payloads.md
+++ b/docs/domains/roads-rail-trade-routes/evidence_drawer_payloads.md
@@ -1,0 +1,13 @@
+# Evidence Drawer Payloads
+
+Defines payload requirements for trust-visible claim drill-through.
+
+## Required fields
+- Claim id, statement, scope, and knowledge character.
+- Source chips (role, date, steward, rights summary).
+- EvidenceBundle references and proof links.
+- Limitations, uncertainty, correction/rollback state.
+
+## Rendering rules
+- Missing required evidence => abstain-safe UI state.
+- Sensitive records show transformed/public-safe context only.

--- a/docs/domains/roads-rail-trade-routes/extension_points.md
+++ b/docs/domains/roads-rail-trade-routes/extension_points.md
@@ -1,0 +1,12 @@
+# Extension Points
+
+Planned expansion areas after the first governed slice is stable.
+
+## Candidate expansions
+- Inter-state corridor continuity handling.
+- Rail operations/event feeds with stricter freshness semantics.
+- Historic uncertainty scoring and public-safe narrative overlays.
+- Cross-domain joins with hydrology, hazards, and settlements lanes.
+
+## Guardrails
+- Additions must preserve non-conflation rules and proof closure requirements.

--- a/docs/domains/roads-rail-trade-routes/file_inventory.md
+++ b/docs/domains/roads-rail-trade-routes/file_inventory.md
@@ -1,0 +1,10 @@
+# File Inventory
+
+Inventory and purpose map for docs in `docs/domains/roads-rail-trade-routes/`.
+
+## Present files
+- `README.md` domain landing and posture.
+- Domain companion docs for architecture, model, source, schema, lifecycle, API/UI, testing, CI, and operations.
+
+## Maintenance
+- Update this index when files are added, removed, or renamed.

--- a/docs/domains/roads-rail-trade-routes/fixture_inventory.md
+++ b/docs/domains/roads-rail-trade-routes/fixture_inventory.md
@@ -1,0 +1,12 @@
+# Fixture Inventory
+
+Planned fixtures for deterministic offline checks.
+
+## Fixture classes
+- Valid canonical segment/route/membership samples.
+- Invalid geometry/temporal/source-role samples.
+- Sensitive facility/corridor samples requiring generalization.
+- Evidence/proof closure samples (good + broken).
+
+## Rules
+- Keep fixtures small, pinned, rights-safe, and auditable.

--- a/docs/domains/roads-rail-trade-routes/focus_mode_behavior.md
+++ b/docs/domains/roads-rail-trade-routes/focus_mode_behavior.md
@@ -1,0 +1,13 @@
+# Focus Mode Behavior
+
+Behavior contract for bounded synthesis in this lane.
+
+## Allowed outcomes
+- `ANSWER`: evidence-closed and policy-allowed.
+- `ABSTAIN`: insufficient/conflicting evidence.
+- `DENY`: policy/rules prohibit disclosure or claim.
+- `ERROR`: runtime failure path.
+
+## Requirements
+- No direct raw-store access.
+- Include evidence refs and reason codes in responses.

--- a/docs/domains/roads-rail-trade-routes/lifecycle_and_promotion.md
+++ b/docs/domains/roads-rail-trade-routes/lifecycle_and_promotion.md
@@ -1,0 +1,16 @@
+# Lifecycle and Promotion
+
+Governed lifecycle for roads/rail/trade-routes artifacts.
+
+## Lifecycle
+`SOURCE -> RAW -> WORK/QUARANTINE -> PROCESSED -> CATALOG/TRIPLET -> PUBLISHED`
+
+## Promotion requirements
+- EvidenceBundle closure and catalog/provenance consistency.
+- Policy decision and finite runtime outcomes.
+- Rollback target and correction lineage registered.
+
+## Fail-closed behavior
+- Unsupported claim: `ABSTAIN`.
+- Policy prohibited claim: `DENY`.
+- Processing/runtime failure: `ERROR`.

--- a/docs/domains/roads-rail-trade-routes/pipeline_inventory.md
+++ b/docs/domains/roads-rail-trade-routes/pipeline_inventory.md
@@ -1,0 +1,17 @@
+# Pipeline Inventory
+
+Inventory of planned pipeline stages and validators for this lane.
+
+## Stages
+1. Source intake and descriptor gate.
+2. RAW capture and fingerprinting.
+3. WORK normalization and schema/geometry/time validation.
+4. QUARANTINE for ambiguous/invalid/sensitive records.
+5. PROCESSED outputs and catalog/prov linkage.
+6. Proof pack and release promotion decision.
+
+## Validators
+- Source role and authority gate.
+- Geometry/CRS and topology checks.
+- Temporal overlap/conflict checks.
+- Sensitivity and public-safe generalization checks.

--- a/docs/domains/roads-rail-trade-routes/rollback_and_corrections.md
+++ b/docs/domains/roads-rail-trade-routes/rollback_and_corrections.md
@@ -1,0 +1,11 @@
+# Rollback and Corrections
+
+Correction and rollback posture for this lane.
+
+## Correction model
+- Preserve immutable artifacts; supersede via new release manifests.
+- Track correction lineage and reason codes.
+
+## Rollback model
+- Move aliases to known-good releases.
+- Keep audit trail linking decision, proof, and operator action.

--- a/docs/domains/roads-rail-trade-routes/schema_index.md
+++ b/docs/domains/roads-rail-trade-routes/schema_index.md
@@ -1,0 +1,12 @@
+# Schema Index
+
+Index of candidate schema contracts for transport lane artifacts.
+
+## Candidate contracts
+- Canonical objects: segments, routes, memberships, events, facilities.
+- Proof objects: `run_receipt`, `evidence_bundle`, `decision_envelope`, `release_manifest`.
+- Delivery objects: `layer_manifest`, `evidence_drawer_payload`, `catalog_matrix`.
+
+## Notes
+- Resolve schema authority (`schemas/` vs `contracts/`) via ADR before duplication.
+- Add explicit versioning and deprecation notes per contract family.

--- a/docs/domains/roads-rail-trade-routes/source_registry.md
+++ b/docs/domains/roads-rail-trade-routes/source_registry.md
@@ -1,0 +1,18 @@
+# Source Registry
+
+Human guide for source descriptor families used by this lane.
+
+## Descriptor minimums
+- Source id, steward, role, rights/license, cadence, access method.
+- Sensitivity defaults and public-safe transform policy.
+- Activation state and verification backlog links.
+
+## Suggested source groups
+- Roads/highways administration and legal designation sources.
+- Rail ownership/operator/network sources.
+- Historic routes and archival documentary sources.
+- Crossings/facilities and critical-infrastructure context sources.
+
+## Rules
+- Keep machine descriptors in `data/registry/transport/` (or verified equivalent).
+- Do not treat convenience aggregators as legal authority by default.

--- a/docs/domains/roads-rail-trade-routes/test_matrix.md
+++ b/docs/domains/roads-rail-trade-routes/test_matrix.md
@@ -1,0 +1,15 @@
+# Test Matrix
+
+Coverage matrix for transport lane validation.
+
+## Test families
+- Contract/schema validation tests.
+- Source-role authority tests.
+- Geometry/CRS/temporal integrity tests.
+- Sensitivity/public-safe transform tests.
+- Runtime envelope and abstain/deny/error behavior tests.
+
+## Minimum negative tests
+- Unsupported authority claims.
+- Ambiguous historic corridor identity.
+- Missing evidence refs for public claims.

--- a/docs/domains/roads-rail-trade-routes/ui_layer_inventory.md
+++ b/docs/domains/roads-rail-trade-routes/ui_layer_inventory.md
@@ -1,0 +1,16 @@
+# UI Layer Inventory
+
+Map/UI layer inventory guidance for roads/rail/trade-routes.
+
+## Layer groups
+- Road and rail base alignments.
+- Route/corridor overlays (modern + historical).
+- Restriction and status overlays.
+- Facilities/crossings/intermodal overlays.
+
+## Trust-visible metadata
+- Freshness, source role, review state, and limitations.
+- Generalized-vs-exact geometry indicator where relevant.
+
+## Boundary
+- UI layers are derivatives and must link to evidence/proof objects.

--- a/docs/domains/roads-rail-trade-routes/verification_backlog.md
+++ b/docs/domains/roads-rail-trade-routes/verification_backlog.md
@@ -1,0 +1,13 @@
+# Verification Backlog
+
+Open checks required before treating these docs as fully verified implementation references.
+
+## P0
+- Confirm canonical schema-home path and ADR linkage.
+- Confirm actual policy and validator directory conventions.
+- Confirm governed API and UI component paths/routes.
+
+## P1
+- Add concrete file citations once machine contracts exist.
+- Map each source family to reviewed rights and cadence descriptors.
+- Define exact CI workflow names and required checks.


### PR DESCRIPTION
### Motivation
- Provide a complete companion-docs scaffold for the `roads-rail-trade-routes` domain so maintainers have a discoverable control-plane for architecture, data model, lifecycle, and proof expectations. 
- Improve navigability from the lane README by linking the companion documents and creating a small change log and file inventory for iterative hardening. 
- Establish a baseline verification backlog and CI/validation guidance so future PRs can target actionable gates rather than ad-hoc prose. 

### Description
- Added 19 new companion markdown files under `docs/domains/roads-rail-trade-routes/` including `architecture.md`, `data_model.md`, `source_registry.md`, `schema_index.md`, `pipeline_inventory.md`, `lifecycle_and_promotion.md`, `catalog_and_proof_objects.md`, `api_surface.md`, `ui_layer_inventory.md`, `evidence_drawer_payloads.md`, `focus_mode_behavior.md`, `test_matrix.md`, `fixture_inventory.md`, `ci_gate_matrix.md`, `rollback_and_corrections.md`, `file_inventory.md`, `change_log.md`, `verification_backlog.md`, and `extension_points.md`. 
- Updated `docs/domains/roads-rail-trade-routes/README.md` to add a “Companion docs in this directory” section linking all newly created files for discoverability. 
- Seeded each companion doc with concise guidance, invariants, and open verification tasks to make the directory ready for iterative content hardening and ADR-driven decisions. 

### Testing
- Verified the new files are present with `find docs/domains/roads-rail-trade-routes -maxdepth 1 -type f | sort` which listed the scaffolded documents. 
- Confirmed the working tree reflects the additions using `git status --short` to validate the change set presence. 
- No automated schema or runtime tests were added in this doc-only pass and the verification backlog documents next actionable validation steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe9f0a564832a82f7ba82be258f86)