### PR TITLE
Build out policy/catalog bundle and gates (matrix, visibility, rights, correction, STAC/DCAT)

### DIFF
--- a/policy/catalog/bundle.yaml
+++ b/policy/catalog/bundle.yaml
@@ -1,0 +1,9 @@
+name: kfm-policy-catalog
+version: 0.1.0
+entrypoints:
+  - kfm.catalog.matrix
+  - kfm.catalog.rights
+  - kfm.catalog.visibility
+  - kfm.catalog.correction
+  - kfm.catalog.dcat
+  - kfm.catalog.stac

--- a/policy/catalog/catalog_correction.rego
+++ b/policy/catalog/catalog_correction.rego
@@ -1,0 +1,25 @@
+package kfm.catalog.correction
+
+default correction_ready := false
+
+deny[msg] {
+  input["status"] == "superseded"
+  not input["replacement_ref"]
+  msg := "superseded catalog record must include replacement_ref"
+}
+
+deny[msg] {
+  input["status"] == "withdrawn"
+  not input["withdrawal_reason"]
+  msg := "withdrawn catalog record must include withdrawal_reason"
+}
+
+deny[msg] {
+  input["status"] == "rollback"
+  not input["rollback_target_ref"]
+  msg := "rollback catalog record must include rollback_target_ref"
+}
+
+correction_ready {
+  count(deny) == 0
+}

--- a/policy/catalog/catalog_matrix.rego
+++ b/policy/catalog/catalog_matrix.rego
@@ -1,0 +1,54 @@
+package kfm.catalog.matrix
+
+default pass := false
+
+required_refs := {
+  "stac_item_ref",
+  "dcat_dataset_ref",
+  "prov_sidecar_ref",
+  "release_manifest_ref",
+  "proof_pack_ref",
+}
+
+deny[msg] {
+  some key in required_refs
+  not input[key]
+  msg := sprintf("catalog matrix missing %v", [key])
+}
+
+deny[msg] {
+  input["closure_status"] != "closed"
+  msg := "catalog matrix closure_status must be closed"
+}
+
+deny[msg] {
+  raw_ref(input)
+  msg := "catalog matrix references RAW / WORK / QUARANTINE material"
+}
+
+raw_ref(x) {
+  is_string(x)
+  contains(lower(x), "data/raw/")
+}
+raw_ref(x) {
+  is_string(x)
+  contains(lower(x), "data/work/")
+}
+raw_ref(x) {
+  is_string(x)
+  contains(lower(x), "data/quarantine/")
+}
+raw_ref(x) {
+  is_object(x)
+  some k
+  raw_ref(x[k])
+}
+raw_ref(x) {
+  is_array(x)
+  some i
+  raw_ref(x[i])
+}
+
+pass {
+  count(deny) == 0
+}

--- a/policy/catalog/catalog_rights.rego
+++ b/policy/catalog/catalog_rights.rego
@@ -1,0 +1,23 @@
+package kfm.catalog.rights
+
+default releasable := false
+
+deny[msg] {
+  not input["rights"]
+  msg := "rights block missing"
+}
+
+deny[msg] {
+  input["rights"]["redistribution"] != "allowed"
+  msg := "redistribution must be allowed for release-linked catalog"
+}
+
+deny[msg] {
+  input["rights"]["attribution_required"]
+  not input["rights"]["attribution_text"]
+  msg := "attribution text required when attribution_required=true"
+}
+
+releasable {
+  count(deny) == 0
+}

--- a/policy/catalog/catalog_visibility.rego
+++ b/policy/catalog/catalog_visibility.rego
@@ -1,0 +1,23 @@
+package kfm.catalog.visibility
+
+default public_visible := false
+
+deny[msg] {
+  input["policy_label"] != "public"
+  msg := "catalog record is not marked public"
+}
+
+deny[msg] {
+  input["sensitivity"] != "public"
+  msg := "catalog record sensitivity must be public"
+}
+
+deny[msg] {
+  input["review_state"] != "reviewed"
+  input["review_state"] != "published"
+  msg := "catalog record review_state must be reviewed or published"
+}
+
+public_visible {
+  count(deny) == 0
+}

--- a/policy/catalog/dcat/README.md
+++ b/policy/catalog/dcat/README.md
@@ -1,1 +1,3 @@
+# policy/catalog/dcat
 
+DCAT dataset gate for catalog publication. `dcat_dataset_gate.rego` denies by default and allows only when required publication-safe fields are present.

