### PR TITLE
Complete ecology policy fixtures and normalize policy case shapes

### DIFF
--- a/tests/fixtures/ecology/policy/README.md
+++ b/tests/fixtures/ecology/policy/README.md
@@ -10,7 +10,7 @@ updated: NEEDS_VERIFICATION__YYYY-MM-DD
 policy_label: NEEDS_VERIFICATION__public_or_restricted
 related: [../../README.md, ../../../README.md, ../../../policy/README.md, ../../../e2e/runtime_proof/README.md, ../../../e2e/release_assembly/README.md, ../../../e2e/correction/README.md, ../../../../policy/README.md, ../../../../schemas/README.md, ../../../../contracts/README.md, ../../../../data/README.md]
 tags: [kfm, tests, fixtures, ecology, policy, fauna, flora, habitat, sensitivity, rights]
-notes: [Target branch was not mounted in this session; exact owner, dates, policy label, fixture inventory, runner wiring, and adjacent path validity remain verification items.]
+notes: [Fixture inventory was updated in-session; owner, dates, policy label, and runner wiring still require branch-level verification.]
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
@@ -58,7 +58,7 @@ In KFM terms, **ecology** here is an umbrella fixture context for fauna, flora, 
 
 | Evidence layer | What this README treats as settled |
 |---|---|
-| **CONFIRMED — current session** | The target file path was requested, but the active repository was not mounted in this workspace. Exact branch inventory, runner wiring, and leaf-level ownership remain unverified. |
+| **CONFIRMED — current session** | The repository is mounted and this fixture lane contains concrete allow/generalize/deny/abstain/error examples; ownership and runner wiring remain unverified. |
 | **CONFIRMED — KFM doctrine** | KFM uses an evidence-first, map-first, time-aware, governed posture; lifecycle state and public exposure must remain explicit; sensitive exact locations fail closed. |
 | **INFERRED — repo role** | This leaf should behave like a `tests/fixtures/` child surface: compact examples for proof lanes, not canonical ecology data. |
 | **PROPOSED — first useful fill** | Add one public-safe allow case, one evidence-thin hold/abstain case, one sensitive-location deny case, one rights-deny case, and one malformed error case. |
@@ -149,39 +149,29 @@ A minimal honest starter set is:
 
 ## Directory tree
 
-### Current safe claim
-
-The active branch contents for this exact leaf were not available in this session. The only safe inventory claim in this README is the requested target document itself.
-
-```text
-tests/fixtures/ecology/policy/
-└── README.md
-```
-
-### Possible next executable fill
-
-The structure below is **PROPOSED**. Preserve any existing branch convention if the mounted repository already uses different names.
+### Current inventory
 
 ```text
 tests/fixtures/ecology/policy/
 ├── README.md
-├── allow/
-│   └── generalized_public_habitat_support/
-│       ├── input.example.json
-│       └── expected.policy_decision.example.json
-├── hold/
-│   ├── missing_evidence_bundle/
-│   └── unresolved_steward_review/
-├── deny/
-│   ├── sensitive_exact_location/
-│   ├── unknown_or_restricted_rights/
-│   ├── source_role_misuse/
-│   ├── raw_work_quarantine_public_leak/
-│   └── missing_redaction_receipt/
-└── error/
-    ├── malformed_ecology_policy_input/
-    └── invalid_lifecycle_state/
+├── abstain_unresolved_evidence_bundle.json
+├── allow_derived_layer_with_catalog_closure.json
+├── allow_public_taxon.json
+├── deny_derived_layer_as_confirmed.json
+├── deny_sensitive_exact_geometry.json
+├── deny_unknown_rights.json
+├── deny_unresolved_evidence_bundle.json
+├── derived_layer_as_confirmed.policy.json
+├── error_malformed_policy_input.json
+├── generalize_sensitive_occurrence.json
+├── restricted_exact_location_case.json
+├── sensitive_exact_public_geometry.policy.json
+└── unknown_rights.policy.json
 ```
+
+### Next executable fill
+
+Keep adding cases in the current flat-file naming convention unless a runner explicitly requires nested lanes.
 
 > [!NOTE]
 > The example filenames are placement guidance, not schema law. If the branch already has a fixture naming convention, use that convention and update this tree.

