### PR TITLE
Add ecology domain docs, registry seeds, schemas, fixtures, policy, and validator

### DIFF
--- a/data/registry/ecology/datasets.yaml
+++ b/data/registry/ecology/datasets.yaml
@@ -1,0 +1,38 @@
+{
+  "version": "v1",
+  "updated": "2026-04-28",
+  "datasets": [
+    {
+      "dataset_id": "ecology.taxon_record.v1",
+      "title": "Normalized ecological taxon records",
+      "source_refs": ["usda_plants", "gbif_occurrence"],
+      "schema_ref": "schemas/contracts/v1/ecology/taxon_record.schema.json",
+      "sensitivity_default": "public",
+      "publication_state": "candidate"
+    },
+    {
+      "dataset_id": "ecology.observation_plot.v1",
+      "title": "Plot-level ecological observations",
+      "source_refs": ["kfs_field_plots"],
+      "schema_ref": "schemas/contracts/v1/ecology/observation_plot.schema.json",
+      "sensitivity_default": "review_required",
+      "publication_state": "candidate"
+    },
+    {
+      "dataset_id": "ecology.derived_vegetation_layer.v1",
+      "title": "Derived vegetation layer descriptors",
+      "source_refs": ["ndvi_derived_layers"],
+      "schema_ref": "schemas/contracts/v1/ecology/derived_vegetation_layer.schema.json",
+      "sensitivity_default": "public",
+      "publication_state": "candidate"
+    },
+    {
+      "dataset_id": "ecology.sensitive_occurrence_record.v1",
+      "title": "Restricted sensitive occurrence records",
+      "source_refs": ["gbif_occurrence", "kfs_field_plots"],
+      "schema_ref": "schemas/contracts/v1/ecology/sensitive_occurrence_record.schema.json",
+      "sensitivity_default": "restricted",
+      "publication_state": "restricted"
+    }
+  ]
+}

--- a/data/registry/ecology/sensitivity_policies.yaml
+++ b/data/registry/ecology/sensitivity_policies.yaml
@@ -1,0 +1,42 @@
+{
+  "version": "v1",
+  "updated": "2026-04-28",
+  "policies": [
+    {
+      "policy_id": "eco-public-v1",
+      "applies_to": ["public"],
+      "decision": "allow",
+      "requires": [
+        "rights_status in [public, open]",
+        "evidence_refs present"
+      ]
+    },
+    {
+      "policy_id": "eco-generalize-v1",
+      "applies_to": ["generalize"],
+      "decision": "generalize",
+      "requires": [
+        "generalization_method present",
+        "precision_served not exact",
+        "evidence_refs present"
+      ]
+    },
+    {
+      "policy_id": "eco-restricted-v1",
+      "applies_to": ["restricted"],
+      "decision": "deny",
+      "requires": [
+        "no exact coordinates in public outputs",
+        "stewardship_review optional override only for non-public lanes"
+      ]
+    },
+    {
+      "policy_id": "eco-review-required-v1",
+      "applies_to": ["review_required"],
+      "decision": "hold",
+      "requires": [
+        "explicit reviewer decision before publication"
+      ]
+    }
+  ]
+}

