### PR TITLE
Add foundational ecology index validator docs

### DIFF
--- a/tools/validators/ecology_index/docs/CHECK_MATRIX.md
+++ b/tools/validators/ecology_index/docs/CHECK_MATRIX.md
@@ -1,0 +1,26 @@
+# Ecology Index Validator Check Matrix
+
+This matrix documents the checks implemented by the ecology index validator and the expected failure codes.
+
+| Check | Description | Fails with |
+|---|---|---|
+| JSON parsing | Input must parse as a JSON object. | `invalid_json`, `input_not_object` |
+| Schema validation | Input must satisfy the configured JSON schema. | `schema_validation_error` |
+| `spec_hash` required | `spec_hash` must be present and non-empty. | `missing_spec_hash` |
+| `domains` required | `domains` must be a non-empty array. | `domains_missing_or_empty` |
+| Domain allowlist | Domains must be in validator allowlist. | `unknown_domain` |
+| `evidence_refs` required | `evidence_refs` must be non-empty. | `evidence_refs_empty` |
+| Join key conditional checks | Domain + geometry combinations must include required join keys. | `missing_watershed_id`, `missing_taxon_or_obs_id`, `missing_soil_pedon_id`, `missing_station_id`, `missing_grid_id_or_habitat_code` |
+
+## Fixture coverage mapping
+
+- `fixtures/valid/` provides passing examples for watershed, fauna/habitat grid, and air station/vegetation joins.
+- `fixtures/invalid/` provides failure examples for unknown domain, empty evidence refs, missing spec hash, and missing conditional join keys.
+
+## CI expectation
+
+The validator CI workflow must run:
+
+1. Unit tests under `tools/validators/ecology_index/tests/`
+2. A direct sweep of valid fixtures (must pass)
+3. A direct sweep of invalid fixtures (must fail)

--- a/tools/validators/ecology_index/docs/README.md
+++ b/tools/validators/ecology_index/docs/README.md
@@ -107,12 +107,12 @@ Content belongs in this docs folder when it explains, constrains, or reviews the
 
 A small, useful initial set is:
 
