### PR TITLE
Add full ecology v1 contract schema set and shared fragments

### DIFF
--- a/schemas/contracts/v1/ecology/_index.schema.json
+++ b/schemas/contracts/v1/ecology/_index.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/_index.schema.json",
+  "title": "Ecology Contract Schema Index",
+  "description": "Union validator for ecology v1 contract objects.",
+  "oneOf": [
+    { "$ref": "taxon_record.schema.json" },
+    { "$ref": "observation_plot.schema.json" },
+    { "$ref": "derived_vegetation_layer.schema.json" },
+    { "$ref": "sensitive_occurrence_record.schema.json" },
+    { "$ref": "habitat_surface_descriptor.schema.json" },
+    { "$ref": "habitat_assignment.schema.json" },
+    { "$ref": "ecology_public_claim.schema.json" },
+    { "$ref": "ecology_layer_manifest.schema.json" },
+    { "$ref": "ecology_evidence_drawer_payload.schema.json" },
+    { "$ref": "ecological_composite_claim.schema.json" }
+  ]
+}

--- a/schemas/contracts/v1/ecology/ecological_composite_claim.schema.json
+++ b/schemas/contracts/v1/ecology/ecological_composite_claim.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/ecological_composite_claim.schema.json",
+  "title": "Ecological Composite Claim",
+  "description": "Composite ecology claim joining taxon identity, occurrence context, habitat assignment, and public-safe claim posture.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "object_type",
+    "claim_id",
+    "taxon_ref",
+    "observation_ref",
+    "claim",
+    "decision",
+    "evidence_refs",
+    "policy",
+    "release",
+    "spec_hash"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v1" },
+    "object_type": { "type": "string", "const": "EcologicalCompositeClaim" },
+    "claim_id": { "type": "string", "pattern": "^kfm://claim/ecology/.+" },
+    "taxon_ref": { "type": "string", "pattern": "^kfm://taxon/.+" },
+    "observation_ref": {
+      "type": "string",
+      "pattern": "^kfm://(plot|occurrence)/.+"
+    },
+    "habitat_assignment_ref": { "type": "string", "pattern": "^kfm://habitat-assignment/.+" },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text", "knowledge_character", "public_precision"],
+      "properties": {
+        "text": { "type": "string", "minLength": 5 },
+        "knowledge_character": { "$ref": "fragments/ecology_knowledge_character.schema.json" },
+        "public_precision": { "$ref": "fragments/public_precision.schema.json" },
+        "sensitivity_status": { "$ref": "fragments/sensitivity_status.schema.json" }
+      }
+    },
+    "decision": { "type": "string", "enum": ["ANSWER", "ABSTAIN", "DENY", "ERROR"] },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "pattern": "^kfm://evidence/.+" } },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "reasons"],
+      "properties": {
+        "label": { "type": "string", "enum": ["public", "restricted", "internal", "review_required"] },
+        "reasons": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "manifest_ref"],
+      "properties": {
+        "state": { "type": "string", "enum": ["candidate", "reviewed", "published", "held", "revoked"] },
+        "manifest_ref": { "type": "string", "pattern": "^kfm://release-manifest/.+" }
+      }
+    },
+    "spec_hash": { "type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$" }
+  }
+}

--- a/schemas/contracts/v1/ecology/ecology_evidence_drawer_payload.schema.json
+++ b/schemas/contracts/v1/ecology/ecology_evidence_drawer_payload.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/ecology_evidence_drawer_payload.schema.json",
+  "title": "Ecology Evidence Drawer Payload",
+  "description": "UI payload contract for evidence drawer content backing an ecology claim response.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "object_type",
+    "payload_id",
+    "claim_ref",
+    "decision",
+    "visible_outcome",
+    "summary",
+    "sources",
+    "evidence_refs",
+    "freshness",
+    "spec_hash"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v1" },
+    "object_type": { "type": "string", "const": "EcologyEvidenceDrawerPayload" },
+    "payload_id": { "type": "string", "pattern": "^kfm://drawer/ecology/.+" },
+    "claim_ref": { "type": "string", "pattern": "^kfm://claim/ecology/.+" },
+    "decision": { "type": "string", "enum": ["ANSWER", "ABSTAIN", "DENY", "ERROR"] },
+    "visible_outcome": { "type": "string", "enum": ["shown", "generalized", "withheld", "unavailable"] },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["headline", "trust_note"],
+      "properties": {
+        "headline": { "type": "string", "minLength": 1 },
+        "trust_note": { "type": "string", "minLength": 1 },
+        "taxon": { "type": "string" },
+        "habitat_class": { "type": "string" }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source_ref", "source_role", "citation"],
+        "properties": {
+          "source_ref": { "type": "string", "pattern": "^kfm://source/.+" },
+          "source_role": { "$ref": "fragments/ecology_source_role.schema.json" },
+          "citation": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "pattern": "^kfm://evidence/.+" } },
+    "policy_flags": { "type": "array", "items": { "type": "string", "enum": ["sensitivity", "rights", "review_required", "generalized"] } },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generated_at", "stale_after"],
+      "properties": {
+        "generated_at": { "type": "string", "format": "date-time" },
+        "stale_after": { "type": "string", "format": "date-time" }
+      }
+    },
+    "spec_hash": { "type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$" }
+  }
+}