--- a/policy/catalog/obligations.yaml
+++ b/policy/catalog/obligations.yaml
@@ -1,0 +1,7 @@
+obligations:
+  - code: catalog_review_hold
+    description: Hold in steward review until missing catalog links are repaired.
+  - code: catalog_rights_repair
+    description: Rights posture must be corrected before release-linked publication.
+  - code: catalog_visibility_recheck
+    description: Re-evaluate public visibility after sensitivity or policy-label changes.

--- a/policy/catalog/reason_codes.yaml
+++ b/policy/catalog/reason_codes.yaml
@@ -1,0 +1,13 @@
+reason_codes:
+  - code: catalog_missing_required_ref
+    family: closure
+    description: Required catalog cross-reference is missing.
+  - code: catalog_rights_not_releasable
+    family: rights
+    description: Rights posture does not allow release-linked publication.
+  - code: catalog_visibility_not_public_safe
+    family: visibility
+    description: Record is not eligible for public discovery.
+  - code: catalog_correction_incomplete
+    family: correction
+    description: Supersession, withdrawal, or rollback metadata is incomplete.

--- a/policy/catalog/stac/README.md
+++ b/policy/catalog/stac/README.md
@@ -1,1 +1,3 @@
+# policy/catalog/stac
 
+STAC item gate for catalog publication. `stac_item_gate.rego` denies by default and allows only when release-linked and provenance-linked fields are present.

--- a/policy/catalog/stac/stac_item_gate.rego
+++ b/policy/catalog/stac/stac_item_gate.rego
@@ -1,4 +1,4 @@
-package kfm.catalog.dcat
+package kfm.catalog.stac
 
 default allow := false
 
