### PR TITLE
Add catalog mounted-record alignment and freshness helpers

### DIFF
--- a/tests/catalog/README.md
+++ b/tests/catalog/README.md
@@ -1,6 +1,6 @@
 # tests/catalog
 
-Catalog-focused tests for `tools/catalog/catalog_crosslink.py`.
+Catalog-focused tests for `tools/catalog/catalog_crosslink.py` and mounted-record helpers in `tools/catalog/`.
 
 ## Scope
 
@@ -13,12 +13,18 @@ This folder validates STAC/DCAT/PROV cross-link behavior with deterministic fixt
 
 Authoritative metadata still lives under `data/catalog/`. These tests only validate helper behavior.
 
+Mounted-record coverage now includes:
+
+- `catalog_record_mount_check.py` alignment checks
+- `catalog_freshness_report.py` freshness-spread checks
+
 ## Layout
 
 ```text
 tests/catalog/
 ├── README.md
 ├── test_catalog_crosslink.py
+├── test_catalog_record_helpers.py
 └── fixtures/
     ├── README.md
     ├── aligned-decision.json
@@ -33,7 +39,7 @@ tests/catalog/
 From repository root:
 
 ```bash
-pytest -q tests/catalog/test_catalog_crosslink.py
+pytest -q tests/catalog/test_catalog_crosslink.py tests/catalog/test_catalog_record_helpers.py
 ```
 
 Optional direct helper run:

--- a/tests/catalog/test_catalog_record_helpers.py
+++ b/tests/catalog/test_catalog_record_helpers.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MOUNT_SCRIPT = ROOT / "tools/catalog/catalog_record_mount_check.py"
+FRESH_SCRIPT = ROOT / "tools/catalog/catalog_freshness_report.py"
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_mounted_record_alignment_passes(tmp_path: Path) -> None:
+    stac = {
+        "id": "stac-item-1",
+        "properties": {
+            "kfm:subject_id": "kfm:subject:floodplain-kansas",
+            "kfm:version": "v1",
+            "kfm:release_ref": "kfm:release:floodplain-kansas:v1",
+        },
+    }
+    dcat = {
+        "id": "kfm:subject:floodplain-kansas",
+        "version": "v1",
+        "release_ref": "kfm:release:floodplain-kansas:v1",
+    }
+    prov = {
+        "subject_id": "kfm:subject:floodplain-kansas",
+        "version": "v1",
+        "release_ref": "kfm:release:floodplain-kansas:v1",
+    }
+
+    _write(tmp_path / "stac.json", stac)
+    _write(tmp_path / "dcat.json", dcat)
+    _write(tmp_path / "prov.json", prov)
+
+    result = subprocess.run(
+        [
+            "python3",
+            str(MOUNT_SCRIPT),
+            "--stac",
+            str(tmp_path / "stac.json"),
+            "--dcat",
+            str(tmp_path / "dcat.json"),
+            "--prov",
+            str(tmp_path / "prov.json"),
+            "--output",
+            str(tmp_path / "report.json"),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0
+    report = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    assert report["status"] == "pass"
+
+
+def test_freshness_report_fails_when_spread_exceeds_threshold(tmp_path: Path) -> None:
+    stac = {"properties": {"updated": "2026-04-01T00:00:00Z"}}
+    dcat = {"modified": "2026-04-02T00:00:00Z"}
+    prov = {"generated_at": "2026-04-20T00:00:00Z"}
+
+    _write(tmp_path / "stac.json", stac)
+    _write(tmp_path / "dcat.json", dcat)
+    _write(tmp_path / "prov.json", prov)
+
+    result = subprocess.run(
+        [
+            "python3",
+            str(FRESH_SCRIPT),
+            "--stac",
+            str(tmp_path / "stac.json"),
+            "--dcat",
+            str(tmp_path / "dcat.json"),
+            "--prov",
+            str(tmp_path / "prov.json"),
+            "--max-spread-days",
+            "7",
+            "--output",
+            str(tmp_path / "freshness-report.json"),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    report = json.loads((tmp_path / "freshness-report.json").read_text(encoding="utf-8"))
+    assert report["status"] == "fail"
+    assert any("spread" in error for error in report["errors"])

--- a/tools/catalog/README.md
+++ b/tools/catalog/README.md
@@ -64,7 +64,7 @@ Catalog QA, cross-link, and reviewer-facing metadata helper surface for Kansas F
 > - `tests/catalog/test_catalog_crosslink.py`
 > - optional JSON output for CI and reviewer rendering
 >
-> The broader lane remains larger than this one executable helper. QA, reporting, and richer closure helpers are still **PROPOSED** unless directly verified in the active branch.
+> The broader lane remains larger than this executable starter set. QA, reporting, and richer closure helpers are still **PROPOSED** unless directly verified in the active branch.
 
 > [!NOTE]
 > This README intentionally does two jobs at once:
@@ -203,7 +203,9 @@ tools/
 ├── attest/
 ├── catalog/
 │   ├── README.md
-│   └── catalog_crosslink.py
+│   ├── catalog_crosslink.py
+│   ├── catalog_record_mount_check.py
+│   └── catalog_freshness_report.py
 ├── ci/
 ├── diff/
 ├── docs/
@@ -216,10 +218,13 @@ tools/
 ```text
 tools/catalog/
 ├── README.md
