### PR TITLE
Add evaluator fixture runner, fixture schema, examples, and tests

### DIFF
--- a/tools/evaluators/README.md
+++ b/tools/evaluators/README.md
@@ -502,3 +502,24 @@ grep -RIn \
 </details>
 
 [Back to top](#top)
+
+---
+
+## Implemented baseline runner
+
+The repository now includes a concrete fixture evaluator runner and sample inputs:
+
+- `tools/evaluators/evaluate_fixture.py`
+- `tools/evaluators/fixture_runner.py`
+- `tools/evaluators/examples/runtime_response.config.json`
+- `tools/evaluators/fixtures/runtime_response/valid_response.json`
+- `tools/evaluators/fixtures/citation_quality/missing_citation.json`
+
+Run the baseline evaluator:
+
+```bash
+python tools/evaluators/evaluate_fixture.py \
+  --config tools/evaluators/examples/runtime_response.config.json \
+  --fixture tools/evaluators/fixtures/runtime_response/valid_response.json \
+  --output build/evaluators/runtime_response.report.json
+```

--- a/tools/evaluators/__init__.py
+++ b/tools/evaluators/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluator helpers for deterministic, explainable fixture scoring."""

--- a/tools/evaluators/evaluate_fixture.py
+++ b/tools/evaluators/evaluate_fixture.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.evaluators.fixture_runner import EvaluatorError, run_fixture_evaluation
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a deterministic evaluator fixture and emit a report."
+    )
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--config-schema",
+        type=Path,
+        default=Path("tools/evaluators/config.schema.json"),
+    )
+    parser.add_argument(
+        "--fixture-schema",
+        type=Path,
+        default=Path("tools/evaluators/fixtures/fixture.schema.json"),
+    )
+    parser.add_argument(
+        "--report-schema",
+        type=Path,
+        default=Path("tools/evaluators/report.schema.json"),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        evaluation = run_fixture_evaluation(
+            config_path=args.config,
+            fixture_path=args.fixture,
+            report_schema_path=args.report_schema,
+            config_schema_path=args.config_schema,
+            fixture_schema_path=args.fixture_schema,
+        )
+    except EvaluatorError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(evaluation.report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote evaluator report: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/evaluators/examples/runtime_response.config.json
+++ b/tools/evaluators/examples/runtime_response.config.json
@@ -1,0 +1,39 @@
+{
+  "config_type": "kfm.evaluator_config.v1",
+  "evaluator": "tools/evaluators/runtime_response/basic",
+  "evaluator_version": "v1",
+  "subject_types": ["runtime_response"],
+  "metrics": [
+    {
+      "name": "schema_valid",
+      "kind": "schema",
+      "enabled": true,
+      "must_pass": true,
+      "failure_flag": "SCHEMA_INVALID",
+      "explanation_required": true
+    },
+    {
+      "name": "citation_present",
+      "kind": "citation",
+      "enabled": true,
+      "must_pass": true,
+      "failure_flag": "MISSING_CITATION",
+      "explanation_required": true
+    },
+    {
+      "name": "abstain_on_missing_evidence",
+      "kind": "abstention",
+      "enabled": true,
+      "must_pass": true,
+      "failure_flag": "MISSING_EVIDENCE",
+      "explanation_required": true
+    }
+  ],
+  "output": {
+    "report_type": "kfm.evaluator_report.v1",
+    "format": "json",
+    "emit_explanations": true,
+    "emit_failure_flags": true,
+    "emit_metric_breakdown": true
+  }
+}

--- a/tools/evaluators/fixture_runner.py
+++ b/tools/evaluators/fixture_runner.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+class EvaluatorError(ValueError):
+    pass
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise EvaluatorError(f"invalid JSON at {path}: {exc}") from exc
+
+    if not isinstance(value, dict):
+        raise EvaluatorError(f"JSON document must be an object: {path}")
+
+    return value
+
+
+def _validator(schema_path: Path) -> Draft202012Validator:
+    schema = _load_json_object(schema_path)
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _validate_payload(payload: dict[str, Any], schema_path: Path, label: str) -> None:
+    validator = _validator(schema_path)
+    errors = sorted(validator.iter_errors(payload), key=lambda item: list(item.path))
+    if errors:
+        details = "; ".join(
+            f"{'.'.join(str(part) for part in error.path) or '<root>'}: {error.message}"
+            for error in errors
+        )
+        raise EvaluatorError(f"{label} failed schema validation: {details}")
+
+
+def _sha256_hex(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    digest = hashlib.sha256(canonical).hexdigest()
+    return f"sha256:{digest}"
+
+
+@dataclass(frozen=True)
+class FixtureEvaluation:
+    report: dict[str, Any]
+
+
+def evaluate_fixture(*, config: dict[str, Any], fixture: dict[str, Any]) -> FixtureEvaluation:
+    metrics_by_name = {
+        metric["name"]: metric
+        for metric in config["metrics"]
+        if metric.get("enabled", True)
+    }
+
+    metric_breakdown: dict[str, float] = {}
+    metric_rows: list[dict[str, Any]] = []
+    failure_flags: list[str] = []
+
+    for metric_result in fixture["metric_results"]:
+        name = metric_result["name"]
+        if name not in metrics_by_name:
+            continue
+
+        metric_cfg = metrics_by_name[name]
+        passed = bool(metric_result["passed"])
+        score = float(metric_result["score"])
+        reason_code = metric_result["reason_code"]
+        explanation = metric_result["explanation"]
+
+        row = {
+            "name": name,
+            "score": score,
+            "passed": passed,
+            "reason_code": reason_code,
+            "severity": "info" if passed else "blocking",
+            "explanation": {"summary": explanation},
+        }
+        metric_rows.append(row)
+        metric_breakdown[name] = score
+
+        if not passed and metric_cfg.get("must_pass", False):
+            failure_flags.append(metric_cfg.get("failure_flag") or reason_code)
+
+    normalized_flags = sorted({flag for flag in failure_flags if flag})
+
+    outcome = "ALLOW"
+    if any(flag.startswith("ERROR") for flag in normalized_flags):
+        outcome = "ERROR"
+    elif normalized_flags:
+        has_abstention_metric = any(
+            not row["passed"] and metrics_by_name[row["name"]].get("kind") == "abstention"
+            for row in metric_rows
+            if row["name"] in metrics_by_name
+        )
+        outcome = "ABSTAIN" if has_abstention_metric else "DENY"
+
+    report = {
+        "report_type": "kfm.evaluator_report.v1",
+        "evaluator": config["evaluator"],
+        "evaluator_version": config.get("evaluator_version", "v1"),
+        "subject_ref": fixture["subject_ref"],
+        "subject_type": fixture["subject_type"],
+        "evaluator_spec_hash": _sha256_hex(config),
+        "artifact_spec_hash": fixture.get("artifact_spec_hash", _sha256_hex(fixture)),
+        "outcome": outcome,
+        "metric_breakdown": metric_breakdown,
+        "failure_flags": normalized_flags,
+        "metrics": metric_rows,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    return FixtureEvaluation(report=report)
+
+
+def run_fixture_evaluation(
+    *,
+    config_path: Path,
+    fixture_path: Path,
+    report_schema_path: Path,
+    config_schema_path: Path,
+    fixture_schema_path: Path,
+) -> FixtureEvaluation:
+    config = _load_json_object(config_path)
+    fixture = _load_json_object(fixture_path)
+
+    _validate_payload(config, config_schema_path, "config")
+    _validate_payload(fixture, fixture_schema_path, "fixture")
+
+    evaluation = evaluate_fixture(config=config, fixture=fixture)
+    _validate_payload(evaluation.report, report_schema_path, "report")
+
+    return evaluation

--- a/tools/evaluators/fixtures/citation_quality/missing_citation.json
+++ b/tools/evaluators/fixtures/citation_quality/missing_citation.json
@@ -1,0 +1,38 @@
+{
+  "fixture_type": "kfm.evaluator_fixture.v1",
+  "fixture_id": "citation.missing_citation.v1",
+  "fixture_category": "negative",
+  "subject_ref": "tests/fixtures/evidence/invalid/claim_envelope_empty_evidence_refs.json",
+  "subject_type": "runtime_response",
+  "expected_outcome": "DENY",
+  "artifact_spec_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "metric_results": [
+    {
+      "name": "schema_valid",
+      "score": 1,
+      "passed": true,
+      "reason_code": "SCHEMA_VALID",
+      "explanation": {
+        "summary": "Envelope shape is syntactically valid."
+      }
+    },
+    {
+      "name": "citation_present",
+      "score": 0,
+      "passed": false,
+      "reason_code": "MISSING_CITATION",
+      "explanation": {
+        "summary": "Expected citation references were missing."
+      }
+    },
+    {
+      "name": "abstain_on_missing_evidence",
+      "score": 1,
+      "passed": true,
+      "reason_code": "EVIDENCE_RESOLVED",
+      "explanation": {
+        "summary": "Evidence completeness metric not triggered for abstention path."
+      }
+    }
+  ]
+}

--- a/tools/evaluators/fixtures/fixture.schema.json
+++ b/tools/evaluators/fixtures/fixture.schema.json
@@ -1,335 +1,73 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "kfm://schema/tools/evaluators/config.schema.json",
-  "title": "KFM Evaluator Config",
-  "description": "Proposed schema for deterministic evaluator configuration consumed by tools/evaluators before report emission, validation, receipt custody, policy review, proof generation, or promotion.",
+  "$id": "kfm://schema/tools/evaluators/fixtures/fixture.schema.json",
+  "title": "KFM Evaluator Fixture",
+  "description": "Schema for deterministic evaluator fixture inputs consumed by tools/evaluators.",
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "config_type",
-    "evaluator",
-    "evaluator_version",
-    "subject_types",
-    "metrics",
-    "output"
+    "fixture_type",
+    "fixture_id",
+    "fixture_category",
+    "subject_ref",
+    "subject_type",
+    "expected_outcome",
+    "metric_results"
   ],
   "properties": {
-    "config_type": {
+    "fixture_type": {
       "type": "string",
-      "const": "kfm.evaluator_config.v1"
+      "const": "kfm.evaluator_fixture.v1"
     },
-    "evaluator": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Stable evaluator identifier, usually a repo-relative evaluator name or tool path."
-    },
-    "evaluator_version": {
+    "fixture_id": {
       "type": "string",
       "minLength": 1
     },
-    "description": {
-      "type": "string",
-      "minLength": 1
-    },
-    "random_seed": {
-      "type": "integer",
-      "minimum": 0,
-      "description": "Optional deterministic seed for evaluator families that use sampling or randomized ordering."
-    },
-    "canonicalization": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "method": {
-          "type": "string",
-          "enum": [
-            "json_canonicalization_scheme",
-            "repo_native",
-            "none"
-          ]
-        },
-        "hash_algorithm": {
-          "type": "string",
-          "const": "sha256"
-        },
-        "include_fields": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "exclude_fields": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        }
-      }
-    },
-    "subject_types": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "enum": [
-          "runtime_response",
-          "model_output",
-          "artifact",
-          "fixture",
-          "catalog_candidate",
-          "proof_candidate",
-          "receipt_candidate",
-          "other"
-        ]
-      }
-    },
-    "fixtures": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/fixture_ref"
-      }
-    },
-    "metrics": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/$defs/metric_config"
-      }
-    },
-    "thresholds": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/$defs/threshold"
-      },
-      "description": "Optional shared thresholds addressable by metric configs."
-    },
-    "failure_policy": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "fail_closed": {
-          "type": "boolean",
-          "const": true
-        },
-        "blocking_flags": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/$defs/reason_code"
-          }
-        },
-        "treat_error_as": {
-          "type": "string",
-          "enum": [
-            "ERROR",
-            "DENY"
-          ]
-        }
-      }
-    },
-    "output": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "report_type",
-        "format"
-      ],
-      "properties": {
-        "report_type": {
-          "type": "string",
-          "const": "kfm.evaluator_report.v1"
-        },
-        "format": {
-          "type": "string",
-          "enum": [
-            "json",
-            "jsonl"
-          ]
-        },
-        "report_path": {
-          "type": "string",
-          "minLength": 1
-        },
-        "emit_explanations": {
-          "type": "boolean",
-          "const": true
-        },
-        "emit_failure_flags": {
-          "type": "boolean",
-          "const": true
-        },
-        "emit_metric_breakdown": {
-          "type": "boolean",
-          "const": true
-        }
-      }
-    },
-    "metadata": {
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "owner": {
-          "type": "string",
-          "minLength": 1
-        },
-        "status": {
-          "type": "string",
-          "enum": [
-            "draft",
-            "review",
-            "published",
-            "deprecated"
-          ]
-        },
-        "policy_label": {
-          "type": "string",
-          "minLength": 1
-        },
-        "notes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
-  "$defs": {
-    "hash": {
-      "type": "string",
-      "pattern": "^(sha256:)?[a-f0-9]{64}$"
-    },
-    "reason_code": {
-      "type": "string",
-      "pattern": "^[A-Z][A-Z0-9_:-]*$"
-    },
-    "fixture_ref": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "fixture_ref",
-        "fixture_type",
-        "expected_outcome"
-      ],
-      "properties": {
-        "fixture_ref": {
-          "type": "string",
-          "minLength": 1
-        },
-        "fixture_type": {
-          "type": "string",
-          "enum": [
-            "positive",
-            "negative",
-            "abstention",
-            "edge",
-            "error"
-          ]
-        },
-        "expected_outcome": {
-          "$ref": "#/$defs/outcome"
-        },
-        "expected_failure_flags": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/$defs/reason_code"
-          }
-        },
-        "fixture_hash": {
-          "$ref": "#/$defs/hash"
-        }
-      }
-    },
-    "metric_config": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "kind",
-        "enabled"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "pattern": "^[a-z][a-z0-9_.:-]*$"
-        },
-        "kind": {
-          "type": "string",
-          "enum": [
-            "schema",
-            "citation",
-            "exact_match",
-            "numeric_tolerance",
-            "span_overlap",
-            "diff",
-            "abstention",
-            "custom"
-          ]
-        },
-        "enabled": {
-          "type": "boolean"
-        },
-        "must_pass": {
-          "type": "boolean"
-        },
-        "threshold": {
-          "$ref": "#/$defs/threshold"
-        },
-        "threshold_ref": {
-          "type": "string",
-          "minLength": 1
-        },
-        "failure_flag": {
-          "$ref": "#/$defs/reason_code"
-        },
-        "explanation_required": {
-          "type": "boolean",
-          "const": true
-        },
-        "params": {
-          "type": "object",
-          "additionalProperties": true
-        }
-      }
-    },
-    "threshold": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "operator",
-        "value"
-      ],
-      "properties": {
-        "operator": {
-          "type": "string",
-          "enum": [
-            "eq",
-            "neq",
-            "gt",
-            "gte",
-            "lt",
-            "lte"
-          ]
-        },
-        "value": {
-          "type": "number"
-        }
-      }
-    },
-    "outcome": {
+    "fixture_category": {
       "type": "string",
       "enum": [
-        "ALLOW",
-        "ABSTAIN",
-        "DENY",
-        "ERROR"
+        "positive",
+        "negative",
+        "abstention",
+        "edge",
+        "error"
       ]
+    },
+    "subject_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "subject_type": {
+      "type": "string",
+      "enum": [
+        "runtime_response",
+        "model_output",
+        "artifact",
+        "fixture",
+        "catalog_candidate",
+        "proof_candidate",
+        "receipt_candidate",
+        "other"
+      ]
+    },
+    "expected_outcome": {
+      "$ref": "../config.schema.json#/$defs/outcome"
+    },
+    "artifact_spec_hash": {
+      "$ref": "../config.schema.json#/$defs/hash"
+    },
+    "metric_results": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "../report.schema.json#/$defs/metric_result"
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/tools/evaluators/fixtures/runtime_response/valid_response.json
+++ b/tools/evaluators/fixtures/runtime_response/valid_response.json
@@ -1,0 +1,38 @@
+{
+  "fixture_type": "kfm.evaluator_fixture.v1",
+  "fixture_id": "runtime.valid_response.v1",
+  "fixture_category": "positive",
+  "subject_ref": "tests/fixtures/evidence/valid/claim_envelope_render_allowed.json",
+  "subject_type": "runtime_response",
+  "expected_outcome": "ALLOW",
+  "artifact_spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "metric_results": [
+    {
+      "name": "schema_valid",
+      "score": 1,
+      "passed": true,
+      "reason_code": "SCHEMA_VALID",
+      "explanation": {
+        "summary": "Runtime response passed schema checks."
+      }
+    },
+    {
+      "name": "citation_present",
+      "score": 1,
+      "passed": true,
+      "reason_code": "CITATION_PRESENT",
+      "explanation": {
+        "summary": "All required citations are present."
+      }
+    },
+    {
+      "name": "abstain_on_missing_evidence",
+      "score": 1,
+      "passed": true,
+      "reason_code": "EVIDENCE_RESOLVED",
+      "explanation": {
+        "summary": "Evidence references resolve cleanly."
+      }
+    }
+  ]
+}

--- a/tools/tests/schemas/test_evaluator_fixture_schema.py
+++ b/tools/tests/schemas/test_evaluator_fixture_schema.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA_REF = Path("tools/evaluators/fixtures/fixture.schema.json")
+
+
+def load_schema(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate(instance: dict) -> list[str]:
+    schema = load_schema(SCHEMA_REF)
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    return [
+        f"{'.'.join(str(p) for p in e.path) or '<root>'}: {e.message}"
+        for e in sorted(validator.iter_errors(instance), key=lambda i: list(i.path))
+    ]
+
+
+def valid_fixture() -> dict:
+    return {
+        "fixture_type": "kfm.evaluator_fixture.v1",
+        "fixture_id": "runtime.valid.v1",
+        "fixture_category": "positive",
+        "subject_ref": "kfm://fixture/runtime/valid",
+        "subject_type": "runtime_response",
+        "expected_outcome": "ALLOW",
+        "metric_results": [
+            {
+                "name": "schema_valid",
+                "score": 1,
+                "passed": True,
+                "reason_code": "SCHEMA_VALID",
+                "explanation": {"summary": "ok"},
+            }
+        ],
+    }
+
+
+def test_valid_fixture_passes() -> None:
+    assert validate(valid_fixture()) == []
+
+
+def test_missing_required_field_fails() -> None:
+    instance = valid_fixture()
+    instance.pop("subject_ref")
+
+    errors = validate(instance)
+
+    assert errors
+    assert any("subject_ref" in error for error in errors)

--- a/tools/tests/test_evaluator_fixture_cli.py
+++ b/tools/tests/test_evaluator_fixture_cli.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "tools/evaluators/evaluate_fixture.py", *args],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_evaluator_fixture_allow(tmp_path: Path) -> None:
+    output_path = tmp_path / "allow-report.json"
+
+    result = run_cli(
+        "--config",
+        "tools/evaluators/examples/runtime_response.config.json",
+        "--fixture",
+        "tools/evaluators/fixtures/runtime_response/valid_response.json",
+        "--output",
+        str(output_path),
+    )
+
+    assert result.returncode == 0
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["outcome"] == "ALLOW"
+    assert report["failure_flags"] == []
+
+
+def test_evaluator_fixture_deny(tmp_path: Path) -> None:
+    output_path = tmp_path / "deny-report.json"
+
+    result = run_cli(
+        "--config",
+        "tools/evaluators/examples/runtime_response.config.json",
+        "--fixture",
+        "tools/evaluators/fixtures/citation_quality/missing_citation.json",
+        "--output",
+        str(output_path),
+    )
+
+    assert result.returncode == 0
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["outcome"] == "DENY"
+    assert report["failure_flags"] == ["MISSING_CITATION"]
+
+
+def test_evaluator_fixture_invalid_fixture_fails(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "bad-fixture.json"
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "fixture_type": "kfm.evaluator_fixture.v1",
+                "fixture_id": "broken",
+                "fixture_category": "negative"
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_cli(
+        "--config",
+        "tools/evaluators/examples/runtime_response.config.json",
+        "--fixture",
+        str(fixture_path),
+        "--output",
+        str(tmp_path / "broken-report.json"),
+    )
+
+    assert result.returncode == 1
+    assert "fixture failed schema validation" in result.stderr


### PR DESCRIPTION
### Motivation

- Provide a minimal, deterministic evaluator execution path so evaluator fixtures can be run, validated, and produce explainable reports. 
- Replace the duplicated/incorrect fixture schema with a proper `kfm.evaluator_fixture.v1` shape so fixtures validate cleanly. 
- Ship a small set of example config + fixtures and tests to make the evaluator lane executable and reviewable.

### Description

- Add a reusable fixture runner implementing schema validation, deterministic spec hashing, outcome derivation, and report construction in `tools/evaluators/fixture_runner.py`.
- Add a CLI entrypoint `tools/evaluators/evaluate_fixture.py` (includes `REPO_ROOT` insertion into `sys.path` to allow running as a standalone script).
- Replace the prior duplicate JSON with a dedicated fixture schema at `tools/evaluators/fixtures/fixture.schema.json` that defines fixture identity, category, subject, expected outcome, and metric result structure.
- Add example config and fixtures: `tools/evaluators/examples/runtime_response.config.json`, `tools/evaluators/fixtures/runtime_response/valid_response.json`, and `tools/evaluators/fixtures/citation_quality/missing_citation.json`.
- Add tests and schema checks: `tools/tests/test_evaluator_fixture_cli.py` and `tools/tests/schemas/test_evaluator_fixture_schema.py`.
- Document the implemented baseline runner and usage in `tools/evaluators/README.md` and add a package `__init__` for the module.

### Testing

- Ran `pytest -q tools/tests/test_evaluator_fixture_cli.py tools/tests/schemas/test_evaluator_fixture_schema.py`; after a quick fix for import path the final run passed with `5 passed`.
- The CLI tests exercise allow/deny/invalid-fixture paths and the schema tests validate the fixture schema shape, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1161fa820832a970c24a547bb3955)