--- a/tests/fixtures/ecology/policy/abstain_unresolved_evidence_bundle.json
+++ b/tests/fixtures/ecology/policy/abstain_unresolved_evidence_bundle.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "ecology-policy-abstain-unresolved-evidence-bundle-001",
+  "object_type": "observation_plot",
+  "source_role": "OBSERVATION_PLOT",
+  "dataset_refs": ["ecology.observation_plot.v1"],
+  "catalog_refs": ["catalog://ecology/observation_plot/v1"],
+  "policy_id": "eco-generalize-v1",
+  "policy_label": "public",
+  "sensitivity": "public",
+  "rights_status": "public",
+  "public_visibility": "public",
+  "public_geometry_policy": "allow_exact",
+  "exact_geometry_present": false,
+  "evidence_refs": ["evidence://ecology/policy/abstain-unresolved-evidence-bundle-001"],
+  "evidence_bundle_resolved": false,
+  "expected_decision": "ABSTAIN",
+  "expected_reasons": ["unresolved_evidence_bundle"]
+}

--- a/tests/fixtures/ecology/policy/derived_layer_as_confirmed.policy.json
+++ b/tests/fixtures/ecology/policy/derived_layer_as_confirmed.policy.json
@@ -1,10 +1,23 @@
 {
-  "case_id": "ecology-policy-derived-layer-confirmed-001",
+  "case_id": "ecology-policy-derived-layer-as-confirmed-policy-001",
+  "object_type": "derived_layer",
+  "source_role": "DERIVED_MODEL_LAYER",
   "dataset_refs": ["ecology.derived_vegetation_layer.v1"],
+  "catalog_refs": [
+    "catalog://ecology/observation_plot/v1",
+    "catalog://ecology/derived_vegetation_layer/v1"
+  ],
   "policy_id": "eco-generalize-v1",
+  "policy_label": "public_after_catalog_closure",
   "sensitivity": "generalize",
   "rights_status": "controlled",
-  "record_status": "confirmed",
-  "expected_decision": "ALLOW",
-  "expected_reason": "DERIVED_LAYER_CONFIRMED"
+  "public_visibility": "generalized",
+  "public_geometry_policy": "deny_exact_generalize_required",
+  "exact_geometry_present": false,
+  "catalog_closure": true,
+  "claim_status": "CONFIRMED",
+  "evidence_refs": ["evidence://ecology/policy/derived-layer-as-confirmed-policy-001"],
+  "evidence_bundle_resolved": true,
+  "expected_decision": "DENY",
+  "expected_reasons": ["derived_layer_as_confirmed_truth"]
 }

--- a/tests/fixtures/ecology/policy/error_malformed_policy_input.json
+++ b/tests/fixtures/ecology/policy/error_malformed_policy_input.json
@@ -1,0 +1,15 @@
+{
+  "case_id": "ecology-policy-error-malformed-policy-input-001",
+  "object_type": "malformed_fixture",
+  "source_role": "OBSERVATION_PLOT",
+  "dataset_refs": ["ecology.observation_plot.v1"],
+  "policy_id": "eco-generalize-v1",
+  "sensitivity": "generalize",
+  "rights_status": "public",
+  "expected_decision": "ERROR",
+  "expected_reasons": ["malformed_policy_input"],
+  "malformed": {
+    "detail": "catalog_refs is intentionally omitted and policy_label has an invalid type",
+    "policy_label": 404
+  }
+}

--- a/tests/fixtures/ecology/policy/restricted_exact_location_case.json
+++ b/tests/fixtures/ecology/policy/restricted_exact_location_case.json
@@ -1,10 +1,22 @@
 {
-  "bundle_id": "ecology-policy-case-001",
+  "case_id": "ecology-policy-restricted-exact-location-case-001",
+  "object_type": "sensitive_occurrence",
+  "source_role": "SENSITIVE_OCCURRENCE",
   "source_refs": ["kfs_field_plots"],
   "dataset_refs": ["ecology.sensitive_occurrence_record.v1"],
+  "catalog_refs": ["catalog://ecology/sensitive_occurrence_record/v1"],
   "policy_id": "eco-restricted-v1",
+  "policy_label": "public",
   "sensitivity": "restricted",
   "rights_status": "controlled",
+  "public_visibility": "public",
+  "public_geometry_policy": "allow_exact",
   "exact_geometry_present": true,
-  "evidence_refs": ["evidence://bundle/sensitive-001"]
+  "evidence_refs": ["evidence://ecology/policy/restricted-exact-location-case-001"],
+  "evidence_bundle_resolved": true,
+  "expected_decision": "DENY",
+  "expected_reasons": [
+    "sensitive_exact_geometry_not_publishable",
+    "restricted_exact_geometry_not_publishable"
+  ]
 }