--- a/schemas/contracts/v1/ecology/ecology_layer_manifest.schema.json
+++ b/schemas/contracts/v1/ecology/ecology_layer_manifest.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/ecology_layer_manifest.schema.json",
+  "title": "Ecology Layer Manifest",
+  "description": "Release and trust metadata for one ecology map layer intended for governed rendering.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "object_type",
+    "layer_id",
+    "title",
+    "knowledge_character",
+    "time_semantics",
+    "visibility",
+    "generalization_rules",
+    "source_refs",
+    "evidence_refs",
+    "release_manifest_ref",
+    "spec_hash"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v1" },
+    "object_type": { "type": "string", "const": "EcologyLayerManifest" },
+    "layer_id": { "type": "string", "pattern": "^kfm://layer/.+" },
+    "title": { "type": "string", "minLength": 1 },
+    "knowledge_character": { "$ref": "fragments/ecology_knowledge_character.schema.json" },
+    "time_semantics": { "type": "string", "enum": ["snapshot", "period", "rolling_window", "unknown"] },
+    "visibility": { "type": "string", "enum": ["public", "restricted", "internal"] },
+    "generalization_rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exact_allowed", "minimum_grid_m"],
+      "properties": {
+        "exact_allowed": { "type": "boolean" },
+        "minimum_grid_m": { "type": "number", "minimum": 0 },
+        "withhold_sensitive": { "type": "boolean", "default": true }
+      }
+    },
+    "source_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "pattern": "^kfm://source/.+" } },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "pattern": "^kfm://evidence/.+" } },
+    "release_manifest_ref": { "type": "string", "pattern": "^kfm://release-manifest/.+" },
+    "spec_hash": { "type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$" }
+  }
+}

--- a/schemas/contracts/v1/ecology/ecology_public_claim.schema.json
+++ b/schemas/contracts/v1/ecology/ecology_public_claim.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/ecology_public_claim.schema.json",
+  "title": "Ecology Public Claim",
+  "description": "Public-safe ecology claim envelope that carries evidence and release posture.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "object_type",
+    "claim_id",
+    "subject",
+    "claim_text",
+    "support_summary",
+    "public_geometry_policy",
+    "public_precision",
+    "policy_decision",
+    "release_state",
+    "freshness",
+    "spec_hash",
+    "evidence_refs"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v1" },
+    "object_type": { "type": "string", "const": "EcologyPublicClaim" },
+    "claim_id": { "type": "string", "pattern": "^kfm://claim/ecology/.+" },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["taxon_id"],
+      "properties": {
+        "taxon_id": { "type": "string", "pattern": "^kfm://taxon/.+" },
+        "occurrence_id": { "type": "string", "pattern": "^kfm://occurrence/.+" },
+        "plot_id": { "type": "string", "pattern": "^kfm://plot/.+" },
+        "surface_id": { "type": "string", "pattern": "^kfm://habitat-surface/.+" }
+      }
+    },
+    "claim_text": { "type": "string", "minLength": 5 },
+    "support_summary": { "type": "string", "minLength": 5 },
+    "public_geometry_policy": { "type": "string", "enum": ["public", "generalized", "withheld"] },
+    "public_precision": { "$ref": "fragments/public_precision.schema.json" },
+    "sensitivity_status": { "$ref": "fragments/sensitivity_status.schema.json" },
+    "policy_decision": { "type": "string", "enum": ["ANSWER", "ABSTAIN", "DENY", "ERROR"] },
+    "release_state": { "type": "string", "enum": ["candidate", "reviewed", "published", "held", "revoked"] },
+    "correction_state": { "type": "string", "enum": ["none", "pending", "corrected"] },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generated_at", "stale_after"],
+      "properties": {
+        "generated_at": { "type": "string", "format": "date-time" },
+        "stale_after": { "type": "string", "format": "date-time" }
+      }
+    },
+    "spec_hash": { "type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$" },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "pattern": "^kfm://evidence/.+" }
+    }
+  }
+}