--- a/data/registry/ecology/sources.yaml
+++ b/data/registry/ecology/sources.yaml
@@ -1,0 +1,55 @@
+{
+  "version": "v1",
+  "updated": "2026-04-28",
+  "sources": [
+    {
+      "source_id": "gbif_occurrence",
+      "title": "Global Biodiversity Information Facility (GBIF) occurrences",
+      "role": "aggregator",
+      "steward": "GBIF Secretariat",
+      "rights_default": "mixed",
+      "cadence": "daily",
+      "trust_tier": "medium",
+      "notes": [
+        "Upstream attribution must be preserved per record.",
+        "Sensitivity class must be evaluated prior to publication."
+      ]
+    },
+    {
+      "source_id": "usda_plants",
+      "title": "USDA PLANTS taxonomy and distribution reference",
+      "role": "authority",
+      "steward": "USDA NRCS",
+      "rights_default": "public",
+      "cadence": "periodic",
+      "trust_tier": "high",
+      "notes": [
+        "Preferred authority for standardized plant naming in this lane."
+      ]
+    },
+    {
+      "source_id": "kfs_field_plots",
+      "title": "Kansas field survey plot observations",
+      "role": "observation",
+      "steward": "Kansas Frontier Matrix partners",
+      "rights_default": "controlled",
+      "cadence": "seasonal",
+      "trust_tier": "high",
+      "notes": [
+        "Can contain sensitive coordinates and private-access sites."
+      ]
+    },
+    {
+      "source_id": "ndvi_derived_layers",
+      "title": "NDVI-based vegetation derivatives",
+      "role": "model",
+      "steward": "KFM ecological modeling",
+      "rights_default": "internal",
+      "cadence": "monthly",
+      "trust_tier": "medium",
+      "notes": [
+        "Model output should be labeled as derived context, not direct occurrence evidence."
+      ]
+    }
+  ]
+}

--- a/docs/domains/ecology/README.md
+++ b/docs/domains/ecology/README.md
@@ -1,0 +1,62 @@
+# Ecology Domain Guide
+
+This domain lane defines how ecological evidence is represented, validated, and published inside Kansas Frontier Matrix (KFM).
+
+## Purpose
+
+The ecology domain exists to keep a strict separation between:
+
+- **Observed records** (field observations, specimen records, sensor measurements)
+- **Derived products** (vegetation layers, interpolated surfaces, model outputs)
+- **Publication-safe records** (generalized or redacted for sensitive locations)
+
+This separation prevents model output from being mistaken as direct observation and ensures privacy controls are applied before publication.
+
+## Core Objects
+
+The ecology lane uses four primary contract objects in `schemas/contracts/v1/ecology/`:
+
+1. `taxon_record` — a normalized taxonomic identity record.
+2. `observation_plot` — plot/site level observations with methods and provenance.
+3. `derived_vegetation_layer` — raster/vector derivative layers plus lineage.
+4. `sensitive_occurrence_record` — restricted object for high-risk occurrence data.
+
+## Required Trust Signals
+
+Every ecology object should make these fields explicit:
+
+- Evidence references
+- Source registry references
+- Spatial precision served to public
+- Rights/license posture
+- Sensitivity posture
+- Review/publication state
+
+## Data Registry Inputs
+
+The ecology registry (`data/registry/ecology/`) has three catalogs:
+
+- `sources.yaml` for steward/source definitions and trust posture
+- `datasets.yaml` for known datasets and schema bindings
+- `sensitivity_policies.yaml` for domain policy rules
+
+## Publication and Geoprivacy
+
+Publication is fail-closed:
+
+- Unknown rights => not publishable
+- Unknown sensitivity => not publishable
+- Restricted species with exact coordinates => not publishable
+- Missing evidence bundle refs => not publishable for consequential claims
+
+See `SENSITIVITY_AND_GEOPRIVACY.md` for concrete public/generalized/restricted handling.
+
+## Validator
+
+`tools/validators/ecology/validate_ecology_bundle.py` validates an ecology bundle descriptor (JSON) that references:
+
+- one or more source definitions from the registry,
+- one or more datasets from the registry,
+- and a declared policy id.
+
+The validator emits a deterministic pass/fail result and can be used as a pre-publication gate in CI.

