### PR TITLE
Finalize tests/crosswalk coverage and pytest integration marker setup

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: marks tests that require local integration dependencies (e.g., PostGIS/CLI tools)

--- a/tests/crosswalk/README.md
+++ b/tests/crosswalk/README.md
@@ -154,12 +154,14 @@ These do **not** belong in this leaf.
 
 ## Directory tree
 
-Current public tree for this leaf is intentionally small.
+Current tree for this leaf includes schema/policy contract checks and catalog emission coverage alongside the core fixture test.
 
 ```text
 tests/crosswalk/
-├── README.md                    # this guide
-└── test_crosswalk_fixture.py    # PostGIS-backed integration fixture
+├── README.md                      # this guide
+├── test_crosswalk_catalog.py      # catalog manifest emission + schema validation
+├── test_crosswalk_contract.py     # schema + OPA policy contract checks
+└── test_crosswalk_fixture.py      # PostGIS-backed integration fixture
 ```
 
 Referenced surfaces to verify in the active checkout:

--- a/tests/crosswalk/test_crosswalk_contract.py
+++ b/tests/crosswalk/test_crosswalk_contract.py
@@ -3,7 +3,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from jsonschema import validate, ValidationError
+from jsonschema import validate
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -14,12 +14,12 @@ VALID_FIXTURE = ROOT / "tests/fixtures/crosswalk/valid/crosswalk_pair.valid.json
 INVALID_CRS_FIXTURE = ROOT / "tests/fixtures/crosswalk/invalid/crosswalk_pair.bad_crs.json"
 
 
-def load_json(path: Path):
+def load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
 @pytest.fixture(scope="module")
-def schema():
+def schema() -> dict:
     return load_json(SCHEMA_PATH)
 
 
@@ -28,7 +28,7 @@ def test_valid_fixture_passes_schema(schema):
     validate(instance=data, schema=schema)
 
 
-def test_invalid_crs_fails_schema(schema):
+def test_invalid_crs_is_schema_valid_by_design(schema):
     data = load_json(INVALID_CRS_FIXTURE)
 
     # JSON schema should NOT catch CRS error (policy should)


### PR DESCRIPTION
### Motivation

- Remove noisy unknown-mark warnings and make the crosswalk integration tests' intent explicit to pytest. 
- Ensure the tests/crosswalk documentation accurately reflects the actual test files present in the lane. 
- Clean up the contract test to remove an unused import, add simple type hints, and make the CRS-related test name reflect the intended design (schema allows CRS issues; policy should deny them).

### Description

- Added a repository-level `pytest.ini` that registers the `integration` marker used by the crosswalk integration tests. 
- Updated `tests/crosswalk/README.md` to reflect the actual directory tree including `test_crosswalk_catalog.py`, `test_crosswalk_contract.py`, and `test_crosswalk_fixture.py`. 
- Modified `tests/crosswalk/test_crosswalk_contract.py` to remove an unused `ValidationError` import, add return type hints for `load_json` and `schema`, and rename `test_invalid_crs_fails_schema` to `test_invalid_crs_is_schema_valid_by_design` to clarify that CRS validation is a policy concern. 

### Testing

- Ran `pytest -q tests/crosswalk`, which completed successfully with `2 passed, 5 skipped`, and removed the previous unknown-mark warnings for the `integration` marker.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f109e18c88832aa51144276cdc21b1)