--- a/schemas/contracts/v1/ecology/fragments/ecology_knowledge_character.schema.json
+++ b/schemas/contracts/v1/ecology/fragments/ecology_knowledge_character.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/fragments/ecology_knowledge_character.schema.json",
+  "title": "Ecology Knowledge Character",
+  "description": "Controlled vocabulary describing how an ecology object is known.",
+  "type": "string",
+  "enum": [
+    "observed",
+    "derived",
+    "modeled",
+    "statutory",
+    "protected_context"
+  ]
+}

--- a/schemas/contracts/v1/ecology/fragments/ecology_source_role.schema.json
+++ b/schemas/contracts/v1/ecology/fragments/ecology_source_role.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/fragments/ecology_source_role.schema.json",
+  "title": "Ecology Source Role",
+  "description": "Controlled source role vocabulary for ecology contract records.",
+  "type": "string",
+  "enum": [
+    "TAXONOMIC_AUTHORITY",
+    "OBSERVATION_SYSTEM",
+    "AGGREGATOR",
+    "DERIVED_MODEL_LAYER",
+    "SENSITIVE_OCCURRENCE",
+    "BASELINE",
+    "REGULATORY_CONTEXT",
+    "RENDER_DESCRIPTOR"
+  ]
+}

--- a/schemas/contracts/v1/ecology/fragments/public_precision.schema.json
+++ b/schemas/contracts/v1/ecology/fragments/public_precision.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/fragments/public_precision.schema.json",
+  "title": "Public Precision",
+  "description": "Public-facing precision class for geometry served by ecology objects.",
+  "type": "string",
+  "enum": [
+    "exact",
+    "generalized",
+    "withheld",
+    "degraded"
+  ]
+}

--- a/schemas/contracts/v1/ecology/fragments/sensitivity_status.schema.json
+++ b/schemas/contracts/v1/ecology/fragments/sensitivity_status.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/fragments/sensitivity_status.schema.json",
+  "title": "Sensitivity Status",
+  "description": "Release sensitivity status for ecology objects.",
+  "type": "string",
+  "enum": [
+    "public_safe",
+    "restricted",
+    "review_required",
+    "withheld"
+  ]
+}

--- a/schemas/contracts/v1/ecology/habitat_assignment.schema.json
+++ b/schemas/contracts/v1/ecology/habitat_assignment.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/habitat_assignment.schema.json",
+  "title": "Habitat Assignment",
+  "description": "Derived join contract between an occurrence/observation and a habitat surface class.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "object_type",
+    "assignment_id",
+    "occurrence_id",
+    "surface_id",
+    "habitat_class",
+    "classification_system",
+    "derivation_method",
+    "derived_at",
+    "quality_flag",
+    "knowledge_character",
+    "spec_hash",
+    "evidence_refs"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v1" },
+    "object_type": { "type": "string", "const": "HabitatAssignment" },
+    "assignment_id": { "type": "string", "pattern": "^kfm://habitat-assignment/.+" },
+    "occurrence_id": { "type": "string", "pattern": "^kfm://occurrence/.+" },
+    "surface_id": { "type": "string", "pattern": "^kfm://habitat-surface/.+" },
+    "plot_id": { "type": "string", "pattern": "^kfm://plot/.+" },
+    "habitat_class": { "type": "string", "minLength": 1 },
+    "classification_system": { "type": "string", "minLength": 1 },
+    "class_confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "derivation_method": { "type": "string", "minLength": 1 },
+    "derivation_parameters": {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "number", "integer", "boolean", "null"]
+      }
+    },
+    "derived_at": { "type": "string", "format": "date-time" },
+    "quality_flag": { "type": "string", "enum": ["high", "medium", "low", "needs_review"] },
+    "knowledge_character": { "$ref": "fragments/ecology_knowledge_character.schema.json" },
+    "policy_label": { "type": "string", "enum": ["public", "restricted", "internal", "restricted_until_reviewed"] },
+    "spec_hash": { "type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$" },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "pattern": "^kfm://evidence/.+" }
+    }
+  }
+}

