### PR TITLE
Add validator CLIs for connector admission, ecology claims, and flora DwC-A

### DIFF
--- a/tools/validators/connector_gate/validate_connector_candidate.py
+++ b/tools/validators/connector_gate/validate_connector_candidate.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Fail-closed validator for connector admission candidates."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED_FIELDS = (
+    "connector_id",
+    "source_id",
+    "source_role",
+    "rights_status",
+    "policy_label",
+    "candidate_ref",
+)
+
+ALLOWED_RIGHTS = {"approved", "public", "licensed"}
+ALLOWED_POLICY_LABEL = {"public", "public-safe"}
+
+
+def fail(message: str) -> None:
+    print(f"DENY: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        fail("candidate payload must be a JSON object")
+    return loaded
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        fail("usage: validate_connector_candidate.py <candidate.json>")
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        fail(f"missing candidate file: {path}")
+
+    doc = load_json(path)
+
+    for key in REQUIRED_FIELDS:
+        value = doc.get(key)
+        if value in (None, ""):
+            fail(f"missing required field: {key}")
+
+    if doc["rights_status"] not in ALLOWED_RIGHTS:
+        fail("rights_status must be one of approved/public/licensed")
+
+    if doc["policy_label"] not in ALLOWED_POLICY_LABEL:
+        fail("policy_label must be public or public-safe")
+
+    if doc.get("status") not in (None, "candidate", "reviewed"):
+        fail("status must be candidate/reviewed when provided")
+
+    print(f"ALLOW: valid connector candidate: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validators/ecology_composite_claim/validate_ecology_composite_claim.py
+++ b/tools/validators/ecology_composite_claim/validate_ecology_composite_claim.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Validate ecology composite claim envelopes with fail-closed checks."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED_FIELDS = (
+    "claim_id",
+    "claim_type",
+    "statement",
+    "evidence_ref",
+    "spec_hash",
+    "policy_label",
+)
+
+ALLOWED_CLAIM_TYPES = {"cite", "abstain", "deny"}
+
+
+def fail(message: str) -> None:
+    print(f"DENY: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        doc = json.load(handle)
+    if not isinstance(doc, dict):
+        fail("claim envelope must be a JSON object")
+    return doc
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        fail("usage: validate_ecology_composite_claim.py <claim.json>")
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        fail(f"missing claim file: {path}")
+
+    doc = load_json(path)
+
+    for field in REQUIRED_FIELDS:
+        if doc.get(field) in (None, ""):
+            fail(f"missing required field: {field}")
+
+    if doc["claim_type"] not in ALLOWED_CLAIM_TYPES:
+        fail("claim_type must be cite, abstain, or deny")
+
+    if doc["policy_label"] not in {"public", "public-safe"}:
+        fail("policy_label must be public or public-safe")
+
+    print(f"ALLOW: valid ecology composite claim: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validators/flora_dwca_validator/validate_dwca_event.py
+++ b/tools/validators/flora_dwca_validator/validate_dwca_event.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Minimal fail-closed DwC-A event row validator for flora ingestion."""
+
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+REQUIRED_COLUMNS = (
+    "eventID",
+    "occurrenceID",
+    "scientificName",
+    "eventDate",
+    "decimalLatitude",
+    "decimalLongitude",
+    "basisOfRecord",
+)
+
+ALLOWED_BASIS = {"HumanObservation", "PreservedSpecimen", "MachineObservation"}
+
+
+def fail(message: str) -> None:
+    print(f"DENY: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        fail("usage: validate_dwca_event.py <events.csv>")
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        fail(f"missing DwC-A events CSV: {path}")
+
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+
+        if reader.fieldnames is None:
+            fail("events CSV is missing header row")
+
+        for column in REQUIRED_COLUMNS:
+            if column not in reader.fieldnames:
+                fail(f"missing required column: {column}")
+
+        rows = 0
+        for idx, row in enumerate(reader, start=2):
+            rows += 1
+            for column in REQUIRED_COLUMNS:
+                if not row.get(column):
+                    fail(f"row {idx} missing required value for {column}")
+
+            if row["basisOfRecord"] not in ALLOWED_BASIS:
+                fail(f"row {idx} basisOfRecord must be one of {sorted(ALLOWED_BASIS)}")
+
+        if rows == 0:
+            fail("events CSV has no data rows")
+
+    print(f"ALLOW: valid DwC-A events CSV: {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Finish the missing executable slices in `tools/validators/` so the repository has small, fail-closed CLI validators for connector admission, ecology composite claims, and DwC-A event rows to support CI and local validation.
- Keep validators deterministic, reviewable, and scoped to shape/linkage checks rather than policy enforcement or attestation creation.

### Description
- Add `tools/validators/connector_gate/validate_connector_candidate.py` which validates required connector candidate fields and enforces allowed `rights_status` and `policy_label` values.
- Add `tools/validators/ecology_composite_claim/validate_ecology_composite_claim.py` which validates required claim-envelope fields and enforces finite `claim_type` and policy enums.
- Add `tools/validators/flora_dwca_validator/validate_dwca_event.py` which validates DwC-A event CSV header presence, required columns, per-row required values, allowed `basisOfRecord`, and non-empty data rows.

### Testing
- Ran byte-compile checks with `python -m py_compile` for the three new modules and they succeeded without syntax errors.
- Ran unit tests with `pytest -q tests/validators` and all tests passed (`37 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12cf2c7dc832abfbd3f306f2a7926)