### PR TITLE
Add settlements-infrastructure domain documentation package

### DIFF
--- a/docs/domains/settlements-infrastructure/CHANGELOG.md
+++ b/docs/domains/settlements-infrastructure/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Settlements & Infrastructure Changelog
+
+## 2026-04-27
+
+- Added companion documentation set for `docs/domains/settlements-infrastructure/`:
+  - `data-model.md`
+  - `source-registry.md`
+  - `schema-registry.md`
+  - `pipeline.md`
+  - `api.md`
+  - `map-layers.md`
+  - `governance.md`
+  - `verification-backlog.md`
+  - `correction-log.md`
+  - `continuity.md`
+  - `file-map.md`
+- Updated `README.md` metadata and directory tree to reflect implemented docs.

--- a/docs/domains/settlements-infrastructure/README.md
+++ b/docs/domains/settlements-infrastructure/README.md
@@ -6,7 +6,7 @@ version: v1
 status: draft
 owners: TODO(repo CODEOWNERS or domain steward)
 created: 2026-04-22
-updated: 2026-04-22
+updated: 2026-04-27
 policy_label: public
 related: [TODO:docs/registers/domain-file-index.md, TODO:docs/domains/settlements/README.md, TODO:docs/domains/infrastructure/README.md, TODO:schemas/contracts/v1/settlements/, TODO:schemas/contracts/v1/infrastructure/]
 tags: [kfm, domain, settlements, infrastructure, map-first, evidence, governance]
@@ -31,7 +31,7 @@ Landing page for the KFM domain lane that keeps Kansas places, civic status, inf
 > **Status:** experimental  
 > **Owners:** TODO — verify against repo CODEOWNERS, stewardship register, or domain ownership docs.  
 > **Path:** `docs/domains/settlements-infrastructure/README.md`  
