### PR TITLE
Build out packages/policy support package

### DIFF
--- a/packages/policy/README.md
+++ b/packages/policy/README.md
@@ -142,7 +142,13 @@ If the change defines **how app/runtime code consumes a policy result consistent
 ```text
 packages/
 └── policy/
-    └── README.md
+    ├── README.md
+    ├── __init__.py
+    ├── __main__.py
+    ├── decision_engine.py
+    ├── inputs.py
+    ├── obligations.py
+    └── results.py
 ```
 
 ### Possible implementation shape (**PROPOSED — adapt after active-branch inspection**)

--- a/packages/policy/__init__.py
+++ b/packages/policy/__init__.py
@@ -1,0 +1,20 @@
+"""Shared helpers for consuming policy decisions in runtime code.
+
+This package is intentionally subordinate to repository-authoritative policy
+assets under ``policy/``.
+"""
+
+from .decision_engine import DecisionEngine, StaticDecisionEngine
+from .inputs import PolicyInput, build_policy_input
+from .obligations import apply_obligations
+from .results import DecisionResult, normalize_decision_result
+
+__all__ = [
+    "DecisionEngine",
+    "DecisionResult",
+    "PolicyInput",
+    "StaticDecisionEngine",
+    "apply_obligations",
+    "build_policy_input",
+    "normalize_decision_result",
+]