@@ -12,115 +12,66 @@ blocked_public_values := {
 }
 
 deny[msg] {
-  input["@type"] != "dcat:Dataset"
-  msg := "DCAT export must be dcat:Dataset"
+  input["type"] != "Feature"
+  msg := "STAC item must be a GeoJSON Feature"
 }
 
 deny[msg] {
-  not input["dct:license"]
-  msg := "dataset missing license"
+  input["stac_version"] == ""
+  msg := "STAC item missing stac_version"
 }
 
 deny[msg] {
-  is_blocked_public_value(input["dct:license"])
-  msg := "dataset license cannot be TODO, unknown, restricted, deny, or empty"
+  not input["properties"]["datetime"]
+  msg := "STAC item missing properties.datetime"
 }
 
 deny[msg] {
-  input["dct:accessRights"] != "public"
-  msg := "public DCAT export requires dct:accessRights=public"
+  input["properties"]["kfm:policy_label"] != "public"
+  msg := "public STAC export requires properties.kfm:policy_label=public"
 }
 
 deny[msg] {
-  input["kfm:policy_label"] != "public"
-  msg := "public DCAT export requires kfm:policy_label=public"
+  input["properties"]["kfm:sensitivity"]
+  input["properties"]["kfm:sensitivity"] != "public"
+  msg := "public STAC export requires properties.kfm:sensitivity=public when provided"
 }
 
 deny[msg] {
-  input["kfm:sensitivity"]
-  input["kfm:sensitivity"] != "public"
-  msg := "public DCAT export requires kfm:sensitivity=public when provided"
+  not input["properties"]["kfm:spec_hash"]
+  msg := "STAC item missing properties.kfm:spec_hash"
 }
 
 deny[msg] {
-  not input["dct:provenance"]
-  msg := "dataset missing provenance pointer"
+  not input["properties"]["kfm:evidence_ref"]
+  msg := "STAC item missing properties.kfm:evidence_ref"
 }
 
 deny[msg] {
-  not input["kfm:spec_hash"]
-  msg := "dataset missing spec_hash"
+  not input["properties"]["kfm:release_manifest_ref"]
+  msg := "STAC item missing properties.kfm:release_manifest_ref"
 }
 
 deny[msg] {
-  not input["kfm:evidence_ref"]
-  msg := "dataset missing evidence_ref"
+  not input["properties"]["kfm:source_role"]
+  msg := "STAC item missing properties.kfm:source_role"
 }
 
 deny[msg] {
-  not input["kfm:release_manifest_ref"]
-  msg := "dataset missing release_manifest_ref"
+  review := input["properties"]["kfm:review_state"]
+  review != "reviewed"
+  review != "published"
+  msg := "public STAC export requires properties.kfm:review_state reviewed or published"
 }
 
 deny[msg] {
-  not input["kfm:source_role"]
-  msg := "dataset missing source_role"
-}
-
-deny[msg] {
-  input["kfm:review_state"] != "reviewed"
-  input["kfm:review_state"] != "published"
-  msg := "DCAT public export requires kfm:review_state reviewed or published"
-}
-
-deny[msg] {
-  not input["dcat:distribution"]
-  msg := "dataset missing distribution"
-}
-
-deny[msg] {
-  count(input["dcat:distribution"]) == 0
-  msg := "dataset distribution cannot be empty"
-}
-
-deny[msg] {
-  some i
-  distribution := input["dcat:distribution"][i]
-  distribution["@type"] != "dcat:Distribution"
-  msg := sprintf("distribution[%v] must be dcat:Distribution", [i])
-}
-
-deny[msg] {
-  some i
-  distribution := input["dcat:distribution"][i]
-  not distribution["dcat:accessURL"]
-  msg := sprintf("distribution[%v] missing accessURL", [i])
-}
-
-deny[msg] {
-  some i
-  distribution := input["dcat:distribution"][i]
-  not distribution["dct:license"]
-  msg := sprintf("distribution[%v] missing license", [i])
-}
-
-deny[msg] {
-  some i
-  distribution := input["dcat:distribution"][i]
-  is_blocked_public_value(distribution["dct:license"])
-  msg := sprintf("distribution[%v] license cannot be TODO, unknown, restricted, deny, or empty", [i])
-}
-
-deny[msg] {
-  some i
-  distribution := input["dcat:distribution"][i]
-  distribution["dct:license"] != input["dct:license"]
-  msg := sprintf("distribution[%v] license differs from dataset license; reviewed exception is not represented", [i])
+  not input["assets"]["provenance"]
+  msg := "STAC item missing assets.provenance"
 }
 
 deny[msg] {
   raw_ref(input)
-  msg := "public DCAT export references RAW / WORK / QUARANTINE material"
+  msg := "public STAC export references RAW / WORK / QUARANTINE material"
 }
 
 is_blocked_public_value(value) {
@@ -128,19 +79,10 @@ is_blocked_public_value(value) {
   blocked_public_values[lower(value)]
 }
 
-raw_ref(x) {
-  is_string(x)
-  contains(lower(x), "/raw/")
-}
-
-raw_ref(x) {
-  is_string(x)
-  contains(lower(x), "/work/")
-}
-
-raw_ref(x) {
-  is_string(x)
-  contains(lower(x), "/quarantine/")
+deny[msg] {
+  license := input["properties"]["license"]
+  is_blocked_public_value(license)
+  msg := "STAC item properties.license cannot be TODO, unknown, restricted, deny, or empty"
 }
 
 raw_ref(x) {


### PR DESCRIPTION
### Motivation
- Provide a concrete `policy/catalog` policy lane that decides catalog closure, release linkage, visibility, rights, and correction readiness for catalog artifacts. 
- Surface a small, stable bundle entrypoint and typed reason/obligation registries so policy outputs are explainable and testable. 
- Implement deny-by-default gates that block raw/work/quarantine references and ensure release/provenance linkage before public exposure. 
- Fix the STAC gate so it enforces STAC-specific requirements rather than the DCAT checks that were previously present.

### Description
- Added a bundle manifest at `policy/catalog/bundle.yaml` that lists the catalog entrypoints (`kfm.catalog.matrix`, `kfm.catalog.rights`, `kfm.catalog.visibility`, `kfm.catalog.correction`, `kfm.catalog.dcat`, `kfm.catalog.stac`).
- Implemented catalog gate modules `policy/catalog/catalog_matrix.rego`, `policy/catalog/catalog_visibility.rego`, `policy/catalog/catalog_rights.rego`, and `policy/catalog/catalog_correction.rego` to validate closure refs, visibility/review state, rights/release posture, and correction metadata respectively.
- Replaced/fixed the STAC gate at `policy/catalog/stac/stac_item_gate.rego` to use `package kfm.catalog.stac` and to check STAC-specific fields (e.g., `properties.kfm:*`, `assets.provenance`, `properties.datetime`, license checks) and raw/work/quarantine blocking.
- Added lightweight module READMEs and initial policy metadata files `policy/catalog/reason_codes.yaml` and `policy/catalog/obligations.yaml` to provide stable reason and obligation codes for policy decisions.

### Testing
- Ran `pytest tests/catalog -q` which completed successfully with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1591e4dbc832a8ec3bf6e5f96eee2)