### PR TITLE
Add watcher documentation templates and example run receipt

### DIFF
--- a/.github/watchers/README.md
+++ b/.github/watchers/README.md
@@ -172,6 +172,9 @@ Use this directory for small, watcher-facing documentation artifacts only.
 | What belongs here | Why |
 |---|---|
 | `README.md` | Directory contract, current public inventory, and review expectations |
+| `WATCHER_PROPOSAL_TEMPLATE.md` | Standard intake shape for review-ready watcher changes |
+| `RECEIPT_PROOF_SEPARATION.md` | Canonical watcher language for receipts vs proofs |
+| `templates/watcher-run-receipt.example.yaml` | Example run receipt structure for reviewers and implementers |
 | short watcher-lane notes | Keeps future implementation handoff reviewable |
 | links to sibling `.github/` docs | Preserves gatehouse context for watcher changes |
 | minimal illustrative examples | Clarifies watcher posture without pretending runtime exists here |
@@ -209,7 +212,11 @@ Keep these out of `.github/watchers/` unless there is a very narrow documentatio
 ```text
 .github/
 └── watchers/
-    └── README.md
+    ├── README.md
+    ├── WATCHER_PROPOSAL_TEMPLATE.md
+    ├── RECEIPT_PROOF_SEPARATION.md
+    └── templates/
+        └── watcher-run-receipt.example.yaml
 ```
 
 ### Adjacent gatehouse surfaces to recheck on the active branch
@@ -266,6 +273,9 @@ data/proofs/**           # optional higher-order proof objects
 ```bash
 ls -la .github/watchers
 sed -n '1,260p' .github/watchers/README.md
+sed -n '1,220p' .github/watchers/WATCHER_PROPOSAL_TEMPLATE.md
+sed -n '1,220p' .github/watchers/RECEIPT_PROOF_SEPARATION.md
+sed -n '1,220p' .github/watchers/templates/watcher-run-receipt.example.yaml
 ```
 
 ### 2) Check the gatehouse surfaces that shape watcher review

--- a/.github/watchers/RECEIPT_PROOF_SEPARATION.md
+++ b/.github/watchers/RECEIPT_PROOF_SEPARATION.md
@@ -1,0 +1,25 @@
+# Receipt vs Proof Separation (Watchers)
+
+This file captures the canonical language for watcher artifacts.
+
+## Definitions
+- **Receipt:** Process memory from a watcher run (inputs, outputs, checks, timestamps, links).
+- **Proof:** A higher-order trust object (attestation/proof pack/release-significant evidence).
+- **Summary:** Reviewer-facing convenience rendering; not sovereign truth.
+- **Work state:** Temporary bounded intermediate state.
+
+## Rules
+1. Every watcher run may emit a receipt.
+2. A receipt is **not automatically** a proof.
+3. Proof objects are assembled only after validation and policy gates pass.
+4. Watchers must not gain hidden publish authority.
+5. Receipts and proofs must be stored in their governed locations, not in `.github/watchers/`.
+
+## Storage
+- Work: `data/work/**`
+- Receipts: `data/receipts/**`
+- Optional proofs: `data/proofs/**`
+
+## Review language
+Prefer: "receipt emitted", "validation passed/failed", "policy gate passed/failed", "proof pack assembled".
+Avoid: "autonomous publish", "self-healing bot", "automatic truth updater".

--- a/.github/watchers/WATCHER_PROPOSAL_TEMPLATE.md
+++ b/.github/watchers/WATCHER_PROPOSAL_TEMPLATE.md
@@ -1,0 +1,36 @@
+# Watcher Proposal Template
+
+Use this template for PRs that add or change watcher behavior.
+
+## 1) Truth posture
+- **Status:** `PROPOSED` / `CONFIRMED`
+- **Owner surface (runtime code):** `<path>`
+- **Workflow orchestration path:** `.github/workflows/<file>.yml`
+
+## 2) Scope and source
+- **Source family:**
+- **Scope window / cadence:**
+- **Claim class:**
+
+## 3) Bounded paths
+- **Work path:** `data/work/<lane>`
+- **Receipt path:** `data/receipts/<lane>`
+- **Optional proof path:** `data/proofs/<lane>`
+
+## 4) Validation and policy
+- **Contract/schema validation command(s):**
+- **Policy gate command(s):**
+- **Failure behavior:** fail-closed / deny-by-default
+
+## 5) Rollback and supersession
+- **Rollback trigger:**
+- **Supersession process:**
+- **Human review checkpoint:**
+
+## 6) Evidence checklist
+- [ ] Runtime owner path exists and is linked.
+- [ ] Workflow YAML exists and is linked.
+- [ ] Validation/policy command outputs included.
+- [ ] Receipt example attached.
+- [ ] Rollback notes included.
+- [ ] No autonomous publish authority introduced.

--- a/.github/watchers/templates/watcher-run-receipt.example.yaml
+++ b/.github/watchers/templates/watcher-run-receipt.example.yaml
@@ -1,0 +1,20 @@
+run_receipt:
+  version: v1
+  watcher_id: example-lane
+  truth_posture: PROPOSED
+  source_family: example
+  started_at: 2026-04-29T00:00:00Z
+  ended_at: 2026-04-29T00:02:00Z
+  work_path: data/work/watchers/example-lane
+  receipt_path: data/receipts/watchers/example-lane
+  validation:
+    contract: pass
+    schema: pass
+    policy: pass
+  outputs:
+    summary: data/work/watchers/example-lane/summary.json
+    receipt: data/receipts/watchers/example-lane/run-20260429T000000Z.yaml
+  proof:
+    assembled: false
+    reason: optional and post-validation only
+  publish_authority: none


### PR DESCRIPTION
### Motivation
- Provide concrete, review-ready documentation and intake forms so the `.github/watchers` lane is no longer README-only. 
- Clarify the separation between watcher receipts and higher-order proof objects to prevent conflating docs with runtime evidence. 
- Give reviewers and implementers an example run-receipt shape to speed future watcher proposals and validation work.

### Description
- Added ` .github/watchers/WATCHER_PROPOSAL_TEMPLATE.md` to standardize PR intake for watcher changes. 
- Added `.github/watchers/RECEIPT_PROOF_SEPARATION.md` to capture canonical receipt vs proof language, storage rules, and review wording. 
- Added `.github/watchers/templates/watcher-run-receipt.example.yaml` as a concrete example of a watcher run receipt. 
- Updated `.github/watchers/README.md` to list the new files in the accepted inputs, directory inventory, and quickstart inspection commands.

### Testing
- Ran `find .github/watchers -maxdepth 3 -type f | sort` to verify the new files are present, and it returned the expected file list (succeeded). 
- Ran `git diff -- .github/watchers/README.md .github/watchers/WATCHER_PROPOSAL_TEMPLATE.md .github/watchers/RECEIPT_PROOF_SEPARATION.md .github/watchers/templates/watcher-run-receipt.example.yaml` to validate the recorded changes (succeeded). 
- Inspected the new files with `sed -n`/file listing commands to confirm content and README references are consistent (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15f945730832ab80c5ede77963184)