### PR TITLE
Reorganize ecology fixtures, add HabitatAssignment examples, and fix doc links

### DIFF
--- a/docs/domains/ecology/README.md
+++ b/docs/domains/ecology/README.md
@@ -287,7 +287,7 @@ Validation should be offline-first and fixture-driven until source terms and rep
 
 ```bash
 # Illustrative only — NEEDS VERIFICATION against mounted repo conventions.
-python tools/validators/ecology/validate_ecology_fixture.py tests/fixtures/ecology/valid/taxon_record.json
+python tools/validators/ecology/validate_ecology_fixture.py tests/fixtures/ecology/valid/taxon_record.valid.json
 ```
 
 <p align="right"><a href="#ecology-domain--control-plane">Back to top ↑</a></p>

--- a/schemas/contracts/v1/ecology/README.md
+++ b/schemas/contracts/v1/ecology/README.md
@@ -249,8 +249,8 @@ find tests/fixtures -maxdepth 3 -type f | grep -E 'ecology|habitat|fauna|flora' 
 # NEEDS VERIFICATION: replace with the repo-native schema validator command.
 python tools/validators/schemas/validate_schema_fixture.py \
   --schema schemas/contracts/v1/ecology/habitat_assignment.schema.json \
-  --valid tests/fixtures/ecology/habitat_assignment.valid.json \
-  --invalid tests/fixtures/ecology/habitat_assignment.missing_class.invalid.json
+  --valid tests/fixtures/ecology/valid/habitat_assignment.valid.json \
+  --invalid tests/fixtures/ecology/invalid/habitat_assignment.missing_class.invalid.json
 ```
 
 > [!CAUTION]

--- a/tests/fixtures/ecology/README.md
+++ b/tests/fixtures/ecology/README.md
@@ -76,7 +76,7 @@ Ecology here is an umbrella test fixture label. It does **not** collapse the str
 | Policy source | [`../../../policy/README.md`](../../../policy/README.md) | allow/deny/review logic belongs upstream |
 | Standards docs | [`../../../docs/standards/README.md`](../../../docs/standards/README.md) | fixture, validator, and documentation conventions; `NEEDS VERIFICATION` |
 | Runtime proof consumers | [`../../e2e/runtime_proof/README.md`](../../e2e/runtime_proof/README.md) | downstream request-time proof harness; `NEEDS VERIFICATION` |
-| Release/correction siblings | [`../release_assembly/README.md`](../release_assembly/README.md), [`../correction/README.md`](../correction/README.md) | use those leaves when proof packs, promotion, rollback, withdrawal, or correction lineage is the main burden |
+| Release/correction siblings | [`../../e2e/release_assembly/README.md`](../../e2e/release_assembly/README.md), [`../../e2e/correction/README.md`](../../e2e/correction/README.md) | use those leaves when proof packs, promotion, rollback, withdrawal, or correction lineage is the main burden |
 
 ### Downstream consumers
 
@@ -146,54 +146,46 @@ This directory is not the authoritative home for every ecology-adjacent concern.
 
 ## Directory tree
 
-### Current safe claim
+### Verified branch snapshot
 
-The active checkout for this exact leaf was not available in this session. The only branch-safe claim is the target README path:
-
-```text
-tests/fixtures/ecology/
-└── README.md
-```
-
-### Preferred growth shape (`PROPOSED` / `NEEDS VERIFICATION`)
-
-Add only the subfolders that the active branch can actually support.
+Current fixture inventory in this branch:
 
 ```text
 tests/fixtures/ecology/
 ├── README.md