--- a/tests/fixtures/ecology/policy/sensitive_exact_public_geometry.policy.json
+++ b/tests/fixtures/ecology/policy/sensitive_exact_public_geometry.policy.json
@@ -1,10 +1,21 @@
 {
-  "case_id": "ecology-policy-sensitive-geometry-001",
+  "case_id": "ecology-policy-sensitive-exact-public-geometry-policy-001",
+  "object_type": "sensitive_occurrence",
+  "source_role": "SENSITIVE_OCCURRENCE",
   "dataset_refs": ["ecology.sensitive_occurrence_record.v1"],
+  "catalog_refs": ["catalog://ecology/sensitive_occurrence_record/v1"],
   "policy_id": "eco-restricted-v1",
+  "policy_label": "public",
   "sensitivity": "restricted",
   "rights_status": "public",
+  "public_visibility": "public",
+  "public_geometry_policy": "allow_exact",
   "exact_geometry_present": true,
+  "evidence_refs": ["evidence://ecology/policy/sensitive-exact-public-geometry-policy-001"],
+  "evidence_bundle_resolved": true,
   "expected_decision": "DENY",
-  "expected_reason": "SENSITIVE_EXACT_GEOMETRY_PUBLIC"
+  "expected_reasons": [
+    "sensitive_exact_geometry_not_publishable",
+    "restricted_exact_geometry_not_publishable"
+  ]
 }

--- a/tests/fixtures/ecology/policy/unknown_rights.policy.json
+++ b/tests/fixtures/ecology/policy/unknown_rights.policy.json
@@ -1,9 +1,18 @@
 {
-  "case_id": "ecology-policy-unknown-rights-001",
+  "case_id": "ecology-policy-unknown-rights-policy-001",
+  "object_type": "observation_plot",
+  "source_role": "OBSERVATION_PLOT",
   "dataset_refs": ["ecology.observation_plot.v1"],
+  "catalog_refs": ["catalog://ecology/observation_plot/v1"],
   "policy_id": "eco-generalize-v1",
+  "policy_label": "public",
   "sensitivity": "generalize",
   "rights_status": "unknown",
+  "public_visibility": "generalized",
+  "public_geometry_policy": "deny_exact_generalize_required",
+  "exact_geometry_present": false,
+  "evidence_refs": ["evidence://ecology/policy/unknown-rights-policy-001"],
+  "evidence_bundle_resolved": true,
   "expected_decision": "DENY",
-  "expected_reason": "UNKNOWN_RIGHTS_STATUS"
+  "expected_reasons": ["unknown_rights"]
 }


### PR DESCRIPTION
### Motivation
- Finish and broaden the `tests/fixtures/ecology/policy` fixture lane so tests can exercise `ALLOW`/`DENY`/`GENERALIZE`/`ABSTAIN`/`ERROR` outcomes for ecology policy seams. 
- Ensure fixture shapes are consistent and reviewable by normalizing older `*.policy.json` and restricted-location cases to the richer modern fixture form (object type, source role, catalog refs, visibility/geometry policy, evidence resolution, and reason arrays).

### Description
- Added explicit ABSTAIN and ERROR cases: `tests/fixtures/ecology/policy/abstain_unresolved_evidence_bundle.json` and `tests/fixtures/ecology/policy/error_malformed_policy_input.json`.
- Normalized and enriched legacy policy fixtures including `tests/fixtures/ecology/policy/derived_layer_as_confirmed.policy.json`, `tests/fixtures/ecology/policy/unknown_rights.policy.json`, `tests/fixtures/ecology/policy/sensitive_exact_public_geometry.policy.json`, and `tests/fixtures/ecology/policy/restricted_exact_location_case.json` to include `object_type`, `source_role`, `catalog_refs`, `public_visibility`, `public_geometry_policy`, `evidence_bundle_resolved`, and `expected_reasons` where appropriate.
- Corrected the derived-layer-confirmed case semantics to reflect the deny outcome for a confirmed derived-layer truth claim and standardized reason codes across deny/generalize cases.
- Updated the policy fixture README `tests/fixtures/ecology/policy/README.md` to reflect the concrete inventory and to mark the meta block as having an in-session inventory update (ownership and runner wiring still require verification).

### Testing
- Ran a JSON syntax validation across the directory using a Python `json.loads` check over `tests/fixtures/ecology/policy/*.json`, which succeeded and reported that all fixtures parsed (`OK 13 json files parsed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0eac36200832a8aea55c142b5f5e3)