### PR TITLE
Add ecology policy fixtures for allow/deny/generalize scenarios

### DIFF
--- a/tests/fixtures/ecology/policy/allow_derived_layer_with_catalog_closure.json
+++ b/tests/fixtures/ecology/policy/allow_derived_layer_with_catalog_closure.json
@@ -1,0 +1,23 @@
+{
+  "case_id": "ecology-policy-allow-derived-layer-with-catalog-closure-001",
+  "object_type": "derived_layer",
+  "source_role": "DERIVED_MODEL_LAYER",
+  "dataset_refs": ["ecology.derived_vegetation_layer.v1"],
+  "catalog_refs": [
+    "catalog://ecology/observation_plot/v1",
+    "catalog://ecology/derived_vegetation_layer/v1"
+  ],
+  "policy_id": "eco-generalize-v1",
+  "policy_label": "public_after_catalog_closure",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "public_visibility": "generalized",
+  "public_geometry_policy": "deny_exact_generalize_required",
+  "exact_geometry_present": false,
+  "catalog_closure": true,
+  "claim_status": "MODEL_OUTPUT",
+  "evidence_refs": ["evidence://ecology/policy/allow-derived-layer-with-catalog-closure-001"],
+  "evidence_bundle_resolved": true,
+  "expected_decision": "ALLOW",
+  "expected_reasons": []
+}

--- a/tests/fixtures/ecology/policy/allow_public_taxon.json
+++ b/tests/fixtures/ecology/policy/allow_public_taxon.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "ecology-policy-allow-public-taxon-001",
+  "object_type": "taxon_record",
+  "source_role": "TAXON_OBSERVATION",
+  "dataset_refs": ["ecology.taxon_record.v1"],
+  "catalog_refs": ["catalog://ecology/taxon_record/v1"],
+  "policy_id": "eco-generalize-v1",
+  "policy_label": "public",
+  "sensitivity": "public",
+  "rights_status": "public",
+  "public_visibility": "public",
+  "public_geometry_policy": "allow_exact",
+  "exact_geometry_present": false,
+  "evidence_refs": ["evidence://ecology/policy/allow-public-taxon-001"],
+  "evidence_bundle_resolved": true,
+  "expected_decision": "ALLOW",
+  "expected_reasons": []
+}

--- a/tests/fixtures/ecology/policy/deny_derived_layer_as_confirmed.json
+++ b/tests/fixtures/ecology/policy/deny_derived_layer_as_confirmed.json
@@ -1,0 +1,23 @@
+{
+  "case_id": "ecology-policy-deny-derived-layer-as-confirmed-001",
+  "object_type": "derived_layer",
+  "source_role": "DERIVED_MODEL_LAYER",
+  "dataset_refs": ["ecology.derived_vegetation_layer.v1"],
+  "catalog_refs": [
+    "catalog://ecology/observation_plot/v1",
+    "catalog://ecology/derived_vegetation_layer/v1"
+  ],
+  "policy_id": "eco-generalize-v1",
+  "policy_label": "public_after_catalog_closure",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "public_visibility": "generalized",
+  "public_geometry_policy": "deny_exact_generalize_required",
+  "exact_geometry_present": false,
+  "catalog_closure": true,
+  "claim_status": "CONFIRMED",
+  "evidence_refs": ["evidence://ecology/policy/deny-derived-layer-as-confirmed-001"],
+  "evidence_bundle_resolved": true,
+  "expected_decision": "DENY",
+  "expected_reasons": ["derived_layer_as_confirmed_truth"]
+}

--- a/tests/fixtures/ecology/policy/deny_sensitive_exact_geometry.json
+++ b/tests/fixtures/ecology/policy/deny_sensitive_exact_geometry.json
@@ -1,0 +1,21 @@
+{
+  "case_id": "ecology-policy-deny-sensitive-exact-geometry-001",
+  "object_type": "sensitive_occurrence",
+  "source_role": "SENSITIVE_OCCURRENCE",
+  "dataset_refs": ["ecology.sensitive_occurrence_record.v1"],
+  "catalog_refs": ["catalog://ecology/sensitive_occurrence_record/v1"],
+  "policy_id": "eco-restricted-v1",
+  "policy_label": "public",
+  "sensitivity": "restricted",
+  "rights_status": "public",
+  "public_visibility": "public",
+  "public_geometry_policy": "allow_exact",
+  "exact_geometry_present": true,
+  "evidence_refs": ["evidence://ecology/policy/deny-sensitive-exact-geometry-001"],
+  "evidence_bundle_resolved": true,
+  "expected_decision": "DENY",
+  "expected_reasons": [
+    "sensitive_exact_geometry_not_publishable",
+    "restricted_exact_geometry_not_publishable"
+  ]
+}