-├── source_descriptors/
-│   ├── valid/
-│   │   └── habitat_context_public_safe.source_descriptor.json
-│   └── invalid/
-│       ├── unknown_rights_public_release.source_descriptor.json
-│       └── unknown_source_role_authority_claim.source_descriptor.json
-├── habitat_assignment/
-│   ├── answer_public_safe_generalized/
-│   │   ├── input.fixture.json
-│   │   └── expected.decision.json
-│   └── abstain_missing_evidence/
-│       ├── input.fixture.json
-│       └── expected.decision.json
-├── occurrence_publication/
-│   ├── deny_sensitive_exact_location/
-│   │   ├── input.fixture.json
-│   │   └── expected.decision.json
-│   └── deny_restricted_license/
-│       ├── input.fixture.json
-│       └── expected.decision.json
-├── catalog_closure/
-│   └── public_safe_ecology_claim/
-│       ├── evidence_bundle.fixture.json
-│       ├── stac.item.fixture.json
-│       ├── dcat.dataset.fixture.json
-│       └── prov.entity.fixture.json
-└── malformed/
-    └── error_invalid_fixture_shape.json
+├── invalid/
+│   ├── README.md
+│   ├── derived_vegetation_layer.missing_catalog_refs.invalid.json
+│   ├── habitat_assignment.missing_class.invalid.json
+│   ├── missing_policy_id.json
+│   ├── observation_plot.unknown_rights.invalid.json
+│   ├── sensitive_occurrence_record.public_exact_geometry.invalid.json
+│   └── taxon_record.missing_spec_hash.invalid.json
+├── policy/
+│   ├── README.md
+│   ├── allow_derived_layer_with_catalog_closure.json
+│   ├── allow_public_taxon.json
+│   ├── deny_derived_layer_as_confirmed.json
+│   ├── deny_sensitive_exact_geometry.json
+│   ├── deny_unknown_rights.json
+│   ├── deny_unresolved_evidence_bundle.json
+│   ├── derived_layer_as_confirmed.policy.json
+│   ├── generalize_sensitive_occurrence.json
+│   ├── restricted_exact_location_case.json
+│   ├── sensitive_exact_public_geometry.policy.json
+│   └── unknown_rights.policy.json
+└── valid/
+    ├── README.md
+    ├── derived_vegetation_layer.valid.json
+    ├── habitat_assignment.valid.json
+    ├── observation_bundle_valid.json
+    ├── observation_plot.valid.json
+    ├── sensitive_occurrence_record.valid.json
+    └── taxon_record.valid.json
 ```
 
 > [!TIP]
-> Start with one **valid fixture** and one **invalid fixture named by failure reason**. A narrow fixture pair that proves a real rule is better than a broad subtree full of untested examples.
+> Use the subdirectory indexes for file navigation: [`valid/README.md`](./valid/README.md), [`invalid/README.md`](./invalid/README.md), and [`policy/README.md`](./policy/README.md).
 
 [Back to top](#top)
 

--- a/tests/fixtures/ecology/invalid/README.md
+++ b/tests/fixtures/ecology/invalid/README.md
@@ -1,0 +1,12 @@
+# Ecology Invalid Fixtures
+
+These fixtures are intentionally invalid and should fail validation for the named reason.
+
+## Files
+
+- [`derived_vegetation_layer.missing_catalog_refs.invalid.json`](./derived_vegetation_layer.missing_catalog_refs.invalid.json)
+- [`habitat_assignment.missing_class.invalid.json`](./habitat_assignment.missing_class.invalid.json)
+- [`missing_policy_id.json`](./missing_policy_id.json)
+- [`observation_plot.unknown_rights.invalid.json`](./observation_plot.unknown_rights.invalid.json)
+- [`sensitive_occurrence_record.public_exact_geometry.invalid.json`](./sensitive_occurrence_record.public_exact_geometry.invalid.json)
+- [`taxon_record.missing_spec_hash.invalid.json`](./taxon_record.missing_spec_hash.invalid.json)

--- a/tests/fixtures/ecology/invalid/habitat_assignment.missing_class.invalid.json
+++ b/tests/fixtures/ecology/invalid/habitat_assignment.missing_class.invalid.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "v1",
+  "object_type": "HabitatAssignment",
+  "assignment_id": "kfm://habitat-assignment/ks-ellsworth-invalid-001",
+  "occurrence_id": "kfm://occurrence/ks-ellsworth-invalid-001",
+  "surface_id": "kfm://habitat-surface/nlcd-2021-cell-3902",
+  "classification_system": "KFM-Habitat-v1",
+  "derivation_method": "raster-overlay",
+  "derived_at": "2026-01-20T14:32:11Z",
+  "quality_flag": "medium",
+  "knowledge_character": "derived",
+  "spec_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "evidence_refs": [
+    "kfm://evidence/ecology/habitat-assignment-invalid-001"
+  ]
+}

--- a/tests/fixtures/ecology/policy/README.md
+++ b/tests/fixtures/ecology/policy/README.md
@@ -1,0 +1,17 @@
+# Ecology Policy Fixtures
+
+Policy-oriented fixtures for allow/deny/generalize decision checks.
+
+## Files
+
+- [`allow_derived_layer_with_catalog_closure.json`](./allow_derived_layer_with_catalog_closure.json)
+- [`allow_public_taxon.json`](./allow_public_taxon.json)
+- [`deny_derived_layer_as_confirmed.json`](./deny_derived_layer_as_confirmed.json)
+- [`deny_sensitive_exact_geometry.json`](./deny_sensitive_exact_geometry.json)
+- [`deny_unknown_rights.json`](./deny_unknown_rights.json)
+- [`deny_unresolved_evidence_bundle.json`](./deny_unresolved_evidence_bundle.json)
+- [`derived_layer_as_confirmed.policy.json`](./derived_layer_as_confirmed.policy.json)
+- [`generalize_sensitive_occurrence.json`](./generalize_sensitive_occurrence.json)
+- [`restricted_exact_location_case.json`](./restricted_exact_location_case.json)
+- [`sensitive_exact_public_geometry.policy.json`](./sensitive_exact_public_geometry.policy.json)
+- [`unknown_rights.policy.json`](./unknown_rights.policy.json)

--- a/tests/fixtures/ecology/valid/README.md
+++ b/tests/fixtures/ecology/valid/README.md
@@ -1,1 +1,12 @@
+# Ecology Valid Fixtures
 
+These fixtures are expected to pass schema and policy prechecks for their object type.
+
+## Files
+
+- [`derived_vegetation_layer.valid.json`](./derived_vegetation_layer.valid.json)
+- [`habitat_assignment.valid.json`](./habitat_assignment.valid.json)
+- [`observation_bundle_valid.json`](./observation_bundle_valid.json)
+- [`observation_plot.valid.json`](./observation_plot.valid.json)
+- [`sensitive_occurrence_record.valid.json`](./sensitive_occurrence_record.valid.json)
+- [`taxon_record.valid.json`](./taxon_record.valid.json)

--- a/tests/fixtures/ecology/valid/habitat_assignment.valid.json
+++ b/tests/fixtures/ecology/valid/habitat_assignment.valid.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "v1",
+  "object_type": "HabitatAssignment",
+  "assignment_id": "kfm://habitat-assignment/ks-ellsworth-001",
+  "occurrence_id": "kfm://occurrence/ks-ellsworth-001",
+  "surface_id": "kfm://habitat-surface/nlcd-2021-cell-3901",
+  "plot_id": "kfm://plot/ks-ellsworth-101",
+  "habitat_class": "Mixed Grass Prairie",
+  "classification_system": "KFM-Habitat-v1",
+  "class_confidence": 0.91,
+  "derivation_method": "raster-overlay",
+  "derivation_parameters": {
+    "buffer_m": 30,
+    "version": "2026-01"
+  },
+  "derived_at": "2026-01-20T14:32:11Z",
+  "quality_flag": "high",
+  "knowledge_character": "derived",
+  "policy_label": "public",
+  "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "evidence_refs": [
+    "kfm://evidence/ecology/habitat-assignment-valid-001"
+  ]
+}


### PR DESCRIPTION
### Motivation

- Make `tests/fixtures/ecology` navigable and accurate by replacing speculative README tree content with the actual branch snapshot. 
- Provide the concrete `HabitatAssignment` fixtures referenced in schema and validator examples so documentation examples resolve to real files. 
- Repair broken relative links in nearby docs so validator and schema README commands point at existing fixture paths and e2e siblings. 

### Description

- Updated `tests/fixtures/ecology/README.md` to show a verified branch snapshot and point users to subdirectory indexes. 
- Added index READMEs under `tests/fixtures/ecology/valid/`, `tests/fixtures/ecology/invalid/`, and `tests/fixtures/ecology/policy/`. 
- Added `tests/fixtures/ecology/valid/habitat_assignment.valid.json` and `tests/fixtures/ecology/invalid/habitat_assignment.missing_class.invalid.json` to provide a valid/invalid pair used by examples. 
- Fixed references in `docs/domains/ecology/README.md` and `schemas/contracts/v1/ecology/README.md` to use `tests/fixtures/ecology/valid/...` and `tests/fixtures/ecology/invalid/...` and updated sibling README links to `tests/e2e` locations. 

### Testing

- Ran JSON syntax checks with `python -m json.tool` on the new fixture files (result: success). 
- Ran a local markdown relative-link existence check across edited files (result: `all_local_links_exist`). 
- Attempted schema validation using `jsonschema` in a small smoke script but `jsonschema` is not installed in this environment so full schema assertion was not executed. 
- Committed the changes under the branch message: `Reorganize ecology fixtures and repair fixture links`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e17009d8832a86ac386824df010e)