### PR TITLE
Add malformed ecology fixture families and update READMEs

### DIFF
--- a/tests/fixtures/ecology/README.md
+++ b/tests/fixtures/ecology/README.md
@@ -163,7 +163,21 @@ tests/fixtures/ecology/
 │   └── taxon_record.missing_spec_hash.invalid.json
 ├── malformed/
 │   ├── README.md
-│   └── error_invalid_fixture_shape.json
+│   ├── error_invalid_fixture_shape.json
+│   ├── geometry/
+│   │   └── precision_served_missing.json
+│   ├── occurrence/
+│   │   ├── missing_provenance.json
+│   │   ├── missing_required_fields.json
+│   │   └── source_role_flattened.json
+│   ├── rights/
+│   │   └── redistribution_posture_missing.json
+│   ├── runtime/
+│   │   └── malformed_envelope_missing_reason_code.json
+│   ├── sensitivity/
+│   │   └── exact_location_conflicts_with_sensitive_flag.json
+│   └── taxonomy/
+│       └── blank_scientific_name.json
 ├── policy/
 │   ├── README.md
 │   ├── allow_derived_layer_with_catalog_closure.json
@@ -270,6 +284,14 @@ python tools/validators/run_all.py --fixtures tests/fixtures/ecology
 | Sensitive exact geometry | `invalid/sensitive_exact_geometry_public_payload.json` |
 | Modeled/observed collapse | `invalid/modeled_habitat_labeled_observed_occurrence.json` |
 | Malformed body | `malformed/error_invalid_fixture_shape.json` |
+| Malformed missing required fields | `malformed/occurrence/missing_required_fields.json` |
+| Malformed missing provenance | `malformed/occurrence/missing_provenance.json` |
+| Malformed source-role flattening | `malformed/occurrence/source_role_flattened.json` |
+| Malformed rights posture | `malformed/rights/redistribution_posture_missing.json` |
+| Malformed sensitivity conflict | `malformed/sensitivity/exact_location_conflicts_with_sensitive_flag.json` |
+| Malformed blank taxon name | `malformed/taxonomy/blank_scientific_name.json` |
+| Malformed missing served precision | `malformed/geometry/precision_served_missing.json` |
+| Malformed runtime envelope | `malformed/runtime/malformed_envelope_missing_reason_code.json` |
 
 ### Outcome grammar
 

--- a/tests/fixtures/ecology/malformed/README.md
+++ b/tests/fixtures/ecology/malformed/README.md
@@ -154,27 +154,28 @@ Use this directory for compact malformed objects that are valuable because they 
 
 ## Directory tree
 
-### Current safe claim
+### Verified branch snapshot
 
-`NEEDS VERIFICATION`: active-branch contents for this exact target directory were not directly available in this session. Treat the tree below as the intended, reviewable shape.
+Current branch contents for this directory are verified below.
 
 ```text
 tests/fixtures/ecology/malformed/
 ├── README.md
+├── error_invalid_fixture_shape.json
+├── geometry/
+│   └── precision_served_missing.json
 ├── occurrence/
-│   ├── missing_required_fields.json
 │   ├── missing_provenance.json
+│   ├── missing_required_fields.json
 │   └── source_role_flattened.json
 ├── rights/
 │   └── redistribution_posture_missing.json
+├── runtime/
+│   └── malformed_envelope_missing_reason_code.json
 ├── sensitivity/
 │   └── exact_location_conflicts_with_sensitive_flag.json
-├── taxonomy/
-│   └── blank_scientific_name.json
-├── geometry/
-│   └── precision_served_missing.json
-└── runtime/
-    └── malformed_envelope_missing_reason_code.json
+└── taxonomy/
+    └── blank_scientific_name.json
 ```
 
 ### Naming pattern

--- a/tests/fixtures/ecology/malformed/geometry/precision_served_missing.json
+++ b/tests/fixtures/ecology/malformed/geometry/precision_served_missing.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "v1",
+  "object_type": "EcologyGeometrySupport",
+  "fixture_id": "kfm://fixture/ecology/malformed/geometry/precision_served_missing",
+  "malformed_reason": "precision_served_missing",
+  "geometry": {
+    "precision_requested": "exact",
+    "public_safe": false,
+    "lat": 38.5,
+    "lon": -98.12
+  },
+  "expected_outcome": "ERROR"
+}

--- a/tests/fixtures/ecology/malformed/occurrence/missing_provenance.json
+++ b/tests/fixtures/ecology/malformed/occurrence/missing_provenance.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "v1",
+  "object_type": "EcologyOccurrenceSupport",
+  "fixture_id": "kfm://fixture/ecology/malformed/occurrence/missing_provenance",
+  "malformed_reason": "missing_provenance",
+  "occurrence_id": "occ-malformed-001",
+  "source_role": "observed_occurrence",
+  "spec_hash": "sha256:17be3f6afb89ef2e95f4c7a41d833913f2e8eb3e5e2ca2258ab54ec4e2a643d5",
+  "expected_outcome": "ERROR",
+  "notes": "Intentionally omits source_uri, retrieved_at, source_record_id, and source_dataset_id."
+}

--- a/tests/fixtures/ecology/malformed/occurrence/missing_required_fields.json
+++ b/tests/fixtures/ecology/malformed/occurrence/missing_required_fields.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "v1",
+  "object_type": "EcologyOccurrenceSupport",
+  "fixture_id": "kfm://fixture/ecology/malformed/occurrence/missing_required_fields",
+  "malformed_reason": "missing_required_fields",
+  "source_role": "observed_occurrence",
+  "expected_outcome": "ERROR",
+  "notes": "Intentionally omits required occurrence identifier and spec_hash."
+}

