### PR TITLE
Build out infra directory scaffolding with lane READMEs

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -200,19 +200,9 @@ A file belongs in `infra/` only when all of the following are true:
 
 ## Directory tree
 
-Current lane depth is **NEEDS VERIFICATION** in the active checkout. Use the commands in [Quickstart](#quickstart) to replace this section with direct inventory evidence before claiming lane maturity.
+Current lane depth now includes baseline lane scaffolding with lane-level README files. Lane **implementation maturity** remains `NEEDS VERIFICATION` until runtime evidence exists.
 
-### Minimal placeholder shape
-
-```text
-infra/
-├── README.md
-└── .gitkeep                  # optional placeholder; remove only when real lane files land
-```
-
-### Proposed lane map
-
-These lanes are **PROPOSED** until the actual repository confirms them.
+### Current lane map
 
 ```text
 infra/
@@ -234,17 +224,17 @@ infra/
 
 | Lane | Expected role | Status |
 | --- | --- | --- |
-| `backup/` | Restore rehearsal, rollback artifacts, stale-state handling. | PROPOSED / NEEDS VERIFICATION |
-| `compose/` | Local service coordination where compose is justified. | PROPOSED / NEEDS VERIFICATION |
-| `dashboards/` | Operator-facing dashboard definitions. | PROPOSED / NEEDS VERIFICATION |
-| `gitops/` | Declarative reconciliation for later maturity stages. | PROPOSED / NEEDS VERIFICATION |
-| `hosted/` | Remote exposure, ingress, VPN, reverse proxy, and environment overlays. | PROPOSED / NEEDS VERIFICATION |
-| `kubernetes/` | Cluster manifests, Helm/Kustomize overlays, and orchestration notes. | PROPOSED / NEEDS VERIFICATION |
-| `local/` | Single-host and local-only bring-up profile. | PROPOSED / NEEDS VERIFICATION |
-| `monitoring/` | Metrics, alerts, health checks, telemetry join keys. | PROPOSED / NEEDS VERIFICATION |
-| `systemd/` | Units, timers, sockets, service isolation, hardening notes. | PROPOSED / NEEDS VERIFICATION |
-| `systemd-or-compose/` | Decision bridge for phase-one runtime orchestration. | PROPOSED / NEEDS VERIFICATION |
-| `terraform/` | Provisioning modules and environment descriptors. | PROPOSED / NEEDS VERIFICATION |
+| `backup/` | Restore rehearsal, rollback artifacts, stale-state handling. | SCAFFOLDED / NEEDS VERIFICATION |
+| `compose/` | Local service coordination where compose is justified. | SCAFFOLDED / NEEDS VERIFICATION |
+| `dashboards/` | Operator-facing dashboard definitions. | SCAFFOLDED / NEEDS VERIFICATION |
+| `gitops/` | Declarative reconciliation for later maturity stages. | SCAFFOLDED / NEEDS VERIFICATION |
+| `hosted/` | Remote exposure, ingress, VPN, reverse proxy, and environment overlays. | SCAFFOLDED / NEEDS VERIFICATION |
+| `kubernetes/` | Cluster manifests, Helm/Kustomize overlays, and orchestration notes. | SCAFFOLDED / NEEDS VERIFICATION |
+| `local/` | Single-host and local-only bring-up profile. | SCAFFOLDED / NEEDS VERIFICATION |
+| `monitoring/` | Metrics, alerts, health checks, telemetry join keys. | SCAFFOLDED / NEEDS VERIFICATION |
+| `systemd/` | Units, timers, sockets, service isolation, hardening notes. | SCAFFOLDED / NEEDS VERIFICATION |
+| `systemd-or-compose/` | Decision bridge for phase-one runtime orchestration. | SCAFFOLDED / NEEDS VERIFICATION |
+| `terraform/` | Provisioning modules and environment descriptors. | SCAFFOLDED / NEEDS VERIFICATION |
 
 ### Subtree README expectation
 

--- a/infra/backup/README.md
+++ b/infra/backup/README.md
@@ -1,0 +1,15 @@
+# infra/backup/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/backup -maxdepth 2 -type f | sort`
+  - `git status --short infra/backup`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Restore rehearsal, rollback references, stale-state handling, and recovery verification pointers.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/compose/README.md
+++ b/infra/compose/README.md
@@ -1,0 +1,15 @@
+# infra/compose/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/compose -maxdepth 2 -type f | sort`
+  - `git status --short infra/compose`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Local or narrowly scoped multi-service orchestration descriptors and decision notes.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/dashboards/README.md
+++ b/infra/dashboards/README.md
@@ -1,0 +1,15 @@
+# infra/dashboards/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/dashboards -maxdepth 2 -type f | sort`
+  - `git status --short infra/dashboards`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Operator dashboard definitions, provisioning notes, and panel ownership metadata.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/gitops/README.md
+++ b/infra/gitops/README.md
@@ -1,0 +1,15 @@
+# infra/gitops/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/gitops -maxdepth 2 -type f | sort`
+  - `git status --short infra/gitops`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Declarative reconciliation plans and environment synchronization controls.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/hosted/README.md
+++ b/infra/hosted/README.md
@@ -1,0 +1,15 @@
+# infra/hosted/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/hosted -maxdepth 2 -type f | sort`
+  - `git status --short infra/hosted`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Reverse proxy, TLS, VPN, ingress, and remote edge deployment notes.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/kubernetes/README.md
+++ b/infra/kubernetes/README.md
@@ -1,0 +1,15 @@
+# infra/kubernetes/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/kubernetes -maxdepth 2 -type f | sort`
+  - `git status --short infra/kubernetes`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Cluster manifests/overlay scaffolding and environment-specific orchestration notes.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/local/README.md
+++ b/infra/local/README.md
@@ -1,0 +1,15 @@
+# infra/local/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/local -maxdepth 2 -type f | sort`
+  - `git status --short infra/local`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Single-host bring-up profile, bind posture, and local runtime guardrails.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,0 +1,15 @@
+# infra/monitoring/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/monitoring -maxdepth 2 -type f | sort`
+  - `git status --short infra/monitoring`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Metrics, alerts, health probes, and observability wiring references.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/systemd-or-compose/README.md
+++ b/infra/systemd-or-compose/README.md
@@ -1,0 +1,15 @@
+# infra/systemd-or-compose/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/systemd-or-compose -maxdepth 2 -type f | sort`
+  - `git status --short infra/systemd-or-compose`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Phase-one orchestration decision bridge and tradeoff tracking.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -1,0 +1,15 @@
+# infra/systemd/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/systemd -maxdepth 2 -type f | sort`
+  - `git status --short infra/systemd`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Units, timers, sockets, overrides, and service hardening guidance.
+  - Lane-specific implementation files and runtime evidence are not yet present.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,15 @@
+# infra/terraform/
+
+- Status: PROPOSED / NEEDS VERIFICATION
+- Owner: NEEDS VERIFICATION
+- Runtime profile: NEEDS VERIFICATION
+- Public exposure posture: Deny-by-default until explicit review evidence exists.
+- Source of truth for related policy/contracts: ../../policy/, ../../contracts/, ../../schemas/
+- Secrets posture: No plaintext secrets; use environment-level secret management.
+- Rollback path: Revert infra change + update release/correction notes as applicable.
+- Verification commands:
+  - `find infra/terraform -maxdepth 2 -type f | sort`
+  - `git status --short infra/terraform`
+- Remaining UNKNOWN / NEEDS VERIFICATION:
+  - Provisioning modules, state-management expectations, and environment descriptors.
+  - Lane-specific implementation files and runtime evidence are not yet present.


### PR DESCRIPTION
### Motivation

- Provide a navigable, reviewable infra surface by replacing the single placeholder with explicit lane scaffolding and lane-level README contracts. 
- Preserve the repo’s evidence-first posture by marking new lanes as `NEEDS VERIFICATION` until runtime or platform evidence is added.

### Description

- Add lane directories and README files for `backup`, `compose`, `dashboards`, `gitops`, `hosted`, `kubernetes`, `local`, `monitoring`, `systemd`, `systemd-or-compose`, and `terraform` containing status, verification commands, and remaining `UNKNOWN / NEEDS VERIFICATION` notes. 
- Remove the placeholder file `infra/.gitkeep` because the lane READMEs provide real tracked content. 
- Update `infra/README.md` to reflect the current lane map and change lane statuses from `PROPOSED / NEEDS VERIFICATION` to `SCAFFOLDED / NEEDS VERIFICATION` and to note that implementation maturity remains `NEEDS VERIFICATION`.
- No runtime manifests, secrets, or deployment artifacts were introduced; this is documentation and scaffolding only.

### Testing

- Ran `find infra -maxdepth 2 -type f | sort` to confirm lane README files are present, which succeeded. 
- Verified repo state with `git status --short` and committed the changes with `git commit`, which succeeded. 
- Confirmed the new commit with `git rev-parse --short HEAD` (commit `f3e9980`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01e23e674832ab2a4879f9b7b7a96)