### PR TITLE
Genealogy ingest: handle FAM events, carry family_id, and dedupe sidecar

### DIFF
--- a/tools/ingest/genealogy/README.md
+++ b/tools/ingest/genealogy/README.md
@@ -254,9 +254,9 @@ python tools/ingest/genealogy/write_sidecar.py \
 | Command | Primary responsibility | Expected output | Truth label |
 |---|---|---|---|
 | `verify_evidence_bundle.py` | Verify payload hash, trust envelope, and consent obligations before ingest | PASS/ERROR plus no parsed data on failure | `IMPLEMENTED (2026-04-28)` |
-| `parse_gedcom.py` | Extract source event rows from GEDCOM | `data/work/genealogy/raw_events.ndjson` | `IMPLEMENTED (2026-04-28)` |
-| `build_canonical_events.py` | Attach pseudonymous key, `bundle_id`, `evidence_ref`, and canonical event fields | `data/processed/genealogy/events.ndjson` | `IMPLEMENTED (2026-04-28)` |
-| `write_sidecar.py` | Emit restricted sidecar mappings for controlled lookup | `data/work/genealogy/sidecar.ndjson` | `IMPLEMENTED (2026-04-28)` |
+| `parse_gedcom.py` | Extract individual and family-backed source event rows from GEDCOM (including spouse-linked `FAM` events) | `data/work/genealogy/raw_events.ndjson` | `IMPLEMENTED (2026-04-28)` |
+| `build_canonical_events.py` | Attach pseudonymous key, `bundle_id`, `evidence_ref`, and canonical event fields (including optional `family_id`) | `data/processed/genealogy/events.ndjson` | `IMPLEMENTED (2026-04-28)` |
+| `write_sidecar.py` | Emit restricted sidecar mappings for controlled lookup (deduplicated per source person id) | `data/work/genealogy/sidecar.ndjson` | `IMPLEMENTED (2026-04-28)` |
 | `read_sidecar.py` | Resolve one sidecar row for controlled review/debug | JSON to stdout for authorized local review | `IMPLEMENTED (2026-04-28)` |
 
 ### Operating rules

