### PR TITLE
Add comprehensive CI fixture case-packs and fixture catalog test

### DIFF
--- a/tests/ci/fixtures/diff_policy/cases/allow.json
+++ b/tests/ci/fixtures/diff_policy/cases/allow.json
@@ -1,0 +1,1 @@
+{"decision":"allow","reasons":["no breaking drift"]}

--- a/tests/ci/fixtures/diff_policy/cases/deny.json
+++ b/tests/ci/fixtures/diff_policy/cases/deny.json
@@ -1,0 +1,1 @@
+{"decision":"deny","reasons":["breaking schema drift","missing approval"]}

--- a/tests/ci/fixtures/diff_policy/cases/review_required.json
+++ b/tests/ci/fixtures/diff_policy/cases/review_required.json
@@ -1,0 +1,1 @@
+{"decision":"review","reasons":["schema drift touches publication metadata"]}

--- a/tests/ci/fixtures/diff_summary/cases/blocking_like.json
+++ b/tests/ci/fixtures/diff_summary/cases/blocking_like.json
@@ -1,0 +1,1 @@
+{"added":2,"changed":7,"removed":5,"blocking":true}

--- a/tests/ci/fixtures/diff_summary/cases/changed.json
+++ b/tests/ci/fixtures/diff_summary/cases/changed.json
@@ -1,0 +1,1 @@
+{"added":3,"changed":4,"removed":1}

--- a/tests/ci/fixtures/diff_summary/cases/same.json
+++ b/tests/ci/fixtures/diff_summary/cases/same.json
@@ -1,0 +1,1 @@
+{"added":0,"changed":0,"removed":0}

--- a/tests/ci/fixtures/promotion_bundle/cases/minimal.json
+++ b/tests/ci/fixtures/promotion_bundle/cases/minimal.json
@@ -1,0 +1,1 @@
+{"bundle_id":"bundle-minimal","artifacts":[]}

--- a/tests/ci/fixtures/promotion_bundle/cases/release_candidate.json
+++ b/tests/ci/fixtures/promotion_bundle/cases/release_candidate.json
@@ -1,0 +1,1 @@
+{"bundle_id":"bundle-rc-2026-04-28","artifacts":["promotion.json","diff.json","diff_policy.json","attestation.json"]}

--- a/tests/ci/fixtures/promotion_summary/cases/approved.json
+++ b/tests/ci/fixtures/promotion_summary/cases/approved.json
@@ -1,0 +1,1 @@
+{"release_id":"release-2026-04-24","state":"approved"}

--- a/tests/ci/fixtures/promotion_summary/cases/denied.json
+++ b/tests/ci/fixtures/promotion_summary/cases/denied.json
@@ -1,0 +1,1 @@
+{"release_id":"release-2026-04-27","state":"denied"}

--- a/tests/ci/fixtures/promotion_summary/cases/pending_review.json
+++ b/tests/ci/fixtures/promotion_summary/cases/pending_review.json
@@ -1,0 +1,1 @@
+{"release_id":"release-2026-05-01","state":"pending_review"}

--- a/tests/ci/fixtures/review_handoff/cases/blocking/bundle.json
+++ b/tests/ci/fixtures/review_handoff/cases/blocking/bundle.json
@@ -1,0 +1,1 @@
+{"bundle_id":"bundle-block-003","artifacts":["artifact-a.json","artifact-z.json"]}

--- a/tests/ci/fixtures/review_handoff/cases/blocking/diff.json
+++ b/tests/ci/fixtures/review_handoff/cases/blocking/diff.json
@@ -1,0 +1,1 @@
+{"added":4,"changed":5,"removed":2}

--- a/tests/ci/fixtures/review_handoff/cases/blocking/diff_policy.json
+++ b/tests/ci/fixtures/review_handoff/cases/blocking/diff_policy.json
@@ -1,0 +1,1 @@
+{"decision":"deny","reasons":["breaking schema drift"]}

--- a/tests/ci/fixtures/review_handoff/cases/blocking/promotion.json
+++ b/tests/ci/fixtures/review_handoff/cases/blocking/promotion.json
@@ -1,0 +1,1 @@
+{"release_id":"release-2026-04-26","state":"blocked"}

--- a/tests/ci/fixtures/review_handoff/cases/promote/bundle.json
+++ b/tests/ci/fixtures/review_handoff/cases/promote/bundle.json
@@ -1,0 +1,1 @@
+{"bundle_id":"bundle-promote-001","artifacts":["artifact-a.json","artifact-b.json"]}

--- a/tests/ci/fixtures/review_handoff/cases/promote/diff.json
+++ b/tests/ci/fixtures/review_handoff/cases/promote/diff.json
@@ -1,0 +1,1 @@
+{"added":1,"changed":0,"removed":0}

--- a/tests/ci/fixtures/review_handoff/cases/promote/diff_policy.json
+++ b/tests/ci/fixtures/review_handoff/cases/promote/diff_policy.json
@@ -1,0 +1,1 @@
+{"decision":"allow","reasons":["no blocking drift"]}

