### PR TITLE
Add fixture files and wire tools/proofs tests to use them

### DIFF
--- a/tools/proofs/tests/fixtures/invalid/catalog_refs.missing_prov.json
+++ b/tools/proofs/tests/fixtures/invalid/catalog_refs.missing_prov.json
@@ -1,0 +1,5 @@
+{
+  "dcat": ["kfm:dcat:dataset:ecology:example"],
+  "stac": ["kfm:stac:item:ecology:example"],
+  "prov": []
+}

--- a/tools/proofs/tests/fixtures/invalid/manifest.not_ready.json
+++ b/tools/proofs/tests/fixtures/invalid/manifest.not_ready.json
@@ -1,0 +1,18 @@
+{
+  "manifest_id": "kfm.receipt_manifest.ecology.eco_index.example",
+  "candidate_id": "eco_index.example",
+  "candidate_type": "eco_index",
+  "spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "receipts": [
+    {
+      "receipt_type": "validator_result",
+      "validator": "tools/validators/ecology_index",
+      "receipt_ref": "data/receipts/ecology/index/example.validator_receipt.json",
+      "decision": "pass",
+      "spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "generated_at": "2026-04-24T00:00:00Z"
+    }
+  ],
+  "decision": "not_ready",
+  "generated_at": "2026-04-24T00:00:00Z"
+}

--- a/tools/proofs/tests/fixtures/valid/catalog_refs.complete.json
+++ b/tools/proofs/tests/fixtures/valid/catalog_refs.complete.json
@@ -1,0 +1,5 @@
+{
+  "dcat": ["kfm:dcat:dataset:ecology:example"],
+  "stac": ["kfm:stac:item:ecology:example"],
+  "prov": ["kfm:prov:entity:ecology:example"]
+}

--- a/tools/proofs/tests/fixtures/valid/manifest.ready_for_promotion.json
+++ b/tools/proofs/tests/fixtures/valid/manifest.ready_for_promotion.json
@@ -1,0 +1,18 @@
+{
+  "manifest_id": "kfm.receipt_manifest.ecology.eco_index.example",
+  "candidate_id": "eco_index.example",
+  "candidate_type": "eco_index",
+  "spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "receipts": [
+    {
+      "receipt_type": "validator_result",
+      "validator": "tools/validators/ecology_index",
+      "receipt_ref": "data/receipts/ecology/index/example.validator_receipt.json",
+      "decision": "pass",
+      "spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "generated_at": "2026-04-24T00:00:00Z"
+    }
+  ],
+  "decision": "ready_for_promotion",
+  "generated_at": "2026-04-24T00:00:00Z"
+}

--- a/tools/proofs/tests/test_ecology_proof_pack_builder.py
+++ b/tools/proofs/tests/test_ecology_proof_pack_builder.py
@@ -11,37 +11,25 @@ from tools.proofs.ecology_proof_pack_builder import (
     write_proof_pack,
 )
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(*parts: str) -> dict:
+    return json.loads(FIXTURES_DIR.joinpath(*parts).read_text(encoding="utf-8"))
+
 
 SPEC_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 
 def manifest(*, decision: str = "ready_for_promotion", receipt_decision: str = "pass") -> dict:
-    return {
-        "manifest_id": "kfm.receipt_manifest.ecology.eco_index.example",
-        "candidate_id": "eco_index.example",
-        "candidate_type": "eco_index",
-        "spec_hash": SPEC_HASH,
-        "receipts": [
-            {
-                "receipt_type": "validator_result",
-                "validator": "tools/validators/ecology_index",
-                "receipt_ref": "data/receipts/ecology/index/example.validator_receipt.json",
-                "decision": receipt_decision,
-                "spec_hash": SPEC_HASH,
-                "generated_at": "2026-04-24T00:00:00Z",
-            }
-        ],
-        "decision": decision,
-        "generated_at": "2026-04-24T00:00:00Z",
-    }
+    value = load_fixture("valid", "manifest.ready_for_promotion.json")
+    value["decision"] = decision
+    value["receipts"][0]["decision"] = receipt_decision
+    return value
 
 
 def catalog_refs() -> dict:
-    return {
-        "dcat": ["kfm:dcat:dataset:ecology:example"],
-        "stac": ["kfm:stac:item:ecology:example"],
-        "prov": ["kfm:prov:entity:ecology:example"],
-    }
+    return load_fixture("valid", "catalog_refs.complete.json")
 
 
 def test_build_proof_pack_success() -> None:
@@ -102,11 +90,7 @@ def test_receipt_spec_hash_mismatch_fails() -> None:
 
 
 def test_missing_prov_catalog_ref_fails() -> None:
