### PR TITLE
Build out tests/e2e leaf documentation and runtime proof guidance

### DIFF
--- a/tests/e2e/correction/README.md
+++ b/tests/e2e/correction/README.md
@@ -1,3 +1,30 @@
 # Correction E2E
 
-This directory is reserved for whole-path correction lineage drills.
+`tests/e2e/correction/` contains whole-path checks for stale, missing, superseded, or
+withdrawn release state handling where KFM must stay fail-closed and preserve visible
+lineage.
+
+## What lives here
+
+- correction-lineage drills that verify unresolved release references are not silently ignored
+- cases that assert explicit `DENY` outcomes with reviewable failure reasons
+
+## Current executable coverage
+
+- `test_unresolved_release_artifact_is_visible_and_fail_closed`
+
+The current test ensures unresolved release artifacts are surfaced in failures and that
+resolution fails closed instead of proceeding with incomplete release state.
+
+## Boundaries
+
+This folder should test correction and lineage behavior, not:
+
+- publishability assembly checks (`tests/e2e/release_assembly/`)
+- request-time evidence/runtime response behavior (`tests/e2e/runtime_proof/`)
+
+## Run
+
+```bash
+pytest -q tests/e2e/correction
+```

--- a/tests/e2e/release_assembly/README.md
+++ b/tests/e2e/release_assembly/README.md
@@ -1,3 +1,36 @@
 # Release Assembly E2E
 
-This directory is reserved for release and publish-path completeness drills.
+`tests/e2e/release_assembly/` contains end-to-end checks that prove a release can be
+assembled from governed inputs and either:
+
+- be marked publishable when closure is complete, or
+- fail closed (`DENY`) when required release references are missing.
+
+## What lives here
+
+- release manifest closure tests
+- publish-plan wiring checks that consume closure results
+- fixtures that represent valid and invalid release-manifest states
+
+## Current executable coverage
+
+- `test_release_manifest_closure_publishable`
+- `test_release_manifest_missing_provenance_is_denied`
+- `test_publish_plan_is_built_from_publishable_closure`
+
+All cases use local fixture manifests under `tests/fixtures/release/` and monkeypatch
+external validators to keep tests deterministic.
+
+## Boundaries
+
+This folder should test publish-path behavior, not:
+
+- request-time runtime outcome behavior (`tests/e2e/runtime_proof/`)
+- correction lineage drills (`tests/e2e/correction/`)
+- low-level schema-only checks (`tests/contracts/`)
+
+## Run
+
+```bash
+pytest -q tests/e2e/release_assembly
+```

--- a/tests/e2e/runtime_proof/evidence_ref/README.md
+++ b/tests/e2e/runtime_proof/evidence_ref/README.md
@@ -1,0 +1,23 @@
+# Runtime Proof: Evidence Ref
+
+`tests/e2e/runtime_proof/evidence_ref/` validates the runtime evidence-ref chain used by
+claim rendering.
+
+## Coverage focus
+
+- promoted evidence refs render (`decision == cite`)
+- missing/invalid/unapproved evidence refs abstain
+- digest mismatch fails closed
+- composed-claim refs must fully resolve to render
+- file-based evidence-ref loading preserves the same fail-closed guarantees
+
+## Key invariant
+
+A runtime path may render only when required evidence and composed-claim references are
+fully valid and approved. Any resolver error path must return abstain/fail-closed.
+
+## Run
+
+```bash
+pytest -q tests/e2e/runtime_proof/evidence_ref
+```


### PR DESCRIPTION
### Motivation
- Provide clear, actionable documentation for the `tests/e2e/` leaf families so contributors understand scope, boundaries, and how to run existing suites. 
- Make the runtime evidence-ref invariants explicit next to the executable proof so maintainers can reason about fail-closed behavior and composability. 

### Description
- Expanded `tests/e2e/release_assembly/README.md` with scope, what belongs in the folder, current executable coverage, boundaries, and the run command. 
- Expanded `tests/e2e/correction/README.md` with correction-lineage intent, fail-closed expectations, current test coverage, boundaries, and the run command. 
- Added `tests/e2e/runtime_proof/evidence_ref/README.md` documenting evidence-ref runtime invariants, coverage focus, and the exact test invocation for the leaf. 

### Testing
- Ran `pytest -q tests/e2e` which completed successfully with `20 passed`. 
- The change is documentation-only and did not modify test behavior; the full `tests/e2e` suite remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10dad09f8832abe61d7c869b241d2)