--- a/tests/fixtures/ecology/policy/deny_unknown_rights.json
+++ b/tests/fixtures/ecology/policy/deny_unknown_rights.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "ecology-policy-deny-unknown-rights-001",
+  "object_type": "observation_plot",
+  "source_role": "OBSERVATION_PLOT",
+  "dataset_refs": ["ecology.observation_plot.v1"],
+  "catalog_refs": ["catalog://ecology/observation_plot/v1"],
+  "policy_id": "eco-generalize-v1",
+  "policy_label": "public",
+  "sensitivity": "generalize",
+  "rights_status": "unknown",
+  "public_visibility": "generalized",
+  "public_geometry_policy": "deny_exact_generalize_required",
+  "exact_geometry_present": false,
+  "evidence_refs": ["evidence://ecology/policy/deny-unknown-rights-001"],
+  "evidence_bundle_resolved": true,
+  "expected_decision": "DENY",
+  "expected_reasons": ["unknown_rights"]
+}

--- a/tests/fixtures/ecology/policy/deny_unresolved_evidence_bundle.json
+++ b/tests/fixtures/ecology/policy/deny_unresolved_evidence_bundle.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "ecology-policy-deny-unresolved-evidence-bundle-001",
+  "object_type": "observation_plot",
+  "source_role": "OBSERVATION_PLOT",
+  "dataset_refs": ["ecology.observation_plot.v1"],
+  "catalog_refs": ["catalog://ecology/observation_plot/v1"],
+  "policy_id": "eco-generalize-v1",
+  "policy_label": "public",
+  "sensitivity": "public",
+  "rights_status": "public",
+  "public_visibility": "public",
+  "public_geometry_policy": "allow_exact",
+  "exact_geometry_present": false,
+  "evidence_refs": ["evidence://ecology/policy/deny-unresolved-evidence-bundle-001"],
+  "evidence_bundle_resolved": false,
+  "expected_decision": "DENY",
+  "expected_reasons": ["unresolved_evidence_bundle"]
+}

--- a/tests/fixtures/ecology/policy/generalize_sensitive_occurrence.json
+++ b/tests/fixtures/ecology/policy/generalize_sensitive_occurrence.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "ecology-policy-generalize-sensitive-occurrence-001",
+  "object_type": "sensitive_occurrence",
+  "source_role": "SENSITIVE_OCCURRENCE",
+  "dataset_refs": ["ecology.sensitive_occurrence_record.v1"],
+  "catalog_refs": ["catalog://ecology/sensitive_occurrence_record/v1"],
+  "policy_id": "eco-generalize-v1",
+  "policy_label": "public",
+  "sensitivity": "generalize",
+  "rights_status": "controlled",
+  "public_visibility": "generalized",
+  "public_geometry_policy": "deny_exact_generalize_required",
+  "exact_geometry_present": false,
+  "evidence_refs": ["evidence://ecology/policy/generalize-sensitive-occurrence-001"],
+  "evidence_bundle_resolved": true,
+  "expected_decision": "GENERALIZE",
+  "expected_reasons": ["generalization_required"]
+}


### PR DESCRIPTION
### Motivation
- Fill missing policy fixture coverage for ecology publication paths so policy tests can assert allow/deny/generalize outcomes for common domain cases.
- Provide deterministic, self-contained inputs that exercise rule branches such as unknown rights, unresolved evidence, sensitive exact geometry, derived-layer claim status, and catalog-closure allow paths.

### Description
- Added seven JSON fixtures under `tests/fixtures/ecology/policy/`: `allow_public_taxon.json`, `allow_derived_layer_with_catalog_closure.json`, `generalize_sensitive_occurrence.json`, `deny_unknown_rights.json`, `deny_unresolved_evidence_bundle.json`, `deny_sensitive_exact_geometry.json`, and `deny_derived_layer_as_confirmed.json`.
- Each fixture includes governance fields (e.g., `policy_id`, `policy_label`, `sensitivity`, `rights_status`, `source_role`, `catalog_refs`), `evidence_refs` and `evidence_bundle_resolved`, and explicit `expected_decision` and `expected_reasons` to make policy outcomes deterministic.
- Fixtures are shaped to align with the policy logic in `policy/ecology/publication.rego`, exercising allow paths (public taxon, derived layer after catalog closure), generalization requirements, and deny reasons (unknown rights, unresolved evidence, sensitive/restricted exact geometry, derived-layer-as-confirmed).

### Testing
- Validated each new file is well-formed JSON using `python -m json.tool` for all seven files, and the validation completed successfully for every fixture.
- No additional automated schema or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0cd77f580832a819275ae9932cef8)