### PR TITLE
Harden attest decision signing and verification flow

### DIFF
--- a/tools/attest/README.md
+++ b/tools/attest/README.md
@@ -446,6 +446,12 @@ The helper names below are part of the **current documented thin slice**. Their 
 - `decision-sign-result.json`
 - `decision-verify-result.json`
 
+### Current thin-slice guardrails (implemented)
+
+- signing fails closed when the decision envelope is missing required identity fields (`decision_id`, `status`)
+- verification checks signature binding **and** signed-result metadata (`status`, algorithm, and signing tool identity)
+- verification emits explicit boolean checks so downstream lanes can render why verification failed without re-running signing logic
+
 ### Typical downstream artifacts this lane may help feed
 
 - `promotion-record.json`

--- a/tools/attest/receipt.schema.json
+++ b/tools/attest/receipt.schema.json
@@ -63,13 +63,19 @@
             "artifact_uri_match",
             "decision_sha256_match",
             "signature_match",
-            "result_type_match"
+            "result_type_match",
+            "status_match",
+            "signature_alg_match",
+            "tool_match"
           ],
           "properties": {
             "artifact_uri_match": { "type": "boolean" },
             "decision_sha256_match": { "type": "boolean" },
             "signature_match": { "type": "boolean" },
-            "result_type_match": { "type": "boolean" }
+            "result_type_match": { "type": "boolean" },
+            "status_match": { "type": "boolean" },
+            "signature_alg_match": { "type": "boolean" },
+            "tool_match": { "type": "boolean" }
           },
           "additionalProperties": true
         },

--- a/tools/attest/sign_decision_envelope.py
+++ b/tools/attest/sign_decision_envelope.py
@@ -54,6 +54,13 @@ def load_json(path: Path) -> dict[str, Any]:
     return value
 
 