--- a/schemas/contracts/v1/ecology/habitat_surface_descriptor.schema.json
+++ b/schemas/contracts/v1/ecology/habitat_surface_descriptor.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/habitat_surface_descriptor.schema.json",
+  "title": "Habitat Surface Descriptor",
+  "description": "Metadata contract for one habitat raster/vector surface used for ecology derivations.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "object_type",
+    "surface_id",
+    "title",
+    "source_id",
+    "source_role",
+    "classification_system",
+    "version",
+    "extent",
+    "resolution",
+    "time_window",
+    "rights_status",
+    "policy_label",
+    "spec_hash",
+    "evidence_refs"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v1" },
+    "object_type": { "type": "string", "const": "HabitatSurfaceDescriptor" },
+    "surface_id": { "type": "string", "pattern": "^kfm://habitat-surface/.+" },
+    "title": { "type": "string", "minLength": 1 },
+    "source_id": { "type": "string", "minLength": 1 },
+    "source_role": {
+      "$ref": "fragments/ecology_source_role.schema.json"
+    },
+    "knowledge_character": {
+      "$ref": "fragments/ecology_knowledge_character.schema.json"
+    },
+    "classification_system": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "extent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bbox", "crs"],
+      "properties": {
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": { "type": "number" }
+        },
+        "crs": { "type": "string", "minLength": 1 }
+      }
+    },
+    "resolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "unit"],
+      "properties": {
+        "value": { "type": "number", "exclusiveMinimum": 0 },
+        "unit": { "type": "string", "enum": ["m", "km", "arcsec"] }
+      }
+    },
+    "time_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "type": "string", "format": "date" },
+        "end": { "type": "string", "format": "date" }
+      }
+    },
+    "citation": { "type": "string", "minLength": 1 },
+    "rights_status": { "type": "string", "enum": ["open", "controlled", "restricted", "unknown"] },
+    "policy_label": { "type": "string", "enum": ["public", "restricted", "internal", "public_after_review"] },
+    "spec_hash": { "type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$" },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "pattern": "^kfm://evidence/.+" }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide complete, non-skeleton JSON Schema contract definitions for the ecology v1 schema home so downstream validators and runtime components have machine-checkable shapes. 
- Supply reusable enum fragments to avoid duplication and to allow consistent `$ref` reuse across ecology contracts.
- Offer a union index to simplify validation entrypoints for tools that consume any ecology contract object.

### Description
- Added full schema documents under `schemas/contracts/v1/ecology/` for ecology contract objects: `habitat_surface_descriptor.schema.json`, `habitat_assignment.schema.json`, `ecology_public_claim.schema.json`, `ecology_layer_manifest.schema.json`, `ecology_evidence_drawer_payload.schema.json`, and `ecological_composite_claim.schema.json`. 
- Added reusable fragment enums under `schemas/contracts/v1/ecology/fragments/`: `ecology_knowledge_character.schema.json`, `ecology_source_role.schema.json`, `public_precision.schema.json`, and `sensitivity_status.schema.json`, and wired them into the new contracts via `$ref`.
- Added `_index.schema.json` as a `oneOf` union entrypoint that references the existing and newly added ecology v1 contract schemas for a single validator entrypoint.
- Kept previously present files (`taxon_record.schema.json`, `observation_plot.schema.json`, `derived_vegetation_layer.schema.json`, `sensitive_occurrence_record.schema.json`) intact and referenced them from the index; all new top-level objects enforce `additionalProperties: false` and strict `required` fields to support a fail-closed posture.

### Testing
- Parsed all JSON schema files to ensure valid JSON syntax using Python: `python - <<'PY'\nimport json,glob\nfiles=glob.glob('schemas/contracts/v1/ecology/**/*.json',recursive=True)\nfor f in files:\n    with open(f) as fh: json.load(fh)\nprint('ok',len(files))\nPY` which succeeded and reported `ok 15`.
- No other automated schema validation was run in this change; schemas are syntactically valid JSON and ready for inclusion in downstream validator test suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0db79f9cc832abfd1134521a74799)