### PR TITLE
Complete release fixtures and normalize invalid publish-receipt JSON

### DIFF
--- a/tests/fixtures/release/invalid/README.md
+++ b/tests/fixtures/release/invalid/README.md
@@ -1,1 +1,13 @@
+# Invalid release fixtures
 
+These files intentionally violate required release fields so validators and tests can
+assert specific failure modes.
+
+## Files
+
+- `missing_provenance_ref.release-manifest.json` — artifact omits required
+  `provenance_ref`.
+- `unresolved_artifact.release-manifest.json` — artifact points to a non-existent local
+  publication path.
+- `missing_closure_status.publish-receipt.json` — publish receipt plan omits
+  `closure_status`.

--- a/tests/fixtures/release/invalid/missing_closure_status.publish-receipt.json
+++ b/tests/fixtures/release/invalid/missing_closure_status.publish-receipt.json
@@ -11,11 +11,7 @@
     "review_state": "reviewed",
     "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "artifact_count": 1,
-
-    /* intentionally missing:
-       "closure_status": "PUBLISHABLE"
-       → MUST FAIL schema + validator
-    */
+    "fixture_note": "intentionally missing closure_status to force schema/validator failure",
 
     "artifacts": [
       {

--- a/tests/fixtures/release/invalid/missing_provenance_ref.release-manifest.json
+++ b/tests/fixtures/release/invalid/missing_provenance_ref.release-manifest.json
@@ -1,1 +1,22 @@
-
+{
+  "manifest_id": "kfm://release-manifest/missing-provenance-ref-fixture",
+  "release_id": "kfm://release/missing-provenance-ref-fixture",
+  "created_at": "2026-04-27T00:00:00Z",
+  "policy_label": "public",
+  "review_state": "reviewed",
+  "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "artifacts": [
+    {
+      "artifact_ref": "https://example.invalid/artifact.ext",
+      "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "evidence_ref": "kfm://evidence/missing-provenance-ref-fixture",
+      "stac_ref": "kfm://catalog/stac/missing-provenance-ref-fixture",
+      "dcat_ref": "kfm://catalog/dcat/missing-provenance-ref-fixture",
+      "attestation_ref": "https://example.invalid/artifact.bundle.json",
+      "run_receipt_ref": "kfm://receipt/run/missing-provenance-ref-fixture",
+      "policy_label": "public",
+      "review_state": "reviewed",
+      "sensitivity": "public"
+    }
+  ]
+}

--- a/tests/fixtures/release/valid/README.md
+++ b/tests/fixtures/release/valid/README.md
@@ -1,1 +1,11 @@
+# Valid release fixtures
 
+These files are minimal, deterministic examples that should pass structural checks for
+release-manifest and publish-receipt payloads used in tests.
+
+## Files
+
+- `minimal.release-manifest.json` — smallest manifest-like object with one artifact and
+  release linkage fields.
+- `minimal.publish-receipt.json` — matching publish receipt with `closure_status` and one
+  artifact summary.


### PR DESCRIPTION
### Motivation
- Provide small, deterministic release fixtures for tests by finishing README metadata and adding a missing invalid manifest case under `tests/fixtures/release`.
- Ensure intentionally-invalid fixtures remain parseable by tooling so validators and test harnesses can load them without syntactic errors.

### Description
- Added `tests/fixtures/release/valid/README.md` documenting the valid fixture set and expected files.
- Added `tests/fixtures/release/invalid/README.md` documenting invalid fixture cases and their failure reasons.
- Added `tests/fixtures/release/invalid/missing_provenance_ref.release-manifest.json` which omits the artifact `provenance_ref` to represent that failure mode.
- Normalized `tests/fixtures/release/invalid/missing_closure_status.publish-receipt.json` by replacing an in-source comment with a `fixture_note` key so the file stays valid JSON while still omitting the required `closure_status` field.

### Testing
- Parsed every JSON fixture under `tests/fixtures/release/**/*.json` using `python` with `json.loads` to verify syntactic validity, and the parser run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f6ec8f24832aaa4d3335c520ee73)