### PR TITLE
Add `--strict-remote` to release resolver and finish release resolver docs

### DIFF
--- a/tools/resolvers/release/README.md
+++ b/tools/resolvers/release/README.md
@@ -1,1 +1,60 @@
+# tools/resolvers/release
 
+Release-level resolver utilities that verify whether a `ReleaseManifest` can be
+closed over all required references before publishing.
+
+## Included tool
+
+- `resolve_release_manifest.py` — offline closure resolver with finite outcomes:
+  - `PUBLISHABLE`
+  - `ABSTAIN`
+  - `DENY`
+  - `ERROR`
+
+## What it checks
+
+For each artifact entry in a release manifest, the resolver checks:
+
+- `artifact_ref`
+- `evidence_ref`
+- `provenance_ref`
+- `stac_ref`
+- `dcat_ref`
+- optional `run_receipt_ref`
+- optional `attestation_ref`
+
+It also:
+
+- validates `spec_hash` alignment between manifest and artifacts
+- runs validators for recognized file kinds:
+  - release manifest (`*.release-manifest.json`)
+  - PROV sidecar (`*.prov.jsonld`)
+  - STAC item (`*.item.json`)
+  - DCAT dataset (`*.dataset.jsonld`)
+
+## Usage
+
+```bash
+python tools/resolvers/release/resolve_release_manifest.py \
+  examples/promotion/release/kfm-demo.release-manifest.json
+```
+
+### Strict remote mode
+
+By default, non-placeholder HTTP(S) references are reported as warnings in
+offline mode. To fail closed for those references, enable strict mode:
+
+```bash
+python tools/resolvers/release/resolve_release_manifest.py \
+  examples/promotion/release/kfm-demo.release-manifest.json \
+  --strict-remote
+```
+
+In strict mode, unresolved remote references are treated as `ABSTAIN`.
+
+## Notes
+
+- `kfm://` references are treated as logical references and require an external
+  mapping layer.
+- `https://example.invalid/...` placeholders are accepted for fixture-safe test
+  data.

--- a/tools/resolvers/release/resolve_release_manifest.py
+++ b/tools/resolvers/release/resolve_release_manifest.py
@@ -137,6 +137,7 @@ def resolve_ref(
     result: ClosureResult,
     required: bool = True,
     allow_fixture_placeholders: bool = True,
+    strict_remote: bool = False,
 ) -> Path | None:
     if not ref:
         if required:
@@ -153,6 +154,10 @@ def resolve_ref(
         return None
 
     if is_http_ref(ref):
+        if strict_remote:
+            result.abstain(f"{label}: remote URL unresolved in strict offline mode: {ref}")
+            result.resolved[label] = {"ref": ref, "mode": "remote-unresolved"}
+            return None
         result.warn(f"{label}: remote URL not fetched in offline resolver mode: {ref}")
         result.resolved[label] = {"ref": ref, "mode": "remote-unchecked"}
         return None
@@ -205,6 +210,7 @@ def check_artifact_entry(
     index: int,
     manifest_spec_hash: str | None,
     result: ClosureResult,
+    strict_remote: bool = False,
 ) -> None:
     label = f"artifacts[{index}]"
 
@@ -225,6 +231,7 @@ def check_artifact_entry(
         label=f"{label}.artifact_ref",
         result=result,
         required=True,
+        strict_remote=strict_remote,
     )
 
     evidence_path = resolve_ref(
@@ -232,6 +239,7 @@ def check_artifact_entry(
         label=f"{label}.evidence_ref",
         result=result,
         required=True,
+        strict_remote=strict_remote,
     )
 
     provenance_path = resolve_ref(
@@ -239,6 +247,7 @@ def check_artifact_entry(
         label=f"{label}.provenance_ref",
         result=result,
         required=True,
+        strict_remote=strict_remote,
     )
 
     stac_path = resolve_ref(
@@ -246,6 +255,7 @@ def check_artifact_entry(
         label=f"{label}.stac_ref",
         result=result,
         required=True,
+        strict_remote=strict_remote,
     )
 
     dcat_path = resolve_ref(
@@ -253,6 +263,7 @@ def check_artifact_entry(
         label=f"{label}.dcat_ref",
         result=result,
         required=True,
+        strict_remote=strict_remote,
     )
 
     run_receipt_path = resolve_ref(
@@ -260,6 +271,7 @@ def check_artifact_entry(
         label=f"{label}.run_receipt_ref",
         result=result,
         required=False,
+        strict_remote=strict_remote,
     )
 
     attestation_path = resolve_ref(
@@ -267,6 +279,7 @@ def check_artifact_entry(
         label=f"{label}.attestation_ref",
         result=result,
         required=False,
+        strict_remote=strict_remote,
     )
 
     for resolved_path, resolved_label in (
@@ -281,7 +294,7 @@ def check_artifact_entry(
         validate_resolved_path(resolved_path, result, resolved_label)
 
 
-def resolve_release_manifest(manifest_path: Path) -> ClosureResult:
+def resolve_release_manifest(manifest_path: Path, *, strict_remote: bool = False) -> ClosureResult:
     result = ClosureResult()
 
     if not manifest_path.exists():
@@ -316,6 +329,7 @@ def resolve_release_manifest(manifest_path: Path) -> ClosureResult:
             index=idx,
             manifest_spec_hash=manifest_spec_hash,
             result=result,
+            strict_remote=strict_remote,
         )
 
     return result
@@ -341,7 +355,7 @@ def main() -> None:
     args = parse_args()
     manifest_path = Path(args.manifest)
 
-    result = resolve_release_manifest(manifest_path)
+    result = resolve_release_manifest(manifest_path, strict_remote=args.strict_remote)
     emit(result)
 
     if result.status == "PUBLISHABLE":


### PR DESCRIPTION
### Motivation
- Complete the release resolver surface so release manifest closure is documented and usable for offline CI and reviewer workflows.
- Make remote HTTP(S) references opt-in strict so offline runs can fail closed when external URLs must be considered unresolved.

### Description
- Add `tools/resolvers/release/README.md` with usage, scope, checks, and notes for the `resolve_release_manifest.py` tool.
- Add a `--strict-remote` CLI flag and thread a `strict_remote` parameter through `resolve_release_manifest`, `check_artifact_entry`, and `resolve_ref` so strict behavior is applied to all per-artifact refs.
- Change HTTP(S) ref handling so that in strict mode non-placeholder remote refs cause an `ABSTAIN` via `result.abstain(...)` and are recorded as `remote-unresolved`, while in default mode they remain warnings and are recorded as `remote-unchecked`.
- Preserve existing behavior for `kfm://` logical refs and `https://example.invalid/...` fixture placeholders.

### Testing
- Ran `python -m py_compile tools/resolvers/release/resolve_release_manifest.py` and it succeeded.
- Ran `pytest -q tests/e2e/release_assembly/test_release_assembly_proof.py tests/e2e/correction/test_correction_lineage_proof.py` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f127d5451c832a9a8a843b6a5fe5c4)