--- a/docs/domains/ecology/SENSITIVITY_AND_GEOPRIVACY.md
+++ b/docs/domains/ecology/SENSITIVITY_AND_GEOPRIVACY.md
@@ -1,0 +1,46 @@
+# Ecology Sensitivity and Geoprivacy
+
+This policy note defines publication-safe handling for ecological records.
+
+## Sensitivity Classes
+
+| Class | Summary | Public Geometry Policy |
+|---|---|---|
+| `public` | Low-risk records approved for normal disclosure. | Exact geometry may be published. |
+| `generalize` | Moderate-risk records requiring reduced precision. | Publish only generalized geometry. |
+| `restricted` | High-risk records (rare species/nests/private land concerns). | No public exact coordinates; withheld or coarse cell only. |
+| `review_required` | Sensitivity unresolved. | Not publishable until steward review closes. |
+
+## Generalization Methods
+
+Approved geoprivacy methods include:
+
+- Grid-cell rounding (e.g., 10km cell)
+- Polygon aggregation to admin/eco region
+- Coordinate jitter with minimum displacement threshold
+- Geometry suppression with non-spatial summary only
+
+Each transform should preserve:
+
+- `generalization_method`
+- `precision_served`
+- `redaction_receipt_ref` (if available)
+
+## Fail-Closed Conditions
+
+A record must not be published if any of the following are true:
+
+- sensitivity class is missing,
+- rights status is unknown/restricted for publication,
+- record carries exact geometry with `restricted` class,
+- policy decision is `deny` or `hold`.
+
+## Recommended Audit Fields
+
+For every published ecology object, keep:
+
+- policy id
+- decision (`allow`, `generalize`, `deny`, `hold`)
+- reviewer or automated gate id
+- decision timestamp (UTC)
+- source and dataset references

--- a/docs/domains/ecology/SOURCE_ROLES.md
+++ b/docs/domains/ecology/SOURCE_ROLES.md
@@ -1,0 +1,30 @@
+# Ecology Source Roles
+
+This document defines source roles used across ecology registries, contracts, and publication policy.
+
+## Role Taxonomy
+
+| Role | Meaning | May be used as direct claim evidence? |
+|---|---|---|
+| `authority` | Taxonomic/reference authority (backbone taxonomy, controlled vocabularies). | Yes, for naming/taxonomic alignment. |
+| `observation` | Primary observed field/specimen/station records. | Yes, with rights and sensitivity checks. |
+| `aggregator` | Repackaged records from upstream publishers (not original observer). | Yes, but provenance to upstream should be retained. |
+| `model` | Predicted/interpolated/suitability outputs. | No direct occurrence claim; only supporting context. |
+| `baseline` | Environmental baselines/time-window summaries. | Yes, for baseline context only. |
+| `regulatory_context` | Legal/protected status or management boundaries. | Yes, as governance context (not occurrence evidence). |
+| `render_descriptor` | Layer styling/renderer metadata. | No. Never counts as evidence. |
+
+## Role Rules
+
+1. `model` outputs cannot be emitted as observed occurrence claims unless explicitly paired with observed evidence.
+2. `aggregator` records must preserve upstream source attribution whenever available.
+3. `render_descriptor` references cannot satisfy evidence requirements.
+4. `authority` records should include version and release date where possible.
+5. Unknown role values are invalid and should fail validation.
+
+## Practical Examples
+
+- GBIF occurrence feed: `aggregator`
+- Herbarium specimen export from custodian institution: `observation`
+- NDVI anomaly surface: `model`
+- US EPA ecoregion definitions: `regulatory_context`

--- a/policy/ecology/publication.rego
+++ b/policy/ecology/publication.rego
@@ -1,0 +1,71 @@
+package ecology.publication
+
+# Fail-closed publication policy for ecology bundles.
+# Input is expected to be an object with at least:
+# - sensitivity
+# - rights_status
+# - policy_id
+# - exact_geometry_present (boolean, optional)
+# - evidence_refs (array)
+
+default allow = false
+
+default decision = "deny"
+
+deny_reasons[r] {
+  not input.sensitivity
+  r := "missing_sensitivity"
+}
+
+deny_reasons[r] {
+  not input.rights_status
+  r := "missing_rights_status"
+}
+
+deny_reasons[r] {
+  not input.policy_id
+  r := "missing_policy_id"
+}
+
+deny_reasons[r] {
+  count(object.get(input, "evidence_refs", [])) == 0
+  r := "missing_evidence_refs"
+}
+
+deny_reasons[r] {
+  input.sensitivity == "restricted"
+  object.get(input, "exact_geometry_present", false)
+  r := "restricted_exact_geometry_not_publishable"
+}
+
+deny_reasons[r] {
+  input.sensitivity == "review_required"
+  r := "requires_steward_review"
+}
+
+allow {
+  count(deny_reasons) == 0
+  input.sensitivity == "public"
+  input.rights_status == "public" or input.rights_status == "open"
+}
+
+allow {
+  count(deny_reasons) == 0
+  input.sensitivity == "generalize"
+  input.rights_status != "unknown"
+}
+
+decision := "allow" {
+  allow
+}
+
+decision := "generalize" {
+  not allow
+  count(deny_reasons) == 0
+  input.sensitivity == "generalize"
+}
+
+decision := "hold" {
+  not allow
+  input.sensitivity == "review_required"
+}