-└── catalog_crosslink.py
+├── catalog_crosslink.py
+├── catalog_record_mount_check.py
+└── catalog_freshness_report.py
 
 tests/catalog/
-└── test_catalog_crosslink.py
+├── test_catalog_crosslink.py
+└── test_catalog_record_helpers.py
 ```
 
 ### Adjacent live catalog seam
@@ -437,8 +442,8 @@ Above: `tools/catalog/` inspects outward catalog seams and emits stable outputs 
 - [x] document `tools/catalog/` as a helper lane distinct from `data/catalog/`
 - [x] document the current thin slice `catalog_crosslink.py`
 - [x] document the thin-slice proof surface `tests/catalog/test_catalog_crosslink.py`
-- [ ] extend triplet checking from ref-shape alignment to declared subject/property alignment inside mounted catalog records
-- [ ] add freshness / report helper support for reviewer-facing closure summaries
+- [x] extend triplet checking from ref-shape alignment to declared subject/property alignment inside mounted catalog records
+- [x] add freshness / report helper support for reviewer-facing closure summaries
 - [ ] add optional rendering handoff to `tools/ci/`
 - [ ] verify exact file-history dates, `doc_id`, and active-branch caller/workflow parity before publication
 

--- a/tools/catalog/catalog_freshness_report.py
+++ b/tools/catalog/catalog_freshness_report.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _first_str(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _parse_date(raw: str | None) -> datetime | None:
+    if raw is None:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _extract_timestamp(payload: dict[str, Any]) -> str | None:
+    props = payload.get("properties") if isinstance(payload.get("properties"), dict) else {}
+    return _first_str(
+        payload.get("updated"),
+        payload.get("modified"),
+        payload.get("generated_at"),
+        props.get("updated"),
+        props.get("modified"),
+        props.get("generated_at"),
+        props.get("kfm:generated_at"),
+    )
+
+
+def build_report(stac: dict[str, Any], dcat: dict[str, Any], prov: dict[str, Any], max_spread_days: int) -> dict[str, Any]:
+    raw = {
+        "stac": _extract_timestamp(stac),
+        "dcat": _extract_timestamp(dcat),
+        "prov": _extract_timestamp(prov),
+    }
+    parsed = {k: _parse_date(v) for k, v in raw.items()}
+
+    errors: list[str] = []
+    checks: list[dict[str, Any]] = []
+
+    complete = all(parsed.values())
+    if not complete:
+        errors.append("missing or invalid freshness timestamp in mounted catalog records")
+    checks.append({"name": "timestamp_presence", "ok": complete, "timestamps": raw})
+
+    spread_ok = False
+    spread_days: float | None = None
+    if complete:
+        values = list(parsed.values())
+        assert all(v is not None for v in values)
+        oldest = min(values)
+        newest = max(values)
+        spread_days = (newest - oldest).total_seconds() / 86400
+        spread_ok = spread_days <= max_spread_days
+        if not spread_ok:
+            errors.append("catalog freshness spread exceeds max-spread-days threshold")
+    checks.append(
+        {
+            "name": "freshness_spread",
+            "ok": spread_ok,
+            "spread_days": spread_days,
+            "max_spread_days": max_spread_days,
+        }
+    )
+
+    status = "pass" if not errors else "fail"
+    return {
+        "status": status,
+        "blocking": status == "fail",
+        "checks": checks,
+        "errors": errors,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build freshness report from mounted STAC/DCAT/PROV records.")
+    parser.add_argument("--stac", type=Path, required=True)
+    parser.add_argument("--dcat", type=Path, required=True)
+    parser.add_argument("--prov", type=Path, required=True)
+    parser.add_argument("--max-spread-days", type=int, default=30)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_report(
+        _read_json(args.stac),
+        _read_json(args.dcat),
+        _read_json(args.prov),
+        args.max_spread_days,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/catalog/catalog_record_mount_check.py
+++ b/tools/catalog/catalog_record_mount_check.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+TRIPLET = ("stac", "dcat", "prov")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _first_str(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _extract_fields(payload: dict[str, Any], lane: str) -> dict[str, str | None]:
+    props = payload.get("properties") if isinstance(payload.get("properties"), dict) else {}
+
+    subject = _first_str(
+        payload.get("subject_id"),
+        payload.get("subject"),
+        payload.get("id") if lane == "dcat" else None,
+        props.get("subject_id"),
+        props.get("kfm:subject_id"),
+    )
+    version = _first_str(
+        payload.get("version"),
+        props.get("version"),
+        props.get("kfm:version"),
+    )
+    release_ref = _first_str(
+        payload.get("release_ref"),
+        props.get("release_ref"),
+        props.get("kfm:release_ref"),
+    )
+    return {"subject_id": subject, "version": version, "release_ref": release_ref}
+
+
+def _alignment_ok(values: dict[str, str | None]) -> tuple[bool, list[str], list[str]]:
+    present = {k: v for k, v in values.items() if v is not None}
+    uniques = sorted(set(present.values()))
+    return len(values) == len(present) == 3 and len(uniques) == 1, sorted(present.keys()), uniques
+
+
+def build_report(stac: dict[str, Any], dcat: dict[str, Any], prov: dict[str, Any]) -> dict[str, Any]:
+    extracted = {
+        "stac": _extract_fields(stac, "stac"),
+        "dcat": _extract_fields(dcat, "dcat"),
+        "prov": _extract_fields(prov, "prov"),
+    }
+
+    checks: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for field in ("subject_id", "version", "release_ref"):
+        values = {lane: extracted[lane][field] for lane in TRIPLET}
+        ok, present_lanes, unique_values = _alignment_ok(values)
+        if not ok:
+            errors.append(f"{field} alignment failed across mounted stac/dcat/prov records")
+        checks.append(
+            {
+                "name": f"mounted_{field}_alignment",
+                "ok": ok,
+                "values": values,
+                "present_lanes": present_lanes,
+                "unique_values": unique_values,
+            }
+        )
+
+    status = "pass" if not errors else "fail"
+    return {
+        "status": status,
+        "blocking": status == "fail",
+        "checks": checks,
+        "errors": errors,
+        "extracted": extracted,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check alignment across mounted STAC/DCAT/PROV records.")
+    parser.add_argument("--stac", type=Path, required=True, help="Path to STAC JSON")
+    parser.add_argument("--dcat", type=Path, required=True, help="Path to DCAT JSON")
+    parser.add_argument("--prov", type=Path, required=True, help="Path to PROV JSON")
+    parser.add_argument("--output", type=Path, required=True, help="Path to write report JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_report(_read_json(args.stac), _read_json(args.dcat), _read_json(args.prov))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide additional catalog closure helpers to validate mounted STAC/DCAT/PROV records beyond the existing triplet ref crosslink checks. 
- Surface deterministic, reviewer-friendly JSON reports for alignment and freshness so CI and promotion gates can consume stable evidence. 

### Description
- Add `tools/catalog/catalog_record_mount_check.py` that extracts `subject_id`, `version`, and `release_ref` from common record fields and emits a blocking JSON report when mounted records do not align. 
- Add `tools/catalog/catalog_freshness_report.py` that extracts timestamps from mounted records, computes the spread in days, and emits a blocking JSON report when spread exceeds `--max-spread-days`. 
- Add tests in `tests/catalog/test_catalog_record_helpers.py` covering a passing mounted-alignment path and a failing freshness-spread path, and update `tools/catalog/README.md` and `tests/catalog/README.md` to document the new helpers. 

### Testing
- Ran `pytest -q tests/catalog/test_catalog_crosslink.py tests/catalog/test_catalog_record_helpers.py` and observed all tests passing (`6 passed`).
- Also ran the crosslink-only test set with `pytest -q tests/catalog/test_catalog_crosslink.py` which passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f112e007fc832a9e2ef37e688bac30)