### PR TITLE
Add conditional JSON Schema support to local validator

### DIFF
--- a/jsonschema/__init__.py
+++ b/jsonschema/__init__.py
@@ -58,6 +58,9 @@ def _iter_schema_errors(instance: Any, schema: dict[str, Any], path: tuple[Any, 
     if enum_values is not None and instance not in enum_values:
         yield _ValidationIssue(path, f"{instance!r} is not one of {enum_values}")
 
+    if "const" in schema and instance != schema["const"]:
+        yield _ValidationIssue(path, f"{instance!r} was expected to be constant {schema.get('const')!r}")
+
     if isinstance(instance, str):
         min_length = schema.get("minLength")
         if isinstance(min_length, int) and len(instance) < min_length:
@@ -95,6 +98,21 @@ def _iter_schema_errors(instance: Any, schema: dict[str, Any], path: tuple[Any, 
             for key in instance:
                 if key not in allowed_keys:
                     yield _ValidationIssue(path, f"Additional properties are not allowed ({key!r} was unexpected)")
+
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list):
+        for subschema in all_of:
+            if isinstance(subschema, dict):
+                yield from _iter_schema_errors(instance, subschema, path)
+
+    if_schema = schema.get("if")
+    then_schema = schema.get("then")
+    else_schema = schema.get("else")
+    if isinstance(if_schema, dict):
+        if_matches = not any(_iter_schema_errors(instance, if_schema, path))
+        branch = then_schema if if_matches else else_schema
+        if isinstance(branch, dict):
+            yield from _iter_schema_errors(instance, branch, path)
 
 
 __all__ = [


### PR DESCRIPTION
### Motivation
- The repository includes a lightweight local `jsonschema` shim that lacked support for several JSON Schema keywords used by schema tests, causing invalid instances to pass validation.
- The change aims to enforce conditional schema rules (used by the ecology map layer binding schema) so `tools/tests` correctly detect invalid `3d_tiles` configurations.

### Description
- Extend the local validator in `jsonschema/__init__.py` to validate `const` constraints and produce a clear error when a value does not match a constant.
- Add support for `allOf` composition evaluation so composed subschemas are validated against instances.
- Implement conditional evaluation for `if` / `then` / `else` to run the appropriate branch when the `if` subschema matches.
- Fix an f-string indexing issue by switching to `schema.get('const')` when formatting the `const` error message.

### Testing
- Running `pytest -q tools/tests` after the change resulted in all tests passing with `22 passed`.
- Prior to the fix, `tools/tests/schemas/test_ecology_map_layer_binding_schema.py` exhibited failing cases for the `3d_tiles` conditional requirements, which are now correctly enforced by the updated validator.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1290d770c832aae2d4d588602ee38)