### PR TITLE
Build out ecology registry leaf artifacts

### DIFF
--- a/data/registry/ecology/ecology/_index.yaml
+++ b/data/registry/ecology/ecology/_index.yaml
@@ -1,0 +1,18 @@
+version: v1
+updated: "2026-04-29"
+status: draft
+
+registry_leaf: data/registry/ecology/ecology
+
+artifacts:
+  - path: sensitivity_policies.yaml
+    kind: policy_matrix
+    description: "Fail-closed policy requirements for ecology source and dataset publication decisions."
+
+  - path: source_roles.md
+    kind: source_role_matrix
+    description: "Role boundaries describing what ecology source classes can and cannot support."
+
+  - path: sensitivity_publication_matrix.md
+    kind: publication_matrix
+    description: "Decision matrix for sensitivity classes and public precision outcomes."

--- a/data/registry/ecology/ecology/sensitivity_policies.yaml
+++ b/data/registry/ecology/ecology/sensitivity_policies.yaml
@@ -1,1 +1,40 @@
+version: v1
+updated: "2026-04-29"
+status: draft
+policy_posture: fail_closed
 
+policies:
+  - policy_id: ecology_public_taxon_publication
+    applies_to:
+      - TaxonRecord
+      - DerivedVegetationLayer
+    decision: allow
+    requires:
+      - rights_status in [public, open]
+      - evidence_bundle_id present
+      - spec_hash present
+      - citation_bundle present
+
+  - policy_id: ecology_sensitive_occurrence_publication
+    applies_to:
+      - ObservationPlot
+      - SensitiveOccurrenceRecord
+    decision: hold_or_generalize
+    requires:
+      - reviewer_approval present
+      - geoprivacy_transform present for public outputs
+      - precision_served not exact in public outputs
+      - redaction_receipt present when sensitive geometry exists
+      - evidence_bundle_id present
+
+  - policy_id: ecology_public_derived_layer_publication
+    applies_to:
+      - DerivedVegetationLayer
+      - HabitatAssignment
+    decision: allow_after_catalog_closure
+    requires:
+      - derived_label present
+      - processing_lineage present
+      - catalog_closure_receipt present
+      - evidence_bundle_id present
+      - spec_hash present

--- a/data/registry/ecology/ecology/sensitivity_publication_matrix.md
+++ b/data/registry/ecology/ecology/sensitivity_publication_matrix.md
@@ -1,0 +1,16 @@
+# Sensitivity Publication Matrix
+
+Fail-closed publication outcomes for ecology records.
+
+| Sensitivity class | Public precision | Default decision | Required controls |
+|---|---|---|---|
+| `low` | Exact or generalized | `allow` | rights clear, evidence bundle present, citation present |
+| `moderate` | Generalized preferred | `review_required` | reviewer approval, precision check, evidence bundle |
+| `high` | Not exact in public lanes | `generalize_or_restrict` | geoprivacy transform, redaction receipt, reviewer approval |
+| `restricted` | No public geometry | `deny_public` | non-public access controls, DUA confirmation |
+
+## Guardrails
+
+- Exact coordinates for sensitive species are denied for public outputs unless policy says otherwise.
+- Missing rights or missing evidence defaults to `hold`.
+- Derived layers must retain derived/model labeling in all runtime surfaces.

--- a/data/registry/ecology/ecology/source_roles.md
+++ b/data/registry/ecology/ecology/source_roles.md
@@ -1,0 +1,21 @@
+# Ecology Source Role Matrix
+
+Defines admissible source roles and claim boundaries for ecology registry descriptors.
+
+| Source role | Allowed support | Must not be used as |
+|---|---|---|
+| `TAXONOMIC_AUTHORITY` | Taxonomic naming, synonym reconciliation, and canonical species references. | Direct proof of current local occurrence. |
+| `OBSERVATION_SYSTEM` | Observed records with time, place, and method context. | Standalone public release when rights, precision, or sensitivity are unresolved. |
+| `AGGREGATOR` | Federated occurrence access and broad discovery context. | Unreviewed canonical truth for sensitive/public claims. |
+| `DERIVED_MODEL_LAYER` | Contextual surfaces (e.g., vegetation indices, modeled habitat context). | Confirmed field observation evidence by itself. |
+| `SENSITIVE_OCCURRENCE` | Restricted stewardship records requiring geoprivacy controls. | Exact public geometry without explicit review and transform receipts. |
+
+## Admission checks
+
+A descriptor should be accepted only if it explicitly states:
+
+1. source role
+2. rights posture
+3. sensitivity class
+4. publication requirements
+5. quarantine triggers


### PR DESCRIPTION
### Motivation

- Complete the ecology registry leaf by adding governance artifacts under `data/registry/ecology/ecology/` so source admission, sensitivity, and publication decisions are governable before ingestion or publication.
- Provide concrete, fail-closed policy definitions to make publication requirements explicit for taxon records, sensitive occurrences, and derived layers.
- Reduce risk of accidental public release of sensitive geometry by documenting source-role boundaries and a sensitivity-to-publication decision matrix.

### Description

- Added `_index.yaml` at `data/registry/ecology/ecology/_index.yaml` to enumerate the leaf artifacts and their intent.
- Created `sensitivity_policies.yaml` with policy entries including `ecology_public_taxon_publication`, `ecology_sensitive_occurrence_publication`, and `ecology_public_derived_layer_publication` to state decisions and required controls.
- Added `source_roles.md` and `sensitivity_publication_matrix.md` to define source-role claim boundaries and fail-closed publication guardrails.

### Testing

- Ran `git status --short` to confirm workspace file state, which executed successfully.
- Attempted a YAML parse with `python - <<'PY' ...` but the run failed due to the environment lacking the `PyYAML` module (automated parse unavailable).
- Inspected files with `nl -ba` to verify content and presence of the new/updated artifacts, which showed the expected files and content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f161f9859c832a90f371ce54b7c048)