--- a/schemas/contracts/v1/ecology/derived_vegetation_layer.schema.json
+++ b/schemas/contracts/v1/ecology/derived_vegetation_layer.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/derived_vegetation_layer.schema.json",
+  "title": "Derived Vegetation Layer",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "layer_id",
+    "title",
+    "derivation_method",
+    "source_refs",
+    "time_window",
+    "spec_hash",
+    "classification",
+    "publication_state"
+  ],
+  "properties": {
+    "layer_id": {"type": "string", "minLength": 1},
+    "title": {"type": "string", "minLength": 1},
+    "derivation_method": {"type": "string", "minLength": 1},
+    "source_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "time_window": {
+      "type": "object",
+      "required": ["start", "end"],
+      "properties": {
+        "start": {"type": "string", "format": "date"},
+        "end": {"type": "string", "format": "date"}
+      },
+      "additionalProperties": false
+    },
+    "classification": {"type": "string", "enum": ["model", "derived_context"]},
+    "spec_hash": {"type": "string", "pattern": "^sha256:[a-fA-F0-9]{16,}$"},
+    "evidence_refs": {"type": "array", "items": {"type": "string"}},
+    "publication_state": {"type": "string", "enum": ["candidate", "reviewed", "published", "held"]}
+  }
+}

--- a/schemas/contracts/v1/ecology/observation_plot.schema.json
+++ b/schemas/contracts/v1/ecology/observation_plot.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/observation_plot.schema.json",
+  "title": "Ecology Observation Plot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "plot_id",
+    "observed_at",
+    "geometry",
+    "taxa",
+    "method",
+    "source_ref",
+    "sensitivity",
+    "rights_status"
+  ],
+  "properties": {
+    "plot_id": {"type": "string", "minLength": 1},
+    "observed_at": {"type": "string", "format": "date-time"},
+    "geometry": {
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": {"type": "string", "enum": ["Point", "Polygon", "MultiPolygon"]},
+        "coordinates": {}
+      },
+      "additionalProperties": true
+    },
+    "taxa": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "method": {"type": "string", "enum": ["field_survey", "remote_sensor", "specimen", "citizen_science"]},
+    "source_ref": {"type": "string", "minLength": 1},
+    "sensitivity": {"type": "string", "enum": ["public", "generalize", "restricted", "review_required"]},
+    "rights_status": {"type": "string", "enum": ["public", "open", "controlled", "restricted", "unknown"]},
+    "evidence_refs": {"type": "array", "items": {"type": "string"}}
+  }
+}

--- a/schemas/contracts/v1/ecology/sensitive_occurrence_record.schema.json
+++ b/schemas/contracts/v1/ecology/sensitive_occurrence_record.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/sensitive_occurrence_record.schema.json",
+  "title": "Sensitive Occurrence Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "occurrence_id",
+    "taxon_id",
+    "sensitivity",
+    "geometry_private",
+    "public_visibility",
+    "policy_id",
+    "source_ref"
+  ],
+  "properties": {
+    "occurrence_id": {"type": "string", "minLength": 1},
+    "taxon_id": {"type": "string", "minLength": 1},
+    "sensitivity": {"type": "string", "enum": ["restricted", "review_required", "generalize"]},
+    "geometry_private": {
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": {"type": "string", "enum": ["Point", "Polygon", "MultiPolygon"]},
+        "coordinates": {}
+      },
+      "additionalProperties": true
+    },
+    "geometry_public": {"type": ["object", "null"]},
+    "generalization_method": {"type": ["string", "null"]},
+    "precision_served": {"type": ["string", "null"], "enum": ["coarse_cell", "admin_polygon", "suppressed", null]},
+    "public_visibility": {"type": "string", "enum": ["withheld", "generalized", "internal_only"]},
+    "policy_id": {"type": "string", "minLength": 1},
+    "source_ref": {"type": "string", "minLength": 1},
+    "evidence_refs": {"type": "array", "items": {"type": "string"}}
+  }
+}

