### PR TITLE
Add missing receipts CLI coverage tests

### DIFF
--- a/tools/receipts/tests/test_compare_receipt_sets_cli.py
+++ b/tools/receipts/tests/test_compare_receipt_sets_cli.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tools.receipts.compare_receipt_sets", *args],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def manifest(*, manifest_id: str, receipts: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "manifest_id": manifest_id,
+        "receipts": receipts,
+    }
+
+
+def test_cli_prints_diff_summary(tmp_path: Path) -> None:
+    left_path = tmp_path / "left.json"
+    right_path = tmp_path / "right.json"
+
+    write_json(
+        left_path,
+        manifest(
+            manifest_id="left",
+            receipts=[
+                {
+                    "receipt_type": "validator_result",
+                    "receipt_ref": "validator.json",
+                    "decision": "pass",
+                }
+            ],
+        ),
+    )
+    write_json(
+        right_path,
+        manifest(
+            manifest_id="right",
+            receipts=[
+                {
+                    "receipt_type": "validator_result",
+                    "receipt_ref": "validator.json",
+                    "decision": "fail",
+                },
+                {
+                    "receipt_type": "promotion_result",
+                    "receipt_ref": "promotion.json",
+                    "decision": "pass",
+                },
+            ],
+        ),
+    )
+
+    result = run_cli("--left", str(left_path), "--right", str(right_path))
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["summary"] == {
+        "added_count": 1,
+        "removed_count": 0,
+        "changed_count": 1,
+    }
+    assert result.stderr == ""
+
+
+def test_cli_writes_diff_file_when_out_is_provided(tmp_path: Path) -> None:
+    left_path = tmp_path / "left.json"
+    right_path = tmp_path / "right.json"
+    out_path = tmp_path / "nested" / "diff.json"
+
+    write_json(left_path, manifest(manifest_id="left", receipts=[]))
+    write_json(right_path, manifest(manifest_id="right", receipts=[]))
+
+    result = run_cli(
+        "--left",
+        str(left_path),
+        "--right",
+        str(right_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode == 0
+    assert out_path.exists()
+    written = json.loads(out_path.read_text(encoding="utf-8"))
+    assert written["left_manifest_ref"] == "left"
+    assert written["right_manifest_ref"] == "right"

--- a/tools/receipts/tests/test_ecology_manifest_builder.py
+++ b/tools/receipts/tests/test_ecology_manifest_builder.py
@@ -145,3 +145,18 @@ def test_write_manifest_creates_parent_directory(tmp_path: Path) -> None:
     assert manifest_path.exists()
     written = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert written["decision"] == "not_ready"
+
+
+def test_markdown_fenced_receipt_is_supported(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "receipt.md"
+    payload = json.dumps(validator_receipt(), indent=2)
+    receipt_path.write_text(f"```json\n{payload}\n```\n", encoding="utf-8")
+
+    manifest = build_manifest(
+        candidate_id="eco_index.example",
+        candidate_type="eco_index",
+        spec_hash=SPEC_HASH,
+        receipt_paths=[receipt_path],
+    )
+
+    assert manifest["decision"] == "ready_for_promotion"


### PR DESCRIPTION
### Motivation
- Improve test coverage for receipt tooling by exercising the CLI surface of `tools.receipts.compare_receipt_sets` and the fenced-JSON parsing path used by the manifest builder.
- Ensure manifest-builder behavior is robust for markdown-fenced receipt files in addition to plain JSON receipts.

### Description
- Add a new pytest module `tools/receipts/tests/test_compare_receipt_sets_cli.py` that verifies the `python -m tools.receipts.compare_receipt_sets` CLI prints a JSON diff summary and writes an output diff file when `--out` is provided.
- Extend `tools/receipts/tests/test_ecology_manifest_builder.py` with `test_markdown_fenced_receipt_is_supported` to assert `build_manifest` accepts markdown-fenced JSON receipts.
- No production code changes were required; the tests exercise existing behavior in `tools/receipts/compare_receipt_sets.py` and `tools/receipts/ecology_manifest_builder.py`.

### Testing
- Ran `pytest -q tools/receipts/tests` and all tests passed: `25 passed`.
- The new CLI tests and the added fenced-JSON builder test both completed successfully under the existing test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f120a82e10832a815c88b215e7814c)