### PR TITLE
Add receipt manifest validation and comparison tools to tools/receipts

### DIFF
--- a/tools/receipts/README.md
+++ b/tools/receipts/README.md
@@ -172,8 +172,12 @@ Do **not** put these under `tools/receipts/` as their authoritative home.
 ```text
 tools/
 └── receipts/
-    ├── README.md                    # CONFIRMED empty before this revision
-    └── ecology_manifest_builder.py  # CONFIRMED file; execution NEEDS VERIFICATION
+    ├── README.md
+    ├── compare_receipt_sets.py
+    ├── ecology_manifest.py
+    ├── ecology_manifest_builder.py
+    ├── validate_receipt_manifest.py
+    └── tests/
 ```
 
 ### Candidate future shape
@@ -184,10 +188,12 @@ The following tree is **PROPOSED**. Do not create every file at once unless a PR
 tools/
 └── receipts/
     ├── README.md
+    ├── compare_receipt_sets.py       # Compare receipt lists across two manifests
+    ├── ecology_manifest.py           # CLI to build and validate manifest candidates
     ├── ecology_manifest_builder.py
-    ├── render_receipt_summary.py      # PROPOSED: render-only reviewer summary
-    ├── validate_receipt_manifest.py   # PROPOSED: manifest-shape and readiness checks
-    └── compare_receipt_sets.py        # PROPOSED: deterministic receipt-set comparison
+    ├── render_receipt_summary.py     # PROPOSED: render-only reviewer summary
+    ├── validate_receipt_manifest.py  # Validate an existing manifest against schema
+    └── tests/
 ```
 
 ### Adjacent surfaces to recheck before merge

--- a/tools/receipts/compare_receipt_sets.py
+++ b/tools/receipts/compare_receipt_sets.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.receipts.compare_receipt_sets",
+        description="Compare receipt sets between two ecology receipt manifests.",
+    )
+
+    parser.add_argument("--left", required=True, help="Path to left manifest JSON.")
+    parser.add_argument("--right", required=True, help="Path to right manifest JSON.")
+    parser.add_argument("--out", default=None, help="Optional output path for diff JSON.")
+
+    return parser
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("Manifest must be a JSON object.")
+    return value
+
+
+def _key(receipt: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(receipt.get("receipt_type", "")),
+        str(receipt.get("receipt_ref", "")),
+    )
+
+
+def compare_manifests(left_manifest: dict[str, Any], right_manifest: dict[str, Any]) -> dict[str, Any]:
+    left_receipts = { _key(item): item for item in left_manifest.get("receipts", []) }
+    right_receipts = { _key(item): item for item in right_manifest.get("receipts", []) }
+
+    added_keys = sorted(set(right_receipts) - set(left_receipts))
+    removed_keys = sorted(set(left_receipts) - set(right_receipts))
+
+    changed: list[dict[str, Any]] = []
+    for shared_key in sorted(set(left_receipts) & set(right_receipts)):
+        left_item = left_receipts[shared_key]
+        right_item = right_receipts[shared_key]
+
+        if left_item != right_item:
+            changed.append(
+                {
+                    "receipt_type": shared_key[0],
+                    "receipt_ref": shared_key[1],
+                    "left": left_item,
+                    "right": right_item,
+                }
+            )
+
+    return {
+        "left_manifest_ref": left_manifest.get("manifest_id"),
+        "right_manifest_ref": right_manifest.get("manifest_id"),
+        "added": [right_receipts[key] for key in added_keys],
+        "removed": [left_receipts[key] for key in removed_keys],
+        "changed": changed,
+        "summary": {
+            "added_count": len(added_keys),
+            "removed_count": len(removed_keys),
+            "changed_count": len(changed),
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    left_path = Path(args.left)
+    right_path = Path(args.right)
+
+    left_manifest = _load_manifest(left_path)
+    right_manifest = _load_manifest(right_path)
+
+    diff = compare_manifests(left_manifest, right_manifest)
+    rendered = json.dumps(diff, indent=2, sort_keys=True)
+
+    if args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(rendered + "\n", encoding="utf-8")
+
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/receipts/tests/test_compare_receipt_sets.py
+++ b/tools/receipts/tests/test_compare_receipt_sets.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from tools.receipts.compare_receipt_sets import compare_manifests
+
+
+def test_compare_manifests_detects_added_removed_and_changed() -> None:
+    left_manifest = {
+        "manifest_id": "kfm.receipt_manifest.ecology.left",
+        "receipts": [
+            {
+                "receipt_type": "validator_result",
+                "receipt_ref": "validator.json",
+                "decision": "pass",
+            },
+            {
+                "receipt_type": "proof_result",
+                "receipt_ref": "proof.json",
+                "decision": "proof_required",
+            },
+        ],
+    }
+
+    right_manifest = {
+        "manifest_id": "kfm.receipt_manifest.ecology.right",
+        "receipts": [
+            {
+                "receipt_type": "validator_result",
+                "receipt_ref": "validator.json",
+                "decision": "fail",
+            },
+            {
+                "receipt_type": "promotion_result",
+                "receipt_ref": "promotion.json",
+                "decision": "pass",
+            },
+        ],
+    }
+
+    diff = compare_manifests(left_manifest, right_manifest)
+
+    assert diff["summary"] == {
+        "added_count": 1,
+        "removed_count": 1,
+        "changed_count": 1,
+    }
+    assert diff["added"][0]["receipt_type"] == "promotion_result"
+    assert diff["removed"][0]["receipt_type"] == "proof_result"
+    assert diff["changed"][0]["receipt_ref"] == "validator.json"

--- a/tools/receipts/tests/test_validate_receipt_manifest_cli.py
+++ b/tools/receipts/tests/test_validate_receipt_manifest_cli.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SPEC_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+SCHEMA_REF = "schemas/ecology/ecology_receipt_manifest.schema.json"
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tools.receipts.validate_receipt_manifest", *args],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def valid_manifest() -> dict:
+    return {
+        "manifest_id": "kfm.receipt_manifest.ecology.eco_index.example",
+        "candidate_id": "eco_index.example",
+        "candidate_type": "eco_index",
+        "spec_hash": SPEC_HASH,
+        "receipts": [
+            {
+                "receipt_type": "validator_result",
+                "validator": "tools/validators/ecology_index",
+                "receipt_ref": "receipt.json",
+                "decision": "pass",
+                "spec_hash": SPEC_HASH,
+                "generated_at": "2026-04-24T00:00:00Z",
+            }
+        ],
+        "decision": "ready_for_promotion",
+        "generated_at": "2026-04-24T00:00:00Z",
+    }
+
+
+def test_cli_valid_manifest(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    write_json(manifest_path, valid_manifest())
+
+    result = run_cli("--manifest", str(manifest_path), "--schema", SCHEMA_REF)
+
+    assert result.returncode == 0
+    assert "manifest schema valid" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_invalid_manifest(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    bad = valid_manifest()
+    bad["receipts"] = []
+    write_json(manifest_path, bad)
+
+    result = run_cli("--manifest", str(manifest_path), "--schema", SCHEMA_REF)
+
+    assert result.returncode == 1
+    assert "manifest schema invalid:" in result.stderr
+
+
+def test_cli_missing_manifest(tmp_path: Path) -> None:
+    result = run_cli("--manifest", str(tmp_path / "missing.json"), "--schema", SCHEMA_REF)
+
+    assert result.returncode == 2
+    assert "missing manifest:" in result.stderr
+
+
+def test_cli_missing_schema(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    write_json(manifest_path, valid_manifest())
+
+    result = run_cli(
+        "--manifest",
+        str(manifest_path),
+        "--schema",
+        str(tmp_path / "missing_schema.json"),
+    )
+
+    assert result.returncode == 3
+    assert "missing schema:" in result.stderr

--- a/tools/receipts/validate_receipt_manifest.py
+++ b/tools/receipts/validate_receipt_manifest.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from jsonschema.exceptions import SchemaError
+
+from .ecology_manifest_builder import validate_manifest
+
+
+EXIT_PASS = 0
+EXIT_FAILURE = 1
+EXIT_MISSING_MANIFEST = 2
+EXIT_MISSING_SCHEMA = 3
+EXIT_INTERNAL_ERROR = 5
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.receipts.validate_receipt_manifest",
+        description="Validate an existing KFM ecology receipt manifest against schema.",
+    )
+
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        help="Path to an ecology receipt manifest JSON file.",
+    )
+
+    parser.add_argument(
+        "--schema",
+        default="schemas/ecology/ecology_receipt_manifest.schema.json",
+        help="Path to ecology receipt manifest schema.",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    manifest_path = Path(args.manifest)
+    schema_path = Path(args.schema)
+
+    if not manifest_path.exists():
+        print(f"missing manifest: {manifest_path}", file=sys.stderr)
+        return EXIT_MISSING_MANIFEST
+
+    if not schema_path.exists():
+        print(f"missing schema: {schema_path}", file=sys.stderr)
+        return EXIT_MISSING_SCHEMA
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        errors = validate_manifest(
+            manifest=manifest,
+            schema_path=schema_path,
+        )
+    except json.JSONDecodeError as exc:
+        print(f"invalid manifest json: {exc}", file=sys.stderr)
+        return EXIT_FAILURE
+    except SchemaError as exc:
+        print(f"invalid manifest schema: {exc}", file=sys.stderr)
+        return EXIT_MISSING_SCHEMA
+    except Exception as exc:
+        print(f"internal manifest validation error: {exc}", file=sys.stderr)
+        return EXIT_INTERNAL_ERROR
+
+    if errors:
+        for error in errors:
+            print(f"manifest schema invalid: {error}", file=sys.stderr)
+        return EXIT_FAILURE
+
+    print("manifest schema valid")
+    return EXIT_PASS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Complete the `tools/receipts` surface by providing runnable helpers for validating and comparing ecology receipt manifests. 
- Allow reviewers and CI to assert manifest schema correctness and inspect differences between manifest versions. 
- Make it easier to wire receipt-manifest checks into promotion and proof workflows without changing existing manifest semantics.

### Description
- Add `tools/receipts/validate_receipt_manifest.py`, a CLI that validates an existing ecology receipt manifest against the manifest schema and returns explicit exit codes for missing inputs, malformed JSON, schema errors, and invalid manifests. 
- Add `tools/receipts/compare_receipt_sets.py`, a deterministic manifest diff tool exposing `compare_manifests(...)` and a small CLI that reports `added`, `removed`, and `changed` receipts and a summary, with optional `--out` JSON output. 
- Add unit tests `tools/receipts/tests/test_validate_receipt_manifest_cli.py` and `tools/receipts/tests/test_compare_receipt_sets.py` covering success and failure cases for manifest validation and added/removed/changed detection for diffs. 
- Update `tools/receipts/README.md` to reflect the implemented tool inventory and document the new helpers.

### Testing
- Ran `pytest -q tools/receipts/tests`, and all tests passed (`22 passed`).
- Verified Python syntax with `python -m py_compile tools/receipts/compare_receipt_sets.py tools/receipts/validate_receipt_manifest.py tools/receipts/ecology_manifest.py tools/receipts/ecology_manifest_builder.py`, which completed without errors.
- The new CLI paths and helper functions exercise the existing `validate_manifest` logic in `ecology_manifest_builder.py` as part of the validation workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11fc20400832a9b005ecae92bc9af)