-    refs = {
-        "dcat": ["kfm:dcat:dataset:ecology:example"],
-        "stac": ["kfm:stac:item:ecology:example"],
-        "prov": [],
-    }
+    refs = load_fixture("invalid", "catalog_refs.missing_prov.json")
 
     with pytest.raises(ValueError, match="proof pack requires at least one PROV catalog reference"):
         build_proof_pack(

--- a/tools/proofs/tests/test_ecology_proof_pack_cli.py
+++ b/tools/proofs/tests/test_ecology_proof_pack_cli.py
@@ -5,8 +5,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
-SPEC_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+def load_fixture(*parts: str) -> dict:
+    return json.loads(FIXTURES_DIR.joinpath(*parts).read_text(encoding="utf-8"))
+
+
 SCHEMA_REF = "schemas/ecology/ecology_proof_pack.schema.json"
 
 
@@ -24,32 +29,15 @@ def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 def manifest(*, decision: str = "ready_for_promotion") -> dict:
-    return {
-        "manifest_id": "kfm.receipt_manifest.ecology.eco_index.example",
-        "candidate_id": "eco_index.example",
-        "candidate_type": "eco_index",
-        "spec_hash": SPEC_HASH,
-        "receipts": [
-            {
-                "receipt_type": "validator_result",
-                "validator": "tools/validators/ecology_index",
-                "receipt_ref": "data/receipts/ecology/index/example.validator_receipt.json",
-                "decision": "pass",
-                "spec_hash": SPEC_HASH,
-                "generated_at": "2026-04-24T00:00:00Z",
-            }
-        ],
-        "decision": decision,
-        "generated_at": "2026-04-24T00:00:00Z",
-    }
+    value = load_fixture("valid", "manifest.ready_for_promotion.json")
+    value["decision"] = decision
+    return value
 
 
 def catalog_refs(*, include_prov: bool = True) -> dict:
-    return {
-        "dcat": ["kfm:dcat:dataset:ecology:example"],
-        "stac": ["kfm:stac:item:ecology:example"],
-        "prov": ["kfm:prov:entity:ecology:example"] if include_prov else [],
-    }
+    if include_prov:
+        return load_fixture("valid", "catalog_refs.complete.json")
+    return load_fixture("invalid", "catalog_refs.missing_prov.json")
 
 
 def cli_args(
@@ -213,7 +201,7 @@ def test_cli_non_promotable_manifest_exits_one(tmp_path: Path) -> None:
     catalog_refs_path = tmp_path / "catalog_refs.json"
     out_path = tmp_path / "proof_pack.json"
 
-    write_json(manifest_path, manifest(decision="not_ready"))
+    write_json(manifest_path, load_fixture("invalid", "manifest.not_ready.json"))
     write_json(catalog_refs_path, catalog_refs())
 
     result = run_cli(

--- a/tools/proofs/tests/test_ecology_proof_pack_schema_validation.py
+++ b/tools/proofs/tests/test_ecology_proof_pack_schema_validation.py
@@ -11,8 +11,13 @@ from tools.proofs.ecology_proof_pack_builder import (
     validate_proof_pack,
 )
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
-SPEC_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+def load_fixture(*parts: str) -> dict:
+    return json.loads(FIXTURES_DIR.joinpath(*parts).read_text(encoding="utf-8"))
+
+
 SCHEMA_REF = Path("schemas/ecology/ecology_proof_pack.schema.json")
 
 
@@ -21,32 +26,11 @@ def write_json(path: Path, value: object) -> None:
 
 
 def manifest() -> dict:
-    return {
-        "manifest_id": "kfm.receipt_manifest.ecology.eco_index.example",
-        "candidate_id": "eco_index.example",
-        "candidate_type": "eco_index",
-        "spec_hash": SPEC_HASH,
-        "receipts": [
-            {
-                "receipt_type": "validator_result",
-                "validator": "tools/validators/ecology_index",
-                "receipt_ref": "data/receipts/ecology/index/example.validator_receipt.json",
-                "decision": "pass",
-                "spec_hash": SPEC_HASH,
-                "generated_at": "2026-04-24T00:00:00Z",
-            }
-        ],
-        "decision": "ready_for_promotion",
-        "generated_at": "2026-04-24T00:00:00Z",
-    }
+    return load_fixture("valid", "manifest.ready_for_promotion.json")
 
 
 def catalog_refs() -> dict:
-    return {
-        "dcat": ["kfm:dcat:dataset:ecology:example"],
-        "stac": ["kfm:stac:item:ecology:example"],
-        "prov": ["kfm:prov:entity:ecology:example"],
-    }
+    return load_fixture("valid", "catalog_refs.complete.json")
 
 
 def test_validate_proof_pack_accepts_generated_pack() -> None:


### PR DESCRIPTION
### Motivation

- Make the proof-pack tests maintainable by moving repeated inline JSON inputs into reusable on-disk fixtures.
- Surface explicit invalid/boundary cases as discrete files so negative-path tests are easier to review and extend.

### Description

- Added fixture files under `tools/proofs/tests/fixtures`: `valid/manifest.ready_for_promotion.json`, `valid/catalog_refs.complete.json`, `invalid/manifest.not_ready.json`, and `invalid/catalog_refs.missing_prov.json`.
- Updated `tools/proofs/tests/test_ecology_proof_pack_builder.py`, `tools/proofs/tests/test_ecology_proof_pack_cli.py`, and `tools/proofs/tests/test_ecology_proof_pack_schema_validation.py` to load manifests and catalog refs from the new fixtures using a local `load_fixture` helper and preserved the original assertions.
- Removed the previous `fixture_utils` dependency and adjusted test module layouts/imports to avoid relative-import and collection collisions during pytest run.

### Testing

- Ran `pytest -q tools/proofs/tests tools/proofs/ecology/tests`, which initially errored during collection due to import-file mismatch caused by duplicate test module basenames (collection error).
- After fixing imports and cleaning conflicting pyc/__pycache__, ran `pytest -q tools/proofs/tests` and observed `22 passed` (all tests in that target succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11ec4b4e8832abcc7e5ded6bcf2b9)