### PR TITLE
Add Ecology Focus Mode docs, schemas, runtime, and fixtures

### DIFF
--- a/apps/governed_api/ecology/focus_mode.py
+++ b/apps/governed_api/ecology/focus_mode.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Minimal governed Ecology Focus Mode runtime.
+
+No-network runtime. It reads released ecology artifacts only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CLAIMS_DIR = REPO_ROOT / "data/triplets/ecology"
+PROCESSED_DIR = REPO_ROOT / "data/processed/ecology"
+PUBLISHED_DIR = REPO_ROOT / "data/published/ecology"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _hash_response(payload: dict[str, Any]) -> str:
+    material = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(material).hexdigest()
+
+
+def _find_claims() -> list[dict[str, Any]]:
+    if not CLAIMS_DIR.exists():
+        return []
+    return [_load_json(path) for path in sorted(CLAIMS_DIR.glob("*.json"))]
+
+
+def _find_decisions() -> list[dict[str, Any]]:
+    if not PROCESSED_DIR.exists():
+        return []
+    return [
+        _load_json(path)
+        for path in sorted(PROCESSED_DIR.glob("decision*.json"))
+    ]
+
+
+def _find_releases() -> list[dict[str, Any]]:
+    if not PUBLISHED_DIR.exists():
+        return []
+    return [_load_json(path) for path in sorted(PUBLISHED_DIR.glob("*.json"))]
+
+
+def answer_focus_request(request: dict[str, Any]) -> dict[str, Any]:
+    request_id = request.get("request_id", "kfm://request/ecology/unknown")
+    surface = request.get("surface", "public")
+
+    base: dict[str, Any] = {
+        "schema_version": "v1",
+        "object_type": "FocusModeResponse",
+        "response_id": request_id.replace("kfm://request/", "kfm://response/"),
+        "request_id": request_id,
+        "surface": surface,
+        "answer": None,
+        "reasons": [],
+        "claim_refs": [],
+        "evidence_bundle_refs": [],
+        "decision_refs": [],
+        "redaction_receipt_refs": [],
+        "limitations": []
+    }
+
+    if surface != "public":
+        base["outcome"] = "DENY"
+        base["reasons"] = ["non_public_surface_not_enabled_in_demo_runtime"]
+        base["spec_hash"] = _hash_response(base)
+        return base
+
+    releases = _find_releases()
+    claims = _find_claims()
+    decisions = _find_decisions()
+
+    published_releases = [
+        release for release in releases
+        if release.get("release_state") == "published"
+        and release.get("surface") == "public"
+        and release.get("policy_pass") is True
+    ]
+
+    if not published_releases:
+        base["outcome"] = "ABSTAIN"
+        base["reasons"] = ["no_public_release_manifest"]
+        base["spec_hash"] = _hash_response(base)
+        return base
+
+    safe_decisions = [
+        decision for decision in decisions
+        if decision.get("decision") in {"allow", "generalize"}
+        and decision.get("surface") == "public"
+    ]
+
+    if not safe_decisions:
+        base["outcome"] = "DENY"
+        base["reasons"] = ["no_public_safe_decision"]
+        base["spec_hash"] = _hash_response(base)
+        return base
+
+    if not claims:
+        base["outcome"] = "ABSTAIN"
+        base["reasons"] = ["no_claims_available"]
+        base["spec_hash"] = _hash_response(base)
+        return base
+
+    claim = claims[0]
+    decision = safe_decisions[0]
+
+    if claim.get("claim_status") == "CONFIRMED" and claim.get("knowledge_character") in {"derived", "modeled"}:
+        base["outcome"] = "DENY"
+        base["reasons"] = ["derived_claim_marked_confirmed"]
+        base["spec_hash"] = _hash_response(base)
+        return base
+
+    base["outcome"] = "ANSWER"
+    base["answer"] = claim.get("statement")
+    base["claim_refs"] = [claim.get("claim_id")]
+    base["evidence_bundle_refs"] = [claim.get("evidence_bundle_ref")]
+    base["decision_refs"] = [claim.get("decision_ref")]
+    if decision.get("redaction_receipt_ref"):
+        base["redaction_receipt_refs"] = [decision["redaction_receipt_ref"]]
+    base["limitations"] = claim.get("limitations", [])
+
+    base["spec_hash"] = _hash_response(base)
+    return base
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run Ecology Focus Mode against a request JSON file")
+    parser.add_argument("request")
+    args = parser.parse_args()
+
+    response = answer_focus_request(_load_json(Path(args.request)))
+    print(json.dumps(response, indent=2, sort_keys=True))

