### PR TITLE
Add runtime policy bundle manifest and Rego rules for finite outcomes

### DIFF
--- a/policy/bundles/runtime/bundle.yaml
+++ b/policy/bundles/runtime/bundle.yaml
@@ -1,4 +1,8 @@
-name: runtime
-version: 0.1.0
-roots:
-  - .
+bundle:
+  name: kfm.policy.runtime
+  version: v0
+  entrypoint: data.kfm.runtime.decision
+  modules:
+    - finite_outcomes.rego
+    - runtime_denials.rego
+    - proof_quartet.rego

--- a/policy/bundles/runtime/finite_outcomes.rego
+++ b/policy/bundles/runtime/finite_outcomes.rego
@@ -1,5 +1,49 @@
 package kfm.runtime
 
-# Placeholder policy module for finite runtime outcomes.
-# TODO: replace with governed rules and paired tests.
+import data.kfm.runtime.denials
+import data.kfm.runtime.proof
+
+# Finite runtime outcomes supported by RuntimeResponseEnvelope.
+allowed_outcomes := {"ANSWER", "ABSTAIN", "DENY", "ERROR"}
+
+# Denials are fail-closed and win over other branches.
+outcome := "DENY" if {
+  denials.deny
+}
+
+# Engine or dependency failures are surfaced as runtime errors.
+outcome := "ERROR" if {
+  not denials.deny
+  proof.engine_error
+}
+
+# Positive answer path requires a complete proof quartet.
+outcome := "ANSWER" if {
+  not denials.deny
+  not proof.engine_error
+  proof.proof_quartet_ok
+}
+
+# Default to ABSTAIN when policy cannot safely produce an answer.
 default outcome := "ABSTAIN"
+
+# Canonical runtime decision envelope for callers that need reasons/obligations.
+decision := {
+  "outcome": outcome,
+  "reasons": reasons,
+  "obligations": obligations,
+}
+
+reasons := ["policy_denied"] if outcome == "DENY"
+reasons := ["policy_engine_error"] if outcome == "ERROR"
+reasons := ["proof_quartet_satisfied"] if outcome == "ANSWER"
+reasons := ["insufficient_evidence_or_policy_signal"] if outcome == "ABSTAIN"
+
+obligations := ["surface_runtime_denial_reason"] if outcome == "DENY"
+obligations := ["emit_runtime_error_receipt"] if outcome == "ERROR"
+obligations := ["attach_citation_and_receipts"] if outcome == "ANSWER"
+obligations := ["present_abstain_with_next_action"] if outcome == "ABSTAIN"
+
+valid_outcome {
+  allowed_outcomes[outcome]
+}

--- a/policy/bundles/runtime/proof_quartet.rego
+++ b/policy/bundles/runtime/proof_quartet.rego
@@ -1,4 +1,21 @@
 package kfm.runtime.proof
 
-# Placeholder proof quartet checks.
+# Proof quartet requires these four runtime trust artifacts.
 default proof_quartet_ok := false
+
+default engine_error := false
+
+proof_quartet_ok if {
+  input.runtime.proof.ai_receipt
+  input.runtime.proof.run_receipt
+  input.runtime.proof.attestation
+  input.runtime.proof.citation
+}
+
+engine_error if {
+  input.runtime.engine_unavailable == true
+}
+
+engine_error if {
+  input.runtime.policy_evaluation_failed == true
+}

--- a/policy/bundles/runtime/runtime_denials.rego
+++ b/policy/bundles/runtime/runtime_denials.rego
@@ -1,4 +1,15 @@
 package kfm.runtime.denials
 
-# Placeholder denial policy module.
+# Runtime denials are explicit and fail-closed.
 default deny := false
+
+deny if {
+  input.request.actor.blocked == true
+}
+
+deny if {
+  input.request.resource.restricted == true
+}
+
+deny_reason := "blocked_actor" if input.request.actor.blocked == true
+deny_reason := "restricted_resource" if input.request.resource.restricted == true


### PR DESCRIPTION
### Motivation
- Provide a concrete runtime policy bundle for request-time decisioning with a stable bundle manifest and entrypoint.  
- Constrain runtime-facing responses to a small, reviewable set of finite outcomes (`ANSWER | ABSTAIN | DENY | ERROR`).  
- Surface a canonical decision envelope with reasons and obligations so runtime consumers have a consistent contract.

### Description
- Replace the placeholder manifest with `policy/bundles/runtime/bundle.yaml` that names the bundle, sets `version`, and registers `entrypoint: data.kfm.runtime.decision` and modules (`finite_outcomes.rego`, `runtime_denials.rego`, `proof_quartet.rego`).  
- Add `policy/bundles/runtime/finite_outcomes.rego` implementing the finite outcome grammar, precedence (DENY > ERROR > ANSWER > ABSTAIN), a `decision` envelope, `reasons`/`obligations`, and a `valid_outcome` guard.  
- Add `policy/bundles/runtime/runtime_denials.rego` implementing fail-closed denial predicates and `deny_reason` mapping for blocked actors and restricted resources.  
- Add `policy/bundles/runtime/proof_quartet.rego` implementing the proof-quartet check (`ai_receipt`, `run_receipt`, `attestation`, `citation`) and detection of engine/policy evaluation errors.

### Testing
- Ran `python3 tools/ci/validate_policy_runtime_fixtures.py --root .` which succeeded and reported validation of 4 runtime fixtures with full finite outcome coverage.  
- Attempted to run the Rego unit test via `opa test policy/tests/runtime/finite_outcomes_test.rego policy/bundles/runtime/*.rego` but the `opa` binary is not installed in this environment so that test could not be executed.  
- The added Rego modules include a testable `data.kfm.runtime.decision` entrypoint for downstream OPA-based tests and CI to run once `opa` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f149256008832a8d4b71a1a00e1f7e)