### PR TITLE
Fix Python import path so unit policy tests run

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/packages/__init__.py
+++ b/packages/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package namespace for repository Python helpers.
+
+This marker file allows imports like ``packages.policy`` in local tests.
+"""
+


### PR DESCRIPTION
### Motivation
- Make unit tests that import the repository-local `packages` namespace import-stable so pytest can collect and run them regardless of invocation style.

### Description
- Add a top-level `conftest.py` that prepends the repository root to `sys.path` during pytest collection so local modules are discoverable.
- Add `packages/__init__.py` as a marker file to declare the `packages` namespace as a Python package so imports like `from packages.policy import ...` succeed.

### Testing
- Ran `pytest -q tests/unit/test_policy_package.py`, `python -m pytest -q tests/unit/test_policy_package.py`, and `pytest -q tests/unit`, and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0fe9d1bfc832aab0c1a2cef4b6d72)