### PR TITLE
Expand tools/registry tests for error paths

### DIFF
--- a/tools/registry/tests/test_ecology_map_layer_registry.py
+++ b/tools/registry/tests/test_ecology_map_layer_registry.py
@@ -211,6 +211,18 @@ def test_resolve_binding_path_relative_to_registry() -> None:
     assert resolved == Path("data/registry/ecology/map_layers/bindings/ndvi.binding.json")
 
 
+def test_resolve_binding_path_accepts_absolute_paths() -> None:
+    registry_path = Path("data/registry/ecology/map_layers/registry.json")
+    absolute_binding = Path("/tmp/kfm/absolute.binding.json")
+
+    resolved = resolve_binding_path(
+        registry_path=registry_path,
+        binding_ref=str(absolute_binding),
+    )
+
+    assert resolved == absolute_binding
+
+
 def test_get_layer_entry_finds_layer() -> None:
     value = registry()
 
@@ -316,6 +328,24 @@ def test_load_layer_binding_spec_hash_mismatch_fails(tmp_path: Path) -> None:
     )
 
     with pytest.raises(LayerRegistryError, match="binding spec_hash does not match"):
+        load_layer_binding(
+            registry_path=registry_path,
+            layer_id="kfm.ecology.vegetation.ndvi_change.v1",
+            schema_path=schema_path,
+        )
+
+
+def test_load_layer_binding_invalid_json_fails_with_decode_error(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    schema_path = tmp_path / "schema.json"
+    binding_path = tmp_path / "bindings" / "ndvi.binding.json"
+
+    write_json(registry_path, registry())
+    write_json(schema_path, schema())
+    binding_path.parent.mkdir(parents=True, exist_ok=True)
+    binding_path.write_text("{not-valid-json", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
         load_layer_binding(
             registry_path=registry_path,
             layer_id="kfm.ecology.vegetation.ndvi_change.v1",

--- a/tools/registry/tests/test_ecology_map_layer_registry_cli.py
+++ b/tools/registry/tests/test_ecology_map_layer_registry_cli.py
@@ -255,6 +255,23 @@ def test_cli_invalid_registry_exits_one(tmp_path: Path) -> None:
     assert "registry.layers must be an array" in result.stderr
 
 
+def test_cli_invalid_registry_json_exits_one(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    schema_path = tmp_path / "schema.json"
+    registry_path.write_text("{not-valid-json", encoding="utf-8")
+    write_json(schema_path, schema())
+
+    result = run_cli(
+        "--registry",
+        str(registry_path),
+        "--schema",
+        str(schema_path),
+    )
+
+    assert result.returncode == 1
+    assert "invalid json:" in result.stderr
+
+
 def test_cli_registry_with_invalid_layer_entry_exits_one(tmp_path: Path) -> None:
     registry_path = tmp_path / "registry.json"
     schema_path = tmp_path / "schema.json"
@@ -314,3 +331,46 @@ def test_cli_invalid_binding_schema_exits_one(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert "invalid registry:" in result.stderr
     assert "binding schema invalid" in result.stderr
+
+
+def test_cli_invalid_binding_json_exits_one(tmp_path: Path) -> None:
+    registry_path, schema_path = setup_registry(tmp_path)
+    binding_path = tmp_path / "bindings" / "active.binding.json"
+    binding_path.write_text("{not-valid-json", encoding="utf-8")
+
+    result = run_cli(
+        "--registry",
+        str(registry_path),
+        "--schema",
+        str(schema_path),
+    )
+
+    assert result.returncode == 1
+    assert "invalid json:" in result.stderr
+
+
+def test_cli_malformed_schema_runtime_error_exits_five(tmp_path: Path) -> None:
+    registry_path, _ = setup_registry(tmp_path)
+    schema_path = tmp_path / "schema.json"
+    write_json(
+        schema_path,
+        {
+            "type": "object",
+            "properties": {
+                "layer_id": {
+                    "type": "string",
+                    "pattern": "[",
+                }
+            },
+        },
+    )
+
+    result = run_cli(
+        "--registry",
+        str(registry_path),
+        "--schema",
+        str(schema_path),
+    )
+
+    assert result.returncode == 5
+    assert "internal registry error:" in result.stderr


### PR DESCRIPTION
### Motivation
- Improve reliability by covering edge and error conditions in the ecology map-layer registry test suite.
- Ensure CLI and library surface behave correctly for malformed or missing inputs such as invalid JSON and malformed schemas.
- Capture resolution behavior for absolute `binding_ref` paths used by downstream tooling.

### Description
- Added `test_resolve_binding_path_accepts_absolute_paths` and `test_load_layer_binding_invalid_json_fails_with_decode_error` to `tools/registry/tests/test_ecology_map_layer_registry.py` to validate absolute binding path resolution and JSON decode error handling.
- Added `test_cli_invalid_registry_json_exits_one`, `test_cli_invalid_binding_json_exits_one`, and `test_cli_malformed_schema_runtime_error_exits_five` to `tools/registry/tests/test_ecology_map_layer_registry_cli.py` to exercise CLI error handling for malformed registry/binding payloads and runtime schema errors.
- Tests only; no production code changes were made to library or CLI modules.

### Testing
- Ran `pytest -q tools/registry/tests` and all tests passed with `31 passed`.
- New tests exercise JSON decoding errors, absolute path resolution, CLI exit-code branches, and malformed schema runtime handling and reported as green in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f122a3b414832a8cdedd3f36ec8385)