### PR TITLE
Add source fixture sets for generic, Kansas Mesonet, and MapLibre; update READMEs

### DIFF
--- a/tests/fixtures/source/README.md
+++ b/tests/fixtures/source/README.md
@@ -166,10 +166,24 @@ Content that belongs here should stay **small**, **explicit**, and **safe to rev
 
 ```text
 tests/fixtures/source/
-└── README.md
+├── README.md
+├── source_descriptor/
+│   ├── expected/
+│   ├── invalid/
+│   └── valid/
+├── kansas_mesonet_source_descriptor/
+│   ├── README.md
+│   ├── expected/
+│   ├── invalid/
+│   └── valid/
+└── maplibre_source_meta/
+    ├── README.md
+    ├── expected/
+    ├── invalid/
+    └── valid/
 ```
 
-That is the only subtree claim this README can make safely without direct active-branch inspection of this exact directory.
+This tree is now grounded by direct active-branch inspection and committed fixture files.
 
 <details>
 <summary><strong>Possible stable growth shape</strong> (<strong>PROPOSED</strong>)</summary>

--- a/tests/fixtures/source/kansas_mesonet_source_descriptor/README.md
+++ b/tests/fixtures/source/kansas_mesonet_source_descriptor/README.md
@@ -138,10 +138,17 @@ The following belong here when they are small, reviewable, and intentionally sha
 
 ```text
 tests/fixtures/source/kansas_mesonet_source_descriptor/
-└── README.md
+├── README.md
+├── expected/
+│   ├── run_receipt.allow.json
+│   └── run_receipt.deny.json
+├── invalid/
+│   └── descriptor.missing_rights.invalid.json
+└── valid/
+    └── descriptor.public_safe.valid.json
 ```
 
-This README does not claim that sibling fixtures already exist on the active branch.
+This README now reflects direct active-branch fixture inventory.
 
 <details>
 <summary><strong>Possible stable growth shape</strong> (<strong>PROPOSED</strong>)</summary>

--- a/tests/fixtures/source/kansas_mesonet_source_descriptor/expected/run_receipt.allow.json
+++ b/tests/fixtures/source/kansas_mesonet_source_descriptor/expected/run_receipt.allow.json
@@ -1,0 +1,10 @@
+{
+  "expected_outcome": "ALLOW",
+  "fixture": "descriptor.public_safe.valid.json",
+  "source_id": "kansas_mesonet",
+  "reason_codes": [
+    "source_identity_present",
+    "documented_surface_only",
+    "rights_posture_present"
+  ]
+}

--- a/tests/fixtures/source/kansas_mesonet_source_descriptor/expected/run_receipt.deny.json
+++ b/tests/fixtures/source/kansas_mesonet_source_descriptor/expected/run_receipt.deny.json
@@ -1,0 +1,10 @@
+{
+  "expected_outcome": "DENY",
+  "fixture": "descriptor.missing_rights.invalid.json",
+  "reason_codes": [
+    "source_identity_missing",
+    "rights_posture_missing",
+    "undocumented_access_mode",
+    "temporal_support_missing"
+  ]
+}

--- a/tests/fixtures/source/kansas_mesonet_source_descriptor/invalid/descriptor.missing_rights.invalid.json
+++ b/tests/fixtures/source/kansas_mesonet_source_descriptor/invalid/descriptor.missing_rights.invalid.json
@@ -1,0 +1,19 @@
+{
+  "version": "v1",
+  "kind": "SourceDescriptor",
+  "identity": {
+    "title": "Kansas Mesonet"
+  },
+  "access": {
+    "mode": "page_scrape"
+  },
+  "support": {
+    "temporal": {}
+  },
+  "expected_invalid_reasons": [
+    "identity.source_id missing",
+    "rights_and_sensitivity missing",
+    "access mode normalizes page scraping",
+    "temporal basis missing"
+  ]
+}

--- a/tests/fixtures/source/kansas_mesonet_source_descriptor/valid/descriptor.public_safe.valid.json
+++ b/tests/fixtures/source/kansas_mesonet_source_descriptor/valid/descriptor.public_safe.valid.json
@@ -1,0 +1,51 @@
+{
+  "version": "v1",
+  "kind": "SourceDescriptor",
+  "identity": {
+    "source_id": "kansas_mesonet",
+    "title": "Kansas Mesonet",
+    "provider": "Kansas Mesonet / Kansas State University"
+  },
+  "role_and_scope": {
+    "source_role": "direct_observation_measurement",
+    "primary_lane": "hydrology",
+    "publication_intent": "station_context"
+  },
+  "access": {
+    "mode": "public_http_csv",
+    "auth_model": "none_documented_for_referenced_public_pages",
+    "preferred_surfaces": [
+      "https://mesonet.k-state.edu/rest/url-builder/",
+      "https://mesonet.k-state.edu/rest/stationnames/",
+      "https://mesonet.k-state.edu/rest/stationactive/",
+      "https://mesonet.k-state.edu/rest/mostrecent"
+    ]
+  },
+  "rights_and_sensitivity": {
+    "public_use_with_citation": true,
+    "redistribution_posture": "public_data_with_source_citation",
+    "policy_label_default": "public",
+    "automation_constraints": [
+      "written_consent_required_for_automated_page_scraping_or_data_ingesting"
+    ]
+  },
+  "support": {
+    "temporal": {
+      "documented_intervals": [
+        "5min",
+        "hour",
+        "day"
+      ]
+    },
+    "soil_moisture_depths_cm": [
+      5,
+      10,
+      20,
+      50
+    ],
+    "quantity_kinds": [
+      "VWC",
+      "percent_saturation"
+    ]
+  }
+}

