### PR TITLE
Build out examples directory with concrete child surfaces

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -166,7 +166,7 @@ Do **not** put these in `examples/`.
 
 ## Directory map
 
-The child structure below is a **proposed orientation map**, not a confirmed inventory.
+The child structure below reflects the current `examples/` layout in this branch.
 
 ```text
 examples/
@@ -187,7 +187,7 @@ examples/
     └── README.md                       # PROPOSED: deprecated examples retained only with successor notes
 ```
 
-Start with this `README.md` only unless the active branch already contains child examples. Add a child directory only when at least one example is small, reviewed, public-safe, and linked to its intended downstream home.
+Each child directory should keep examples small, reviewed, public-safe, and linked to an intended downstream schema, contract, policy, or fixture home.
 
 <p align="right"><a href="#top">Back to top ↑</a></p>
 
@@ -446,7 +446,7 @@ Only as documentation smoke material unless a repo-native validator explicitly t
 
 ### Does this README prove that `examples/` currently contains child directories?
 
-No. The tree is proposed until confirmed in the active repository checkout.
+Yes in this branch context: the tree shown above is implemented and intended to be maintained as examples are added or removed.
 
 <p align="right"><a href="#top">Back to top ↑</a></p>
 

--- a/examples/_archive/README.md
+++ b/examples/_archive/README.md
@@ -1,0 +1,9 @@
+# Archived Examples
+
+Deprecated example files can be retained here only when they include a clear successor note.
+
+## Rules
+
+- Keep archived examples read-only.
+- Include why the file was replaced.
+- Remove any archived file that contains unsafe material.

--- a/examples/evidence/README.md
+++ b/examples/evidence/README.md
@@ -1,0 +1,12 @@
+# Evidence Examples
+
+Illustrative EvidenceBundle and DecisionEnvelope payloads for explaining review outcomes.
+
+## Included examples
+
+- `decision_envelope__abstain_missing_evidence__example.json`
+- `evidence_bundle__released_claim_support__example.json`
+
+## Boundaries
+
+These files do not prove runtime behavior, policy approval, or evidence resolution.

--- a/examples/evidence/decision_envelope__abstain_missing_evidence__example.json
+++ b/examples/evidence/decision_envelope__abstain_missing_evidence__example.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "kind": "DecisionEnvelope",
+  "status": "illustrative_only",
+  "outcome": "ABSTAIN",
+  "reason_codes": [
+    "missing_evidence_bundle",
+    "source_role_not_verified"
+  ],
+  "evidence_refs": [],
+  "policy": {
+    "decision": "hold",
+    "reason": "Example intentionally abstains when evidence is unresolved."
+  }
+}

--- a/examples/evidence/evidence_bundle__released_claim_support__example.json
+++ b/examples/evidence/evidence_bundle__released_claim_support__example.json
@@ -1,0 +1,19 @@
+{
+  "version": "v1",
+  "kind": "EvidenceBundle",
+  "status": "illustrative_only",
+  "bundle_id": "evidence_bundle__released_claim_support__example",
+  "claims": [
+    {
+      "claim_id": "claim_001",
+      "summary": "Illustrative claim for documentation only",
+      "evidence_refs": [
+        "catalog:stac:item/example-item"
+      ]
+    }
+  ],
+  "notes": [
+    "This object is not a proof artifact.",
+    "This object is not release state."
+  ]
+}

--- a/examples/maplibre/README.md
+++ b/examples/maplibre/README.md
@@ -1,0 +1,11 @@
+# MapLibre Examples
+
+Public-safe MapLibre source/layer examples that demonstrate shape only.
+
+## Included examples
+
+- `maplibre_layer__released_pmtiles_source__example.json`
+
+## Boundaries
+
+No guarantee that endpoints exist or are approved for release.

