### PR TITLE
Finalize GitHub workflow definitions and action versions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,8 +21,8 @@ Governed GitHub Actions orchestration surface for validation, runtime proof, rec
 
 > [!NOTE]
 > **Status:** `experimental` · **Document status:** `draft` · **Owners:** `@bartytime4life` · **Path:** `.github/workflows/README.md`  
-> **Current public inventory:** `README.md`, `verification-baseline.yml`, and scaffold workflows (`docs-lint.yml`, `contracts.yml`, `policy.yml`, `tests.yml`, `release-dry-run.yml`).
-> **Badges:** ![status](https://img.shields.io/badge/status-experimental-orange) ![doc](https://img.shields.io/badge/doc-draft-8250df) ![owner](https://img.shields.io/badge/owner-%40bartytime4life-0969da) ![lane](https://img.shields.io/badge/lane-.github%2Fworkflows-6f42c1) ![posture](https://img.shields.io/badge/posture-governed%20automation-0a7d5a) ![inventory](https://img.shields.io/badge/current%20inventory-README%20%2B%20verification--baseline.yml-lightgrey)
+> **Current public inventory:** `README.md` plus active workflows: `verification-baseline.yml`, `docs-lint.yml`, `contracts.yml`, `policy.yml`, `tests.yml`, `release-dry-run.yml`, `ecology-validation.yml`, `evidence-chain.yml`, and `provenance-gates.yml`.
+> **Badges:** ![status](https://img.shields.io/badge/status-experimental-orange) ![doc](https://img.shields.io/badge/doc-draft-8250df) ![owner](https://img.shields.io/badge/owner-%40bartytime4life-0969da) ![lane](https://img.shields.io/badge/lane-.github%2Fworkflows-6f42c1) ![posture](https://img.shields.io/badge/posture-governed%20automation-0a7d5a) ![inventory](https://img.shields.io/badge/current%20inventory-README%20%2B%209%20workflow%20YAMLs-lightgrey)
 > **Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Inputs](#inputs) · [Exclusions](#exclusions) · [Directory tree](#directory-tree) · [Quickstart](#quickstart) · [Usage](#usage) · [Diagram](#diagram) · [Workflow lanes](#workflow-lanes) · [Task list](#task-list--definition-of-done) · [FAQ](#faq) · [Appendix](#appendix)
 
 > [!IMPORTANT]

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -30,7 +30,7 @@ jobs:
       KFM_POLICY_STRICT: ${{ github.event_name == 'workflow_dispatch' && inputs.strict || false }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -62,7 +62,7 @@ jobs:
       KFM_RELEASE_DRY_RUN_STRICT: ${{ inputs.strict_mode || 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -475,7 +475,7 @@ jobs:
 
       - name: Upload release dry-run receipt
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: release-dry-run-${{ github.run_id }}-${{ github.run_attempt }}
           path: release-dry-run-output/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -126,7 +126,7 @@ jobs:
           printf 'Test surfaces: %s\n' "${targets[*]:-bootstrap override only}"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -234,7 +234,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.detect.outputs.has_node == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/verification-baseline.yml
+++ b/.github/workflows/verification-baseline.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Install PostgreSQL client
         run: |
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload baseline report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: baseline-report
           path: baseline-report.txt
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload governed artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: governed-artifacts
           path: artifacts/governed
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload observability artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: observability-artifacts
           path: artifacts/observability


### PR DESCRIPTION
### Motivation
- Prevent CI breakage by replacing unsupported or non-existent action major versions with known-stable majors so workflows are runnable under current Actions hosts.
- Keep repository documentation accurate by updating the `.github/workflows/README.md` inventory to reflect the active workflow YAMLs.

### Description
- Standardized key action `uses:` references to supported majors: `actions/checkout@v4`, `actions/setup-python@v5`, `actions/setup-node@v4`, and `actions/upload-artifact@v4` across workflow files.
- Updated `.github/workflows/README.md` to list the actual active workflows including `ecology-validation.yml`, `evidence-chain.yml`, and `provenance-gates.yml` and adjusted the inventory badge.
- Changes were applied to workflow YAMLs: `contracts.yml`, `policy.yml`, `release-dry-run.yml`, `tests.yml`, and `verification-baseline.yml` and the README under `.github/workflows`.

### Testing
- Searched the workflows for target `uses:` patterns with `rg` to locate and confirm replacements, and the search succeeded.
- Ran an automated in-place update script to replace action majors (Python script edits) and the modifications were written to disk successfully.
- Verified repository state with `git status --short` and committed the changes, and the commit succeeded.
- Attempted a local YAML parse check using `python -c` with `PyYAML`, which failed due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15ed78444832ab237b0f64cc88441)