### PR TITLE
Add executable probes to tools/probes (hydrology, catalog refs, STAC materiality) and tests

### DIFF
--- a/tools/probes/README.md
+++ b/tools/probes/README.md
@@ -181,11 +181,11 @@ This table records the lane posture carried forward for this README. Recheck it 
 | Evidence item | Status | Current meaning |
 |---|---:|---|
 | `tools/probes/README.md` is the target lane surface | **CONFIRMED** | This README is a real lane document, not a hypothetical path. |
-| Public-tree evidence for `tools/probes/` is README-first | **CONFIRMED / NEEDS VERIFICATION in active checkout** | Prevents overclaiming executable probe inventory. |
+| Public-tree evidence for `tools/probes/` is README-plus-executables | **CONFIRMED** | Lane now includes documented executable probes plus this README. |
 | The existing probe README lineage is substantive | **CONFIRMED** | This revision builds upward instead of resetting the lane to generic scaffold prose. |
 | Sibling `tools/` lanes include validators, diff, catalog, CI, attest, docs, and probes | **CONFIRMED from retrieved repo-doc evidence / NEEDS ACTIVE CHECKOUT VERIFICATION** | Grounds handoff boundaries and relative-link structure. |
 | `/tools/` owner coverage uses `@bartytime4life` | **CONFIRMED from retrieved repo-doc evidence / NEEDS ACTIVE CODEOWNERS VERIFICATION** | Grounds the owner line without inventing a narrower `/tools/probes/` owner rule. |
-| Exact executable probes under `tools/probes/` | **UNKNOWN** | Do not claim executable inventory until the active branch is inspected. |
+| Executable probes under `tools/probes/` | **CONFIRMED** | Current lane includes `hydrology_freshness_probe.py`, `catalog_release_refs_probe.py`, and `stac_materiality_probe.py`. |
 | Exact workflow callers, rulesets, or non-public runtime use | **UNKNOWN** | Not derivable from README lineage alone. |
 | Whether `data/run_receipts/` is populated or active | **NEEDS VERIFICATION** | Probe outputs may land there only when repo conventions confirm it. |
 
@@ -199,7 +199,11 @@ This table records the lane posture carried forward for this README. Recheck it 
 
 ```text
 tools/probes/
-└── README.md
+├── README.md
+├── __init__.py
+├── catalog_release_refs_probe.py
+├── hydrology_freshness_probe.py
+└── stac_materiality_probe.py
 ```
 
 ### Confirmed parent-family context from repo-doc evidence

--- a/tools/probes/__init__.py
+++ b/tools/probes/__init__.py
@@ -1,0 +1,7 @@
+"""Probe helpers for bounded observational checks."""
+
+__all__ = [
+    "catalog_release_refs_probe",
+    "hydrology_freshness_probe",
+    "stac_materiality_probe",
+]

