### PR TITLE
Expand schema tests for evaluator fixtures

### DIFF
--- a/tools/tests/schemas/test_evaluator_fixture_schema.py
+++ b/tools/tests/schemas/test_evaluator_fixture_schema.py
@@ -56,3 +56,53 @@ def test_missing_required_field_fails() -> None:
 
     assert errors
     assert any("subject_ref" in error for error in errors)
+
+
+def test_invalid_fixture_type_fails() -> None:
+    instance = valid_fixture()
+    instance["fixture_type"] = "kfm.evaluator_fixture.v2"
+
+    errors = validate(instance)
+
+    assert errors
+    assert any("fixture_type" in error and "kfm.evaluator_fixture.v1" in error for error in errors)
+
+
+def test_invalid_subject_type_fails() -> None:
+    instance = valid_fixture()
+    instance["subject_type"] = "unsupported_subject"
+
+    errors = validate(instance)
+
+    assert errors
+    assert any("subject_type" in error for error in errors)
+
+
+def test_metric_results_requires_at_least_one_item() -> None:
+    instance = valid_fixture()
+    instance["metric_results"] = []
+
+    errors = validate(instance)
+
+    assert errors
+    assert any("metric_results" in error and "minimum size" in error.lower() for error in errors)
+
+
+def test_additional_properties_fail_closed() -> None:
+    instance = valid_fixture()
+    instance["unexpected"] = "nope"
+
+    errors = validate(instance)
+
+    assert errors
+    assert any("unexpected" in error and "additional properties" in error.lower() for error in errors)
+
+
+def test_invalid_notes_type_fails() -> None:
+    instance = valid_fixture()
+    instance["notes"] = "not-an-array"
+
+    errors = validate(instance)
+
+    assert errors
+    assert any("notes" in error and "array" in error.lower() for error in errors)


### PR DESCRIPTION
### Motivation
- Provide a finished, tool-local schema test surface for evaluator fixtures so the tools-side harness can assert both happy-path and negative-path behavior. 
- Broaden coverage to catch common schema regressions (invalid constants/enums, empty arrays, additional properties, and wrong types) that validators should reject. 

### Description
- Extended `tools/tests/schemas/test_evaluator_fixture_schema.py` with negative-path tests for invalid `fixture_type`, invalid `subject_type`, empty `metric_results`, `additionalProperties: false` behavior, and invalid `notes` type. 
- Kept the original valid fixture and required-field test while aligning error assertions to the `jsonschema` Draft2020-12 messages (e.g. "minimum size" wording). 
- Test harness still reads `tools/evaluators/fixtures/fixture.schema.json` and uses `Draft202012Validator` through the helper `validate()` function. 

### Testing
- Ran `pytest -q tools/tests/schemas` and the final run reported `16 passed` indicating all schema tests in the lane succeeded. 
- Intermediate runs were used to iterate on assertions until the negative-path expectations matched the validator output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12bb886b4832a87fee2abccb7bbe5)