--- a/tests/fixtures/ecology/malformed/occurrence/source_role_flattened.json
+++ b/tests/fixtures/ecology/malformed/occurrence/source_role_flattened.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "v1",
+  "object_type": "EcologyOccurrenceSupport",
+  "fixture_id": "kfm://fixture/ecology/malformed/occurrence/source_role_flattened",
+  "malformed_reason": "source_role_flattened",
+  "occurrence_id": "occ-malformed-002",
+  "source_role": "observed_occurrence+modeled_range",
+  "spec_hash": "sha256:b13cbb3ef44a39e5c8613129f11fd4070f4d8632f3a23365ea0f45258d4598f1",
+  "source_uri": "kfm://fixture/source/observed-and-modeled-mixed",
+  "retrieved_at": "2026-04-28T00:00:00Z",
+  "expected_outcome": "ERROR"
+}

--- a/tests/fixtures/ecology/malformed/rights/redistribution_posture_missing.json
+++ b/tests/fixtures/ecology/malformed/rights/redistribution_posture_missing.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "v1",
+  "object_type": "EcologyRightsSupport",
+  "fixture_id": "kfm://fixture/ecology/malformed/rights/redistribution_posture_missing",
+  "malformed_reason": "redistribution_posture_missing",
+  "rights_status": "controlled",
+  "license": "CC-BY-4.0",
+  "expected_outcome": "DENY",
+  "notes": "Intentionally omits redistribution_posture required for publication decisions."
+}

--- a/tests/fixtures/ecology/malformed/runtime/malformed_envelope_missing_reason_code.json
+++ b/tests/fixtures/ecology/malformed/runtime/malformed_envelope_missing_reason_code.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "v1",
+  "object_type": "EcologyRuntimeEnvelope",
+  "fixture_id": "kfm://fixture/ecology/malformed/runtime/malformed_envelope_missing_reason_code",
+  "malformed_reason": "runtime_reason_code_missing",
+  "outcome": "ERROR",
+  "reason": {
+    "message": "Missing reason.code in runtime error envelope"
+  },
+  "audit": {
+    "fixture_ref": "kfm://fixture/ecology/malformed/runtime/malformed_envelope_missing_reason_code"
+  }
+}

--- a/tests/fixtures/ecology/malformed/sensitivity/exact_location_conflicts_with_sensitive_flag.json
+++ b/tests/fixtures/ecology/malformed/sensitivity/exact_location_conflicts_with_sensitive_flag.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "v1",
+  "object_type": "EcologySensitivitySupport",
+  "fixture_id": "kfm://fixture/ecology/malformed/sensitivity/exact_location_conflicts_with_sensitive_flag",
+  "malformed_reason": "exact_public_geometry_conflicts_with_sensitive_flag",
+  "sensitivity": "sensitive",
+  "geometry": {
+    "precision_served": "exact",
+    "public_safe": true,
+    "lat": 38.500123,
+    "lon": -98.123456
+  },
+  "expected_outcome": "DENY"
+}

--- a/tests/fixtures/ecology/malformed/taxonomy/blank_scientific_name.json
+++ b/tests/fixtures/ecology/malformed/taxonomy/blank_scientific_name.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "v1",
+  "object_type": "EcologyTaxonSupport",
+  "fixture_id": "kfm://fixture/ecology/malformed/taxonomy/blank_scientific_name",
+  "malformed_reason": "blank_scientific_name",
+  "taxon": {
+    "scientific_name": "",
+    "rank": "species",
+    "taxon_id": "kfm-taxon-blank-001"
+  },
+  "expected_outcome": "ERROR"
+}


### PR DESCRIPTION
### Motivation
- Complete the malformed ecology fixture lane so validators and runtime-proof tests can exercise fail-closed behaviors across several common malformed cases.  
- Make the on-disk README state accurate by documenting the actual fixture tree rather than a placeholder inventory.

### Description
- Added synthetic malformed fixtures under `tests/fixtures/ecology/malformed/` for the families: `occurrence` (`missing_required_fields.json`, `missing_provenance.json`, `source_role_flattened.json`), `rights` (`redistribution_posture_missing.json`), `sensitivity` (`exact_location_conflicts_with_sensitive_flag.json`), `taxonomy` (`blank_scientific_name.json`), `geometry` (`precision_served_missing.json`), and `runtime` (`malformed_envelope_missing_reason_code.json`).  
- Each fixture includes `schema_version`, an identifying `fixture_id`, a `malformed_reason`, and a narrow `expected_outcome` such as `ERROR` or `DENY` to keep failure attribution explicit.  
- Updated `tests/fixtures/ecology/malformed/README.md` to replace the placeholder inventory with a verified branch snapshot and the concrete directory tree.  
- Updated the parent `tests/fixtures/ecology/README.md` to reflect the expanded malformed subtree and to add the new filenames to the naming-guidance table.

### Testing
- Ran `find tests/fixtures/ecology/malformed -maxdepth 3 -type f | sort` to confirm the new files are present and discoverable, which listed the expected files. (succeeded)  
- Ran a Python JSON validation script that loads every `*.json` in `tests/fixtures/ecology/malformed` with `json.loads(...)` to ensure syntactic validity, which printed `json-ok`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e6e2a170832a9976acc94f517233)