--- a/schemas/contracts/v1/ecology/taxon_record.schema.json
+++ b/schemas/contracts/v1/ecology/taxon_record.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/taxon_record.schema.json",
+  "title": "Ecology Taxon Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "taxon_id",
+    "scientific_name",
+    "rank",
+    "authority_source",
+    "source_role",
+    "evidence_refs"
+  ],
+  "properties": {
+    "taxon_id": {"type": "string", "minLength": 1},
+    "scientific_name": {"type": "string", "minLength": 1},
+    "vernacular_name": {"type": "string"},
+    "rank": {
+      "type": "string",
+      "enum": ["kingdom", "phylum", "class", "order", "family", "genus", "species", "subspecies", "variety"]
+    },
+    "authority_source": {"type": "string", "minLength": 1},
+    "source_role": {
+      "type": "string",
+      "enum": ["authority", "observation", "aggregator", "model", "baseline", "regulatory_context", "render_descriptor"]
+    },
+    "taxonomic_status": {"type": "string", "enum": ["accepted", "synonym", "unresolved"]},
+    "evidence_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+  }
+}

--- a/tests/fixtures/ecology/invalid/missing_policy_id.json
+++ b/tests/fixtures/ecology/invalid/missing_policy_id.json
@@ -1,0 +1,8 @@
+{
+  "bundle_id": "ecology-bundle-invalid-001",
+  "source_refs": ["kfs_field_plots"],
+  "dataset_refs": ["ecology.observation_plot.v1"],
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "evidence_refs": ["evidence://bundle/obs-002"]
+}

--- a/tests/fixtures/ecology/policy/restricted_exact_location_case.json
+++ b/tests/fixtures/ecology/policy/restricted_exact_location_case.json
@@ -1,0 +1,10 @@
+{
+  "bundle_id": "ecology-policy-case-001",
+  "source_refs": ["kfs_field_plots"],
+  "dataset_refs": ["ecology.sensitive_occurrence_record.v1"],
+  "policy_id": "eco-restricted-v1",
+  "sensitivity": "restricted",
+  "rights_status": "controlled",
+  "exact_geometry_present": true,
+  "evidence_refs": ["evidence://bundle/sensitive-001"]
+}

--- a/tests/fixtures/ecology/valid/observation_bundle_valid.json
+++ b/tests/fixtures/ecology/valid/observation_bundle_valid.json
@@ -1,0 +1,9 @@
+{
+  "bundle_id": "ecology-bundle-valid-001",
+  "source_refs": ["kfs_field_plots"],
+  "dataset_refs": ["ecology.observation_plot.v1"],
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "evidence_refs": ["evidence://bundle/obs-001"]
+}