--- a/tests/ci/fixtures/review_handoff/cases/promote/promotion.json
+++ b/tests/ci/fixtures/review_handoff/cases/promote/promotion.json
@@ -1,0 +1,1 @@
+{"release_id":"release-2026-04-24","state":"approved"}

--- a/tests/ci/fixtures/review_handoff/cases/review_required/bundle.json
+++ b/tests/ci/fixtures/review_handoff/cases/review_required/bundle.json
@@ -1,0 +1,1 @@
+{"bundle_id":"bundle-review-002","artifacts":["artifact-a.json","artifact-c.json"]}

--- a/tests/ci/fixtures/review_handoff/cases/review_required/diff.json
+++ b/tests/ci/fixtures/review_handoff/cases/review_required/diff.json
@@ -1,0 +1,1 @@
+{"added":0,"changed":2,"removed":0}

--- a/tests/ci/fixtures/review_handoff/cases/review_required/diff_policy.json
+++ b/tests/ci/fixtures/review_handoff/cases/review_required/diff_policy.json
@@ -1,0 +1,1 @@
+{"decision":"review","reasons":["security policy labels changed"]}

--- a/tests/ci/fixtures/review_handoff/cases/review_required/promotion.json
+++ b/tests/ci/fixtures/review_handoff/cases/review_required/promotion.json
@@ -1,0 +1,1 @@
+{"release_id":"release-2026-04-25","state":"pending_review"}

--- a/tests/ci/test_fixture_catalog.py
+++ b/tests/ci/test_fixture_catalog.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _run(*args: str) -> None:
+    subprocess.run(["python3", *args], check=True)
+
+
+def test_fixture_case_catalog_renders() -> None:
+    diff_cases = sorted(Path("tests/ci/fixtures/diff_summary/cases").glob("*.json"))
+    for case in diff_cases:
+        _run("tools/ci/render_diff_summary.py", "--input", str(case))
+
+    diff_policy_cases = sorted(Path("tests/ci/fixtures/diff_policy/cases").glob("*.json"))
+    for case in diff_policy_cases:
+        _run("tools/ci/render_bundle_diff_policy_summary.py", "--input", str(case))
+
+    promotion_cases = sorted(Path("tests/ci/fixtures/promotion_summary/cases").glob("*.json"))
+    for case in promotion_cases:
+        _run("tools/ci/render_promotion_summary.py", "--input", str(case))
+
+    bundle_cases = sorted(Path("tests/ci/fixtures/promotion_bundle/cases").glob("*.json"))
+    for case in bundle_cases:
+        _run("tools/ci/render_promotion_bundle_summary.py", "--input", str(case))
+
+    review_case_roots = sorted(Path("tests/ci/fixtures/review_handoff/cases").glob("*"))
+    for case_root in review_case_roots:
+        _run(
+            "tools/ci/render_promotion_review_handoff.py",
+            "--promotion",
+            str(case_root / "promotion.json"),
+            "--bundle",
+            str(case_root / "bundle.json"),
+            "--diff",
+            str(case_root / "diff.json"),
+            "--diff-policy",
+            str(case_root / "diff_policy.json"),
+        )


### PR DESCRIPTION
### Motivation
- Provide richer, deterministic input coverage for CI renderer tests so each renderer can be exercised with multiple realistic scenarios instead of a single baseline fixture. 
- Ensure fixture cases remain runnable and schema-valid by adding an automated catalog-based smoke test that exercises each fixture against its renderer.

### Description
- Added grouped case-packs under `tests/ci/fixtures/*/cases` for the renderers: diff_summary (`same`, `changed`, `blocking_like`), diff_policy (`allow`, `review_required`, `deny`), promotion_summary (`approved`, `pending_review`, `denied`), promotion_bundle (`minimal`, `release_candidate`), and review_handoff (three case dirs: `promote`, `review_required`, `blocking`) with the required JSON inputs. 
- Added `tests/ci/test_fixture_catalog.py` which iterates the new case-packs and invokes the corresponding renderer scripts to ensure every case renders without error. 
- Kept existing baseline fixtures and golden checks unchanged; the new files are additive and organized under `cases/` to avoid interfering with current end-to-end golden tests.

### Testing
- Ran the renderer fixture validator via `python3 tools/ci/validate_renderer_fixtures.py` which printed `validate_renderer_fixtures: all renderer fixtures satisfy schema contracts`.
- Executed the focused fixture catalog and end-to-end renderer tests via `pytest -q tests/ci/test_fixture_catalog.py tests/ci/test_validate_renderer_fixtures.py tests/ci/test_end_to_end_*.py` resulting in `11 passed` for that targeted run.
- Ran the full CI test suite for the `tests/ci` lane via `pytest -q tests/ci` which completed successfully with `106 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f106c9f340832aaca59f464d528280)