### PR TITLE
Add ecology fixture matrix: valid, invalid, and policy cases

### DIFF
--- a/tests/fixtures/ecology/invalid/derived_vegetation_layer.missing_catalog_refs.invalid.json
+++ b/tests/fixtures/ecology/invalid/derived_vegetation_layer.missing_catalog_refs.invalid.json
@@ -1,0 +1,15 @@
+{
+  "layer_id": "derived-veg-layer-invalid-001",
+  "source_refs": ["kfs_field_plots", "kfs_satellite_imagery"],
+  "dataset_refs": ["ecology.derived_vegetation_layer.v1"],
+  "spec_hash": "sha256:f7707fd5f0b2d9936c2f20f9202c26fda4c1a57422f1528a08fbe7f15e7ae9f4",
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "derivation": {
+    "method": "canopy_cover_model_v3",
+    "input_plot_count": 42,
+    "resolution_m": 30
+  },
+  "evidence_refs": ["evidence://ecology/derived-layer-invalid-001"]
+}

--- a/tests/fixtures/ecology/invalid/observation_plot.unknown_rights.invalid.json
+++ b/tests/fixtures/ecology/invalid/observation_plot.unknown_rights.invalid.json
@@ -1,0 +1,17 @@
+{
+  "plot_id": "observation-plot-invalid-001",
+  "source_refs": ["kfs_field_plots"],
+  "dataset_refs": ["ecology.observation_plot.v1"],
+  "catalog_refs": ["catalog://ecology/observation_plot/v1"],
+  "spec_hash": "sha256:c6aa7d85c787fd4f1b0887b30ab8b7578a37b9824f2c76bc949f8d63a4f57880",
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "unknown",
+  "plot": {
+    "observed_on": "2025-09-14",
+    "vegetation_class": "mixed_grass_prairie",
+    "sample_area_m2": 1000,
+    "geometry_precision": "generalized"
+  },
+  "evidence_refs": ["evidence://ecology/observation-plot-invalid-001"]
+}

--- a/tests/fixtures/ecology/invalid/sensitive_occurrence_record.public_exact_geometry.invalid.json
+++ b/tests/fixtures/ecology/invalid/sensitive_occurrence_record.public_exact_geometry.invalid.json
@@ -1,0 +1,13 @@
+{
+  "occurrence_id": "sensitive-occurrence-invalid-001",
+  "source_refs": ["kfs_rare_species_program"],
+  "dataset_refs": ["ecology.sensitive_occurrence_record.v1"],
+  "catalog_refs": ["catalog://ecology/sensitive_occurrence_record/v1"],
+  "spec_hash": "sha256:895ec4ded5abf28921fdb4a527ddf2f31ad5f1ef27ca6934836f47c42caa31be",
+  "policy_id": "eco-restricted-v1",
+  "sensitivity": "restricted",
+  "rights_status": "public",
+  "exact_geometry_present": true,
+  "geometry_precision": "exact",
+  "evidence_refs": ["evidence://ecology/sensitive-occurrence-invalid-001"]
+}

--- a/tests/fixtures/ecology/invalid/taxon_record.missing_spec_hash.invalid.json
+++ b/tests/fixtures/ecology/invalid/taxon_record.missing_spec_hash.invalid.json
@@ -1,0 +1,15 @@
+{
+  "record_id": "taxon-record-invalid-001",
+  "source_refs": ["kfs_taxonomy_program"],
+  "dataset_refs": ["ecology.taxon_record.v1"],
+  "catalog_refs": ["catalog://ecology/taxon_record/v1"],
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "taxon": {
+    "scientific_name": "Asclepias syriaca",
+    "common_name": "Common milkweed",
+    "rank": "species"
+  },
+  "evidence_refs": ["evidence://ecology/taxon-record-invalid-001"]
+}

--- a/tests/fixtures/ecology/policy/derived_layer_as_confirmed.policy.json
+++ b/tests/fixtures/ecology/policy/derived_layer_as_confirmed.policy.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "ecology-policy-derived-layer-confirmed-001",
+  "dataset_refs": ["ecology.derived_vegetation_layer.v1"],
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "record_status": "confirmed",
+  "expected_decision": "ALLOW",
+  "expected_reason": "DERIVED_LAYER_CONFIRMED"
+}

--- a/tests/fixtures/ecology/policy/sensitive_exact_public_geometry.policy.json
+++ b/tests/fixtures/ecology/policy/sensitive_exact_public_geometry.policy.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "ecology-policy-sensitive-geometry-001",
+  "dataset_refs": ["ecology.sensitive_occurrence_record.v1"],
+  "policy_id": "eco-restricted-v1",
+  "sensitivity": "restricted",
+  "rights_status": "public",
+  "exact_geometry_present": true,
+  "expected_decision": "DENY",
+  "expected_reason": "SENSITIVE_EXACT_GEOMETRY_PUBLIC"
+}

--- a/tests/fixtures/ecology/policy/unknown_rights.policy.json
+++ b/tests/fixtures/ecology/policy/unknown_rights.policy.json
@@ -1,0 +1,9 @@
+{
+  "case_id": "ecology-policy-unknown-rights-001",
+  "dataset_refs": ["ecology.observation_plot.v1"],
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "unknown",
+  "expected_decision": "DENY",
+  "expected_reason": "UNKNOWN_RIGHTS_STATUS"
+}

