### PR TITLE
Add promotion_review_handoff golden and document current CI golden set

### DIFF
--- a/tests/ci/golden/README.md
+++ b/tests/ci/golden/README.md
@@ -151,6 +151,19 @@ tests/ci/golden/
 └── README.md
 ```
 
+### Current checked-in shape
+
+```text
+tests/ci/golden/
+├── README.md
+├── diff_policy_summary.md
+├── diff_summary.md
+├── promotion_bundle_summary.md
+├── promotion_review_handoff.md
+├── promotion_summary.md
+└── review_handoff.md
+```
+
 ### Stable growth shape
 
 The following structure is **PROPOSED** and should be created only as corresponding tests and helper contracts land.

--- a/tests/ci/golden/promotion_review_handoff.md
+++ b/tests/ci/golden/promotion_review_handoff.md
@@ -1,0 +1,7 @@
+# Promotion Review Handoff
+
+- Release: **release-2026-04-24**
+- Promotion state: **approved**
+- Bundle id: **bundle-001**
+- Diff totals: added=2, changed=1, removed=0
+- Diff policy decision: **allow**


### PR DESCRIPTION
### Motivation
- Provide a checked-in expected output for the `promotion_review_handoff` naming variant and keep the golden directory README accurate about what goldens are present.

### Description
- Added `tests/ci/golden/promotion_review_handoff.md` with the rendered promotion review handoff fragment and updated `tests/ci/golden/README.md` to include a "Current checked-in shape" tree that lists the active golden files.

### Testing
- Ran the end-to-end golden and build helper tests with `pytest -q tests/ci/test_end_to_end_review_handoff.py tests/ci/test_build_governed_artifacts.py tests/ci/test_end_to_end_diff_summary.py tests/ci/test_end_to_end_diff_policy_summary.py tests/ci/test_end_to_end_promotion_summary.py tests/ci/test_end_to_end_promotion_bundle_summary.py`, which completed successfully (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10603b480832aab3db13d5fc1a42e)