--- a/docs/domains/ecology/FOCUS_MODE.md
+++ b/docs/domains/ecology/FOCUS_MODE.md
@@ -1,0 +1,92 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/TODO-ecology-focus-mode
+title: Ecology Focus Mode
+type: standard
+version: v1
+status: draft
+owners: TODO
+created: TODO
+updated: TODO
+policy_label: public
+related: [
+  docs/domains/ecology/README.md,
+  policy/ecology/publication.rego,
+  tools/validators/ecology/validate_ecology_bundle.py
+]
+tags: [kfm, ecology, focus-mode]
+notes: [
+  NEEDS_VERIFICATION: owners, dates, doc_id
+]
+[/KFM_META_BLOCK_V2] -->
+
+# Ecology Focus Mode
+
+> Governed question-answer surface for ecology claims using released EvidenceBundles, DecisionEnvelopes, and public-safe ReleaseManifests.
+
+## Impact Block
+
+**Status:** draft  
+**Owners:** TODO  
+**Policy:** cite-or-abstain / fail-closed  
+**Runtime outcomes:** ANSWER | ABSTAIN | DENY | ERROR
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![domain](https://img.shields.io/badge/domain-ecology-green)
+![runtime](https://img.shields.io/badge/runtime-governed-blue)
+
+## Scope
+
+Ecology Focus Mode answers public-safe ecology questions only when it can resolve:
+
+1. a released or reviewed ecology claim,
+2. a valid EvidenceBundle,
+3. a compatible DecisionEnvelope,
+4. a policy-safe public surface.
+
+## Inputs
+
+- query text
+- optional geometry reference
+- optional taxon reference
+- released claim references
+- EvidenceBundle references
+
+## Exclusions
+
+Focus Mode must not:
+
+- read RAW, WORK, or QUARANTINE data
+- expose exact sensitive geometry
+- treat derived layers as confirmed truth
+- answer without evidence
+- use AI as a truth source
+
+## Runtime Outcomes
+
+| Outcome | Meaning |
+|---|---|
+| ANSWER | Evidence resolved and policy allows public-safe response |
+| ABSTAIN | Evidence is missing, incomplete, or conflicting |
+| DENY | Policy blocks answer |
+| ERROR | Runtime or contract failure |
+
+## Flow
+
+```mermaid
+flowchart TD
+  Request[FocusModeRequest] --> Validate[Validate request]
+  Validate --> Evidence{EvidenceBundle resolved?}
+  Evidence -- no --> Abstain[ABSTAIN]
+  Evidence -- yes --> Policy{Policy safe?}
+  Policy -- no --> Deny[DENY]
+  Policy -- yes --> Claim{Released claim available?}
+  Claim -- no --> Abstain
+  Claim -- yes --> Answer[ANSWER with citations]
+```
+
+## Public Safety Rules
+
+- Public outputs must only reference public-safe or generalized geometry.
+- Sensitive exact coordinates must never appear.
+- Derived context must be labeled as derived.
+- Evidence references must resolve before answering.

--- a/schemas/contracts/v1/ecology/focus_mode_request.schema.json
+++ b/schemas/contracts/v1/ecology/focus_mode_request.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/focus_mode_request.schema.json",
+  "title": "Ecology Focus Mode Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "object_type",
+    "request_id",
+    "query",
+    "surface"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v1" },
+    "object_type": { "type": "string", "const": "FocusModeRequest" },
+    "request_id": { "type": "string", "pattern": "^kfm://request/ecology/.+" },
+    "query": { "type": "string", "minLength": 1 },
+    "surface": { "type": "string", "enum": ["public", "restricted", "internal"] },
+    "taxon_ref": { "type": "string", "pattern": "^kfm://taxon/.+" },
+    "geometry_ref": { "type": "string", "pattern": "^kfm://geometry/.+" },
+    "claim_refs": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^kfm://claim/ecology/.+" }
+    },
+    "evidence_bundle_refs": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^kfm://evidence/ecology/.+" }
+    }
+  }
+}