--- a/tools/probes/catalog_release_refs_probe.py
+++ b/tools/probes/catalog_release_refs_probe.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REQUIRED_KEYS = ("receipt_ref", "proof_ref", "release_ref")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_report(*, source_ref: str, payload: dict[str, Any]) -> dict[str, Any]:
+    refs = payload.get("refs") if isinstance(payload.get("refs"), dict) else {}
+    missing = [key for key in REQUIRED_KEYS if not isinstance(refs.get(key), str) or not refs.get(key).strip()]
+
+    status = "OBSERVED" if not missing else "CHANGED"
+
+    return {
+        "probe_id": "kfm.probes.catalog_release_refs.v1",
+        "question": "Are required release trust references present in the catalog payload?",
+        "checked_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "inputs": {"source_ref": source_ref, "required_refs": list(REQUIRED_KEYS)},
+        "status": status,
+        "observations": {
+            "present_refs": {key: refs.get(key) for key in REQUIRED_KEYS if key in refs},
+            "missing_refs": missing,
+        },
+        "refs": {
+            "receipt_ref": refs.get("receipt_ref"),
+            "proof_ref": refs.get("proof_ref"),
+            "evidence_ref": None,
+        },
+        "warnings": ["missing required release refs"] if missing else [],
+        "errors": [],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Probe catalog payload for release reference presence.")
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--source-ref", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_report(source_ref=args.source_ref, payload=_read_json(args.input))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if report["status"] == "OBSERVED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/probes/hydrology_freshness_probe.py
+++ b/tools/probes/hydrology_freshness_probe.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _parse_iso8601(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_report(*, source_ref: str, payload: dict[str, Any], checked_at: datetime, freshness_threshold_seconds: int) -> dict[str, Any]:
+    observed_at_raw = payload.get("observed_at") or payload.get("updated")
+    observed_at = _parse_iso8601(observed_at_raw) if isinstance(observed_at_raw, str) else None
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    lag_seconds: int | None = None
+    reachable = True
+    status = "OBSERVED"
+
+    if observed_at is None:
+        status = "ERROR"
+        errors.append("missing or invalid observed_at/updated timestamp")
+    else:
+        lag_seconds = int((checked_at - observed_at.astimezone(timezone.utc)).total_seconds())
+        if lag_seconds > freshness_threshold_seconds:
+            status = "STALE"
+            warnings.append("observed timestamp exceeds freshness threshold")
+
+    return {
+        "probe_id": "kfm.probes.hydrology_freshness.v1",
+        "question": "Is the declared hydrology source fresh enough for review?",
+        "checked_at": checked_at.isoformat().replace("+00:00", "Z"),
+        "inputs": {
+            "source_ref": source_ref,
+            "freshness_threshold_seconds": freshness_threshold_seconds,
+        },
+        "status": status,
+        "observations": {
+            "reachable": reachable,
+            "observed_at": observed_at_raw,
+            "lag_seconds": lag_seconds,
+        },
+        "refs": {"receipt_ref": None, "proof_ref": None, "evidence_ref": None},
+        "warnings": warnings,
+        "errors": errors,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Probe hydrology source freshness from a JSON payload.")
+    parser.add_argument("--input", type=Path, required=True, help="Hydrology payload JSON path.")
+    parser.add_argument("--source-ref", required=True, help="Logical source reference identifier.")
+    parser.add_argument("--freshness-threshold-seconds", type=int, default=86_400)
+    parser.add_argument("--checked-at", default=None, help="Override check time with ISO8601 UTC timestamp.")
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    checked_at = _parse_iso8601(args.checked_at) if args.checked_at else datetime.now(timezone.utc)
+    if checked_at is None:
+        raise SystemExit("invalid --checked-at timestamp")
+
+    report = build_report(
+        source_ref=args.source_ref,
+        payload=_read_json(args.input),
+        checked_at=checked_at.astimezone(timezone.utc),
+        freshness_threshold_seconds=args.freshness_threshold_seconds,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if report["status"] == "ERROR":
+        return 2
+    if report["status"] == "STALE":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/probes/stac_materiality_probe.py
+++ b/tools/probes/stac_materiality_probe.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    features = payload.get("features")
+    if isinstance(features, list):
+        return [item for item in features if isinstance(item, dict)]
+    if payload.get("type") == "Feature":
+        return [payload]
+    return []
+
+
+def _digest_items(items: list[dict[str, Any]]) -> str:
+    canonical = json.dumps(items, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_report(*, source_ref: str, baseline: dict[str, Any], candidate: dict[str, Any], max_count_delta: int) -> dict[str, Any]:
+    base_items = _normalize_items(baseline)
+    cand_items = _normalize_items(candidate)
+
+    base_count = len(base_items)
+    cand_count = len(cand_items)
+    count_delta = cand_count - base_count
+    digest_changed = _digest_items(base_items) != _digest_items(cand_items)
+
+    changed = abs(count_delta) > max_count_delta or digest_changed
+    status = "CHANGED" if changed else "UNCHANGED"
+
+    return {
+        "probe_id": "kfm.probes.stac_materiality.v1",
+        "question": "Did the candidate STAC surface drift materially from baseline?",
+        "checked_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "inputs": {
+            "source_ref": source_ref,
+            "max_count_delta": max_count_delta,
+        },
+        "status": status,
+        "observations": {
+            "baseline_count": base_count,
+            "candidate_count": cand_count,
+            "count_delta": count_delta,
+            "digest_changed": digest_changed,
+        },
+        "refs": {"receipt_ref": None, "proof_ref": None, "evidence_ref": None},
+        "warnings": ["material drift observed"] if changed else [],
+        "errors": [],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Probe STAC materiality between baseline and candidate payloads.")
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--source-ref", required=True)
+    parser.add_argument("--max-count-delta", type=int, default=0)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_report(
+        source_ref=args.source_ref,
+        baseline=_read_json(args.baseline),
+        candidate=_read_json(args.candidate),
+        max_count_delta=args.max_count_delta,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if report["status"] == "UNCHANGED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_probes_cli.py
+++ b/tools/tests/test_probes_cli.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, *args], text=True, capture_output=True, check=False)
+
+
+def test_hydrology_freshness_probe_observed(tmp_path: Path) -> None:
+    payload = tmp_path / "hydrology.json"
+    payload.write_text(json.dumps({"observed_at": "2026-04-27T23:00:00Z"}), encoding="utf-8")
+    out = tmp_path / "report.json"
+
+    result = _run(
+        "tools/probes/hydrology_freshness_probe.py",
+        "--input",
+        str(payload),
+        "--source-ref",
+        "kfm://source/hydrology/demo",
+        "--freshness-threshold-seconds",
+        "86400",
+        "--checked-at",
+        "2026-04-28T00:00:00Z",
+        "--output",
+        str(out),
+    )
+
+    assert result.returncode == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["status"] == "OBSERVED"
+    assert report["observations"]["lag_seconds"] == 3600
+
+
+def test_catalog_release_refs_probe_missing_ref(tmp_path: Path) -> None:
+    payload = tmp_path / "catalog.json"
+    payload.write_text(
+        json.dumps({"refs": {"receipt_ref": "kfm://receipts/x", "proof_ref": "kfm://proofs/y"}}),
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.json"
+
+    result = _run(
+        "tools/probes/catalog_release_refs_probe.py",
+        "--input",
+        str(payload),
+        "--source-ref",
+        "kfm://catalog/stac/demo",
+        "--output",
+        str(out),
+    )
+
+    assert result.returncode == 1
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["status"] == "CHANGED"
+    assert report["observations"]["missing_refs"] == ["release_ref"]
+
+
+def test_stac_materiality_probe_changed(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline.write_text(json.dumps({"type": "FeatureCollection", "features": [{"id": "A"}]}), encoding="utf-8")
+    candidate.write_text(
+        json.dumps({"type": "FeatureCollection", "features": [{"id": "A"}, {"id": "B"}]}),
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.json"
+
+    result = _run(
+        "tools/probes/stac_materiality_probe.py",
+        "--baseline",
+        str(baseline),
+        "--candidate",
+        str(candidate),
+        "--source-ref",
+        "kfm://catalog/stac/demo",
+        "--max-count-delta",
+        "0",
+        "--output",
+        str(out),
+    )
+
+    assert result.returncode == 1
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["status"] == "CHANGED"
+    assert report["observations"]["count_delta"] == 1


### PR DESCRIPTION
### Motivation
- Provide a narrow, read-only probe lane with executable helpers that observe, summarize, and emit reviewable JSON reports.  
- Surface common probe questions for freshness, release reference presence, and STAC materiality so callers and CI can consume bounded observations.  
- Ship minimal CLI entrypoints plus tests to prove expected exit codes and report shapes.

### Description
- Add three probe CLIs: `tools/probes/hydrology_freshness_probe.py` (freshness/lag observation with `OBSERVED`/`STALE`/`ERROR` outcomes and mapped exit codes), `tools/probes/catalog_release_refs_probe.py` (checks required release refs and reports missing refs as `CHANGED`), and `tools/probes/stac_materiality_probe.py` (baseline vs candidate STAC materiality using count delta and digest comparison).  
- Add `tools/probes/__init__.py` to declare probe exports.  
- Update `tools/probes/README.md` to mark the lane as README-plus-executables and document the current directory tree with the new files.  
- Add CLI tests at `tools/tests/test_probes_cli.py` that exercise positive and negative paths and assert report content and exit codes.

### Testing
- Ran `pytest -q tools/tests/test_probes_cli.py`, which reported `3 passed`.  
- Ran the repository Python syntax check via `bash tools/ci/check_python_syntax.sh`, which completed successfully (`check_python_syntax: ok (all python files)`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11bbb3a60832a9c1b851ecc93baf6)