### PR TITLE
Add fixtures and pytest coverage for ecology_composite_claim validator

### DIFF
--- a/tools/validators/ecology_composite_claim/fixtures/invalid/cite_missing_evidence.json
+++ b/tools/validators/ecology_composite_claim/fixtures/invalid/cite_missing_evidence.json
@@ -1,0 +1,18 @@
+{
+  "claim_id": "kfm.claim.ecology.veg_soil_missing_evidence.example.v1",
+  "claim_type": "composite_ecological_claim",
+  "spec_hash": "sha256:ghi789",
+  "policy_label": "public-safe",
+  "domains": ["vegetation", "soil"],
+  "runtime_behavior": {
+    "decision": "cite",
+    "evidence_drawer_required": true
+  },
+  "evidence": {
+    "status": "resolved",
+    "items": []
+  },
+  "uncertainty": {
+    "status": "declared"
+  }
+}

--- a/tools/validators/ecology_composite_claim/fixtures/invalid/single_domain.json
+++ b/tools/validators/ecology_composite_claim/fixtures/invalid/single_domain.json
@@ -1,0 +1,18 @@
+{
+  "claim_id": "kfm.claim.ecology.vegetation_only.example.v1",
+  "claim_type": "composite_ecological_claim",
+  "spec_hash": "sha256:def456",
+  "policy_label": "public",
+  "domains": ["vegetation"],
+  "runtime_behavior": {
+    "decision": "abstain",
+    "evidence_drawer_required": true
+  },
+  "evidence": {
+    "status": "unresolved",
+    "items": []
+  },
+  "uncertainty": {
+    "status": "declared"
+  }
+}

--- a/tools/validators/ecology_composite_claim/fixtures/valid/cite_resolved.json
+++ b/tools/validators/ecology_composite_claim/fixtures/valid/cite_resolved.json
@@ -1,0 +1,24 @@
+{
+  "claim_id": "kfm.claim.ecology.vegetation_soil.example.v1",
+  "claim_type": "composite_ecological_claim",
+  "spec_hash": "sha256:abc123",
+  "policy_label": "public-safe",
+  "domains": ["vegetation", "soil"],
+  "runtime_behavior": {
+    "decision": "cite",
+    "evidence_drawer_required": true
+  },
+  "evidence": {
+    "status": "resolved",
+    "items": [
+      {
+        "evidence_ref": "kfm://evidence/ecology/veg-soil/2026-01",
+        "layer_ref": "kfm://layer/ecology/veg-soil/preview"
+      }
+    ]
+  },
+  "uncertainty": {
+    "status": "declared",
+    "summary": "Bounded uncertainty remains within documented range."
+  }
+}

--- a/tools/validators/ecology_composite_claim/tests/test_validate_ecology_composite_claim.py
+++ b/tools/validators/ecology_composite_claim/tests/test_validate_ecology_composite_claim.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.validators.ecology_composite_claim.validate_ecology_composite_claim import (
+    ValidationError,
+    validate,
+)
+
+
+FIXTURE_ROOT = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def _load(rel: str) -> dict:
+    return json.loads((FIXTURE_ROOT / rel).read_text(encoding="utf-8"))
+
+
+def test_validate_accepts_valid_cite_claim() -> None:
+    doc = _load("valid/cite_resolved.json")
+    warnings = validate(doc)
+    assert warnings == []
+
+
+def test_validate_rejects_single_domain() -> None:
+    doc = _load("invalid/single_domain.json")
+    with pytest.raises(ValidationError, match="at least two domains"):
+        validate(doc)
+
+
+def test_validate_rejects_cite_without_evidence() -> None:
+    doc = _load("invalid/cite_missing_evidence.json")
+    with pytest.raises(ValidationError, match="at least one evidence item"):
+        validate(doc)
+
+
+def test_cli_report_json_failure() -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "tools.validators.ecology_composite_claim",
+        str(FIXTURE_ROOT / "invalid" / "single_domain.json"),
+        "--report-json",
+    ]
+    proc = subprocess.run(cmd, check=False, text=True, capture_output=True)
+    assert proc.returncode == 1
+    payload = json.loads(proc.stdout)
+    assert payload["result"] == "fail"
+
+
+def test_cli_allow_message_success() -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "tools.validators.ecology_composite_claim",
+        str(FIXTURE_ROOT / "valid" / "cite_resolved.json"),
+    ]
+    proc = subprocess.run(cmd, check=False, text=True, capture_output=True)
+    assert proc.returncode == 0
+    assert "ALLOW:" in proc.stdout


### PR DESCRIPTION
### Motivation
- Provide deterministic fixtures and automated tests to validate fail-closed behavior for ecological composite claims.
- Exercise both function-level validation (`validate`) and the CLI entrypoint to ensure machine-readable failure reports and ALLOW messaging behave as expected.

### Description
- Add `tools/validators/ecology_composite_claim/tests/test_validate_ecology_composite_claim.py` which tests the validator function and CLI behavior including `--report-json` output.
- Add a passing fixture `tools/validators/ecology_composite_claim/fixtures/valid/cite_resolved.json` representing a resolved `cite` claim with evidence and uncertainty.
- Add two failing fixtures `tools/validators/ecology_composite_claim/fixtures/invalid/single_domain.json` and `tools/validators/ecology_composite_claim/fixtures/invalid/cite_missing_evidence.json` covering single-domain and cite-without-evidence failure cases.
- No changes were required to the validator implementation file; tests validate current behavior and CLI reporting.

### Testing
- Ran `pytest -q tools/validators/ecology_composite_claim/tests` and all tests completed successfully.
- Test run result: `5 passed` (covers function-level validation and CLI payload/exit-code behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13b6f5178832aa3312ed14bd65068)