-1. `CHECK_MATRIX.md`
-2. `REASON_CODES.md`
-3. `SOURCE_ROLE_BOUNDARIES.md`
-4. `SENSITIVITY_AND_GEOPRIVACY.md`
-5. `CONTINUITY_NOTES.md`
-6. `ROLLBACK.md`
+1. [`CHECK_MATRIX.md`](./CHECK_MATRIX.md) ✅
+2. [`REASON_CODES.md`](./REASON_CODES.md) ✅
+3. [`SOURCE_ROLE_BOUNDARIES.md`](./SOURCE_ROLE_BOUNDARIES.md) ✅
+4. [`SENSITIVITY_AND_GEOPRIVACY.md`](./SENSITIVITY_AND_GEOPRIVACY.md) ✅
+5. `CONTINUITY_NOTES.md` (next)
+6. `ROLLBACK.md` (next)
 
 [Back to top](#top)
 

--- a/tools/validators/ecology_index/docs/REASON_CODES.md
+++ b/tools/validators/ecology_index/docs/REASON_CODES.md
@@ -1,0 +1,29 @@
+# Ecology Index Validator Reason Codes
+
+Canonical reason codes emitted by the validator.
+
+## Input and schema
+
+- `invalid_json`: input could not be decoded as JSON.
+- `input_not_object`: decoded JSON was not an object.
+- `schema_validation_error`: JSON schema validation failed.
+
+## Required fields
+
+- `missing_spec_hash`: `spec_hash` absent or empty.
+- `domains_missing_or_empty`: `domains` absent or empty.
+- `evidence_refs_empty`: `evidence_refs` absent or empty.
+
+## Domain and conditional join keys
+
+- `unknown_domain`: one or more listed domains are unsupported.
+- `missing_watershed_id`: required watershed join key missing for hydrology + `huc12` geometry.
+- `missing_taxon_or_obs_id`: required `taxon_id` or `observation_id` missing for fauna rows.
+- `missing_soil_pedon_id`: required `soil_pedon_id` missing for soil rows.
+- `missing_station_id`: required `station_id` missing for air rows.
+- `missing_grid_id_or_habitat_code`: required `grid_id` or `habitat_code` missing for vegetation rows.
+
+## Notes
+
+- A single record may emit multiple reason codes.
+- CLI output deduplicates repeated reasons in user-facing output while preserving error count semantics in tests.

--- a/tools/validators/ecology_index/docs/SENSITIVITY_AND_GEOPRIVACY.md
+++ b/tools/validators/ecology_index/docs/SENSITIVITY_AND_GEOPRIVACY.md
@@ -1,0 +1,25 @@
+# Sensitivity and Geoprivacy Notes
+
+This validator does not currently classify geoprivacy sensitivity directly, but it protects prerequisites needed for downstream policy checks.
+
+## What this validator guarantees
+
+- Row structure is schema-valid.
+- Domain and join-key requirements are satisfied.
+- Evidence references are present.
+
+## What this validator does not guarantee
+
+- Restricted-coordinate redaction.
+- Public-safe geometry generalization policy.
+- Embargo windows or steward-review disposition.
+- Release authorization.
+
+## Required downstream checks
+
+Before publication, downstream policy gates should verify:
+
+1. Coordinate precision policy by sensitivity class.
+2. Redaction/generalization receipts for restricted records.
+3. Rights and redistribution posture.
+4. Release-state and correction/rollback readiness.

--- a/tools/validators/ecology_index/docs/SOURCE_ROLE_BOUNDARIES.md
+++ b/tools/validators/ecology_index/docs/SOURCE_ROLE_BOUNDARIES.md
@@ -1,0 +1,24 @@
+# Source Role Boundaries
+
+The ecology index validator enforces structural safety only. It does not assign authority across source roles.
+
+## Role boundary rules
+
+1. **Observed occurrence is not legal authority**
+   - Observation or occurrence data supports presence claims, not regulation or legal status.
+2. **Modeled habitat is not direct observation**
+   - Habitat suitability and grid-level predictions cannot replace event-level evidence.
+3. **Air/station telemetry is environmental context**
+   - Station data may support context but does not identify taxa by itself.
+4. **Hydrology joins are spatial context**
+   - Watershed joins anchor place; they do not establish species presence without evidence refs.
+
+## Validator implication
+
+Because source-role metadata is enforced in upstream contracts/policy, this validator relies on:
+
+- non-empty `domains`
+- non-empty `evidence_refs`
+- domain-specific join key conditionals
+
+These constraints prevent the most common source-role collapse pattern: publishing structurally joined rows with no evidence anchor.


### PR DESCRIPTION
### Motivation

- Provide the missing core documentation for the ecology-index validator lane so the docs directory matches the README's "good first docs" checklist.
- Make it easier for reviewers and CI authors to understand expected checks, reason codes, source-role boundaries, and geoprivacy expectations before implementing or wiring CI.

### Description

- Added `tools/validators/ecology_index/docs/CHECK_MATRIX.md` documenting validator check families, fixture coverage mapping, and CI expectations.
- Added `tools/validators/ecology_index/docs/REASON_CODES.md` enumerating canonical reason codes emitted by the validator.
- Added `tools/validators/ecology_index/docs/SOURCE_ROLE_BOUNDARIES.md` describing source-role boundary rules and validator implications.
- Added `tools/validators/ecology_index/docs/SENSITIVITY_AND_GEOPRIVACY.md` describing what the validator guarantees and the downstream geoprivacy checks required.
- Updated `tools/validators/ecology_index/docs/README.md` to link to and mark the new docs as completed while leaving `CONTINUITY_NOTES.md` and `ROLLBACK.md` as next steps.

### Testing

- Ran the validator test suite with `pytest -q tools/validators/ecology_index/tests`, which completed successfully.
- Result: `38 passed` (all tests in the validator test directory passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13d2223a0832aa1b65d02bec0216b)