--- a/examples/maplibre/maplibre_layer__released_pmtiles_source__example.json
+++ b/examples/maplibre/maplibre_layer__released_pmtiles_source__example.json
@@ -1,0 +1,26 @@
+{
+  "version": 8,
+  "status": "illustrative_only",
+  "sources": {
+    "kfm_example_released_tiles": {
+      "type": "vector",
+      "url": "NEEDS_VERIFICATION__released_tilejson_or_pmtiles_uri",
+      "attribution": "NEEDS_VERIFICATION__source_attribution"
+    }
+  },
+  "layers": [
+    {
+      "id": "kfm-example-public-safe-layer",
+      "type": "fill",
+      "source": "kfm_example_released_tiles",
+      "source-layer": "NEEDS_VERIFICATION__source_layer",
+      "metadata": {
+        "kfm:example_only": true,
+        "kfm:not_canonical_truth": true
+      },
+      "paint": {
+        "fill-opacity": 0.4
+      }
+    }
+  ]
+}

--- a/examples/promotion/README.md
+++ b/examples/promotion/README.md
@@ -1,0 +1,11 @@
+# Promotion Review Examples
+
+Dry-run promotion payload examples for review workflows.
+
+## Included examples
+
+- `promotion_review_payload__hold_for_rights__example.json`
+
+## Boundaries
+
+These files are not receipts, proofs, signatures, or release manifests.

--- a/examples/promotion/promotion_review_payload__hold_for_rights__example.json
+++ b/examples/promotion/promotion_review_payload__hold_for_rights__example.json
@@ -1,0 +1,12 @@
+{
+  "version": "v1",
+  "kind": "PromotionReviewPayload",
+  "status": "illustrative_only",
+  "requested_action": "promote",
+  "review_decision": "hold",
+  "reason_codes": [
+    "rights_posture_not_confirmed",
+    "source_terms_need_verification"
+  ],
+  "next_step": "Resolve rights posture in governed policy/contract surfaces."
+}

--- a/examples/runtime/README.md
+++ b/examples/runtime/README.md
@@ -1,0 +1,12 @@
+# Runtime Envelope Examples
+
+Finite-outcome runtime response examples for documentation and UX safety review.
+
+## Included examples
+
+- `runtime_response__deny_sensitive_location__example.json`
+- `runtime_response__answer_with_citations__example.json`
+
+## Boundaries
+
+No model call, no live policy engine output, and no production response guarantees.

--- a/examples/runtime/runtime_response__answer_with_citations__example.json
+++ b/examples/runtime/runtime_response__answer_with_citations__example.json
@@ -1,0 +1,17 @@
+{
+  "version": "v1",
+  "kind": "RuntimeResponseEnvelope",
+  "status": "illustrative_only",
+  "outcome": "ANSWER",
+  "policy": {
+    "decision": "allow",
+    "reason_codes": []
+  },
+  "answer": "Illustrative answer text tied to cited evidence refs.",
+  "citations": [
+    {
+      "evidence_ref": "catalog:dcat:dataset/example-dataset",
+      "status": "illustrative_only"
+    }
+  ]
+}

--- a/examples/runtime/runtime_response__deny_sensitive_location__example.json
+++ b/examples/runtime/runtime_response__deny_sensitive_location__example.json
@@ -1,0 +1,12 @@
+{
+  "version": "v1",
+  "kind": "RuntimeResponseEnvelope",
+  "status": "illustrative_only",
+  "outcome": "DENY",
+  "policy": {
+    "decision": "deny",
+    "reason_codes": ["sensitive_exact_location_not_public_safe"]
+  },
+  "answer": null,
+  "citations": []
+}

--- a/examples/source-descriptors/README.md
+++ b/examples/source-descriptors/README.md
@@ -1,0 +1,13 @@
+# Source Descriptor Examples
+
+Illustrative, non-authoritative SourceDescriptor examples for onboarding and review.
+
+## Included examples
+
+- `source_descriptor__ks_water_observations__example.yaml`: public-safe sketch of source identity, role, access, and rights posture.
+
+## Boundaries
+
+- Not source custody, not connector code, not activation state.
+- No secrets, tokens, or private endpoints.
+- Any unresolved field stays `NEEDS_VERIFICATION`.