+def ensure_decision_envelope_shape(value: dict[str, Any]) -> None:
+    if not str(value.get("decision_id", "")).strip():
+        raise ValueError("decision envelope missing required field: decision_id")
+    if not str(value.get("status", "")).strip():
+        raise ValueError("decision envelope missing required field: status")
+
+
 def write_json(path: Path, value: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -76,6 +83,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         decision = load_json(decision_path)
+        ensure_decision_envelope_shape(decision)
         decision_digest = sha256_hex(canonical_json(decision))
         key_material = os.environ.get(args.key_env, "")
         signature = sha256_hex(f"{args.artifact_uri}\n{decision_digest}\n{args.signer}\n{key_material}")

--- a/tools/attest/verify_decision_envelope.py
+++ b/tools/attest/verify_decision_envelope.py
@@ -56,6 +56,13 @@ def load_json(path: Path) -> dict[str, Any]:
     return value
 
 
+def ensure_decision_envelope_shape(value: dict[str, Any]) -> None:
+    if not str(value.get("decision_id", "")).strip():
+        raise ValueError("decision envelope missing required field: decision_id")
+    if not str(value.get("status", "")).strip():
+        raise ValueError("decision envelope missing required field: status")
+
+
 def write_json(path: Path, value: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -78,6 +85,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         decision = load_json(decision_path)
+        ensure_decision_envelope_shape(decision)
         sign_result = load_json(sign_result_path)
 
         decision_digest = sha256_hex(canonical_json(decision))
@@ -92,6 +100,9 @@ def main(argv: list[str] | None = None) -> int:
             "decision_sha256_match": sign_result.get("decision_sha256") == decision_digest,
             "signature_match": signature_value == expected_signature,
             "result_type_match": sign_result.get("result_type") == "kfm:DecisionEnvelopeSignResult",
+            "status_match": sign_result.get("status") == "signed",
+            "signature_alg_match": sign_result.get("signature", {}).get("alg") == "sha256",
+            "tool_match": sign_result.get("tool") == "tools/attest/sign_decision_envelope.py",
         }
         verified = all(checks.values())
 

--- a/tools/tests/test_attest_decision_envelope_cli.py
+++ b/tools/tests/test_attest_decision_envelope_cli.py
@@ -137,3 +137,63 @@ def test_verify_fails_on_artifact_mismatch(tmp_path: Path) -> None:
     result = json.loads(verify_out.read_text(encoding="utf-8"))
     assert result["verified"] is False
     assert result["checks"]["artifact_uri_match"] is False
+
+
+def test_sign_fails_when_decision_shape_invalid(tmp_path: Path) -> None:
+    decision_path = tmp_path / "decision.json"
+    sign_out = tmp_path / "decision-sign-result.json"
+
+    write_json(decision_path, {"status": "allow"})
+
+    sign = run_sign(
+        str(decision_path),
+        "--artifact-uri",
+        "ghcr.io/example/promotion:overlay-floodplain-kansas-v1",
+        "--output",
+        str(sign_out),
+        "--yes",
+        env={"KFM_ATTEST_SIGNING_KEY": "unit-test-key"},
+    )
+
+    assert sign.returncode == 1
+    assert "decision envelope missing required field: decision_id" in sign.stderr
+    assert not sign_out.exists()
+
+
+def test_verify_fails_when_sign_result_metadata_tampered(tmp_path: Path) -> None:
+    decision_path = tmp_path / "decision.json"
+    sign_out = tmp_path / "decision-sign-result.json"
+    verify_out = tmp_path / "decision-verify-result.json"
+
+    write_json(decision_path, decision_fixture())
+
+    sign = run_sign(
+        str(decision_path),
+        "--artifact-uri",
+        "ghcr.io/example/promotion:correct",
+        "--output",
+        str(sign_out),
+        "--yes",
+        env={"KFM_ATTEST_SIGNING_KEY": "unit-test-key"},
+    )
+    assert sign.returncode == 0
+
+    tampered = json.loads(sign_out.read_text(encoding="utf-8"))
+    tampered["signature"]["alg"] = "sha512"
+    sign_out.write_text(json.dumps(tampered, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    verify = run_verify(
+        "ghcr.io/example/promotion:correct",
+        "--decision",
+        str(decision_path),
+        "--sign-result",
+        str(sign_out),
+        "--output",
+        str(verify_out),
+        env={"KFM_ATTEST_SIGNING_KEY": "unit-test-key"},
+    )
+
+    assert verify.returncode == 1
+    result = json.loads(verify_out.read_text(encoding="utf-8"))
+    assert result["verified"] is False
+    assert result["checks"]["signature_alg_match"] is False


### PR DESCRIPTION
### Motivation

- Prevent silent or downstream confusion by making the thin-slice sign/verify helpers fail closed on malformed decision envelopes and detect tampering in sign-result metadata.

### Description

- Add decision-envelope shape validation to `tools/attest/sign_decision_envelope.py` and `tools/attest/verify_decision_envelope.py` to require `decision_id` and `status` before signing or verification.
- Strengthen verification checks in `verify_decision_envelope.py` to validate sign-result metadata fields `status`, signature algorithm (`alg`), and signing tool identity in addition to digest and signature matching.
- Update `tools/attest/receipt.schema.json` to require the new boolean `checks` fields (`status_match`, `signature_alg_match`, `tool_match`).
- Add tests in `tools/tests/test_attest_decision_envelope_cli.py` covering invalid decision shape at sign time and tampered sign-result metadata at verify time.
- Document the implemented thin-slice guardrails in `tools/attest/README.md`.

### Testing

- Ran the new unit/CLI tests with `python -m pytest -q tools/tests/test_attest_decision_envelope_cli.py`, which passed (`5 passed`).
- Performed a smoke CLI roundtrip sign/verify using `KFM_ATTEST_SIGNING_KEY` and validated the produced verify JSON with `python -m json.tool`, which succeeded.
- Tests added exercise the new failure paths and the tampering detection and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f111a6428c832a8ae91363bfe7cea1)