--- a/packages/policy/__main__.py
+++ b/packages/policy/__main__.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .decision_engine import StaticDecisionEngine
+from .inputs import build_policy_input
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m packages.policy",
+        description="Evaluate a policy-support decision using the packages/policy adapter.",
+    )
+    parser.add_argument("--input", required=True, help="Path to runtime policy input JSON.")
+    parser.add_argument("--decision", required=True, help="Proposed decision (ANSWER/ABSTAIN/DENY/ERROR).")
+    parser.add_argument("--out", default=None, help="Optional output path for normalized result JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    input_doc = json.loads(Path(args.input).read_text(encoding="utf-8"))
+
+    policy_input = build_policy_input(
+        request_id=str(input_doc.get("request_id", "<unknown>")),
+        actor_id=input_doc.get("actor_id"),
+        release_state=input_doc.get("release_state"),
+        evidence_renderable=bool(input_doc.get("evidence_renderable", True)),
+        payload=input_doc,
+    )
+
+    engine = StaticDecisionEngine(decision=args.decision)
+    result = engine.evaluate(policy_input)
+    output = {
+        "decision": result.decision,
+        "reasons": list(result.reasons),
+        "obligations": list(result.obligations),
+    }
+
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/policy/decision_engine.py
+++ b/packages/policy/decision_engine.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .inputs import PolicyInput
+from .results import DecisionResult, normalize_decision_result
+
+
+class DecisionEngine(Protocol):
+    """Protocol for policy evaluators used by runtime consumers."""
+
+    def evaluate(self, policy_input: PolicyInput) -> DecisionResult:
+        ...
+
+
+class StaticDecisionEngine:
+    """Deterministic adapter useful for local wiring and tests.
+
+    This does not define policy law. It only adapts predeclared outcomes.
+    """
+
+    def __init__(self, *, decision: str, reasons: list[str] | None = None, obligations: list[str] | None = None) -> None:
+        self._raw_result = {
+            "decision": decision,
+            "reasons": reasons or [],
+            "obligations": obligations or [],
+        }
+
+    def evaluate(self, policy_input: PolicyInput) -> DecisionResult:
+        raw_result = dict(self._raw_result)
+
+        if not policy_input.evidence_renderable and raw_result.get("decision") == "ANSWER":
+            raw_result["decision"] = "ABSTAIN"
+            raw_result.setdefault("reasons", [])
+            raw_result["reasons"] = [*raw_result["reasons"], "EVIDENCE_NOT_RENDERABLE"]
+
+        return normalize_decision_result(raw_result)
+
+    def as_dict(self) -> dict[str, object]:
+        return dict(self._raw_result)

--- a/packages/policy/inputs.py
+++ b/packages/policy/inputs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PolicyInput:
+    request_id: str
+    actor_id: str | None
+    release_state: str | None
+    evidence_renderable: bool
+    payload: dict[str, Any]
+
+
+def build_policy_input(
+    *,
+    request_id: str,
+    payload: dict[str, Any],
+    actor_id: str | None = None,
+    release_state: str | None = None,
+    evidence_renderable: bool = True,
+) -> PolicyInput:
+    """Build a stable, explicit policy input envelope for runtime adapters."""
+    return PolicyInput(
+        request_id=request_id,
+        actor_id=actor_id,
+        release_state=release_state,
+        evidence_renderable=evidence_renderable,
+        payload=payload,
+    )

--- a/packages/policy/obligations.py
+++ b/packages/policy/obligations.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from .results import DecisionResult
+
+
+def apply_obligations(*, result: DecisionResult, supported: set[str]) -> tuple[str, ...]:
+    """Return enforced obligations that are recognized by the caller.
+
+    Unknown obligations are ignored so callers can explicitly choose what they
+    support while retaining deterministic behavior.
+    """
+    return tuple(ob for ob in result.obligations if ob in supported)

--- a/packages/policy/results.py
+++ b/packages/policy/results.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+FINITE_DECISIONS = {"ANSWER", "ABSTAIN", "DENY", "ERROR"}
+
+
+@dataclass(frozen=True)
+class DecisionResult:
+    decision: str
+    reasons: tuple[str, ...] = ()
+    obligations: tuple[str, ...] = ()
+
+
+def normalize_decision_result(raw_result: dict[str, Any]) -> DecisionResult:
+    """Normalize engine-specific output into a finite decision result.
+
+    Unknown or missing outcomes fail closed to ``ERROR``.
+    """
+    raw_decision = str(raw_result.get("decision", "ERROR")).upper()
+    decision = raw_decision if raw_decision in FINITE_DECISIONS else "ERROR"
+
+    reasons = tuple(
+        str(reason)
+        for reason in raw_result.get("reasons", [])
+        if isinstance(reason, (str, int, float, bool))
+    )
+    obligations = tuple(
+        str(obligation)
+        for obligation in raw_result.get("obligations", [])
+        if isinstance(obligation, (str, int, float, bool))
+    )
+
+    return DecisionResult(decision=decision, reasons=reasons, obligations=obligations)

--- a/tests/unit/test_policy_package.py
+++ b/tests/unit/test_policy_package.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from packages.policy import (
+    StaticDecisionEngine,
+    apply_obligations,
+    build_policy_input,
+    normalize_decision_result,
+)
+
+
+def test_normalize_decision_result_fail_closed_unknown_decision() -> None:
+    result = normalize_decision_result({"decision": "allow", "reasons": ["X"]})
+
+    assert result.decision == "ERROR"
+    assert result.reasons == ("X",)
+
+
+def test_static_decision_engine_abstains_when_evidence_not_renderable() -> None:
+    policy_input = build_policy_input(
+        request_id="req-1",
+        payload={"request_id": "req-1"},
+        evidence_renderable=False,
+    )
+
+    engine = StaticDecisionEngine(decision="ANSWER", reasons=["SAFE"])
+    result = engine.evaluate(policy_input)
+
+    assert result.decision == "ABSTAIN"
+    assert "EVIDENCE_NOT_RENDERABLE" in result.reasons
+
+
+def test_apply_obligations_returns_supported_subset() -> None:
+    result = normalize_decision_result(
+        {
+            "decision": "DENY",
+            "obligations": ["REQUIRE_REVIEW", "REDACT_SOURCE_COORDS"],
+        }
+    )
+
+    enforced = apply_obligations(
+        result=result,
+        supported={"REQUIRE_REVIEW"},
+    )
+
+    assert enforced == ("REQUIRE_REVIEW",)


### PR DESCRIPTION
### Motivation
- Provide a concrete, reusable runtime boundary so services can consume policy decisions via a small, explicit package rather than a README-only surface. 
- Ensure runtime adapters produce a finite, fail-closed set of outcomes (`ANSWER` / `ABSTAIN` / `DENY` / `ERROR`) to avoid ambiguous engine results. 
- Make it easy to deterministically test and wire policy behavior (including obligation filtering and evidence-renderability fallbacks).

### Description
- Add a new `packages/policy` Python package with `__init__.py`, `__main__.py`, `decision_engine.py`, `inputs.py`, `results.py`, and `obligations.py` implementing adapters, an input envelope builder, result normalization, obligation filtering, and a static deterministic engine. 
- Implement `normalize_decision_result` to map raw engine output to the finite decision set and to fail closed to `ERROR` for unknown outcomes. 
- Add `StaticDecisionEngine` which converts `ANSWER` to `ABSTAIN` when `evidence_renderable` is false and appends an `EVIDENCE_NOT_RENDERABLE` reason. 
- Add `apply_obligations` to filter obligations to a caller-supported subset and provide a `python -m packages.policy` CLI for local adapter checks. 
- Update `packages/policy/README.md` directory tree to reflect the new module layout and add unit tests at `tests/unit/test_policy_package.py` covering normalization, abstain behavior, and obligations filtering. 

### Testing
- Ran unit tests with `PYTHONPATH=. pytest -q tests/unit/test_policy_package.py`, which passed (3 passed). 
- Exercised the CLI with `PYTHONPATH=. python -m packages.policy --help`, which printed the usage successfully. 
- Attempted broader validator tests (`pytest -q tests/validators/test_evidence_ref.py`) but collection failed in this environment due to a missing `jsonschema` dependency; this is an environment dependency issue and not a failure of the new package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0274fa0bc832aae3f0652b542fe18)