--- a/tools/validators/ecology/validate_ecology_bundle.py
+++ b/tools/validators/ecology/validate_ecology_bundle.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate ecology bundle descriptors against registry references and policy prerequisites."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_yaml_like(path: Path) -> dict[str, Any]:
+    """Load YAML using PyYAML if available, else JSON fallback for YAML-compatible JSON."""
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text)
+    except Exception:
+        data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at top-level in {path}")
+    return data
+
+
+def validate_bundle(
+    bundle: dict[str, Any],
+    sources_registry: dict[str, Any],
+    datasets_registry: dict[str, Any],
+    policies_registry: dict[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+
+    required = [
+        "bundle_id",
+        "source_refs",
+        "dataset_refs",
+        "policy_id",
+        "sensitivity",
+        "rights_status",
+        "evidence_refs",
+    ]
+    for field in required:
+        if field not in bundle:
+            errors.append(f"missing_required_field:{field}")
+
+    source_ids = {s.get("source_id") for s in sources_registry.get("sources", []) if isinstance(s, dict)}
+    dataset_ids = {d.get("dataset_id") for d in datasets_registry.get("datasets", []) if isinstance(d, dict)}
+    policy_ids = {p.get("policy_id") for p in policies_registry.get("policies", []) if isinstance(p, dict)}
+
+    for ref in bundle.get("source_refs", []):
+        if ref not in source_ids:
+            errors.append(f"unknown_source_ref:{ref}")
+
+    for ref in bundle.get("dataset_refs", []):
+        if ref not in dataset_ids:
+            errors.append(f"unknown_dataset_ref:{ref}")
+
+    pid = bundle.get("policy_id")
+    if pid and pid not in policy_ids:
+        errors.append(f"unknown_policy_id:{pid}")
+
+    evidence_refs = bundle.get("evidence_refs", [])
+    if not isinstance(evidence_refs, list) or len(evidence_refs) == 0:
+        errors.append("evidence_refs_required")
+
+    sensitivity = bundle.get("sensitivity")
+    if sensitivity == "restricted" and bundle.get("exact_geometry_present", False):
+        errors.append("restricted_exact_geometry_not_allowed")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate ecology bundle descriptor")
+    parser.add_argument("--bundle", required=True, help="Path to bundle JSON file")
+    parser.add_argument("--sources", default="data/registry/ecology/sources.yaml")
+    parser.add_argument("--datasets", default="data/registry/ecology/datasets.yaml")
+    parser.add_argument("--policies", default="data/registry/ecology/sensitivity_policies.yaml")
+    parser.add_argument("--json", action="store_true", help="Emit JSON result")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    sources_registry = _load_yaml_like(Path(args.sources))
+    datasets_registry = _load_yaml_like(Path(args.datasets))
+    policies_registry = _load_yaml_like(Path(args.policies))
+
+    errors = validate_bundle(bundle, sources_registry, datasets_registry, policies_registry)
+
+    result = {
+        "validator": "tools/validators/ecology/validate_ecology_bundle.py",
+        "bundle_id": bundle.get("bundle_id"),
+        "decision": "pass" if not errors else "fail",
+        "errors": errors,
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Introduce a governed ecology lane so ecological sources, dataset descriptors, sensitivity posture, and map-layer/derived-product contracts can be reasoned about and validated before promotion. 
- Provide machine-readable schema contracts and registry seeds to enable validators, policy gates, and CI to exercise fail-closed publication rules for ecological records. 

### Description

- Added domain documentation under `docs/domains/ecology/` describing scope, source roles, geoprivacy classes, and validator expectations. 
- Provisioned registry seed files at `data/registry/ecology/` (`sources.yaml`, `datasets.yaml`, `sensitivity_policies.yaml`) populated with example sources, dataset-to-schema bindings, and policy stubs. 
- Implemented JSON Schema contracts under `schemas/contracts/v1/ecology/` for `taxon_record`, `observation_plot`, `derived_vegetation_layer`, and `sensitive_occurrence_record` with required fields and constraints. 
- Added policy at `policy/ecology/publication.rego`, fixtures in `tests/fixtures/ecology/{valid,invalid,policy}`, and a CLI validator `tools/validators/ecology/validate_ecology_bundle.py` that cross-checks bundle descriptors against the registry and emits deterministic pass/fail results (supports PyYAML when available and falls back to JSON for YAML-compatible files). 

### Testing

- Ran the validator against the valid fixture with `python tools/validators/ecology/validate_ecology_bundle.py --bundle tests/fixtures/ecology/valid/observation_bundle_valid.json --json` which produced a `decision: pass` and exited `0`. 
- Ran the validator against the invalid fixture with `python tools/validators/ecology/validate_ecology_bundle.py --bundle tests/fixtures/ecology/invalid/missing_policy_id.json --json` which produced a `decision: fail` reporting `missing_required_field:policy_id` and exited non-zero as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bebf9074832aae241a92b3cc2a64)