### PR TITLE
Add ecology map layer registry artifacts and fixtures

### DIFF
--- a/data/registry/ecology/map_layers/CHANGELOG.md
+++ b/data/registry/ecology/map_layers/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-04-29
+- Added initial ecology map-layer registry (`registry.json`).
+- Added baseline active layer binding (`ndvi_change.binding.json`).
+- Added validation fixtures for one valid and two invalid binding cases.

--- a/data/registry/ecology/map_layers/fixtures/invalid.bad_spec_hash.binding.json
+++ b/data/registry/ecology/map_layers/fixtures/invalid.bad_spec_hash.binding.json
@@ -1,0 +1,13 @@
+{
+  "layer_id": "kfm.ecology.vegetation.ndvi_change.v1",
+  "candidate_id": "eco_index.example",
+  "evidence_bundle_id": "kfm.evidence.ecology.eco_index.example",
+  "drawer_id": "kfm.drawer.ecology.eco_index.example",
+  "render_type": "raster",
+  "time_enabled": true,
+  "default_visibility": true,
+  "source_ref": "maplibre://sources/ecology/ndvi_change",
+  "style_layer_ref": "maplibre://layers/ecology/ndvi_change",
+  "spec_hash": "sha256:not-valid",
+  "status": "active"
+}

--- a/data/registry/ecology/map_layers/fixtures/invalid.missing_evidence_bundle.binding.json
+++ b/data/registry/ecology/map_layers/fixtures/invalid.missing_evidence_bundle.binding.json
@@ -1,0 +1,12 @@
+{
+  "layer_id": "kfm.ecology.vegetation.ndvi_change.v1",
+  "candidate_id": "eco_index.example",
+  "drawer_id": "kfm.drawer.ecology.eco_index.example",
+  "render_type": "raster",
+  "time_enabled": true,
+  "default_visibility": true,
+  "source_ref": "maplibre://sources/ecology/ndvi_change",
+  "style_layer_ref": "maplibre://layers/ecology/ndvi_change",
+  "spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "status": "active"
+}

--- a/data/registry/ecology/map_layers/fixtures/valid.ndvi_change.binding.json
+++ b/data/registry/ecology/map_layers/fixtures/valid.ndvi_change.binding.json
@@ -1,0 +1,13 @@
+{
+  "layer_id": "kfm.ecology.vegetation.ndvi_change.v1",
+  "candidate_id": "eco_index.example",
+  "evidence_bundle_id": "kfm.evidence.ecology.eco_index.example",
+  "drawer_id": "kfm.drawer.ecology.eco_index.example",
+  "render_type": "raster",
+  "time_enabled": true,
+  "default_visibility": true,
+  "source_ref": "maplibre://sources/ecology/ndvi_change",
+  "style_layer_ref": "maplibre://layers/ecology/ndvi_change",
+  "spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "status": "active"
+}

--- a/data/registry/ecology/map_layers/ndvi_change.binding.json
+++ b/data/registry/ecology/map_layers/ndvi_change.binding.json
@@ -1,0 +1,13 @@
+{
+  "layer_id": "kfm.ecology.vegetation.ndvi_change.v1",
+  "candidate_id": "eco_index.example",
+  "evidence_bundle_id": "kfm.evidence.ecology.eco_index.example",
+  "drawer_id": "kfm.drawer.ecology.eco_index.example",
+  "render_type": "raster",
+  "time_enabled": true,
+  "default_visibility": true,
+  "source_ref": "maplibre://sources/ecology/ndvi_change",
+  "style_layer_ref": "maplibre://layers/ecology/ndvi_change",
+  "spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "status": "active"
+}

--- a/data/registry/ecology/map_layers/registry.json
+++ b/data/registry/ecology/map_layers/registry.json
@@ -1,0 +1,12 @@
+{
+  "registry_id": "kfm.registry.ecology.map_layers",
+  "layers": [
+    {
+      "layer_id": "kfm.ecology.vegetation.ndvi_change.v1",
+      "binding_ref": "ndvi_change.binding.json",
+      "status": "active",
+      "spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ],
+  "generated_at": "2026-04-29T00:00:00Z"
+}


### PR DESCRIPTION
### Motivation
- Provide a concrete, reviewable ecology map-layer registry and example bindings so MapLibre-facing layers are evidence-bound and CI-validatable.
- Supply small valid/invalid fixtures and a changelog to support schema validation and CI fail-closed checks.

### Description
- Added `data/registry/ecology/map_layers/registry.json` with `registry_id`, one active `layer_id`, `binding_ref`, `spec_hash`, and `generated_at` timestamp.
- Added `data/registry/ecology/map_layers/ndvi_change.binding.json` as a schema-aligned binding that includes `candidate_id`, `evidence_bundle_id`, `drawer_id`, render/source/style refs, `spec_hash`, and `status`.
- Added fixtures under `data/registry/ecology/map_layers/fixtures/` including `valid.ndvi_change.binding.json`, `invalid.missing_evidence_bundle.binding.json`, and `invalid.bad_spec_hash.binding.json` to exercise positive and negative validation paths.
- Added `data/registry/ecology/map_layers/CHANGELOG.md` documenting the initial drop and committed the new files to the branch.

### Testing
- Ran `python -m pytest tools/registry/tests/test_ecology_map_layer_registry.py -q`, which passed with `18 passed`.
- Executed the registry CLI (`python -m tools.registry.ecology_map_layer_registry_cli --registry data/registry/ecology/map_layers/registry.json --schema schemas/ecology/ecology_map_layer_binding.schema.json --layer-id kfm.ecology.vegetation.ndvi_change.v1`), which failed with `invalid json: Expecting value: line 1 column 1 (char 0)` due to the in-branch `schemas/ecology/ecology_map_layer_binding.schema.json` containing fenced markdown and not being plain JSON.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1603b202c832aa8e6895ed2e62bb4)