### PR TITLE
Add initial accessibility tests and web-shell a11y semantics

### DIFF
--- a/apps/web/src/evidence/evidence-drawer.js
+++ b/apps/web/src/evidence/evidence-drawer.js
@@ -1,9 +1,10 @@
 export function createEvidenceDrawer() {
   const panel = document.createElement("section");
   panel.className = "panel";
+  panel.setAttribute("aria-labelledby", "evidence-drawer-heading");
   panel.innerHTML = `
-    <h2>Evidence Drawer</h2>
-    <p>Status: <strong>Support available</strong></p>
+    <h2 id="evidence-drawer-heading">Evidence Drawer</h2>
+    <p id="evidence-drawer-status" role="status" aria-live="polite">Status: <strong>Support available</strong></p>
     <ul>
       <li>Source role: state agency</li>
       <li>EvidenceBundle: eb://placeholder/1</li>

--- a/apps/web/src/focus/focus-panel.js
+++ b/apps/web/src/focus/focus-panel.js
@@ -1,10 +1,11 @@
 export function createFocusPanel() {
   const panel = document.createElement("section");
   panel.className = "panel";
+  panel.setAttribute("aria-labelledby", "focus-panel-heading");
   panel.innerHTML = `
-    <h2>Focus Mode</h2>
+    <h2 id="focus-panel-heading">Focus Mode</h2>
     <p>Question runtime is delegated to the governed API.</p>
-    <div class="runtime-outcome">Latest outcome: <strong>ABSTAIN</strong> (insufficient released support).</div>
+    <div class="runtime-outcome" role="status" aria-live="polite">Latest outcome: <strong>ABSTAIN</strong> (insufficient released support).</div>
   `;
   return panel;
 }

--- a/apps/web/src/map/map-pane.js
+++ b/apps/web/src/map/map-pane.js
@@ -3,7 +3,7 @@ export function createMapPane() {
   section.className = "map-pane";
   section.innerHTML = `
     <h2>Map Canvas</h2>
-    <div class="map-surface">MapLibre adapter placeholder</div>
+    <div class="map-surface" role="img" aria-label="Map preview placeholder for released layers">MapLibre adapter placeholder</div>
     <p class="note">Render released layers only; no direct RAW/WORK/QUARANTINE access.</p>
   `;
   return section;

--- a/apps/web/src/shell/shell-frame.js
+++ b/apps/web/src/shell/shell-frame.js
@@ -7,12 +7,13 @@ export function createShellFrame() {
   shell.className = "shell-frame";
 
   shell.innerHTML = `
+    <a class="skip-link" href="#workspace-start">Skip to workspace</a>
     <header class="top-bar">
       <h1>KFM Governed Web Shell</h1>
       <p class="subtitle">Map-first · Evidence-first · Cite-or-abstain</p>
     </header>
-    <section class="workspace">
-      <aside class="left-rail">
+    <section class="workspace" id="workspace-start" tabindex="-1" aria-label="Map and trust workspace">
+      <aside class="left-rail" aria-label="Primary">
         <h2>Layers</h2>
         <ul>
           <li>Hydrology (released)</li>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -61,3 +61,30 @@ body {
   font-size: 0.9rem;
   color: #334155;
 }
+
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0 0 8px 8px;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  z-index: 1000;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/tests/accessibility/fixtures.accessibility-checklist.md
+++ b/tests/accessibility/fixtures.accessibility-checklist.md
@@ -1,0 +1,11 @@
+# Accessibility Checklist Fixture
+
+This checklist is a lightweight, review-facing fixture used by `tests/accessibility/test_web_shell_accessibility.py`.
+
+## Required trust-surface accessibility markers
+
+- Skip link to the main workspace start target.
+- Landmark labels for primary and workspace regions.
+- Evidence Drawer and Focus Mode status regions announced politely.
+- Non-visual descriptor for the map placeholder surface.
+- Reduced-motion style hook present in app styles.

--- a/tests/accessibility/test_web_shell_accessibility.py
+++ b/tests/accessibility/test_web_shell_accessibility.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_shell_frame_exposes_landmarks_and_skip_link() -> None:
+    shell_frame = _read("apps/web/src/shell/shell-frame.js")
+
+    assert 'href="#workspace-start"' in shell_frame
+    assert 'aria-label="Primary"' in shell_frame
+    assert 'aria-label="Map and trust workspace"' in shell_frame
+
+
+def test_evidence_and_focus_panels_expose_announced_runtime_state() -> None:
+    evidence_drawer = _read("apps/web/src/evidence/evidence-drawer.js")
+    focus_panel = _read("apps/web/src/focus/focus-panel.js")
+
+    assert 'setAttribute("aria-labelledby", "evidence-drawer-heading")' in evidence_drawer
+    assert 'id="evidence-drawer-status" role="status" aria-live="polite"' in evidence_drawer
+
+    assert 'setAttribute("aria-labelledby", "focus-panel-heading")' in focus_panel
+    assert 'role="status" aria-live="polite"' in focus_panel
+
+
+def test_map_surface_has_non_visual_descriptor_and_reduced_motion_hook() -> None:
+    map_pane = _read("apps/web/src/map/map-pane.js")
+    styles = _read("apps/web/src/styles/app.css")
+
+    assert 'role="img"' in map_pane
+    assert 'aria-label="Map preview placeholder for released layers"' in map_pane
+    assert "@media (prefers-reduced-motion: reduce)" in styles


### PR DESCRIPTION
### Motivation

- Provide an executable baseline for accessibility checks that protect KFM's trust-visible shell surfaces (skip links, landmarks, live-region announcements, map descriptors, and reduced-motion hooks).

### Description

- Add `tests/accessibility/test_web_shell_accessibility.py` which validates skip-link/landmark wiring, live-region trust-state announcements, map descriptor, and `prefers-reduced-motion` CSS presence.
- Add a lightweight fixture `tests/accessibility/fixtures.accessibility-checklist.md` documenting required trust-surface accessibility markers.
- Update the web shell UI modules to expose the accessibility semantics consumed by the tests: add a skip link and `id`/landmark on the workspace in `apps/web/src/shell/shell-frame.js`.
- Make Evidence Drawer and Focus Mode announce runtime state via `aria-labelledby` and polite live regions in `apps/web/src/evidence/evidence-drawer.js` and `apps/web/src/focus/focus-panel.js`, add non-visual map descriptor in `apps/web/src/map/map-pane.js`, and add skip-link styling plus a `prefers-reduced-motion` rule in `apps/web/src/styles/app.css`.

### Testing

- Ran `pytest -q tests/accessibility/test_web_shell_accessibility.py`, which ultimately passed (3 tests passed) after resolving an initial failure by wiring the live-region/label attributes.
- Ran `npm --prefix apps/web run check`, which completed successfully (emitted a non-fatal npm env-config warning but returned no error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f102a5548c832aab8a44d0b9a395db)