--- a/tests/fixtures/ecology/valid/derived_vegetation_layer.valid.json
+++ b/tests/fixtures/ecology/valid/derived_vegetation_layer.valid.json
@@ -1,0 +1,19 @@
+{
+  "layer_id": "derived-veg-layer-valid-001",
+  "source_refs": ["kfs_field_plots", "kfs_satellite_imagery"],
+  "dataset_refs": ["ecology.derived_vegetation_layer.v1"],
+  "catalog_refs": [
+    "catalog://ecology/observation_plot/v1",
+    "catalog://ecology/derived_vegetation_layer/v1"
+  ],
+  "spec_hash": "sha256:b6f2d0dd3fa9dc0e55643fca2d63f6d3c4b6f03b005c298eb1db57f8600f6c8f",
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "derivation": {
+    "method": "canopy_cover_model_v3",
+    "input_plot_count": 42,
+    "resolution_m": 30
+  },
+  "evidence_refs": ["evidence://ecology/derived-layer-valid-001"]
+}

--- a/tests/fixtures/ecology/valid/observation_plot.valid.json
+++ b/tests/fixtures/ecology/valid/observation_plot.valid.json
@@ -1,0 +1,17 @@
+{
+  "plot_id": "observation-plot-valid-001",
+  "source_refs": ["kfs_field_plots"],
+  "dataset_refs": ["ecology.observation_plot.v1"],
+  "catalog_refs": ["catalog://ecology/observation_plot/v1"],
+  "spec_hash": "sha256:d8f8d3676fe6f9b1757c8ed5ac15d291ef1e0de8b69096b8dc4dbfdeb6de7158",
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "plot": {
+    "observed_on": "2025-09-14",
+    "vegetation_class": "mixed_grass_prairie",
+    "sample_area_m2": 1000,
+    "geometry_precision": "generalized"
+  },
+  "evidence_refs": ["evidence://ecology/observation-plot-valid-001"]
+}

--- a/tests/fixtures/ecology/valid/sensitive_occurrence_record.valid.json
+++ b/tests/fixtures/ecology/valid/sensitive_occurrence_record.valid.json
@@ -1,0 +1,13 @@
+{
+  "occurrence_id": "sensitive-occurrence-valid-001",
+  "source_refs": ["kfs_rare_species_program"],
+  "dataset_refs": ["ecology.sensitive_occurrence_record.v1"],
+  "catalog_refs": ["catalog://ecology/sensitive_occurrence_record/v1"],
+  "spec_hash": "sha256:9e58e2b3f06f5af4f8f4a6132ea8cbc243cd6da9ef2a67fbe772ec5e932ea569",
+  "policy_id": "eco-restricted-v1",
+  "sensitivity": "restricted",
+  "rights_status": "controlled",
+  "exact_geometry_present": false,
+  "geometry_precision": "generalized",
+  "evidence_refs": ["evidence://ecology/sensitive-occurrence-valid-001"]
+}

--- a/tests/fixtures/ecology/valid/taxon_record.valid.json
+++ b/tests/fixtures/ecology/valid/taxon_record.valid.json
@@ -1,0 +1,16 @@
+{
+  "record_id": "taxon-record-valid-001",
+  "source_refs": ["kfs_taxonomy_program"],
+  "dataset_refs": ["ecology.taxon_record.v1"],
+  "catalog_refs": ["catalog://ecology/taxon_record/v1"],
+  "spec_hash": "sha256:4a471f0f48de7fb95f2f5c6e8cd9678ef6e43a1c18e67c2df92f90ece2f13f4b",
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "taxon": {
+    "scientific_name": "Asclepias syriaca",
+    "common_name": "Common milkweed",
+    "rank": "species"
+  },
+  "evidence_refs": ["evidence://ecology/taxon-record-valid-001"]
+}


### PR DESCRIPTION
### Motivation
- Complete the missing ecology fixture set used by validators and policy tests to ensure coverage of typical valid, known-invalid, and policy-case scenarios.
- Provide concrete examples that encode `source_refs`, `dataset_refs`, `policy_id`, `rights_status`, `sensitivity`, and `spec_hash` presence/absence to exercise schema and policy logic.
- Make it easier to author and verify policy decision expectations for ecology datasets during CI and local development.

### Description
- Added valid fixtures under `tests/fixtures/ecology/valid/`: `taxon_record.valid.json`, `derived_vegetation_layer.valid.json`, `observation_plot.valid.json`, and `sensitive_occurrence_record.valid.json`.
- Added invalid fixtures under `tests/fixtures/ecology/invalid/`: `taxon_record.missing_spec_hash.invalid.json`, `derived_vegetation_layer.missing_catalog_refs.invalid.json`, `observation_plot.unknown_rights.invalid.json`, and `sensitive_occurrence_record.public_exact_geometry.invalid.json`.
- Added policy case fixtures under `tests/fixtures/ecology/policy/`: `derived_layer_as_confirmed.policy.json`, `sensitive_exact_public_geometry.policy.json`, and `unknown_rights.policy.json` which encode expected decisions and reason codes.
- Fixtures are modeled to be explicit about catalog references, spec hashes (or deliberate omission for invalid cases), derivation metadata, geometry precision flags, and expected policy outcomes where relevant.

### Testing
- Parsed all new and existing ecology fixture JSON files with a Python `json.load` loop to verify syntactic validity, which reported `validated 14 json files` and completed successfully.
- No additional automated schema or policy runtime tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0caf4ecac832aa8e0d569311b2d83)