--- a/tools/ingest/genealogy/build_canonical_events.py
+++ b/tools/ingest/genealogy/build_canonical_events.py
@@ -26,6 +26,9 @@ def build_rows(rows: list[dict[str, Any]], bundle_id: str, evidence_ref: str, re
     out: list[dict[str, Any]] = []
     for index, row in enumerate(rows, start=1):
         person_id = str(row.get("person_id", "UNKNOWN"))
+        event_type = row.get("event_type")
+        if not event_type:
+            continue
         pseudonymous_key = _stable_person_key(person_id, repo_salt)
         out.append(
             {
@@ -33,10 +36,11 @@ def build_rows(rows: list[dict[str, Any]], bundle_id: str, evidence_ref: str, re
                 "bundle_id": bundle_id,
                 "evidence_ref": evidence_ref,
                 "person_key": pseudonymous_key,
-                "event_type": row.get("event_type"),
+                "event_type": event_type,
                 "event_date": row.get("event_date"),
                 "place": row.get("place"),
                 "source_line": row.get("source_line"),
+                "family_id": row.get("family_id"),
             }
         )
     return out

--- a/tools/ingest/genealogy/parse_gedcom.py
+++ b/tools/ingest/genealogy/parse_gedcom.py
@@ -25,7 +25,28 @@ def _line_record(line: str) -> tuple[int, str | None, str, str]:
 def parse_gedcom(input_path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     current_person: str | None = None
+    current_family: str | None = None
+    family_spouses: dict[str, set[str]] = {}
     current_event: dict[str, Any] | None = None
+    current_family_event: dict[str, Any] | None = None
+
+    def flush_family_event() -> None:
+        nonlocal current_family_event
+        if current_family is None or current_family_event is None:
+            return
+        for spouse in sorted(family_spouses.get(current_family, set())):
+            rows.append(
+                {
+                    "person_id": spouse,
+                    "event_type": current_family_event["event_type"],
+                    "event_date": current_family_event["event_date"],
+                    "place": current_family_event["place"],
+                    "source_value": current_family_event["source_value"],
+                    "source_line": current_family_event["source_line"],
+                    "family_id": current_family,
+                }
+            )
+        current_family_event = None
 
     with input_path.open("r", encoding="utf-8") as handle:
         for line_no, raw in enumerate(handle, start=1):
@@ -36,17 +57,22 @@ def parse_gedcom(input_path: Path) -> list[dict[str, Any]]:
             level, xref, tag, rest = _line_record(raw)
 
             if level == 0:
+                flush_family_event()
                 current_event = None
+                current_family_event = None
                 if tag == "INDI" and xref:
                     current_person = xref
+                    current_family = None
+                elif tag == "FAM" and xref:
+                    current_family = xref
+                    current_person = None
+                    family_spouses.setdefault(current_family, set())
                 else:
                     current_person = None
+                    current_family = None
                 continue
 
-            if current_person is None:
-                continue
-
-            if level == 1 and tag in EVENT_TAGS:
+            if level == 1 and current_person and tag in EVENT_TAGS:
                 current_event = {
                     "person_id": current_person,
                     "event_type": tag,
@@ -58,13 +84,41 @@ def parse_gedcom(input_path: Path) -> list[dict[str, Any]]:
                 rows.append(current_event)
                 continue
 
-            if current_event is None:
+            if level == 1 and current_family and tag in EVENT_TAGS:
+                current_family_event = {
+                    "family_id": current_family,
+                    "event_type": tag,
+                    "event_date": None,
+                    "place": None,
+                    "source_value": rest or None,
+                    "source_line": line_no,
+                }
                 continue
 
-            if level == 2 and tag == "DATE":
-                current_event["event_date"] = rest or None
-            elif level == 2 and tag == "PLAC":
-                current_event["place"] = rest or None
+            if level == 1 and current_family and tag in {"HUSB", "WIFE"} and rest:
+                family_spouses[current_family].add(rest)
+                continue
+
+            if level == 2 and current_event is not None:
+                if tag == "DATE":
+                    current_event["event_date"] = rest or None
+                elif tag == "PLAC":
+                    current_event["place"] = rest or None
+                continue
+
+            if level == 2 and current_family_event is not None:
+                if tag == "DATE":
+                    current_family_event["event_date"] = rest or None
+                elif tag == "PLAC":
+                    current_family_event["place"] = rest or None
+
+                if tag in {"DATE", "PLAC"}:
+                    continue
+
+            if level == 1 and current_family and current_family_event is not None and tag not in {"DATE", "PLAC"}:
+                flush_family_event()
+
+    flush_family_event()
 
     return rows
 

--- a/tools/ingest/genealogy/write_sidecar.py
+++ b/tools/ingest/genealogy/write_sidecar.py
@@ -29,10 +29,12 @@ def _encode_payload(payload: dict[str, Any]) -> str:
 
 def build_sidecar(rows: list[dict[str, Any]], repo_salt: str, kek_id: str) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
+    seen: set[str] = set()
     for row in rows:
         person_id = str(row.get("person_id", ""))
-        if not person_id:
+        if not person_id or person_id in seen:
             continue
+        seen.add(person_id)
 
         payload = {
             "person_id": person_id,


### PR DESCRIPTION
### Motivation
- Parse GEDCOM family-level events so marriage and other FAM records are projected to person-level rows for downstream processing. 
- Ensure canonical events only include real event rows and carry optional family context for traceability. 
- Prevent repeated sidecar entries for the same source person id to reduce noise and leakage risk.

### Description
- Extended `tools/ingest/genealogy/parse_gedcom.py` to recognize `FAM` blocks, collect `HUSB`/`WIFE` members, flush family-level events into per-person rows, and emit `family_id` on derived rows. 
- Updated `tools/ingest/genealogy/build_canonical_events.py` to skip rows missing `event_type` and to propagate `family_id` into canonical event output. 
- Updated `tools/ingest/genealogy/write_sidecar.py` to deduplicate sidecar rows by source `person_id` so each person produces at most one sidecar entry. 
- Clarified the README (`tools/ingest/genealogy/README.md`) command responsibilities to document FAM handling, `family_id` propagation, and sidecar deduplication.

### Testing
- Ran `python -m py_compile tools/ingest/genealogy/*.py` which completed successfully. 
- Executed an end-to-end smoke sequence using temporary GEDCOM fixtures covering `parse_gedcom.py`, `build_canonical_events.py`, `write_sidecar.py`, and `read_sidecar.py`, and verified expected output line counts (raw rows, canonical events, sidecar rows) which all passed. 
- Ran `verify_evidence_bundle.py` with a generated SHA256 bundle and a small trusted-keys fixture which returned `PASS: evidence bundle verification`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f119544134832aa00042c9afbe4d3e)