### PR TITLE
Add catalog closure validator and receipt emitter

### DIFF
--- a/tools/validators/catalog/emit_catalog_validation_receipt.py
+++ b/tools/validators/catalog/emit_catalog_validation_receipt.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Emit a deterministic catalog validation receipt from validator decisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release-id", required=True)
+    parser.add_argument("--catalog-matrix", required=True)
+    parser.add_argument("--release-manifest", required=True)
+    parser.add_argument("--stac-decision", required=True, choices=["ALLOW", "DENY", "ERROR"])
+    parser.add_argument("--dcat-decision", required=True, choices=["ALLOW", "DENY", "ERROR"])
+    parser.add_argument("--matrix-decision", required=True, choices=["ALLOW", "DENY", "ERROR"])
+    parser.add_argument("--closure-decision", required=True, choices=["ALLOW", "DENY", "ERROR"])
+    parser.add_argument("--out", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    decisions = {
+        "stac": args.stac_decision,
+        "dcat": args.dcat_decision,
+        "catalog_matrix": args.matrix_decision,
+        "release_catalog_closure": args.closure_decision,
+    }
+
+    if any(value == "ERROR" for value in decisions.values()):
+        decision = "ERROR"
+    elif all(value == "ALLOW" for value in decisions.values()):
+        decision = "PASS"
+    else:
+        decision = "DENY"
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "schema": "kfm.catalog.validation_report.v1",
+        "validator": "tools/validators/catalog/emit_catalog_validation_receipt.py",
+        "decision": decision,
+        "checked_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "release_id": args.release_id,
+        "inputs": {
+            "catalog_matrix": args.catalog_matrix,
+            "release_manifest": args.release_manifest,
+        },
+        "checks": decisions,
+    }
+
+    out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"WROTE: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validators/catalog/validate_release_catalog_closure.py
+++ b/tools/validators/catalog/validate_release_catalog_closure.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Validate release-to-catalog closure across manifest and catalog artifacts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+FORBIDDEN_PUBLIC_REFS = (
+    "/raw/",
+    "/work/",
+    "/quarantine/",
+    "data/raw/",
+    "data/work/",
+    "data/quarantine/",
+)
+
+BLOCKED_PUBLIC_VALUES = {
+    "TODO",
+    "todo",
+    "UNKNOWN",
+    "unknown",
+    "NEEDS-VERIFICATION",
+    "restricted",
+    "deny",
+    "",
+}
+
+
+def fail(message: str) -> None:
+    print(f"DENY: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def assert_present(mapping: dict[str, Any], key: str, label: str) -> Any:
+    value = mapping.get(key)
+    if value in (None, ""):
+        fail(f"{label} missing {key}")
+    return value
+
+
+def assert_not_blocked(value: Any, label: str) -> None:
+    if isinstance(value, str) and value in BLOCKED_PUBLIC_VALUES:
+        fail(f"{label} cannot be {value}")
+
+
+def contains_forbidden_ref(value: Any) -> bool:
+    if isinstance(value, str):
+        lowered = value.lower()
+        return any(token in lowered for token in FORBIDDEN_PUBLIC_REFS)
+    if isinstance(value, dict):
+        return any(contains_forbidden_ref(v) for v in value.values())
+    if isinstance(value, list):
+        return any(contains_forbidden_ref(v) for v in value)
+    return False
+
+
+def check_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    if manifest.get("policy_label") != "public":
+        fail("ReleaseManifest requires policy_label=public")
+
+    if manifest.get("review_state") not in {"reviewed", "published"}:
+        fail("ReleaseManifest requires review_state reviewed or published")
+
+    artifacts = manifest.get("artifacts", [])
+    if not isinstance(artifacts, list) or not artifacts:
+        fail("ReleaseManifest missing artifacts")
+
+    for idx, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            fail(f"artifacts[{idx}] must be an object")
+
+        label = f"artifacts[{idx}]"
+        for key in (
+            "artifact_ref",
+            "evidence_ref",
+            "provenance_ref",
+            "stac_ref",
+            "dcat_ref",
+            "release_ref",
+            "publish_receipt_ref",
+            "spec_hash",
+        ):
+            value = assert_present(artifact, key, label)
+            assert_not_blocked(value, f"{label}.{key}")
+
+    return artifacts
+
+
+def check_catalog(matrix: dict[str, Any]) -> list[dict[str, Any]]:
+    if matrix.get("status") != "closed":
+        fail("CatalogMatrix requires status=closed")
+
+    artifacts = matrix.get("artifacts", [])
+    if not isinstance(artifacts, list) or not artifacts:
+        fail("CatalogMatrix missing artifacts")
+
+    return artifacts
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        fail(
+            "usage: validate_release_catalog_closure.py "
+            "<release-manifest.json> <catalog-matrix.json>"
+        )
+
+    manifest_path = Path(sys.argv[1])
+    matrix_path = Path(sys.argv[2])
+
+    if not manifest_path.exists():
+        fail(f"missing ReleaseManifest: {manifest_path}")
+
+    if not matrix_path.exists():
+        fail(f"missing CatalogMatrix: {matrix_path}")
+
+    manifest = load_json(manifest_path)
+    matrix = load_json(matrix_path)
+
+    manifest_artifacts = check_manifest(manifest)
+    matrix_artifacts = check_catalog(matrix)
+
+    manifest_by_artifact_ref = {
+        item["artifact_ref"]: item
+        for item in manifest_artifacts
+        if isinstance(item.get("artifact_ref"), str)
+    }
+
+    matrix_by_artifact_ref = {
+        item["artifact_ref"]: item
+        for item in matrix_artifacts
+        if isinstance(item.get("artifact_ref"), str)
+    }
+
+    missing_in_matrix = sorted(set(manifest_by_artifact_ref) - set(matrix_by_artifact_ref))
+    if missing_in_matrix:
+        fail(f"CatalogMatrix missing artifacts present in ReleaseManifest: {missing_in_matrix}")
+
+    for artifact_ref, manifest_artifact in manifest_by_artifact_ref.items():
+        matrix_artifact = matrix_by_artifact_ref[artifact_ref]
+
+        for key in (
+            "evidence_ref",
+            "provenance_ref",
+            "stac_ref",
+            "dcat_ref",
+            "release_ref",
+            "publish_receipt_ref",
+            "spec_hash",
+        ):
+            if manifest_artifact.get(key) != matrix_artifact.get(key):
+                fail(
+                    f"artifact {artifact_ref} mismatch for {key}: "
+                    f"manifest={manifest_artifact.get(key)} matrix={matrix_artifact.get(key)}"
+                )
+
+    if contains_forbidden_ref(manifest) or contains_forbidden_ref(matrix):
+        fail("closure references RAW / WORK / QUARANTINE material")
+
+    print(
+        "ALLOW: valid release-catalog closure: "
+        f"manifest={manifest_path} matrix={matrix_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a deterministic validator that enforces closure between a `ReleaseManifest` and a `CatalogMatrix` so release promotion can rely on machine-checkable catalog proofs.
- Provide a small deterministic emitter to produce a machine-readable validation receipt that consolidates per-validator decisions for CI and promotion gates.

### Description
- Add `tools/validators/catalog/validate_release_catalog_closure.py` which verifies manifest and matrix parity, requires `policy_label=public` and reviewed/published `review_state`, enforces presence and non-blocked values for required artifact refs, requires `CatalogMatrix.status=closed`, and fails if RAW/WORK/QUARANTINE references or blocked sentinel values are present.
- Add `tools/validators/catalog/emit_catalog_validation_receipt.py` which accepts individual validator decisions (`stac`, `dcat`, `catalog_matrix`, `release_catalog_closure`), rolls them up into a single `PASS`/`DENY`/`ERROR` decision, and writes a deterministic JSON validation receipt including timestamps and inputs to `--out`.
- Place both tools under `tools/validators/catalog/` to integrate with existing catalog validators (`validate_stac_item.py`, `validate_catalog_matrix.py`, `validate_dcat_dataset.py`).

### Testing
- Run `python -m py_compile tools/validators/catalog/validate_stac_item.py tools/validators/catalog/validate_dcat_dataset.py tools/validators/catalog/validate_catalog_matrix.py tools/validators/catalog/validate_release_catalog_closure.py tools/validators/catalog/emit_catalog_validation_receipt.py` which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f133243304832a9b2d01aabc661916)