--- a/examples/source-descriptors/source_descriptor__ks_water_observations__example.yaml
+++ b/examples/source-descriptors/source_descriptor__ks_water_observations__example.yaml
@@ -1,0 +1,22 @@
+version: v1
+kind: SourceDescriptor
+status: illustrative_only
+
+identity:
+  source_id: ks_water_observations_example
+  title: Kansas Water Observations (Illustrative)
+  provider: Example Public Agency
+
+role_and_scope:
+  source_role: reference_dataset
+  primary_lane: hydrology
+  publication_intent: example_only
+
+access:
+  mode: no_live_access
+  auth_model: none
+
+rights_and_sensitivity:
+  redistribution_posture: NEEDS_VERIFICATION
+  sensitivity_posture: public_safe_synthetic
+  public_use_with_citation: NEEDS_VERIFICATION

--- a/examples/stories/README.md
+++ b/examples/stories/README.md
@@ -1,0 +1,12 @@
+# Story and Focus Mode Examples
+
+Illustrative Story Node and Focus Mode payloads for UI trust-state design.
+
+## Included examples
+
+- `focus_mode_payload__answer_with_citations__example.json`
+- `story_node_binding__time_scoped_claim__example.json`
+
+## Boundaries
+
+These are UI shape examples only; they are not published narratives or runtime truth.

--- a/examples/stories/focus_mode_payload__answer_with_citations__example.json
+++ b/examples/stories/focus_mode_payload__answer_with_citations__example.json
@@ -1,0 +1,12 @@
+{
+  "version": "v1",
+  "kind": "FocusModePayload",
+  "status": "illustrative_only",
+  "query": "What changed in watershed condition?",
+  "response_envelope_ref": "runtime:response:illustrative-answer",
+  "trust_state": {
+    "outcome": "ANSWER",
+    "citations_required": true,
+    "policy_state": "allow"
+  }
+}

--- a/examples/stories/story_node_binding__time_scoped_claim__example.json
+++ b/examples/stories/story_node_binding__time_scoped_claim__example.json
@@ -1,0 +1,14 @@
+{
+  "version": "v1",
+  "kind": "StoryNodeBinding",
+  "status": "illustrative_only",
+  "node_id": "watershed-change-overview",
+  "temporal_scope": {
+    "start": "2019-01-01",
+    "end": "2025-12-31"
+  },
+  "claim_ref": "claim_001",
+  "evidence_refs": [
+    "catalog:stac:item/example-item"
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide a complete, discoverable `examples/` surface with small, public-safe illustrative artifacts to teach object shapes and workflows. 
- Make it easy for contributors to find safe examples for source descriptors, evidence envelopes, runtime envelopes, map fragments, promotion dry-runs, and UI/story payloads.
- Ensure examples are explicitly non-authoritative and visibly separated from fixtures, proofs, and production data.

### Description

- Add child directories `examples/source-descriptors`, `examples/evidence`, `examples/runtime`, `examples/maplibre`, `examples/promotion`, `examples/stories`, and `examples/_archive` with focused `README.md` guidance in each. 
- Add concrete illustrative payloads including `source_descriptor__ks_water_observations__example.yaml`, `decision_envelope__abstain_missing_evidence__example.json`, `evidence_bundle__released_claim_support__example.json`, runtime responses (`runtime_response__deny_sensitive_location__example.json` and `runtime_response__answer_with_citations__example.json`), `maplibre_layer__released_pmtiles_source__example.json`, `promotion_review_payload__hold_for_rights__example.json`, and story/focus examples (`focus_mode_payload__answer_with_citations__example.json`, `story_node_binding__time_scoped_claim__example.json`).
- Update the top-level `examples/README.md` wording to reflect that the child tree is implemented in this branch and to clarify per-child expectations; mark unresolved operational details with `NEEDS_VERIFICATION` and all payloads as `illustrative_only`.

### Testing

- Ran `find examples -maxdepth 3 -type f | sort` to enumerate the created files and confirm the directory layout, which succeeded. 
- Ran a Python JSON parse over `examples/**/*.json` with `json.load()` which succeeded and validated 8 JSON example files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01c615cb8832a8507ecf686c8fd04)