### PR TITLE
Build connector gate validator and sample candidate fixtures

### DIFF
--- a/tools/validators/connector_gate/README.md
+++ b/tools/validators/connector_gate/README.md
@@ -575,3 +575,32 @@ These fields are a review checklist, not a canonical schema.
 </details>
 
 [Back to top](#top)
+
+---
+
+## Current implementation snapshot
+
+The directory currently includes a working Python validator entrypoint:
+
+- `validate_connector_candidate.py`
+- `candidate.example.json`
+- `candidate.invalid.json`
+
+Quick local checks:
+
+```bash
+python3 tools/validators/connector_gate/validate_connector_candidate.py \
+  tools/validators/connector_gate/candidate.example.json
+
+python3 tools/validators/connector_gate/validate_connector_candidate.py \
+  tools/validators/connector_gate/candidate.invalid.json
+```
+
+Optional strict digest mode:
+
+```bash
+python3 tools/validators/connector_gate/validate_connector_candidate.py \
+  --enforce-spec-hash tools/validators/connector_gate/candidate.example.json
+```
+
+In strict mode, `spec_hash` must be present and equal to the sha256 digest of the candidate file bytes.

--- a/tools/validators/connector_gate/candidate.example.json
+++ b/tools/validators/connector_gate/candidate.example.json
@@ -1,0 +1,16 @@
+{
+  "candidate_id": "example-source.connector-candidate.v1",
+  "connector_id": "kfm.connector.example-source.v1",
+  "source_id": "example-source",
+  "source_role": "reference",
+  "rights_status": "public",
+  "policy_label": "public-safe",
+  "candidate_ref": "data/registry/sources/example-source.yaml",
+  "status": "candidate",
+  "validation_plan": ["schema", "source_role", "rights", "crs", "time"],
+  "handoff_targets": {
+    "allow": "data/work/example-source/",
+    "deny": "data/quarantine/example-source/",
+    "receipt": "data/receipts/connector_gate/"
+  }
+}

--- a/tools/validators/connector_gate/candidate.invalid.json
+++ b/tools/validators/connector_gate/candidate.invalid.json
@@ -1,0 +1,15 @@
+{
+  "candidate_id": "",
+  "connector_id": "kfm.connector.example-source.v1",
+  "source_id": "example-source",
+  "source_role": "reference",
+  "rights_status": "unknown",
+  "policy_label": "restricted",
+  "candidate_ref": "",
+  "status": "draft",
+  "validation_plan": ["schema", "made_up"],
+  "handoff_targets": {
+    "allow": "",
+    "deny": "data/quarantine/example-source/"
+  }
+}

--- a/tools/validators/connector_gate/validate_connector_candidate.py
+++ b/tools/validators/connector_gate/validate_connector_candidate.py
@@ -1,24 +1,36 @@
 #!/usr/bin/env python3
-"""Fail-closed validator for connector admission candidates."""
+"""Fail-closed validator for connector admission candidates.
+
+This script validates a connector candidate JSON document and exits non-zero
+when the candidate is incomplete or unsafe to admit into downstream work lanes.
+"""
 
 from __future__ import annotations
 
+import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
 from typing import Any
 
 REQUIRED_FIELDS = (
+    "candidate_id",
     "connector_id",
     "source_id",
     "source_role",
     "rights_status",
     "policy_label",
     "candidate_ref",
+    "validation_plan",
+    "handoff_targets",
 )
 
 ALLOWED_RIGHTS = {"approved", "public", "licensed"}
 ALLOWED_POLICY_LABEL = {"public", "public-safe"}
+ALLOWED_STATUS = {"candidate", "reviewed"}
+ALLOWED_VALIDATION_PLAN = {"schema", "source_role", "rights", "crs", "time"}
+REQUIRED_HANDOFF_KEYS = {"allow", "deny", "receipt"}
 
 
 def fail(message: str) -> None:
@@ -34,19 +46,44 @@ def load_json(path: Path) -> dict[str, Any]:
     return loaded
 
 
-def main() -> None:
-    if len(sys.argv) != 2:
-        fail("usage: validate_connector_candidate.py <candidate.json>")
+def is_non_empty_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
 
-    path = Path(sys.argv[1])
-    if not path.exists():
-        fail(f"missing candidate file: {path}")
 
-    doc = load_json(path)
+def validate_handoffs(handoffs: Any) -> None:
+    if not isinstance(handoffs, dict):
+        fail("handoff_targets must be an object")
 
+    missing = sorted(REQUIRED_HANDOFF_KEYS - set(handoffs.keys()))
+    if missing:
+        fail(f"handoff_targets missing keys: {', '.join(missing)}")
+
+    for key in REQUIRED_HANDOFF_KEYS:
+        value = handoffs.get(key)
+        if not is_non_empty_text(value):
+            fail(f"handoff_targets.{key} must be a non-empty string")
+
+
+def validate_validation_plan(plan: Any) -> None:
+    if not isinstance(plan, list) or not plan:
+        fail("validation_plan must be a non-empty list")
+
+    invalid = [item for item in plan if item not in ALLOWED_VALIDATION_PLAN]
+    if invalid:
+        fail(
+            "validation_plan contains unsupported values: "
+            + ", ".join(sorted({str(item) for item in invalid}))
+        )
+
+
+def compute_spec_hash(path: Path) -> str:
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def validate_candidate(doc: dict[str, Any], *, candidate_path: Path, enforce_spec_hash: bool) -> None:
     for key in REQUIRED_FIELDS:
-        value = doc.get(key)
-        if value in (None, ""):
+        if not is_non_empty_text(doc.get(key)) and key not in {"validation_plan", "handoff_targets"}:
             fail(f"missing required field: {key}")
 
     if doc["rights_status"] not in ALLOWED_RIGHTS:
@@ -55,9 +92,48 @@ def main() -> None:
     if doc["policy_label"] not in ALLOWED_POLICY_LABEL:
         fail("policy_label must be public or public-safe")
 
-    if doc.get("status") not in (None, "candidate", "reviewed"):
+    status = doc.get("status")
+    if status is not None and status not in ALLOWED_STATUS:
         fail("status must be candidate/reviewed when provided")
 
+    validate_validation_plan(doc["validation_plan"])
+    validate_handoffs(doc["handoff_targets"])
+
+    spec_hash = doc.get("spec_hash")
+    if spec_hash is not None and not is_non_empty_text(spec_hash):
+        fail("spec_hash must be a non-empty string when provided")
+
+    if enforce_spec_hash:
+        if spec_hash is None:
+            fail("spec_hash is required when --enforce-spec-hash is enabled")
+
+        expected = compute_spec_hash(candidate_path)
+        if spec_hash != expected:
+            fail("spec_hash does not match candidate file content")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a connector admission candidate in fail-closed mode."
+    )
+    parser.add_argument("candidate", type=Path, help="Path to candidate JSON document")
+    parser.add_argument(
+        "--enforce-spec-hash",
+        action="store_true",
+        help="Require spec_hash to equal sha256 hash of the candidate file",
+    )
+    return parser.parse_args(argv)
+
+
+def main() -> None:
+    args = parse_args(sys.argv[1:])
+    path = args.candidate
+
+    if not path.exists():
+        fail(f"missing candidate file: {path}")
+
+    doc = load_json(path)
+    validate_candidate(doc, candidate_path=path, enforce_spec_hash=args.enforce_spec_hash)
     print(f"ALLOW: valid connector candidate: {path}")
 
 


