### PR TITLE
Add invalid ecology_index fixtures for missing domain join-keys and update expectations/tests

### DIFF
--- a/tools/validators/ecology_index/fixtures/expected_failures.json
+++ b/tools/validators/ecology_index/fixtures/expected_failures.json
@@ -16,7 +16,7 @@
     {
       "fixture": "invalid/fauna_without_taxon_or_obs.json",
       "expected_rule": "ECO_INDEX_TAXON_OR_OBS_REQUIRED",
-      "expected_message": "domain fauna requires taxon_id or obs_id"
+      "expected_message": "flora/fauna rows require join_keys.taxon_id or join_keys.obs_id"
     },
     {
       "fixture": "invalid/evidence_refs_empty.json",
@@ -27,6 +27,21 @@
       "fixture": "invalid/unknown_domain.json",
       "expected_rule": "ECO_INDEX_UNKNOWN_DOMAIN",
       "expected_message": "unknown domain: unknown_domain"
+    },
+    {
+      "fixture": "invalid/hydrology_without_required_join_key.json",
+      "expected_rule": "ECO_INDEX_HYDROLOGY_KEY_REQUIRED",
+      "expected_message": "hydrology rows require watershed_id, reach_id, or station_id"
+    },
+    {
+      "fixture": "invalid/soil_without_required_join_key.json",
+      "expected_rule": "ECO_INDEX_SOIL_KEY_REQUIRED",
+      "expected_message": "soil rows require soil_id or station_id"
+    },
+    {
+      "fixture": "invalid/vegetation_without_required_join_key.json",
+      "expected_rule": "ECO_INDEX_VEGETATION_KEY_REQUIRED",
+      "expected_message": "vegetation rows require layer_id or landcover_class"
     }
   ]
 }

--- a/tools/validators/ecology_index/fixtures/invalid/hydrology_without_required_join_key.json
+++ b/tools/validators/ecology_index/fixtures/invalid/hydrology_without_required_join_key.json
@@ -1,0 +1,11 @@
+{
+  "index_id": "kfm.eco_index.invalid.hydrology_without_required_join_key",
+  "geom_id": "GRID:KS_10KM_209",
+  "geometry_type": "grid",
+  "time_bucket": "2024_annual",
+  "spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "domains": ["hydrology"],
+  "join_keys": {"layer_id": "kfm.ecology.vegetation.ndvi_change.v1"},
+  "evidence_refs": [{"domain": "hydrology", "evidence_ref": "kfm:evidence:hydrology:stream_health:v1"}],
+  "status": "valid"
+}

--- a/tools/validators/ecology_index/fixtures/invalid/soil_without_required_join_key.json
+++ b/tools/validators/ecology_index/fixtures/invalid/soil_without_required_join_key.json
@@ -1,0 +1,11 @@
+{
+  "index_id": "kfm.eco_index.invalid.soil_without_required_join_key",
+  "geom_id": "GRID:KS_10KM_210",
+  "geometry_type": "grid",
+  "time_bucket": "2024_annual",
+  "spec_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "domains": ["soil"],
+  "join_keys": {"layer_id": "kfm.ecology.vegetation.ndvi_change.v1"},
+  "evidence_refs": [{"domain": "soil", "evidence_ref": "kfm:evidence:soil:ssurgo:mapunit:123"}],
+  "status": "valid"
+}

--- a/tools/validators/ecology_index/fixtures/invalid/vegetation_without_required_join_key.json
+++ b/tools/validators/ecology_index/fixtures/invalid/vegetation_without_required_join_key.json
@@ -1,0 +1,11 @@
+{
+  "index_id": "kfm.eco_index.invalid.vegetation_without_required_join_key",
+  "geom_id": "GRID:KS_10KM_211",
+  "geometry_type": "grid",
+  "time_bucket": "2024_annual",
+  "spec_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "domains": ["vegetation"],
+  "join_keys": {"station_id": "MESONET:ELL"},
+  "evidence_refs": [{"domain": "vegetation", "evidence_ref": "kfm:evidence:vegetation:ndvi_change:v1"}],
+  "status": "valid"
+}

--- a/tools/validators/ecology_index/tests/test_validator_fixtures.py
+++ b/tools/validators/ecology_index/tests/test_validator_fixtures.py
@@ -87,3 +87,33 @@ def test_unknown_domain_fails() -> None:
 
     assert not result.ok
     assert any(error.code == "ECO_INDEX_UNKNOWN_DOMAIN" for error in result.errors)
+
+
+def test_hydrology_without_required_join_key_fails() -> None:
+    result = validate_file(
+        input_path=FIXTURE_ROOT / "invalid" / "hydrology_without_required_join_key.json",
+        schema_ref=SCHEMA_REF,
+    )
+
+    assert not result.ok
+    assert any(error.code == "ECO_INDEX_HYDROLOGY_KEY_REQUIRED" for error in result.errors)
+
+
+def test_soil_without_required_join_key_fails() -> None:
+    result = validate_file(
+        input_path=FIXTURE_ROOT / "invalid" / "soil_without_required_join_key.json",
+        schema_ref=SCHEMA_REF,
+    )
+
+    assert not result.ok
+    assert any(error.code == "ECO_INDEX_SOIL_KEY_REQUIRED" for error in result.errors)
+
+
+def test_vegetation_without_required_join_key_fails() -> None:
+    result = validate_file(
+        input_path=FIXTURE_ROOT / "invalid" / "vegetation_without_required_join_key.json",
+        schema_ref=SCHEMA_REF,
+    )
+
+    assert not result.ok
+    assert any(error.code == "ECO_INDEX_VEGETATION_KEY_REQUIRED" for error in result.errors)


### PR DESCRIPTION
### Motivation
- Complete negative-fixture coverage for the `ecology_index` validator by adding cases that exercise missing domain-specific `join_keys` semantics so the validator fails closed on those inputs. 
- Ensure the fixtures and manifest reflect the actual error messages emitted by the validator for consistent test expectations.

### Description
- Added three invalid fixtures: `tools/validators/ecology_index/fixtures/invalid/hydrology_without_required_join_key.json`, `.../soil_without_required_join_key.json`, and `.../vegetation_without_required_join_key.json` which omit required domain join keys. 
- Updated `tools/validators/ecology_index/fixtures/expected_failures.json` to include expected rule and message entries for the three new fixtures and corrected the fauna expected message to match the validator output. 
- Extended `tools/validators/ecology_index/tests/test_validator_fixtures.py` with three tests asserting each new fixture fails with the corresponding error codes (`ECO_INDEX_HYDROLOGY_KEY_REQUIRED`, `ECO_INDEX_SOIL_KEY_REQUIRED`, `ECO_INDEX_VEGETATION_KEY_REQUIRED`).

### Testing
- Ran `pytest -q tools/validators/ecology_index/tests/test_validator_fixtures.py` which executed the fixture coverage suite. 
- All tests in that suite passed: `11 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1440e6c0c832ab61ae30e76694158)