### PR TITLE
Build out tests/policy runtime parity fixtures and checks

### DIFF
--- a/tests/policy/README.md
+++ b/tests/policy/README.md
@@ -34,7 +34,7 @@ Repo-facing policy-behavior verification family for KFM deny-by-default decision
 > **Status:** experimental  
 > **Owners:** `@bartytime4life`  
 > **Path:** `tests/policy/README.md`  
-> **Repo fit:** parent policy-verification family inside [`../README.md`](../README.md); local child lane currently indexed at [`./genealogy/README.md`](./genealogy/README.md); adjacent to policy law in [`../../policy/README.md`](../../policy/README.md), shared contracts in [`../../contracts/README.md`](../../contracts/README.md), schema-boundary guidance in [`../../schemas/README.md`](../../schemas/README.md), and workflow guardrails in [`../../.github/workflows/README.md`](../../.github/workflows/README.md).  
+> **Repo fit:** parent policy-verification family inside [`../README.md`](../README.md); local child lanes currently indexed at [`./genealogy/README.md`](./genealogy/README.md) and [`./runtime_parity/README.md`](./runtime_parity/README.md); adjacent to policy law in [`../../policy/README.md`](../../policy/README.md), shared contracts in [`../../contracts/README.md`](../../contracts/README.md), schema-boundary guidance in [`../../schemas/README.md`](../../schemas/README.md), and workflow guardrails in [`../../.github/workflows/README.md`](../../.github/workflows/README.md).  
 > **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Accepted inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Current verified snapshot](#current-verified-snapshot) · [Directory tree](#directory-tree) · [Quickstart](#quickstart) · [Usage](#usage) · [Diagram](#diagram) · [Operating tables](#operating-tables) · [Task list](#task-list--definition-of-done) · [FAQ](#faq) · [Appendix](#appendix)
 
 > [!NOTE]
@@ -73,7 +73,8 @@ This is narrower than all tests and broader than local bundle assertions. It sho
 | Direction | Surface | Why it matters |
 |---|---|---|
 | Parent | [`../README.md`](../README.md) | Defines the broader governed verification map for `tests/`. |
-| Child | [`./genealogy/README.md`](./genealogy/README.md) | Current policy-behavior child lane for consent, living-person, DNA, provenance, and publication-control negative tests. |
+| Child | [`./genealogy/README.md`](./genealogy/README.md) | Policy-behavior child lane for consent, living-person, DNA, provenance, and publication-control negative tests. |
+| Child | [`./runtime_parity/README.md`](./runtime_parity/README.md) | Runtime-policy parity leaf for finite outward outcomes and reason/obligation visibility checks. |
 | Policy law | [`../../policy/README.md`](../../policy/README.md) | Owns policy bundles, fixtures, runtime-policy notes, and checked-in policy data. |
 | Contracts | [`../../contracts/README.md`](../../contracts/README.md) | Owns shared contract meaning that policy tests should consume rather than fork. |
 | Schema boundary | [`../../schemas/README.md`](../../schemas/README.md) | Keeps schema-home ambiguity explicit and prevents test fixtures from becoming shadow schemas. |
@@ -171,7 +172,9 @@ The strongest safe current-branch claim is intentionally bounded.
 tests/
 └── policy/
     ├── README.md
-    └── genealogy/
+    ├── genealogy/
+    │   └── README.md
+    └── runtime_parity/
         └── README.md
 ```
 
@@ -183,12 +186,15 @@ tests/
     ├── README.md
     ├── genealogy/
     │   ├── README.md
-    │   ├── runtime_parity.md
     │   ├── release_parity.md
     │   ├── correction_parity.md
     │   └── fixtures/              # only if repo-facing verification truly needs local copies
-    ├── runtime/
-    │   └── README.md              # optional future cross-domain runtime policy parity
+    ├── runtime_parity/
+    │   ├── README.md
+    │   ├── fixtures/
+    │   ├── expected/
+    │   ├── cases/
+    │   └── test_runtime_parity.py
     ├── release/
     │   └── README.md              # optional future promotion/publication policy parity
     └── correction/

--- a/tests/policy/runtime_parity/cases/README.md
+++ b/tests/policy/runtime_parity/cases/README.md
@@ -1,0 +1,16 @@
+# Runtime parity case index
+
+This directory documents the executable case set used by `test_runtime_parity.py`.
+
+## Case set
+
+- `answer_public_safe`
+- `abstain_missing_evidence`
+- `deny_unresolved_rights`
+- `error_schema_fault`
+
+Each case has:
+
+1. A policy-facing fixture in `../fixtures/*.input.json`.
+2. An expected runtime envelope fragment in `../expected/*.runtime_response.json`.
+3. Assertions in `../test_runtime_parity.py` that enforce finite outcomes and reason/obligation parity.

--- a/tests/policy/runtime_parity/expected/abstain_missing_evidence.runtime_response.json
+++ b/tests/policy/runtime_parity/expected/abstain_missing_evidence.runtime_response.json
@@ -1,0 +1,11 @@
+{
+  "kind": "RuntimeResponseEnvelope",
+  "outcome": "ABSTAIN",
+  "reason_codes": [
+    "EVIDENCE_NOT_RENDERABLE"
+  ],
+  "obligation_codes": [
+    "REQUIRE_REVIEW"
+  ],
+  "audit_ref": "audit:runtime_parity:abstain_missing_evidence"
+}

--- a/tests/policy/runtime_parity/expected/answer_public_safe.runtime_response.json
+++ b/tests/policy/runtime_parity/expected/answer_public_safe.runtime_response.json
@@ -1,0 +1,12 @@
+{
+  "kind": "RuntimeResponseEnvelope",
+  "outcome": "ANSWER",
+  "reason_codes": [
+    "ALLOWED_PUBLIC_EVIDENCE"
+  ],
+  "obligation_codes": [
+    "REQUIRE_CITATION",
+    "RECORD_AUDIT"
+  ],
+  "audit_ref": "audit:runtime_parity:answer_public_safe"
+}

--- a/tests/policy/runtime_parity/expected/deny_unresolved_rights.runtime_response.json
+++ b/tests/policy/runtime_parity/expected/deny_unresolved_rights.runtime_response.json
@@ -1,0 +1,12 @@
+{
+  "kind": "RuntimeResponseEnvelope",
+  "outcome": "DENY",
+  "reason_codes": [
+    "RIGHTS_UNRESOLVED"
+  ],
+  "obligation_codes": [
+    "RESTRICT_TO_ALLOWED_AUDIENCE",
+    "RECORD_AUDIT"
+  ],
+  "audit_ref": "audit:runtime_parity:deny_unresolved_rights"
+}

--- a/tests/policy/runtime_parity/expected/error_schema_fault.runtime_response.json
+++ b/tests/policy/runtime_parity/expected/error_schema_fault.runtime_response.json
@@ -1,0 +1,11 @@
+{
+  "kind": "RuntimeResponseEnvelope",
+  "outcome": "ERROR",
+  "reason_codes": [
+    "RUNTIME_SCHEMA_VALIDATION_FAILED"
+  ],
+  "obligation_codes": [
+    "RECORD_AUDIT"
+  ],
+  "audit_ref": "audit:runtime_parity:error_schema_fault"
+}

--- a/tests/policy/runtime_parity/fixtures/abstain_missing_evidence.input.json
+++ b/tests/policy/runtime_parity/fixtures/abstain_missing_evidence.input.json
@@ -1,0 +1,17 @@
+{
+  "case_id": "abstain_missing_evidence",
+  "policy_input_ref": "tests/policy/runtime_parity/fixtures/abstain_missing_evidence.input.json",
+  "expected_policy_result": "abstain",
+  "expected_runtime_outcome": "ABSTAIN",
+  "reason_codes": [
+    "EVIDENCE_NOT_RENDERABLE"
+  ],
+  "obligation_codes": [
+    "REQUIRE_REVIEW"
+  ],
+  "evidence_state": "missing",
+  "contract_refs": [
+    "schemas/contracts/v1/runtime/runtime_response_envelope.schema.json"
+  ],
+  "notes": "Insufficient evidence should abstain instead of inventing confidence."
+}

--- a/tests/policy/runtime_parity/fixtures/answer_public_safe.input.json
+++ b/tests/policy/runtime_parity/fixtures/answer_public_safe.input.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "answer_public_safe",
+  "policy_input_ref": "tests/policy/runtime_parity/fixtures/answer_public_safe.input.json",
+  "expected_policy_result": "allow",
+  "expected_runtime_outcome": "ANSWER",
+  "reason_codes": [
+    "ALLOWED_PUBLIC_EVIDENCE"
+  ],
+  "obligation_codes": [
+    "REQUIRE_CITATION",
+    "RECORD_AUDIT"
+  ],
+  "evidence_state": "resolved",
+  "contract_refs": [
+    "schemas/contracts/v1/runtime/runtime_response_envelope.schema.json"
+  ],
+  "notes": "Happy-path parity case where policy allow remains a governed answer."
+}

--- a/tests/policy/runtime_parity/fixtures/deny_unresolved_rights.input.json
+++ b/tests/policy/runtime_parity/fixtures/deny_unresolved_rights.input.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "deny_unresolved_rights",
+  "policy_input_ref": "tests/policy/runtime_parity/fixtures/deny_unresolved_rights.input.json",
+  "expected_policy_result": "deny",
+  "expected_runtime_outcome": "DENY",
+  "reason_codes": [
+    "RIGHTS_UNRESOLVED"
+  ],
+  "obligation_codes": [
+    "RESTRICT_TO_ALLOWED_AUDIENCE",
+    "RECORD_AUDIT"
+  ],
+  "evidence_state": "resolved",
+  "contract_refs": [
+    "schemas/contracts/v1/runtime/runtime_response_envelope.schema.json"
+  ],
+  "notes": "Rights and redistribution uncertainty must remain explicit denial."
+}

--- a/tests/policy/runtime_parity/fixtures/error_schema_fault.input.json
+++ b/tests/policy/runtime_parity/fixtures/error_schema_fault.input.json
@@ -1,0 +1,17 @@
+{
+  "case_id": "error_schema_fault",
+  "policy_input_ref": "tests/policy/runtime_parity/fixtures/error_schema_fault.input.json",
+  "expected_policy_result": "error",
+  "expected_runtime_outcome": "ERROR",
+  "reason_codes": [
+    "RUNTIME_SCHEMA_VALIDATION_FAILED"
+  ],
+  "obligation_codes": [
+    "RECORD_AUDIT"
+  ],
+  "evidence_state": "unknown",
+  "contract_refs": [
+    "schemas/contracts/v1/runtime/runtime_response_envelope.schema.json"
+  ],
+  "notes": "Technical validation failure must surface as runtime error, not policy deny."
+}

--- a/tests/policy/runtime_parity/test_runtime_parity.py
+++ b/tests/policy/runtime_parity/test_runtime_parity.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+RUNTIME_PARITY_DIR = Path(__file__).resolve().parent
+FIXTURES_DIR = RUNTIME_PARITY_DIR / "fixtures"
+EXPECTED_DIR = RUNTIME_PARITY_DIR / "expected"
+
+FINITE_OUTCOMES = {"ANSWER", "ABSTAIN", "DENY", "ERROR"}
+ALLOWED_EVIDENCE_STATES = {"resolved", "missing", "unknown", "stale", "restricted"}
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _case_ids() -> list[str]:
+    return sorted(path.name.replace(".input.json", "") for path in FIXTURES_DIR.glob("*.input.json"))
+
+
+@pytest.mark.parametrize("case_id", _case_ids())
+def test_runtime_parity_case_shapes(case_id: str) -> None:
+    fixture = _load_json(FIXTURES_DIR / f"{case_id}.input.json")
+    expected = _load_json(EXPECTED_DIR / f"{case_id}.runtime_response.json")
+
+    assert fixture["case_id"] == case_id
+    assert fixture["expected_runtime_outcome"] in FINITE_OUTCOMES
+    assert fixture["evidence_state"] in ALLOWED_EVIDENCE_STATES
+    assert "schemas/contracts/v1/runtime/runtime_response_envelope.schema.json" in fixture["contract_refs"]
+
+    assert expected["kind"] == "RuntimeResponseEnvelope"
+    assert expected["outcome"] == fixture["expected_runtime_outcome"]
+    assert set(fixture["reason_codes"]).issubset(set(expected["reason_codes"]))
+    assert set(fixture["obligation_codes"]).issubset(set(expected["obligation_codes"]))
+    assert expected["audit_ref"].startswith(f"audit:runtime_parity:{case_id}")
+
+
+def test_runtime_parity_fixture_expected_file_sets_match() -> None:
+    fixture_case_ids = {path.name.replace(".input.json", "") for path in FIXTURES_DIR.glob("*.input.json")}
+    expected_case_ids = {path.name.replace(".runtime_response.json", "") for path in EXPECTED_DIR.glob("*.runtime_response.json")}
+
+    assert fixture_case_ids == expected_case_ids


### PR DESCRIPTION
### Motivation
- Provide an executable, reviewable test lane that proves policy decision semantics survive translation into outward runtime envelopes such as `RuntimeResponseEnvelope`.
- Supply a minimal, offline-friendly case set that covers the finite runtime outcomes `ANSWER`/`ABSTAIN`/`DENY`/`ERROR` and preserves reason/obligation visibility.

### Description
- Added `tests/policy/runtime_parity/test_runtime_parity.py` which enforces finite outcomes, verifies `reason_codes`/`obligation_codes` parity between policy fixtures and expected runtime fragments, and checks an audit reference pattern. 
- Added four policy-facing fixtures under `tests/policy/runtime_parity/fixtures/` for `answer_public_safe`, `abstain_missing_evidence`, `deny_unresolved_rights`, and `error_schema_fault` containing metadata used by the tests. 
- Added matching expected runtime envelope fragments under `tests/policy/runtime_parity/expected/` so outward envelopes are diffable and machine-checkable. 
- Added a case index `tests/policy/runtime_parity/cases/README.md` and updated `tests/policy/README.md` to index the new `runtime_parity` child lane and reflect the executable directory shape. 

### Testing
- Ran the new test suite with `pytest -q tests/policy/runtime_parity` and observed an initial run with failing assertions due to an absolute-path vs relative-path expectation, corrected the test to use the repository-relative contract ref, and re-ran the suite. 
- Final automated result: `pytest -q tests/policy/runtime_parity` passed with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0fb8b77ac832abd5265b453a2e9e3)