### PR DESCRIPTION
### Motivation
- Provide a fail-closed admission validator for connector-facing candidate documents so source admission decisions are explicit and reviewable before broader work lanes run. 
- Make candidate shape, rights posture, validation expectations, and handoff targets machine-checkable to avoid implicit trust propagation.

### Description
- Expanded `tools/validators/connector_gate/validate_connector_candidate.py` into a full CLI-based validator with `argparse`, stricter required-field checks, validation-plan enforcement, and handoff-target validation. 
- Added optional strict digest verification via `--enforce-spec-hash` that computes `sha256:` of the candidate bytes and compares to `spec_hash`. 
- Added two fixtures: a positive example at `tools/validators/connector_gate/candidate.example.json` and a negative fixture at `tools/validators/connector_gate/candidate.invalid.json`. 
- Updated `tools/validators/connector_gate/README.md` with a "Current implementation snapshot" including usage examples and the strict-digest note.

### Testing
- Ran `python3 tools/validators/connector_gate/validate_connector_candidate.py tools/validators/connector_gate/candidate.example.json` which returned `ALLOW` and exited with code `0`. 
- Ran `python3 tools/validators/connector_gate/validate_connector_candidate.py tools/validators/connector_gate/candidate.invalid.json` which returned `DENY` and exited with non-zero status as expected for fail-closed behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f133d3268c832ab1e0b80347d29b3d)