### PR TITLE
Add soil domain companion docs (SOURCE_BURDEN, SUPPORT_TYPES, LAYER_GUIDE, OPEN_VERIFICATION, CHANGELOG)

### DIFF
--- a/docs/domains/soil/CHANGELOG.md
+++ b/docs/domains/soil/CHANGELOG.md
@@ -1,0 +1,26 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/soil/changelog
+title: Soil Domain Changelog
+type: changelog
+version: v1
+status: active
+owners: TODO-VERIFY
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO-VERIFY
+related: [kfm://doc/TODO-VERIFY-uuid]
+tags: [kfm, soil, changelog]
+notes: [Changelog for docs/domains/soil docs set.]
+[/KFM_META_BLOCK_V2] -->
+
+# Soil Domain Changelog
+
+## 2026-04-27
+
+- Added initial companion docs for the soil domain directory:
+  - `SOURCE_BURDEN.md`
+  - `SUPPORT_TYPES.md`
+  - `LAYER_GUIDE.md`
+  - `OPEN_VERIFICATION.md`
+  - `CHANGELOG.md`
+- Retained draft posture and TODO ownership fields pending steward confirmation.

--- a/docs/domains/soil/LAYER_GUIDE.md
+++ b/docs/domains/soil/LAYER_GUIDE.md
@@ -1,0 +1,54 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/soil/layer-guide
+title: Soil Layer Guide
+type: standard
+version: v1
+status: draft
+owners: TODO-VERIFY
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO-VERIFY
+related: [kfm://doc/TODO-VERIFY-uuid]
+tags: [kfm, soil, maplibre, evidence-drawer, layers]
+notes: [UI-oriented guidance companion for the soil domain README.]
+[/KFM_META_BLOCK_V2] -->
+
+# Soil Layer Guide
+
+Guidance for presenting soil layers in map-first experiences while preserving evidence-first trust.
+
+## Layer design principles
+
+1. Each layer has one primary `support_type`.
+2. Legends and tooltips must not hide derivation status.
+3. Click actions must resolve to an `EvidenceBundle` (or finite refusal).
+4. Non-authoritative overlays must carry visible caveats.
+
+## Recommended layer families
+
+| Layer ID | Theme | support_type | Minimum click payload |
+|---|---|---|---|
+| `soil-mapunits` | Survey map units | `authoritative_static_soil` | `mukey`, source/version, spec hash, validation timestamp |
+| `soil-components` | Component composition | `authoritative_static_soil` | `mukey`, `cokey`, component percentage, lineage refs |
+| `soil-horizons` | Horizon details | `authoritative_static_soil` or `profile_soil_evidence` | `chkey`, depth interval, method/source |
+| `soil-property-summary` | Derived properties and ratings | `soil_interpretation` | value, units, method, weighting/aggregation basis |
+| `soil-moisture-stations` | Station points | `station_soil_moisture` | station ID, depth list, freshness/QC summary |
+| `soil-moisture-series` | Time-series chart hooks | `station_soil_moisture` | timestamp, depth, value, QC flags |
+| `soil-gridded-derivative` | Raster/grid derivatives | `gridded_derivative_soil` | resolution, derivation lineage, limitations |
+| `smap-soil-moisture-context` | Satellite moisture context | `satellite_soil_moisture_grid` | product/version, grid/time window, QA status |
+
+## Drawer behavior expectations
+
+The Evidence Drawer should include, at minimum:
+
+- source family + version/release indicator,
+- support type and interpretation/derivation caveats,
+- identity keys (e.g., `mukey`, station ID, depth/time for readings),
+- policy/rights visibility marker,
+- links/references to catalog and receipt/proof artifacts where available.
+
+## Copy constraints
+
+- Avoid declarative language that overstates certainty (e.g., “proves”).
+- Prefer bounded phrasing (e.g., “indicates”, “derived from”, “as observed at”).
+- Clearly separate station observations from gridded/satellite context.

--- a/docs/domains/soil/OPEN_VERIFICATION.md
+++ b/docs/domains/soil/OPEN_VERIFICATION.md
@@ -1,0 +1,42 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/soil/open-verification
+title: Soil Open Verification Backlog
+type: standard
+version: v1
+status: draft
+owners: TODO-VERIFY
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO-VERIFY
+related: [kfm://doc/TODO-VERIFY-uuid]
+tags: [kfm, soil, verification, backlog]
+notes: [Action backlog for unresolved soil-lane verification work.]
+[/KFM_META_BLOCK_V2] -->
+
+# Soil Open Verification Backlog
+
+Track unresolved decisions required to move the soil lane from draft domain docs to enforceable implementation.
+
+## Priority queue
+
+| Priority | Item | Why it matters | Exit criteria |
+|---|---|---|---|
+| P0 | Confirm canonical directory naming (`soil/` vs `soils/`) | Avoid split implementations and broken links | one canonical path documented and applied |
+| P0 | Confirm schema/contract home | Prevent machine contract drift | soil contract path exists and is referenced by README |
+| P0 | Confirm source-descriptor home + format | Required for source admission | at least one concrete descriptor template merged |
+| P0 | Confirm policy engine + test convention | Needed for fail-closed behavior | passing policy tests and deny-path examples |
+| P1 | Confirm validator locations and output envelope | Required for deterministic review outcomes | validator docs + fixtures + output schema linked |
+| P1 | Confirm map layer registry + drawer payload contract | Needed for UI trust posture | documented payload contract with sample fixture |
+| P1 | Confirm governed API route naming | Needed for stable consumers | route contract doc or schema updated |
+| P2 | Confirm terms/rate limits/auth for each external source | Rights and reliability risk reduction | source-by-source terms table with review date |
+| P2 | Confirm offline-first CI coverage | Prevent flaky PR validation | CI job(s) prove no live network dependency by default |
+
+## Evidence needed for closure
+
+Each closed item should include:
+
+- a commit/PR reference,
+- the owning steward/team,
+- verification date (UTC),
+- link to authoritative file(s),
+- note describing any residual risk.

--- a/docs/domains/soil/README.md
+++ b/docs/domains/soil/README.md
@@ -159,15 +159,23 @@ Current branch contents are **NEEDS VERIFICATION**. The tree below is a conserva
 ```text
 docs/domains/soil/
 ├── README.md                 # this domain orientation
-├── SOURCE_BURDEN.md          # PROPOSED: source role and support burden notes
-├── SUPPORT_TYPES.md          # PROPOSED: support_type taxonomy and examples
-├── LAYER_GUIDE.md            # PROPOSED: MapLibre layer and Evidence Drawer expectations
-├── OPEN_VERIFICATION.md      # PROPOSED: unresolved source, rights, owner, and path checks
-└── CHANGELOG.md              # PROPOSED: doc-level evolution notes
+├── SOURCE_BURDEN.md          # source role and support burden notes
+├── SUPPORT_TYPES.md          # support_type taxonomy and examples
+├── LAYER_GUIDE.md            # MapLibre layer and Evidence Drawer expectations
+├── OPEN_VERIFICATION.md      # unresolved source, rights, owner, and path checks
+└── CHANGELOG.md              # doc-level evolution notes
 ```
 
 > [!TIP]
 > Keep this directory small. Put executable contracts, fixtures, policies, validators, pipeline code, and emitted artifacts in their stronger homes.
+
+Companion docs in this directory:
+
+- [`SOURCE_BURDEN.md`](./SOURCE_BURDEN.md)
+- [`SUPPORT_TYPES.md`](./SUPPORT_TYPES.md)
+- [`LAYER_GUIDE.md`](./LAYER_GUIDE.md)
+- [`OPEN_VERIFICATION.md`](./OPEN_VERIFICATION.md)
+- [`CHANGELOG.md`](./CHANGELOG.md)
 
 [Back to top](#top)
 

--- a/docs/domains/soil/SOURCE_BURDEN.md
+++ b/docs/domains/soil/SOURCE_BURDEN.md
@@ -1,0 +1,58 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/soil/source-burden
+title: Soil Source Burden
+type: standard
+version: v1
+status: draft
+owners: TODO-VERIFY
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO-VERIFY
+related: [kfm://doc/TODO-VERIFY-uuid]
+tags: [kfm, soil, source-registry, burden, validation]
+notes: [Companion to soil domain README.]
+[/KFM_META_BLOCK_V2] -->
+
+# Soil Source Burden
+
+Defines what each admitted soil source family must preserve before a candidate can move from RAW/WORK into governed review.
+
+## Shared minimum burden (all soil sources)
+
+Every source family should provide:
+
+1. **Source identity**: source name, publisher, citation text, version/release marker.
+2. **Rights posture**: usage terms URL or embedded terms text, plus redistribution posture.
+3. **Acquisition context**: endpoint/package path, retrieval timestamp (UTC), and transport metadata.
+4. **Normalization contract**: transform version and schema/contract version.
+5. **Identity keys**: stable keys sufficient to join/trace records without heuristic guessing.
+6. **Quality signals**: source QC/status fields preserved without silent coercion.
+7. **Deterministic evidence linkage**: `content_spec_hash`, `run_hash`, and `EvidenceRef` joinability.
+
+## Source-family specifics
+
+| Source family | Required keys | Required context | Deny/quarantine triggers |
+|---|---|---|---|
+| `ssurgo` | `mukey`; where present `cokey`, `chkey`, `areasymbol`, `musym` | survey/package version, CRS, geometry lineage | missing `mukey`; invalid geometry; unknown CRS |
+| `soil_data_access` | `query_hash` + returned row keys (`mukey`/`cokey`/`chkey`) | full SQL/template identity, API/service version | missing query identity; unbounded query; column drift |
+| `gssurgo` | raster/grid identity + MUKEY mapping metadata | resolution, package checksum/version | published as if equal to raw SSURGO table truth |
+| `gnatsgo` | product version + grid identity | refresh cadence and derivative caveats | provenance omitted; stale version unmarked |
+| `kansas_mesonet` | station ID, variable, `depth_cm`, timestamp | station metadata and timezone handling | depth missing; station join fails; stale/unknown QC |
+| `scan` | station ID, element, depth, timestamp | access method, QC fields, timezone basis | ambiguous timezone; unit mismatch without conversion |
+| `uscrn` | station ID, product ID, timestamp, depth | product version and QC semantics | unknown product variant; dropped QC flags |
+| `smap` | product/version, grid cell identity, temporal window | QA mask fields, resolution, latency class | presented as station truth; QA ignored |
+
+## Publication guardrails
+
+A soil candidate is **not publishable** by source presence alone. At minimum:
+
+- validator outputs must be finite (`pass`, `quarantine`, `deny`, `error`),
+- evidence must resolve to an `EvidenceBundle`,
+- policy checks must pass,
+- catalog/proof/release requirements must be satisfied in their dedicated lanes.
+
+## Notes for implementers
+
+- Preserve source-native units in raw fields; add normalized fields explicitly.
+- Never infer missing identity keys when a source omits them; quarantine instead.
+- Treat source-to-source joins (e.g., SSURGO↔SDA) as explicit, testable transforms.

--- a/docs/domains/soil/SUPPORT_TYPES.md
+++ b/docs/domains/soil/SUPPORT_TYPES.md
@@ -1,0 +1,50 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/soil/support-types
+title: Soil Support Types
+type: standard
+version: v1
+status: draft
+owners: TODO-VERIFY
+created: 2026-04-27
+updated: 2026-04-27
+policy_label: TODO-VERIFY
+related: [kfm://doc/TODO-VERIFY-uuid]
+tags: [kfm, soil, support-type, evidence]
+notes: [Companion taxonomy for docs/domains/soil/README.md.]
+[/KFM_META_BLOCK_V2] -->
+
+# Soil Support Types
+
+This file defines the support-type taxonomy referenced by the soil domain README.
+
+## Normative intent
+
+A `support_type` identifies **how a claim is supported**, not just where data came from.
+
+## Types and boundaries
+
+| support_type | Primary use | Must include | Must not imply |
+|---|---|---|---|
+| `authoritative_static_soil` | static survey-backed map/component/horizon facts | source/version + stable soil keys | near-real-time moisture state |
+| `authoritative_static_soil_query` | query-derived tabular soil facts | reproducible query identity (`query_hash`) | untracked ad hoc SQL |
+| `gridded_derivative_soil` | gridded convenience/derivative surfaces | derivative lineage and resolution | replacement for canonical survey lineage |
+| `station_soil_moisture` | in-situ moisture observations | station identity, depth, timestamp, units | statewide static soil classification |
+| `reference_station_soil_climate` | climate/reference-network station context | network/source and QC behavior | same semantics as all other station feeds |
+| `satellite_soil_moisture_grid` | satellite/grid moisture context | product version, grid/time window, QA fields | point-level station precision |
+| `profile_soil_evidence` | pedon/profile/horizon analytical support | profile keys and method context | generalized map-wide truth |
+| `soil_interpretation` | interpreted classes/ratings | explicit interpretation method/basis | raw source table row |
+| `governed_change_evidence` | change-detection and promotion support | prior/current identity and reason codes | direct publication guarantee |
+
+## Finite outcomes guidance
+
+When support is insufficient or unsafe:
+
+- **ABSTAIN** when evidence is missing,
+- **DENY** when policy/provenance constraints are violated,
+- **ERROR** for invalid request/runtime failures.
+
+## Modeling guidance
+
+- Keep `support_type` explicit in every published payload.
+- Do not collapse multiple support types into one layer without visible provenance.
+- If a value blends sources, declare the blend rule and preserve contributing references.


### PR DESCRIPTION
### Motivation
- Turn the soil domain README’s proposed file tree into concrete companion docs so maintainers have operational guidance for source burden, support-type taxonomy, UI layer/evidence behavior, and outstanding verification work. 
- Provide a minimal, navigable docs set that preserves draft/status metadata and signals next verification steps before enforcing machine contracts or pipelines.

### Description
- Added five companion files under `docs/domains/soil/`: `SOURCE_BURDEN.md`, `SUPPORT_TYPES.md`, `LAYER_GUIDE.md`, `OPEN_VERIFICATION.md`, and `CHANGELOG.md`, each including a `KFM_META_BLOCK_V2` header and draft guidance. 
- Updated `docs/domains/soil/README.md` to reflect the concrete directory tree (removed “PROPOSED” markers) and added relative links to the new companion docs. 
- The new documents capture required source admission burdens, a support_type taxonomy, MapLibre/Evidence Drawer layer guidance, a prioritized verification backlog, and an initial changelog entry. 
- All files are intentionally draft-status and include TODO ownership placeholders pending steward confirmation.

### Testing
- Verified presence of the new and updated files using `rg --files docs/domains/soil` which listed the expected files and succeeded. 
- Confirmed each file exists with `for f in docs/domains/soil/README.md docs/domains/soil/SOURCE_BURDEN.md docs/domains/soil/SUPPORT_TYPES.md docs/domains/soil/LAYER_GUIDE.md docs/domains/soil/OPEN_VERIFICATION.md docs/domains/soil/CHANGELOG.md; do test -f "$f" && echo "OK $f"; done` which printed `OK` for each path. 
- No automated unit or integration tests were added or run for schema/pipeline behavior as this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efed0e4fc4832a93a473a80388fe89)