--- a/tests/fixtures/source/maplibre_source_meta/README.md
+++ b/tests/fixtures/source/maplibre_source_meta/README.md
@@ -175,11 +175,18 @@ Content that belongs here should stay **small**, **explicit**, deterministic, an
 
 ### Current safe claim
 
-Without direct active-branch inspection, this README claims no child inventory beyond the intended target file.
+This README now reflects direct active-branch inspection.
 
 ```text
 tests/fixtures/source/maplibre_source_meta/
-└── README.md
+├── README.md
+├── expected/
+│   ├── decision.allow.json
+│   └── decision.deny.json
+├── invalid/
+│   └── source.missing_type.invalid.json
+└── valid/
+    └── source.vector_tilejson_min.valid.json
 ```
 
 <details>

--- a/tests/fixtures/source/maplibre_source_meta/expected/decision.allow.json
+++ b/tests/fixtures/source/maplibre_source_meta/expected/decision.allow.json
@@ -1,0 +1,9 @@
+{
+  "expected_outcome": "ALLOW",
+  "fixture": "source.vector_tilejson_min.valid.json",
+  "reason_codes": [
+    "source_type_present",
+    "source_layer_boundary_explicit",
+    "adapter_disclosure_explicit"
+  ]
+}

--- a/tests/fixtures/source/maplibre_source_meta/expected/decision.deny.json
+++ b/tests/fixtures/source/maplibre_source_meta/expected/decision.deny.json
@@ -1,0 +1,7 @@
+{
+  "expected_outcome": "DENY",
+  "fixture": "source.missing_type.invalid.json",
+  "reason_codes": [
+    "source_type_missing"
+  ]
+}

--- a/tests/fixtures/source/maplibre_source_meta/invalid/source.missing_type.invalid.json
+++ b/tests/fixtures/source/maplibre_source_meta/invalid/source.missing_type.invalid.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "kind": "SourceDescriptor",
+  "identity": {
+    "source_id": "maplibre_invalid_missing_type",
+    "title": "MapLibre Source Missing Type"
+  },
+  "maplibre_source": {
+    "tiles": [
+      "https://example.org/tiles/{z}/{x}/{y}.pbf"
+    ]
+  },
+  "expected_invalid_reasons": [
+    "maplibre_source.type missing"
+  ]
+}

--- a/tests/fixtures/source/maplibre_source_meta/valid/source.vector_tilejson_min.valid.json
+++ b/tests/fixtures/source/maplibre_source_meta/valid/source.vector_tilejson_min.valid.json
@@ -1,0 +1,30 @@
+{
+  "version": "v1",
+  "kind": "SourceDescriptor",
+  "identity": {
+    "source_id": "maplibre_ecology_vector_source",
+    "title": "MapLibre Ecology Vector Source",
+    "provider": "KFM Fixture Provider"
+  },
+  "maplibre_source": {
+    "type": "vector",
+    "tiles": [
+      "https://example.org/tiles/ecology/{z}/{x}/{y}.pbf"
+    ],
+    "minzoom": 0,
+    "maxzoom": 14,
+    "bounds": [
+      -102.051744,
+      36.993016,
+      -94.588413,
+      40.003166
+    ]
+  },
+  "source_layer_boundary": {
+    "renders_only_when_layer_references_source": true
+  },
+  "adapter_disclosure": {
+    "adapter_required": false,
+    "delivery_mode": "tilejson"
+  }
+}

--- a/tests/fixtures/source/source_descriptor/README.md
+++ b/tests/fixtures/source/source_descriptor/README.md
@@ -1,0 +1,11 @@
+# Generic SourceDescriptor Fixtures
+
+This lane contains small, reviewable `SourceDescriptor` fixtures for generic source-admission behavior.
+
+## Layout
+
+- `valid/`: positive fixtures that should pass source-admission checks.
+- `invalid/`: negative fixtures named by failure reason.
+- `expected/`: compact expected decision fragments consumed by tests or validators.
+
+These fixtures are intentionally tiny and public-safe; they are not source registry, receipt, proof, or release artifacts.

