### PR TITLE
Complete ecology valid fixture payloads in tests/fixtures/ecology/valid

### DIFF
--- a/tests/fixtures/ecology/valid/derived_vegetation_layer.valid.json
+++ b/tests/fixtures/ecology/valid/derived_vegetation_layer.valid.json
@@ -1,19 +1,33 @@
 {
-  "layer_id": "derived-veg-layer-valid-001",
-  "source_refs": ["kfs_field_plots", "kfs_satellite_imagery"],
-  "dataset_refs": ["ecology.derived_vegetation_layer.v1"],
-  "catalog_refs": [
-    "catalog://ecology/observation_plot/v1",
-    "catalog://ecology/derived_vegetation_layer/v1"
+  "schema_version": "v1",
+  "object_type": "DerivedVegetationLayer",
+  "layer_id": "kfm://layer/ks-ndvi-2025-q3",
+  "title": "Kansas NDVI-derived Vegetation Context Layer (Q3 2025)",
+  "source_id": "ndvi_derived_layers",
+  "source_role": "DERIVED_MODEL_LAYER",
+  "product": "NDVI_DERIVED",
+  "version": "2025.09",
+  "derivation_method": "ndvi-temporal-composite-v3",
+  "source_refs": [
+    "source://kfs_field_plots/2025",
+    "source://sentinel-2/l2a/2025-q3"
   ],
-  "spec_hash": "sha256:b6f2d0dd3fa9dc0e55643fca2d63f6d3c4b6f03b005c298eb1db57f8600f6c8f",
-  "policy_id": "eco-generalize-v1",
-  "sensitivity": "generalize",
-  "rights_status": "controlled",
-  "derivation": {
-    "method": "canopy_cover_model_v3",
-    "input_plot_count": 42,
-    "resolution_m": 30
+  "time_window": {
+    "start": "2025-07-01",
+    "end": "2025-09-30"
   },
-  "evidence_refs": ["evidence://ecology/derived-layer-valid-001"]
+  "classification": "derived_context",
+  "derived_status": "derived",
+  "spatial_resolution_m": 30,
+  "policy_label": "public_after_catalog_closure",
+  "spec_hash": "sha256:b6f2d0dd3fa9dc0e55643fca2d63f6d3c4b6f03b005c298eb1db57f8600f6c8f",
+  "evidence_refs": [
+    "kfm://evidence/ecology/derived-layer-valid-001"
+  ],
+  "catalog_refs": {
+    "stac": "kfm://catalog/stac/ecology/derived-veg-layer-valid-001",
+    "prov": "kfm://catalog/prov/ecology/derived-veg-layer-valid-001",
+    "dcat": "kfm://catalog/dcat/ecology/derived-veg-layer-valid-001"
+  },
+  "publication_state": "candidate"
 }

--- a/tests/fixtures/ecology/valid/habitat_assignment.valid.json
+++ b/tests/fixtures/ecology/valid/habitat_assignment.valid.json
@@ -11,7 +11,7 @@
   "derivation_method": "raster-overlay",
   "derivation_parameters": {
     "buffer_m": 30,
-    "version": "2026-01"
+    "epoch": "2021"
   },
   "derived_at": "2026-01-20T14:32:11Z",
   "quality_flag": "high",

--- a/tests/fixtures/ecology/valid/observation_bundle_public_safe.valid.json
+++ b/tests/fixtures/ecology/valid/observation_bundle_public_safe.valid.json
@@ -1,9 +1,15 @@
 {
   "bundle_id": "ecology-bundle-valid-001",
-  "source_refs": ["kfs_field_plots"],
-  "dataset_refs": ["ecology.observation_plot.v1"],
+  "source_refs": [
+    "kfs_field_plots"
+  ],
+  "dataset_refs": [
+    "ecology.observation_plot.v1"
+  ],
   "policy_id": "eco-generalize-v1",
   "sensitivity": "generalize",
   "rights_status": "controlled",
-  "evidence_refs": ["evidence://bundle/obs-001"]
+  "evidence_refs": [
+    "kfm://evidence/bundle/obs-001"
+  ]
 }

--- a/tests/fixtures/ecology/valid/observation_plot.valid.json
+++ b/tests/fixtures/ecology/valid/observation_plot.valid.json
@@ -1,17 +1,36 @@
 {
-  "plot_id": "observation-plot-valid-001",
-  "source_refs": ["kfs_field_plots"],
-  "dataset_refs": ["ecology.observation_plot.v1"],
-  "catalog_refs": ["catalog://ecology/observation_plot/v1"],
-  "spec_hash": "sha256:d8f8d3676fe6f9b1757c8ed5ac15d291ef1e0de8b69096b8dc4dbfdeb6de7158",
-  "policy_id": "eco-generalize-v1",
+  "schema_version": "v1",
+  "object_type": "ObservationPlot",
+  "plot_id": "kfm://plot/ks-ellsworth-101",
+  "observed_at": "2025-09-14T10:15:00Z",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      -98.214,
+      38.742
+    ]
+  },
+  "geometry_ref": "kfm://geometry/observation/ks-ellsworth-101",
+  "geometry_policy": "generalized",
+  "taxa": [
+    "Asclepias syriaca"
+  ],
+  "taxon_refs": [
+    "kfm://taxon/asclepias-syriaca"
+  ],
+  "method": "field_survey",
+  "source_id": "kfs_field_plots",
+  "source_role": "OBSERVATION_SYSTEM",
+  "source_ref": "source://kfs_field_plots/2025/fall/ellsworth-101",
   "sensitivity": "generalize",
   "rights_status": "controlled",
-  "plot": {
-    "observed_on": "2025-09-14",
-    "vegetation_class": "mixed_grass_prairie",
+  "measurement_summary": {
     "sample_area_m2": 1000,
-    "geometry_precision": "generalized"
+    "vegetation_class": "mixed_grass_prairie"
   },
-  "evidence_refs": ["evidence://ecology/observation-plot-valid-001"]
+  "policy_label": "restricted_until_reviewed",
+  "spec_hash": "sha256:d8f8d3676fe6f9b1757c8ed5ac15d291ef1e0de8b69096b8dc4dbfdeb6de7158",
+  "evidence_refs": [
+    "kfm://evidence/ecology/observation-plot-valid-001"
+  ]
 }

--- a/tests/fixtures/ecology/valid/sensitive_occurrence_record.valid.json
+++ b/tests/fixtures/ecology/valid/sensitive_occurrence_record.valid.json
@@ -1,13 +1,34 @@
 {
-  "occurrence_id": "sensitive-occurrence-valid-001",
-  "source_refs": ["kfs_rare_species_program"],
-  "dataset_refs": ["ecology.sensitive_occurrence_record.v1"],
-  "catalog_refs": ["catalog://ecology/sensitive_occurrence_record/v1"],
-  "spec_hash": "sha256:9e58e2b3f06f5af4f8f4a6132ea8cbc243cd6da9ef2a67fbe772ec5e932ea569",
-  "policy_id": "eco-restricted-v1",
+  "schema_version": "v1",
+  "object_type": "SensitiveOccurrenceRecord",
+  "occurrence_id": "kfm://occurrence/ks-sensitive-001",
+  "taxon_id": "taxon:asclepias-meadii",
+  "taxon_ref": "kfm://taxon/asclepias-meadii",
+  "source_id": "kfs_field_plots",
+  "source_role": "SENSITIVE_OCCURRENCE",
+  "source_ref": "source://kfs_field_plots/restricted/ks-sensitive-001",
   "sensitivity": "restricted",
+  "sensitivity_class": "threatened_or_endangered_species",
+  "geometry_private": {
+    "type": "Point",
+    "coordinates": [
+      -98.244832,
+      38.761512
+    ]
+  },
+  "restricted_geometry_ref": "kfm://restricted/geometry/ks-sensitive-001",
+  "geometry_public": null,
+  "generalized_geometry_ref": "kfm://geometry/generalized/ks-sensitive-001",
+  "generalization_method": "county-centroid-offset",
+  "precision_served": "suppressed",
+  "public_geometry_policy": "deny_exact_generalize_required",
+  "public_visibility": "withheld",
+  "policy_id": "eco-restricted-v1",
+  "policy_label": "restricted",
   "rights_status": "controlled",
-  "exact_geometry_present": false,
-  "geometry_precision": "generalized",
-  "evidence_refs": ["evidence://ecology/sensitive-occurrence-valid-001"]
+  "redaction_receipt_ref": "kfm://receipt/redaction/ks-sensitive-001",
+  "spec_hash": "sha256:9e58e2b3f06f5af4f8f4a6132ea8cbc243cd6da9ef2a67fbe772ec5e932ea569",
+  "evidence_refs": [
+    "kfm://evidence/ecology/sensitive-occurrence-valid-001"
+  ]
 }

--- a/tests/fixtures/ecology/valid/taxon_record.valid.json
+++ b/tests/fixtures/ecology/valid/taxon_record.valid.json
@@ -1,16 +1,22 @@
 {
-  "record_id": "taxon-record-valid-001",
-  "source_refs": ["kfs_taxonomy_program"],
-  "dataset_refs": ["ecology.taxon_record.v1"],
-  "catalog_refs": ["catalog://ecology/taxon_record/v1"],
+  "schema_version": "v1",
+  "object_type": "TaxonRecord",
+  "taxon_id": "kfm://taxon/asclepias-syriaca",
+  "scientific_name": "Asclepias syriaca",
+  "vernacular_name": "Common milkweed",
+  "common_names": [
+    "Common milkweed",
+    "Silkweed"
+  ],
+  "rank": "species",
+  "family": "Apocynaceae",
+  "authority_source": "USDA PLANTS",
+  "source_id": "usda_plants",
+  "source_role": "TAXONOMIC_AUTHORITY",
+  "taxonomic_status": "accepted",
+  "policy_label": "public",
   "spec_hash": "sha256:4a471f0f48de7fb95f2f5c6e8cd9678ef6e43a1c18e67c2df92f90ece2f13f4b",
-  "policy_id": "eco-generalize-v1",
-  "sensitivity": "generalize",
-  "rights_status": "controlled",
-  "taxon": {
-    "scientific_name": "Asclepias syriaca",
-    "common_name": "Common milkweed",
-    "rank": "species"
-  },
-  "evidence_refs": ["evidence://ecology/taxon-record-valid-001"]
+  "evidence_refs": [
+    "kfm://evidence/ecology/taxon-record-valid-001"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Provide fully-populated, schema-aligned positive fixtures for the ecology fixture lane so validators and downstream tooling can exercise governed shapes without network access.
- Normalize identifiers, evidence URIs, and source fields to match the current ecology v1 contracts and registry expectations.

### Description
- Updated the existing fixtures under `tests/fixtures/ecology/valid/` (`taxon_record.valid.json`, `observation_plot.valid.json`, `derived_vegetation_layer.valid.json`, `sensitive_occurrence_record.valid.json`, `habitat_assignment.valid.json`, and `observation_bundle_public_safe.valid.json`) to include required `schema_version`/`object_type` and contract fields, canonical `kfm://` URIs, and consistent `evidence_refs`.
- Expanded the derived layer fixture to include `title`, `time_window`, `classification`, `derived_status`, `catalog_refs` object, and `publication_state` to satisfy the `DerivedVegetationLayer` contract.
- Reworked the observation plot into the governed `ObservationPlot` shape with `geometry`, `geometry_policy`, `taxa`/`taxon_refs`, `method`, `source_id`/`source_role` and `measurement_summary` fields.
- Completed the sensitive occurrence record with private geometry, generalized/public geometry references, geoprivacy fields, `policy_id`/`policy_label`, `redaction_receipt_ref`, and `spec_hash` aligned to the `SensitiveOccurrenceRecord` schema.
- Minor parameter normalization in `habitat_assignment.valid.json` (renamed `version` -> `epoch` in `derivation_parameters`) and normalized the observation bundle `evidence_refs` to `kfm://` style.

### Testing
- Parsed all JSON fixtures with `json.loads(...)` to confirm syntactic validity, which succeeded for all fixtures in `tests/fixtures/ecology/valid`.
- Ran a lightweight required-field assertion script (checking schema-required top-level keys for each schema-backed fixture), which passed for the inspected fixtures.
- Executed `tools/validators/ecology/validate_ecology_bundle.py` against `tests/fixtures/ecology/valid/observation_bundle_public_safe.valid.json` using temporary registry JSON inputs via `--sources`, `--datasets`, and `--policies`, and received a `pass` decision with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0eb9df99c832a8d6a2a4a0179c280)