### PR TITLE
Add Focus Mode API surface for governed ecology runtime

### DIFF
--- a/apps/governed_api/ecology/app.py
+++ b/apps/governed_api/ecology/app.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from apps.governed_api.ecology.focus_mode import answer_focus_request
+
+
+app = FastAPI(title="KFM Ecology Focus Mode")
+
+
+class FocusModeRequest(BaseModel):
+    payload: dict
+
+
+@app.post("/ecology/focus")
+def ecology_focus(req: FocusModeRequest) -> dict:
+    try:
+        return answer_focus_request(req.payload)
+    except Exception as exc:  # pragma: no cover - defensive runtime boundary
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/apps/governed_api/ecology/tests/test_focus_app.py
+++ b/apps/governed_api/ecology/tests/test_focus_app.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from apps.governed_api.ecology import app as focus_app
+
+
+def test_ecology_focus_returns_runtime_response(monkeypatch) -> None:
+    expected = {"outcome": "ANSWER", "answer": "example"}
+
+    def fake_answer(payload: dict) -> dict:
+        assert payload == {"request_id": "kfm://request/ecology/example"}
+        return expected
+
+    monkeypatch.setattr(focus_app, "answer_focus_request", fake_answer)
+    client = TestClient(focus_app.app)
+
+    response = client.post(
+        "/ecology/focus",
+        json={"payload": {"request_id": "kfm://request/ecology/example"}},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == expected
+
+
+def test_ecology_focus_wraps_runtime_errors(monkeypatch) -> None:
+    def boom(_: dict) -> dict:
+        raise RuntimeError("runtime failed")
+
+    monkeypatch.setattr(focus_app, "answer_focus_request", boom)
+    client = TestClient(focus_app.app)
+
+    response = client.post("/ecology/focus", json={"payload": {}})
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "runtime failed"}

--- a/apps/governed_api/openapi/ecology_focus_mode.yaml
+++ b/apps/governed_api/openapi/ecology_focus_mode.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: KFM Ecology Focus Mode
+  version: v1
+paths:
+  /ecology/focus:
+    post:
+      summary: Run governed ecology Focus Mode query
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FocusModeRequest'
+      responses:
+        "200":
+          description: Governed response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FocusModeResponse'
+components:
+  schemas:
+    FocusModeRequest:
+      type: object
+      properties:
+        payload:
+          type: object
+      required:
+        - payload
+    FocusModeResponse:
+      type: object


### PR DESCRIPTION
### Motivation
- Expose the existing governed ecology Focus Mode runtime as a minimal HTTP service so it can be used by humans and systems.
- Provide a clear runtime boundary with strict input shape and predictable error handling for production-like integration.
- Ship a machine-readable contract sketch (OpenAPI) so the endpoint can be discovered and integrated.

### Description
- Add a minimal FastAPI application at `POST /ecology/focus` in `apps/governed_api/ecology/app.py` that delegates to `answer_focus_request` and returns the governed response.
- Convert runtime exceptions into HTTP 500 responses by catching exceptions and raising `HTTPException` with the error detail at the endpoint boundary.
- Add an OpenAPI sketch at `apps/governed_api/openapi/ecology_focus_mode.yaml` describing the request (`payload`) and response shapes.
- Add unit tests in `apps/governed_api/ecology/tests/test_focus_app.py` validating the success path and that runtime errors are wrapped as HTTP 500 responses.

### Testing
- Ran `pytest -q apps/governed_api/ecology/tests/test_focus_app.py apps/governed_api/ecology/tests/test_fastapi_routes.py` in the environment, and the tests were skipped due to the runtime `fastapi` dependency not being available (2 skipped).
- The new endpoint tests exercise both the happy path (returns runtime response) and error path (returns HTTP 500) and are present to run in CI or a developer environment with `fastapi` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1735b08d8832a90b9fba76000c6bb)