--- a/schemas/contracts/v1/ecology/focus_mode_response.schema.json
+++ b/schemas/contracts/v1/ecology/focus_mode_response.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.local/schemas/contracts/v1/ecology/focus_mode_response.schema.json",
+  "title": "Ecology Focus Mode Response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "object_type",
+    "response_id",
+    "request_id",
+    "outcome",
+    "surface",
+    "evidence_bundle_refs",
+    "decision_refs",
+    "spec_hash"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "v1" },
+    "object_type": { "type": "string", "const": "FocusModeResponse" },
+    "response_id": { "type": "string", "pattern": "^kfm://response/ecology/.+" },
+    "request_id": { "type": "string", "pattern": "^kfm://request/ecology/.+" },
+    "outcome": { "type": "string", "enum": ["ANSWER", "ABSTAIN", "DENY", "ERROR"] },
+    "surface": { "type": "string", "enum": ["public", "restricted", "internal"] },
+    "answer": { "type": ["string", "null"] },
+    "reasons": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "claim_refs": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^kfm://claim/ecology/.+" }
+    },
+    "evidence_bundle_refs": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^kfm://evidence/ecology/.+" }
+    },
+    "decision_refs": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^kfm://decision/ecology/.+" }
+    },
+    "redaction_receipt_refs": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^kfm://receipt/redaction/.+" }
+    },
+    "limitations": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "spec_hash": { "type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$" }
+  }
+}

--- a/tests/fixtures/ecology/focus_mode/abstain_missing_evidence.json
+++ b/tests/fixtures/ecology/focus_mode/abstain_missing_evidence.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "v1",
+  "object_type": "FocusModeRequest",
+  "request_id": "kfm://request/ecology/abstain-missing-evidence-001",
+  "query": "What species occur here?",
+  "surface": "public",
+  "evidence_bundle_refs": [
+    "kfm://evidence/ecology/missing"
+  ]
+}

--- a/tests/fixtures/ecology/focus_mode/deny_sensitive_request.json
+++ b/tests/fixtures/ecology/focus_mode/deny_sensitive_request.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "v1",
+  "object_type": "FocusModeRequest",
+  "request_id": "kfm://request/ecology/deny-sensitive-001",
+  "query": "Show exact coordinates for the sensitive occurrence.",
+  "surface": "public",
+  "geometry_ref": "kfm://restricted/geometry/ks-sensitive-001"
+}

--- a/tests/fixtures/ecology/focus_mode/valid_request.json
+++ b/tests/fixtures/ecology/focus_mode/valid_request.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "v1",
+  "object_type": "FocusModeRequest",
+  "request_id": "kfm://request/ecology/demo-001",
+  "query": "What ecology claim can be answered for the demo release?",
+  "surface": "public",
+  "taxon_ref": "kfm://taxon/asclepias-syriaca",
+  "claim_refs": [
+    "kfm://claim/ecology/demo-001"
+  ],
+  "evidence_bundle_refs": [
+    "kfm://evidence/ecology/demo-001"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, governed Focus Mode surface for ecology that enforces cite-or-abstain public-safety rules and can operate against released artifacts only.
- Capture the contract schema and runtime behavior needed to validate requests and produce deterministic, auditable responses for demo and testing.

### Description
- Add domain documentation at `docs/domains/ecology/FOCUS_MODE.md` describing scope, flow, exclusions, outcomes, and public-safety rules.
- Add v1 JSON Schemas at `schemas/contracts/v1/ecology/focus_mode_request.schema.json` and `schemas/contracts/v1/ecology/focus_mode_response.schema.json` defining request/response contracts and required fields.
- Add a minimal no-network governed runtime at `apps/governed_api/ecology/focus_mode.py` that loads released claims/decisions/releases, enforces public-only behavior, implements deny/abstain/answer logic, and produces a `spec_hash`.
- Add example request fixtures under `tests/fixtures/ecology/focus_mode/` for valid, deny-sensitive, and abstain-missing-evidence scenarios.

### Testing
- Compiled the runtime with `python -m py_compile apps/governed_api/ecology/focus_mode.py` and it succeeded.
- Validated both JSON schemas with `python -m json.tool` and the validations succeeded for `focus_mode_request.schema.json` and `focus_mode_response.schema.json`.
- No automated unit tests were included beyond the schema and compile validations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f166413118832aa9ff73b07aa282da)