-> **Posture:** **CONFIRMED** requested landing page path; **PROPOSED** lane structure; **UNKNOWN** current implementation depth until the mounted repo, tests, workflows, schemas, policy bundles, and runtime evidence are inspected.
+> **Posture:** **CONFIRMED** requested landing page path and companion docs landed in this directory; **NEEDS VERIFICATION** for owners, schema homes, runtime routes, and policy wiring.
 
 **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Directory tree](#directory-tree) · [Lifecycle](#governed-lifecycle) · [Contracts](#contracts-and-object-families) · [Map/UI](#map-ui-and-focus-mode) · [Done](#definition-of-done) · [Verification](#verification-backlog)
 
@@ -73,7 +73,7 @@ It is not just a map layer catalog. It is the reviewable control surface for cla
 | Role | README-like domain landing page and review entry point |
 | Upstream doctrine | KFM pipeline doctrine, documentation control plane, settlements/infrastructure blueprint, MapLibre UI doctrine, governed AI doctrine |
 | Upstream machine surfaces | `schemas/contracts/v1/settlements/` and `schemas/contracts/v1/infrastructure/` are **PROPOSED** until repo conventions are verified |
-| Downstream docs | `data-model.md`, `source-registry.md`, `schema-registry.md`, `pipeline.md`, `api.md`, `map-layers.md`, `governance.md`, `verification-backlog.md`, `correction-log.md` are **PROPOSED** companion docs |
+| Downstream docs | `data-model.md`, `source-registry.md`, `schema-registry.md`, `pipeline.md`, `api.md`, `map-layers.md`, `governance.md`, `verification-backlog.md`, `correction-log.md`, `continuity.md`, and `file-map.md` are implemented companion docs in this directory. |
 | Downstream runtime | Governed API, released layer descriptors, Evidence Drawer payloads, Focus Mode envelopes, catalog/proof/release objects |
 | Must not become | A raw data directory, schema authority by itself, operational status dashboard, critical-infrastructure exposure surface, or uncited historical narrative |
 
@@ -129,22 +129,23 @@ These do **not** belong in this README or companion documentation unless explici
 
 ## Directory tree
 
-**NEEDS VERIFICATION:** The actual repo tree was not available in the inspected workspace. The tree below is the intended documentation shape for this requested combined path. Do not create duplicate authority if the real repo already has separate `docs/domains/settlements/` and `docs/domains/infrastructure/` homes.
+Current directory shape in this repository checkout.
 
 ```text
 docs/domains/settlements-infrastructure/
 ├── README.md                    # this landing page
-├── data-model.md                # PROPOSED: bounded contexts and field dictionary
-├── source-registry.md           # PROPOSED: source roles, rights posture, cadence
-├── schema-registry.md           # PROPOSED: schema/object index and compatibility notes
-├── pipeline.md                  # PROPOSED: RAW -> PUBLISHED flow and receipts
-├── api.md                       # PROPOSED: governed API contracts and finite outcomes
-├── map-layers.md                # PROPOSED: released layer descriptors and Evidence Drawer mapping
-├── governance.md                # PROPOSED: rights, sensitivity, policy, review, release gates
-├── verification-backlog.md      # PROPOSED: open checks before activation
-├── correction-log.md            # PROPOSED: post-release correction and supersession notes
-├── continuity.md                # PROPOSED: migration from prior scaffold/lineage docs
-└── file-map.md                  # PROPOSED: links into docs/registers/domain-file-index.md
+├── data-model.md                # bounded contexts and field dictionary
+├── source-registry.md           # source roles, rights posture, cadence
+├── schema-registry.md           # schema/object index and compatibility notes
+├── pipeline.md                  # RAW -> PUBLISHED flow and receipts
+├── api.md                       # governed API contracts and finite outcomes
+├── map-layers.md                # released layer descriptors and Evidence Drawer mapping
+├── governance.md                # rights, sensitivity, policy, review, release gates
+├── verification-backlog.md      # open checks before activation
+├── correction-log.md            # post-release correction and supersession notes
+├── continuity.md                # migration from prior scaffold/lineage docs
+├── file-map.md                  # links into docs/registers/domain-file-index.md
+└── CHANGELOG.md                 # lane documentation change history
 ```
 
 Companion homes, also **NEEDS VERIFICATION**:

--- a/docs/domains/settlements-infrastructure/api.md
+++ b/docs/domains/settlements-infrastructure/api.md
@@ -1,0 +1,23 @@
+# Settlements & Infrastructure API Contracts
+
+Public APIs must resolve released artifacts only.
+
+## Public contract obligations
+
+- No direct RAW/WORK/QUARANTINE reads.
+- Each consequential claim resolves `EvidenceRef -> EvidenceBundle`.
+- Responses include source role, confidence/uncertainty, and temporal scope.
+- Focus outcomes are finite: `ANSWER`, `ABSTAIN`, `DENY`, `ERROR`.
+
+## Candidate endpoints (naming TBD)
+
+- Settlements search/list/detail.
+- Settlement boundary versions and status timeline.
+- Infrastructure assets/networks/nodes/segments.
+- Layer metadata and Evidence Drawer payloads.
+- Release and correction lineage lookup.
+
+## Response safety
+
+- Redact or generalize restricted geometry.
+- Return policy reason codes for denied/abstained outcomes.

--- a/docs/domains/settlements-infrastructure/continuity.md
+++ b/docs/domains/settlements-infrastructure/continuity.md
@@ -1,0 +1,16 @@
+# Settlements & Infrastructure Continuity Notes
+
+This document captures migration and continuity assumptions for the combined lane.
+
+## Continuity posture
+
+- Keep this directory as a landing/index lane unless governance chooses split documentation homes.
+- If split homes are adopted, maintain this README as the orchestration entry point.
+- Preserve historical links by mapping old paths to successor docs.
+
+## Migration checklist
+
+1. Decide combined vs split governance ownership.
+2. Record canonical schema location decision.
+3. Update domain file index and cross-domain references.
+4. Add supersession mapping for renamed or relocated docs.

--- a/docs/domains/settlements-infrastructure/correction-log.md
+++ b/docs/domains/settlements-infrastructure/correction-log.md
@@ -1,0 +1,15 @@
+# Settlements & Infrastructure Correction Log
+
+Track post-release corrections and supersession lineage for this lane.
+
+## Entries
+
+| Date | Release ID | Artifact/claim | Action | Reason | Supersedes |
+|---|---|---|---|---|---|
+| _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+
+## Logging rules
+
+- Record correction date in UTC.
+- Include decision reason code and approving authority.
+- Link to replacement ReleaseManifest and rollback reference when applicable.

--- a/docs/domains/settlements-infrastructure/data-model.md
+++ b/docs/domains/settlements-infrastructure/data-model.md
@@ -1,0 +1,37 @@
+# Settlements & Infrastructure Data Model
+
+This document defines the minimum bounded contexts for the settlements-infrastructure lane.
+
+## Bounded contexts
+
+| Context | Purpose | Canonical identity |
+|---|---|---|
+| Settlements | Human place entities, names, legal status, civic roles, and temporal boundaries | settlement ID + time validity |
+| Infrastructure | Assets, networks, nodes, segments, facilities, operators, and dependencies | infrastructure ID + network/asset type |
+| Observations | Population, condition, service, and status observations | subject ID + observed timestamp + source |
+| Governance | Evidence, review, policy, release, and correction lineage | evidence/release/decision IDs |
+
+## Core object families
+
+- `Settlement`
+- `SettlementName`
+- `SettlementBoundaryVersion`
+- `SettlementStatusEvent`
+- `PopulationObservation`
+- `InfrastructureAsset`
+- `InfrastructureNetwork`
+- `InfrastructureNode`
+- `InfrastructureSegment`
+- `InfrastructureFacility`
+- `InfrastructureConditionObservation`
+- `EvidenceBundle`
+- `DecisionEnvelope`
+- `ReleaseManifest`
+
+## Modeling rules
+
+1. Preserve temporal validity explicitly; avoid flattening legal/status history into one row.
+2. Separate legal place identity from rendered geometry snapshots.
+3. Keep source role and rights posture attached at record level for consequential claims.
+4. Represent network topology as relations, not inferred map adjacency.
+5. Public DTOs must carry claim scope and uncertainty affordances.

--- a/docs/domains/settlements-infrastructure/file-map.md
+++ b/docs/domains/settlements-infrastructure/file-map.md
@@ -1,0 +1,18 @@
+# Settlements & Infrastructure File Map
+
+Quick index for documents in this lane.
+
+| File | Purpose |
+|---|---|
+| `README.md` | Lane landing page and doctrine summary |
+| `data-model.md` | Bounded contexts and object-family model rules |
+| `source-registry.md` | Source descriptor requirements and admission checklist |
+| `schema-registry.md` | Schema authority and version compatibility notes |
+| `pipeline.md` | Lifecycle operations and incident handling |
+| `api.md` | Public API trust contracts and safety expectations |
+| `map-layers.md` | Map layer classes and release coupling |
+| `governance.md` | Promotion gates and fail-closed policy posture |
+| `verification-backlog.md` | Open verification tasks before activation |
+| `correction-log.md` | Post-release correction/supersession register |
+| `continuity.md` | Combined/split lane continuity and migration guidance |
+| `file-map.md` | This index |

--- a/docs/domains/settlements-infrastructure/governance.md
+++ b/docs/domains/settlements-infrastructure/governance.md
@@ -1,0 +1,24 @@
+# Settlements & Infrastructure Governance
+
+Governance requirements for promotion and public trust.
+
+## Gate classes
+
+1. Rights and redistribution gate.
+2. Sensitivity and exact-geometry gate.
+3. Source-role and claim-scope compatibility gate.
+4. Review and approval gate.
+5. Catalog/provenance closure gate.
+6. Release manifest and rollback readiness gate.
+
+## Fail-closed rules
+
+- Unknown rights -> deny publication.
+- Missing evidence support -> abstain.
+- Restricted geometry without approved generalization -> deny.
+- Conflicting source assertions without adjudication -> quarantine.
+
+## Correction obligations
+
+- Corrections supersede; they do not erase lineage.
+- Every public correction links prior release IDs and reason codes.

--- a/docs/domains/settlements-infrastructure/map-layers.md
+++ b/docs/domains/settlements-infrastructure/map-layers.md
@@ -1,0 +1,19 @@
+# Settlements & Infrastructure Map Layers
+
+Map delivery is a released derivative surface.
+
+## Layer classes
+
+| Layer class | Source family | Public precision rule |
+|---|---|---|
+| Settlement points/polygons | Municipal/census/historic boundaries | Generalize when sensitivity or uncertainty requires |
+| Settlement status overlays | Legal/status event records | Time-scoped labels only when evidence-backed |
+| Infrastructure assets | Public-safe asset representations | Hide or generalize restricted classes |
+| Infrastructure networks | Corridor/service topology | Publish only policy-approved detail |
+| Condition/observation overlays | Condition/service snapshots | Include observation time and source role |
+
+## UI integration rules
+
+- Layer cards link to Evidence Drawer payloads.
+- Layer versions are tied to ReleaseManifest IDs.
+- Map aliases are governed state transitions, not mutable pointers.

--- a/docs/domains/settlements-infrastructure/pipeline.md
+++ b/docs/domains/settlements-infrastructure/pipeline.md
@@ -1,0 +1,21 @@
+# Settlements & Infrastructure Pipeline
+
+Fixture-first lifecycle for governed promotion.
+
+## Lifecycle
+
+1. Register source descriptor.
+2. Ingest RAW fixture/live payload with immutable receipt.
+3. Normalize to WORK while preserving source IDs, time semantics, and CRS.
+4. Validate schema, source-role, policy, and precision gates.
+5. Route failed candidates to QUARANTINE with reason codes.
+6. Promote valid artifacts to PROCESSED and emit catalog/provenance objects.
+7. Evaluate promotion gate and emit DecisionEnvelope.
+8. Publish approved release artifacts with ReleaseManifest + rollback reference.
+
+## Incident responses
+
+- **Malformed legal/status event**: quarantine and require source correction.
+- **Sensitive exact geometry**: deny publication or force generalized derivative.
+- **Missing EvidenceBundle links**: fail publication gate.
+- **Regression in negative fixtures**: rollback candidate release and reopen validation.

--- a/docs/domains/settlements-infrastructure/schema-registry.md
+++ b/docs/domains/settlements-infrastructure/schema-registry.md
@@ -1,0 +1,28 @@
+# Settlements & Infrastructure Schema Registry
+
+Track schema object families, versioning posture, and compatibility expectations.
+
+## Canonical home
+
+Canonical schema home is **NEEDS VERIFICATION**:
+
+- `schemas/contracts/v1/settlements/` + `schemas/contracts/v1/infrastructure/`, or
+- repo-native `contracts/` equivalents.
+
+Use one authority and record the decision in an ADR.
+
+## Required object families
+
+| Family | Minimum purpose |
+|---|---|
+| Settlement contracts | Place identity, names, status, boundaries, civic functions |
+| Infrastructure contracts | Asset/network identity, topology, operator and dependency links |
+| Observation contracts | Population/condition/service observations with source/time context |
+| Governance contracts | EvidenceBundle, DecisionEnvelope, ReleaseManifest, correction records |
+
+## Compatibility policy
+
+- Version contracts semantically.
+- Do not break published API DTOs without explicit migration notes.
+- Preserve backward readability for at least one minor version.
+- Encode supersession relationships for corrected records.

--- a/docs/domains/settlements-infrastructure/source-registry.md
+++ b/docs/domains/settlements-infrastructure/source-registry.md
@@ -1,0 +1,26 @@
+# Settlements & Infrastructure Source Registry Guidance
+
+This file defines the source descriptor requirements for this lane.
+
+## Required fields
+
+- `source_id`
+- `source_name`
+- `owner`
+- `steward`
+- `source_role` (`authority`, `observation`, `documentary`, `derived`, `mirror`, `aggregate`)
+- `rights` (license + redistribution constraints)
+- `sensitivity` (`public`, `review_required`, `restricted`)
+- `spatial_support` (geometry type/precision)
+- `temporal_support` (event time semantics + cadence)
+- `stable_keys` (identifiers preserved end-to-end)
+- `ingest_mode` (`fixture_only` or `live`)
+- `activation_state` (`planned`, `approved`, `active`, `blocked`)
+
+## Admission checklist
+
+1. Rights and sensitivity are explicit and reviewed.
+2. Source role is compatible with claim class.
+3. Stable keys and timestamps survive normalization.
+4. Negative fixtures exist for denial/abstention paths.
+5. Policy checks enforce fail-closed publication behavior.

--- a/docs/domains/settlements-infrastructure/verification-backlog.md
+++ b/docs/domains/settlements-infrastructure/verification-backlog.md
@@ -1,0 +1,14 @@
+# Settlements & Infrastructure Verification Backlog
+
+Open checks before this lane is considered production-ready.
+
+## Must verify
+
+- [ ] Confirm domain owners against `CODEOWNERS` and stewardship registers.
+- [ ] Confirm canonical schema home (`schemas/contracts` vs `contracts`).
+- [ ] Confirm existing policy bundle location and command entry points.
+- [ ] Confirm validator script paths and CI workflow wiring.
+- [ ] Confirm governed API route names and DTO locations.
+- [ ] Confirm map layer manifest and alias conventions.
+- [ ] Confirm release/proof object storage paths.
+- [ ] Confirm whether split docs homes (`settlements/` + `infrastructure/`) should supersede this combined lane.


### PR DESCRIPTION
### Motivation

- Provide a complete, repo-resident documentation surface for the Settlements & Infrastructure lane so downstream work (schemas, pipelines, API, UI, and governance) has an authoritative human reference.
- Replace the README's prior "proposed" placeholders with implemented companion docs to reduce ambiguity about expected files and next verification steps.
- Surface verification tasks (owners, canonical schema home, CI wiring, policy bundle locations) so activation remains gated and auditable.

### Description

- Added a full companion doc set under `docs/domains/settlements-infrastructure/` including `data-model.md`, `source-registry.md`, `schema-registry.md`, `pipeline.md`, `api.md`, `map-layers.md`, `governance.md`, `verification-backlog.md`, `correction-log.md`, `continuity.md`, `file-map.md`, and `CHANGELOG.md`.
- Updated the landing `README.md` to reflect that the companion docs are implemented, bumped the `updated` date to `2026-04-27`, and refreshed the directory tree to list the new files.
- Added a changelog entry for `2026-04-27` documenting the implemented companion docs and README alignment.

### Testing

- Ran `git diff --check` to verify there are no whitespace or diff-check issues and it passed.
- Verified repository workspace changes with basic status checks to ensure the expected files are present.
- No automated schema/policy validation was run as part of this PR; `verification-backlog.md` records required follow-up checks that must pass before activation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efeb3ceb4c832a966a55b65b6efbac)