### PR TITLE
Build out contract fixture payloads under tests/contracts

### DIFF
--- a/tests/contracts/fixtures/evidence/README.md
+++ b/tests/contracts/fixtures/evidence/README.md
@@ -1,1 +1,15 @@
-y
+# `tests/contracts/fixtures/evidence/`
+
+Evidence-oriented contract fixtures for `tests/contracts/`.
+
+## Current fixtures
+
+- `kfm_geo_manifest.valid.json`
+  - Valid example for `EcologyLayerManifest` shape.
+  - Intended for schema/contract validation and fixture-driven contract tests.
+
+## Notes
+
+- Keep fixtures deterministic and small.
+- Name files by object family + polarity (`.valid` / `.invalid`) + reason when invalid.
+- This directory stores examples only; canonical schema authority remains under `schemas/contracts/`.

--- a/tests/contracts/fixtures/evidence/kfm_geo_manifest.valid.json
+++ b/tests/contracts/fixtures/evidence/kfm_geo_manifest.valid.json
@@ -1,5 +1,23 @@
 {
-  "fixture": "kfm_geo_manifest",
-  "variant": "valid",
-  "status": "skeletal"
+  "schema_version": "v1",
+  "object_type": "EcologyLayerManifest",
+  "layer_id": "kfm://layer/ecology/chase-county-tallgrass-v3",
+  "title": "Chase County Tallgrass Habitat Composite (v3)",
+  "knowledge_character": "observational",
+  "time_semantics": "snapshot",
+  "visibility": "public",
+  "generalization_rules": {
+    "exact_allowed": false,
+    "minimum_grid_m": 1000,
+    "withhold_sensitive": true
+  },
+  "source_refs": [
+    "kfm://source/kansas_flora/kanu_ipt",
+    "kfm://source/kansas_flora/gbif"
+  ],
+  "evidence_refs": [
+    "kfm://evidence/ecology/chase-county-tallgrass-v3/summary"
+  ],
+  "release_manifest_ref": "kfm://release-manifest/ecology/chase-county-tallgrass-v3",
+  "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 }

--- a/tests/contracts/fixtures/runtime/geospatial_review_action_request.promote.json
+++ b/tests/contracts/fixtures/runtime/geospatial_review_action_request.promote.json
@@ -1,5 +1,23 @@
 {
-  "fixture": "geospatial_review_action_request",
-  "operation": "promote",
-  "status": "skeletal"
+  "schema_version": "v1",
+  "object_type": "GeospatialReviewActionRequest",
+  "request_id": "kfm://request/review-action/geo-promote-2026-04-28-001",
+  "review": {
+    "candidate_id": "kfm://candidate/ecology-layer/chase-county-tallgrass-v3",
+    "action": "promote",
+    "reviewer_role": "steward",
+    "reason_code": "EVIDENCE_VERIFIED",
+    "notes": "Promote after evidence and policy checks passed.",
+    "submitted_at": "2026-04-28T12:00:00Z"
+  },
+  "expected": {
+    "target_state": "promoted",
+    "requires_receipt": true,
+    "requires_proof_pack": true
+  },
+  "meta": {
+    "surface": "tests/contracts/fixtures/runtime",
+    "fixture_name": "geospatial_review_action_request.promote",
+    "deterministic": true
+  }
 }

--- a/tests/contracts/fixtures/runtime/geospatial_review_action_response.expected_mismatch.json
+++ b/tests/contracts/fixtures/runtime/geospatial_review_action_response.expected_mismatch.json
@@ -1,6 +1,21 @@
 {
-  "fixture": "geospatial_review_action_response",
-  "operation": "promote",
-  "outcome": "expected_mismatch",
-  "status": "skeletal"
+  "schema_version": "v1",
+  "object_type": "GeospatialReviewActionResponse",
+  "request_id": "kfm://request/review-action/geo-promote-2026-04-28-001",
+  "ok": false,
+  "status": "expected_mismatch",
+  "errors": [
+    {
+      "code": "EXPECTED_STATE_MISMATCH",
+      "field": "expected.target_state",
+      "expected": "promoted",
+      "actual": "abstain",
+      "message": "Promotion target state does not match the runtime decision."
+    }
+  ],
+  "meta": {
+    "review_action": "promote",
+    "reviewer_role": "steward",
+    "completed_at": "2026-04-28T12:01:15Z"
+  }
 }

--- a/tests/contracts/fixtures/runtime/geospatial_review_action_response.promote.ok.json
+++ b/tests/contracts/fixtures/runtime/geospatial_review_action_response.promote.ok.json
@@ -1,6 +1,19 @@
 {
-  "fixture": "geospatial_review_action_response",
-  "operation": "promote",
-  "outcome": "ok",
-  "status": "skeletal"
+  "schema_version": "v1",
+  "object_type": "GeospatialReviewActionResponse",
+  "request_id": "kfm://request/review-action/geo-promote-2026-04-28-001",
+  "ok": true,
+  "status": "promoted",
+  "data": {
+    "candidate_id": "kfm://candidate/ecology-layer/chase-county-tallgrass-v3",
+    "promotion_receipt_ref": "kfm://receipt/promotion/chase-county-tallgrass-v3",
+    "proof_pack_ref": "kfm://proof-pack/chase-county-tallgrass-v3",
+    "release_manifest_ref": "kfm://release-manifest/ecology/chase-county-tallgrass-v3"
+  },
+  "meta": {
+    "review_action": "promote",
+    "reviewer_role": "steward",
+    "completed_at": "2026-04-28T12:01:15Z",
+    "latency_ms": 221
+  }
 }


### PR DESCRIPTION
### Motivation

- Replace skeletal placeholders in `tests/contracts/fixtures` with deterministic, reviewable examples to support manifest-driven contract validation.
- Provide concrete positive and negative runtime review-action payloads and a valid evidence manifest so tests can exercise realistic object shape and named failure states.

### Description

- Replaced the skeletal runtime request fixture with a deterministic promote request at `tests/contracts/fixtures/runtime/geospatial_review_action_request.promote.json` that includes `schema_version`, `object_type`, `request_id`, `review`, `expected`, and `meta` fields.
- Replaced the skeletal runtime response fixtures with a positive response at `tests/contracts/fixtures/runtime/geospatial_review_action_response.promote.ok.json` (includes `ok`, `data`, and `meta`) and a negative mismatch case at `tests/contracts/fixtures/runtime/geospatial_review_action_response.expected_mismatch.json` (includes `errors` array detailing mismatch information).
- Replaced the skeletal evidence fixture with a valid `EcologyLayerManifest` example at `tests/contracts/fixtures/evidence/kfm_geo_manifest.valid.json` including manifest metadata, `generalization_rules`, `source_refs`, `evidence_refs`, `release_manifest_ref`, and `spec_hash`.
- Replaced the placeholder `tests/contracts/fixtures/evidence/README.md` content with guidance on fixture purpose, naming, and usage.

### Testing

- Ran `python -m json.tool` against the updated JSON fixtures (`geospatial_review_action_request.promote.json`, `geospatial_review_action_response.promote.ok.json`, `geospatial_review_action_response.expected_mismatch.json`, and `kfm_geo_manifest.valid.json`) and all files parsed successfully.
- No additional automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f107bd72f4832ab1da9db7b47f97c2)