### PR TITLE
Add e2e tests for release assembly and correction lineage

### DIFF
--- a/tests/e2e/correction/test_correction_lineage_proof.py
+++ b/tests/e2e/correction/test_correction_lineage_proof.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.resolvers.release import resolve_release_manifest as release_resolver
+
+ROOT = Path(__file__).resolve().parents[3]
+
+UNRESOLVED_MANIFEST = ROOT / "tests/fixtures/release/invalid/unresolved_artifact.release-manifest.json"
+
+
+def _disable_external_validators(monkeypatch) -> None:
+    for key in list(release_resolver.VALIDATORS):
+        monkeypatch.setitem(release_resolver.VALIDATORS, key, ROOT / "_missing_validator.py")
+
+
+def test_unresolved_release_artifact_is_visible_and_fail_closed(monkeypatch) -> None:
+    _disable_external_validators(monkeypatch)
+
+    closure = release_resolver.resolve_release_manifest(UNRESOLVED_MANIFEST)
+
+    assert closure.status == "DENY"
+    assert any("path does not exist" in failure for failure in closure.failures)
+    assert any("artifacts[0].artifact_ref" in failure for failure in closure.failures)

--- a/tests/e2e/release_assembly/test_release_assembly_proof.py
+++ b/tests/e2e/release_assembly/test_release_assembly_proof.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.release.publish_release import build_publish_plan
+from tools.resolvers.release import resolve_release_manifest as release_resolver
+
+ROOT = Path(__file__).resolve().parents[3]
+
+VALID_MANIFEST = ROOT / "tests/fixtures/release/valid/minimal.release-manifest.json"
+INVALID_MANIFEST = ROOT / "tests/fixtures/release/invalid/missing_provenance_ref.release-manifest.json"
+
+
+def _disable_external_validators(monkeypatch) -> None:
+    for key in list(release_resolver.VALIDATORS):
+        monkeypatch.setitem(release_resolver.VALIDATORS, key, ROOT / "_missing_validator.py")
+
+
+def test_release_manifest_closure_publishable(monkeypatch) -> None:
+    _disable_external_validators(monkeypatch)
+
+    closure = release_resolver.resolve_release_manifest(VALID_MANIFEST)
+
+    assert closure.status == "PUBLISHABLE"
+    assert closure.failures == []
+
+
+def test_release_manifest_missing_provenance_is_denied(monkeypatch) -> None:
+    _disable_external_validators(monkeypatch)
+
+    closure = release_resolver.resolve_release_manifest(INVALID_MANIFEST)
+
+    assert closure.status == "DENY"
+    assert any("missing reference" in failure for failure in closure.failures)
+
+
+def test_publish_plan_is_built_from_publishable_closure(monkeypatch) -> None:
+    _disable_external_validators(monkeypatch)
+
+    manifest = json.loads(VALID_MANIFEST.read_text(encoding="utf-8"))
+    closure = release_resolver.resolve_release_manifest(VALID_MANIFEST)
+
+    assert closure.status == "PUBLISHABLE"
+
+    plan = build_publish_plan(VALID_MANIFEST, manifest, {"status": closure.status})
+    assert plan["closure_status"] == "PUBLISHABLE"
+    assert plan["artifact_count"] == 1
+    assert plan["release_id"] == manifest["release_id"]


### PR DESCRIPTION
### Motivation
- Fill previously README-only `tests/e2e/release_assembly/` and `tests/e2e/correction/` lanes with executable whole-path proof cases. 
- Ensure release manifest closure, publish-plan construction, and fail-closed correction visibility are deterministic and reviewable using existing release fixtures. 

### Description
- Add `tests/e2e/release_assembly/test_release_assembly_proof.py` which exercises `tools.resolvers.release.resolve_release_manifest` and `tools.release.publish_release.build_publish_plan` against `tests/fixtures/release/*` to assert publishable and denied closure outcomes. 
- Add `tests/e2e/correction/test_correction_lineage_proof.py` which exercises `tools.resolvers.release.resolve_release_manifest` against an unresolved-artifact fixture to assert a `DENY` closure and visible failure messages. 
- Make tests deterministic by importing the resolver and monkeypatching `release_resolver.VALIDATORS` to disable external validator subprocesses rather than invoking external tools or requiring `jsonschema` on the subprocess path. 
- Use existing fixtures under `tests/fixtures/release/valid` and `tests/fixtures/release/invalid` as test inputs. 

### Testing
- Ran `pytest -q tests/e2e/runtime_proof/evidence_ref/test_evidence_ref_proof.py tests/e2e/release_assembly/test_release_assembly_proof.py tests/e2e/correction/test_correction_lineage_proof.py` which initially surfaced external-dependency failures with a subprocess-based approach. 
- Updated tests to import the resolver and monkeypatch validators to avoid subprocess/environment dependency, and re-ran the same `pytest` command. 
- Final test result: `20 passed` (all targeted e2e cases passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10ab8e618832a9d7382d45894ec73)