--- a/tests/fixtures/source/source_descriptor/expected/decision.allow.json
+++ b/tests/fixtures/source/source_descriptor/expected/decision.allow.json
@@ -1,0 +1,9 @@
+{
+  "expected_outcome": "ALLOW",
+  "fixture": "descriptor.minimal_public_safe.valid.json",
+  "reasons": [
+    "source identity present",
+    "access mode documented",
+    "rights posture present"
+  ]
+}

--- a/tests/fixtures/source/source_descriptor/expected/decision.deny.json
+++ b/tests/fixtures/source/source_descriptor/expected/decision.deny.json
@@ -1,0 +1,10 @@
+{
+  "expected_outcome": "DENY",
+  "fixture": "descriptor.missing_source_id.invalid.json",
+  "reasons": [
+    "missing source id",
+    "missing rights posture",
+    "undocumented acquisition mode",
+    "missing temporal basis"
+  ]
+}

--- a/tests/fixtures/source/source_descriptor/invalid/descriptor.missing_source_id.invalid.json
+++ b/tests/fixtures/source/source_descriptor/invalid/descriptor.missing_source_id.invalid.json
@@ -1,0 +1,20 @@
+{
+  "version": "v1",
+  "kind": "SourceDescriptor",
+  "identity": {
+    "title": "Example Source Without Stable ID",
+    "provider": "Example Provider"
+  },
+  "access": {
+    "mode": "undocumented_scrape"
+  },
+  "support": {
+    "temporal": {}
+  },
+  "expected_invalid_reasons": [
+    "identity.source_id missing",
+    "rights_and_sensitivity missing",
+    "undocumented access mode",
+    "temporal basis missing"
+  ]
+}

--- a/tests/fixtures/source/source_descriptor/valid/descriptor.minimal_public_safe.valid.json
+++ b/tests/fixtures/source/source_descriptor/valid/descriptor.minimal_public_safe.valid.json
@@ -1,0 +1,47 @@
+{
+  "version": "v1",
+  "kind": "SourceDescriptor",
+  "identity": {
+    "source_id": "example_public_source",
+    "title": "Example Public Source",
+    "provider": "Example Provider"
+  },
+  "role_and_scope": {
+    "source_role": "direct_observation_measurement",
+    "primary_lane": "reference",
+    "publication_intent": "fixture_only"
+  },
+  "access": {
+    "mode": "documented_public_http",
+    "auth_model": "none_documented",
+    "preferred_surfaces": [
+      "https://example.org/data"
+    ]
+  },
+  "rights_and_sensitivity": {
+    "public_use_with_citation": true,
+    "redistribution_posture": "public_metadata_only",
+    "sensitivity_posture": "public_safe_fixture_only"
+  },
+  "support": {
+    "temporal": {
+      "basis": "observation_time",
+      "documented_intervals": [
+        "daily"
+      ]
+    },
+    "spatial": {
+      "crs": "EPSG:4326",
+      "precision_served": "generalized_fixture"
+    }
+  },
+  "validation": {
+    "required_checks": [
+      "source_identity_present",
+      "source_role_present",
+      "documented_access_mode",
+      "rights_posture_present",
+      "temporal_support_explicit"
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide small, reviewable source-admission fixtures to support tests for `SourceDescriptor`, Kansas Mesonet, and MapLibre source metadata.
- Ensure the repo documentation accurately reflects the active-branch fixture inventory so validators and reviewers can locate examples.

### Description
- Added generic `SourceDescriptor` fixtures under `tests/fixtures/source/source_descriptor/{valid,invalid,expected}` including a minimal valid descriptor and a named invalid case plus expected decisions.
- Added Kansas Mesonet source-descriptor fixtures under `tests/fixtures/source/kansas_mesonet_source_descriptor/{valid,invalid,expected}` with a public-safe descriptor, an invalid descriptor, and expected `run_receipt` fragments.
- Added MapLibre source-metadata fixtures under `tests/fixtures/source/maplibre_source_meta/{valid,invalid,expected}` with a minimal vector TileJSON example, a missing-type invalid fixture, and expected allow/deny fragments.
- Updated `tests/fixtures/source/README.md`, `tests/fixtures/source/kansas_mesonet_source_descriptor/README.md`, and `tests/fixtures/source/maplibre_source_meta/README.md` directory-tree sections to reflect the committed fixture files.

### Testing
- Parsed all JSON files under `tests/fixtures/source/**/*.json` successfully using a small Python check (validated 12 JSON files).
- Ran `pytest -q tests/ci/test_validate_renderer_fixtures.py` and received `5 passed`.
- All referenced automated validation checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f474446c832a9cd84e71abea3c78)