### PR TITLE
Build out ecology validator toolchain and runners

### DIFF
--- a/tools/validators/ecology/README.md
+++ b/tools/validators/ecology/README.md
@@ -452,3 +452,22 @@ Quarantine with reason codes, preserve reviewable receipts where policy allows, 
 </details>
 
 [Back to top](#top)
+
+---
+
+## Implemented validator scripts (current)
+
+The following scripts are currently implemented in this folder and executable as standalone checks:
+
+- `validate_ecology_bundle.py`
+- `validate_source_descriptors.py`
+- `validate_taxa.py`
+- `validate_occurrences.py`
+- `validate_habitat_surfaces.py`
+- `validate_habitat_assignments.py`
+- `validate_sensitivity.py`
+- `validate_catalog_closure.py`
+- `validate_release_bundle.py`
+- `validate_runtime_envelope.py`
+- `run_all.py`
+- `render_summary.py`

--- a/tools/validators/ecology/render_summary.py
+++ b/tools/validators/ecology/render_summary.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Render ecology validator summary from run_all output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render ecology validator summary")
+    parser.add_argument("report", help="Path to run_all JSON output")
+    args = parser.parse_args()
+
+    report = json.loads(Path(args.report).read_text(encoding="utf-8"))
+    print(f"# Ecology validation summary\n")
+    print(f"Overall decision: **{report.get('decision', 'unknown')}**\n")
+    print("| Validator | Decision | Errors |")
+    print("| --- | --- | --- |")
+    for result in report.get("results", []):
+        errors = ", ".join(result.get("errors", [])) if result.get("errors") else "-"
+        print(f"| {result.get('validator')} | {result.get('decision')} | {errors} |")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/run_all.py
+++ b/tools/validators/ecology/run_all.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Run ecology validator suite against a descriptor bundle JSON file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+VALIDATORS = (
+    "validate_ecology_bundle.py",
+    "validate_source_descriptors.py",
+    "validate_taxa.py",
+    "validate_occurrences.py",
+    "validate_habitat_surfaces.py",
+    "validate_habitat_assignments.py",
+    "validate_sensitivity.py",
+    "validate_catalog_closure.py",
+    "validate_release_bundle.py",
+    "validate_runtime_envelope.py",
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run all ecology validators")
+    parser.add_argument("--bundle", required=True, help="Candidate ecology bundle JSON")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable summary")
+    args = parser.parse_args()
+
+    base = Path(__file__).parent
+    results: list[dict[str, object]] = []
+
+    for validator in VALIDATORS:
+        if validator == "validate_ecology_bundle.py":
+            cmd = [sys.executable, str(base / validator), "--bundle", args.bundle, "--json"]
+        else:
+            cmd = [sys.executable, str(base / validator), args.bundle, "--json"]
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        payload: dict[str, object]
+        try:
+            payload = json.loads(proc.stdout) if proc.stdout.strip() else {"decision": "fail", "errors": ["empty_output"]}
+        except json.JSONDecodeError:
+            payload = {"decision": "fail", "errors": ["invalid_json_output"], "stdout": proc.stdout.strip()}
+        payload["validator"] = validator
+        payload["exit_code"] = proc.returncode
+        results.append(payload)
+
+    failed = [r for r in results if r.get("decision") != "pass" or r.get("exit_code") != 0]
+    summary = {"decision": "pass" if not failed else "fail", "bundle": args.bundle, "results": results}
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(f"decision={summary['decision']}")
+        for item in results:
+            print(f"{item['validator']}: {item.get('decision')} (exit={item.get('exit_code')})")
+
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/validate_catalog_closure.py
+++ b/tools/validators/ecology/validate_catalog_closure.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ecology validator: validate_catalog_closure.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def validate(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    value = bundle.get("catalog_refs")
+    if not isinstance(value, list) or not value:
+        errors.append("catalog_refs_required")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate catalog_refs in ecology bundle")
+    parser.add_argument("bundle", help="Path to bundle JSON file")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    errors = validate(bundle)
+    result = {"decision": "pass" if not errors else "fail", "errors": errors}
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/validate_ecology_bundle.py
+++ b/tools/validators/ecology/validate_ecology_bundle.py
@@ -9,6 +9,48 @@ from pathlib import Path
 from typing import Any
 
 
+
+
+def _parse_min_yaml(text: str) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    current_list: str | None = None
+    current_item: dict[str, Any] | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if not line or line.lstrip().startswith('#'):
+            continue
+        if line.startswith('  - '):
+            if current_list is None:
+                continue
+            item: dict[str, Any] = {}
+            data.setdefault(current_list, []).append(item)
+            current_item = item
+            rem = line[4:]
+            if ':' in rem:
+                k, v = rem.split(':', 1)
+                current_item[k.strip()] = v.strip().strip('"')
+            continue
+        if line.startswith('    ') and current_item is not None and ':' in line.strip():
+            k, v = line.strip().split(':', 1)
+            val = v.strip().strip('"')
+            if val.startswith('[') and val.endswith(']'):
+                val = [x.strip().strip('"') for x in val[1:-1].split(',') if x.strip()]
+            current_item[k.strip()] = val
+            continue
+        if not line.startswith(' ') and ':' in line:
+            k, v = line.split(':', 1)
+            key = k.strip()
+            val = v.strip().strip('"')
+            if val == '':
+                current_list = key
+                data[current_list] = []
+                current_item = None
+            else:
+                data[key] = val
+                current_list = None
+                current_item = None
+    return data
+
 def _load_yaml_like(path: Path) -> dict[str, Any]:
     """Load YAML using PyYAML if available, else JSON fallback for YAML-compatible JSON."""
     text = path.read_text(encoding="utf-8")
@@ -17,7 +59,10 @@ def _load_yaml_like(path: Path) -> dict[str, Any]:
 
         data = yaml.safe_load(text)
     except Exception:
-        data = json.loads(text)
+        try:
+            data = json.loads(text)
+        except Exception:
+            data = _parse_min_yaml(text)
     if not isinstance(data, dict):
         raise ValueError(f"Expected mapping at top-level in {path}")
     return data

--- a/tools/validators/ecology/validate_habitat_assignments.py
+++ b/tools/validators/ecology/validate_habitat_assignments.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ecology validator: validate_habitat_assignments.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def validate(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    value = bundle.get("habitat_assignment_refs")
+    if not isinstance(value, list) or not value:
+        errors.append("habitat_assignment_refs_required")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate habitat_assignment_refs in ecology bundle")
+    parser.add_argument("bundle", help="Path to bundle JSON file")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    errors = validate(bundle)
+    result = {"decision": "pass" if not errors else "fail", "errors": errors}
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/validate_habitat_surfaces.py
+++ b/tools/validators/ecology/validate_habitat_surfaces.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ecology validator: validate_habitat_surfaces.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def validate(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    value = bundle.get("habitat_surface_refs")
+    if not isinstance(value, list) or not value:
+        errors.append("habitat_surface_refs_required")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate habitat_surface_refs in ecology bundle")
+    parser.add_argument("bundle", help="Path to bundle JSON file")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    errors = validate(bundle)
+    result = {"decision": "pass" if not errors else "fail", "errors": errors}
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/validate_occurrences.py
+++ b/tools/validators/ecology/validate_occurrences.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ecology validator: validate_occurrences.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def validate(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    value = bundle.get("occurrence_refs")
+    if not isinstance(value, list) or not value:
+        errors.append("occurrence_refs_required")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate occurrence_refs in ecology bundle")
+    parser.add_argument("bundle", help="Path to bundle JSON file")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    errors = validate(bundle)
+    result = {"decision": "pass" if not errors else "fail", "errors": errors}
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/validate_release_bundle.py
+++ b/tools/validators/ecology/validate_release_bundle.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ecology validator: validate_release_bundle.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def validate(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    value = bundle.get("release_refs")
+    if not isinstance(value, list) or not value:
+        errors.append("release_refs_required")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate release_refs in ecology bundle")
+    parser.add_argument("bundle", help="Path to bundle JSON file")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    errors = validate(bundle)
+    result = {"decision": "pass" if not errors else "fail", "errors": errors}
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/validate_runtime_envelope.py
+++ b/tools/validators/ecology/validate_runtime_envelope.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ecology validator: validate_runtime_envelope.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def validate(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    value = bundle.get("runtime_refs")
+    if not isinstance(value, list) or not value:
+        errors.append("runtime_refs_required")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate runtime_refs in ecology bundle")
+    parser.add_argument("bundle", help="Path to bundle JSON file")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    errors = validate(bundle)
+    result = {"decision": "pass" if not errors else "fail", "errors": errors}
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/validate_sensitivity.py
+++ b/tools/validators/ecology/validate_sensitivity.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Ecology validator for sensitivity and public-safe geometry handling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def validate(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    sensitivity = bundle.get("sensitivity")
+    if sensitivity not in {"public", "restricted", "sensitive", "public-safe"}:
+        errors.append("invalid_sensitivity")
+
+    if sensitivity in {"restricted", "sensitive"} and bundle.get("exact_geometry_present") is True:
+        errors.append("restricted_exact_geometry_not_allowed")
+
+    if sensitivity in {"restricted", "sensitive"} and not bundle.get("geoprivacy_receipt_ref"):
+        errors.append("missing_geoprivacy_receipt_ref")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate ecology sensitivity posture")
+    parser.add_argument("bundle", help="Path to bundle JSON file")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    errors = validate(bundle)
+    result = {"decision": "pass" if not errors else "fail", "errors": errors}
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/validate_source_descriptors.py
+++ b/tools/validators/ecology/validate_source_descriptors.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ecology validator: validate_source_descriptors.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def validate(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    value = bundle.get("source_refs")
+    if not isinstance(value, list) or not value:
+        errors.append("source_refs_required")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate source_refs in ecology bundle")
+    parser.add_argument("bundle", help="Path to bundle JSON file")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    errors = validate(bundle)
+    result = {"decision": "pass" if not errors else "fail", "errors": errors}
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/ecology/validate_taxa.py
+++ b/tools/validators/ecology/validate_taxa.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ecology validator: validate_taxa.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def validate(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    value = bundle.get("taxa_refs")
+    if not isinstance(value, list) or not value:
+        errors.append("taxa_refs_required")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate taxa_refs in ecology bundle")
+    parser.add_argument("bundle", help="Path to bundle JSON file")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = json.loads(Path(args.bundle).read_text(encoding="utf-8"))
+    errors = validate(bundle)
+    result = {"decision": "pass" if not errors else "fail", "errors": errors}
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"decision={result['decision']}")
+        for error in errors:
+            print(f"error={error}")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a runnable, fail-closed validator lane for ecology artifacts so candidate bundles can be checked end-to-end before promotion. 
- Supply small, focused validators for distinct ecology artifact classes (sources, taxa, occurrences, habitat surfaces/assignments, sensitivity, catalog/release/runtime) to avoid collapsing responsibilities. 
- Add an orchestrator and summary renderer to make local CI and reviewer handoff straightforward. 

### Description

- Added a set of executable validator scripts under `tools/validators/ecology/` that perform presence and basic posture checks for `source_refs`, `taxa_refs`, `occurrence_refs`, `habitat_surface_refs`, `habitat_assignment_refs`, `catalog_refs`, `release_refs`, and `runtime_refs` (files: `validate_*.py`).
- Added `validate_sensitivity.py` to enforce allowed sensitivity values and deny exact public geometry for restricted/sensitive items and require a `geoprivacy_receipt_ref` when appropriate. 
- Added `run_all.py` to orchestrate the suite and emit aggregated JSON with per-validator decisions and exit codes, and added `render_summary.py` to render a Markdown table from the `run_all` JSON output. 
- Updated `validate_ecology_bundle.py` to include a minimal YAML fallback parser (`_parse_min_yaml`) so the registry YAML files can be read in environments without `PyYAML`. 
- Updated `tools/validators/ecology/README.md` to list implemented scripts and reflect the current, runnable lane shape. 

### Testing

- Ran CLI help checks for `validate_ecology_bundle.py` and `run_all.py` via `python tools/validators/ecology/validate_ecology_bundle.py --help` and `python tools/validators/ecology/run_all.py --help`, both succeeded. 
- Executed the orchestrator with a synthetic bundle via `python tools/validators/ecology/run_all.py --bundle /tmp/eco_bundle.json --json` and verified the aggregate decision was `pass` with per-validator results (succeeded after fixing `validate_ecology_bundle.py` invocation). 
- Verified the minimal YAML fallback by exercising registry reads in the environment without `PyYAML` (fallback exercised during run, no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13953c9b8832aa7c42ee398316393)