### PR TITLE
Add expected_failures.json for ecology_index fixtures

### DIFF
--- a/tools/validators/ecology_index/fixtures/expected_failures.json
+++ b/tools/validators/ecology_index/fixtures/expected_failures.json
@@ -1,0 +1,32 @@
+{
+  "manifest_id": "kfm.ecology_index.expected_failures.v1",
+  "truth_posture": "PROPOSED",
+  "schema_target": "schemas/ecology/kfm_eco_index.schema.json",
+  "invalid": [
+    {
+      "fixture": "invalid/missing_spec_hash.json",
+      "expected_rule": "ECO_INDEX_SPEC_HASH_REQUIRED",
+      "expected_message": "spec_hash is required"
+    },
+    {
+      "fixture": "invalid/huc12_missing_watershed_id.json",
+      "expected_rule": "ECO_INDEX_HUC12_WATERSHED_REQUIRED",
+      "expected_message": "geometry_type huc12 requires join_keys.watershed_id"
+    },
+    {
+      "fixture": "invalid/fauna_without_taxon_or_obs.json",
+      "expected_rule": "ECO_INDEX_TAXON_OR_OBS_REQUIRED",
+      "expected_message": "domain fauna requires taxon_id or obs_id"
+    },
+    {
+      "fixture": "invalid/evidence_refs_empty.json",
+      "expected_rule": "ECO_INDEX_EVIDENCE_REQUIRED",
+      "expected_message": "evidence_refs must contain at least one item"
+    },
+    {
+      "fixture": "invalid/unknown_domain.json",
+      "expected_rule": "ECO_INDEX_UNKNOWN_DOMAIN",
+      "expected_message": "unknown domain: unknown_domain"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a machine-readable expected-failures manifest so the `tools/validators/ecology_index/fixtures` set is complete and automated tests can assert precise negative behavior.

### Description
- Add `tools/validators/ecology_index/fixtures/expected_failures.json` mapping each invalid fixture to an `expected_rule` and `expected_message`.
- Align the manifest's rule codes and messages with the validator's current error-code naming (e.g. `ECO_INDEX_HUC12_WATERSHED_REQUIRED`, `ECO_INDEX_TAXON_OR_OBS_REQUIRED`, `ECO_INDEX_UNKNOWN_DOMAIN`).

### Testing
- Validated the JSON with `python -m json.tool tools/validators/ecology_index/fixtures/expected_failures.json` which completed without error.
- Ran `pytest -q tools/validators/ecology_index/tests/test_validator_fixtures.py` which succeeded (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13dc7e8a4832ab1ae03db46c4f55c)