### PR TITLE
Wire Ecology Evidence Drawer payload into validator and UI

### DIFF
--- a/.github/workflows/ecology-validation.yml
+++ b/.github/workflows/ecology-validation.yml
@@ -60,6 +60,7 @@ jobs:
           chmod +x tools/validators/ecology/run_ecology_fixture_checks.sh
           chmod +x tools/validators/ecology/run_ecology_release_checks.sh
           chmod +x tools/validators/ecology/run_ecology_focus_mode_checks.sh
+          chmod +x tools/validators/ecology/run_ecology_ui_checks.sh
 
       - name: Run ecology fixture checks
         run: tools/validators/ecology/run_ecology_fixture_checks.sh
@@ -69,3 +70,6 @@ jobs:
 
       - name: Run ecology Focus Mode checks
         run: tools/validators/ecology/run_ecology_focus_mode_checks.sh
+
+      - name: Run ecology UI checks
+        run: tools/validators/ecology/run_ecology_ui_checks.sh

--- a/apps/web/src/ecology/EvidenceDrawer.tsx
+++ b/apps/web/src/ecology/EvidenceDrawer.tsx
@@ -2,14 +2,44 @@ import { TrustBadges, type TrustBadge } from "./trustBadges";
 
 export type EvidenceDrawerPayload = {
   schema_version: "v1";
-  object_type: "EvidenceDrawerPayload";
+  object_type: "EcologyEvidenceDrawerPayload";
+  payload_id: string;
   claim_ref: string;
   evidence_bundle_ref: string;
   decision_ref: string;
   release_ref: string;
+  decision: "ANSWER" | "ABSTAIN" | "DENY" | "ERROR";
+  visible_outcome: "shown" | "generalized" | "withheld" | "unavailable";
+  summary: {
+    headline: string;
+    trust_note: string;
+    taxon?: string;
+    habitat_class?: string;
+    knowledge_character?: "derived" | "observed" | "interpreted" | "modeled";
+  };
+  sources: Array<{
+    source_ref: string;
+    source_role:
+      | "TAXONOMIC_AUTHORITY"
+      | "OBSERVATION_SYSTEM"
+      | "AGGREGATOR"
+      | "DERIVED_MODEL_LAYER"
+      | "SENSITIVE_OCCURRENCE"
+      | "BASELINE"
+      | "REGULATORY_CONTEXT"
+      | "RENDER_DESCRIPTOR";
+    citation: string;
+  }>;
+  evidence_refs: string[];
   trust_badges: TrustBadge[];
-  limitations: string[];
-  redaction_receipt_refs: string[];
+  policy_flags?: Array<"sensitivity" | "rights" | "review_required" | "generalized" | "derived_context" | "redacted">;
+  redaction_receipt_refs?: string[];
+  limitations?: string[];
+  freshness: {
+    generated_at: string;
+    stale_after: string;
+  };
+  spec_hash: string;
 };
 
 export default function EvidenceDrawer({ payload }: { payload: EvidenceDrawerPayload }) {
@@ -17,22 +47,26 @@ export default function EvidenceDrawer({ payload }: { payload: EvidenceDrawerPay
     <aside style={{ borderLeft: "1px solid #ddd", padding: 12, width: 340 }}>
       <h2>Evidence Drawer</h2>
       <p style={{ marginTop: 0, color: "#555" }}>Inspect why this claim is visible and how it was constrained.</p>
+      <p><strong>{payload.summary.headline}</strong></p>
+      <p style={{ color: "#444" }}>{payload.summary.trust_note}</p>
 
       <TrustBadges badges={payload.trust_badges} />
 
       <h4>References</h4>
       <ul>
+        <li><strong>Payload:</strong> {payload.payload_id}</li>
         <li><strong>Claim:</strong> {payload.claim_ref}</li>
         <li><strong>EvidenceBundle:</strong> {payload.evidence_bundle_ref}</li>
         <li><strong>DecisionEnvelope:</strong> {payload.decision_ref}</li>
         <li><strong>ReleaseManifest:</strong> {payload.release_ref}</li>
       </ul>
 
-      <h4>Limitations</h4>
-      <ul>{payload.limitations.map((item) => <li key={item}>{item}</li>)}</ul>
+      <h4>Sources</h4>
+      <ul>{payload.sources.map((source) => <li key={source.source_ref}>{source.source_role}: {source.citation}</li>)}</ul>
 
-      <h4>Redaction receipts</h4>
-      <ul>{payload.redaction_receipt_refs.map((ref) => <li key={ref}>{ref}</li>)}</ul>
+      {payload.limitations?.length ? <><h4>Limitations</h4><ul>{payload.limitations.map((item) => <li key={item}>{item}</li>)}</ul></> : null}
+
+      {payload.redaction_receipt_refs?.length ? <><h4>Redaction receipts</h4><ul>{payload.redaction_receipt_refs.map((ref) => <li key={ref}>{ref}</li>)}</ul></> : null}
     </aside>
   );
 }

--- a/apps/web/src/ecology/trustBadges.tsx
+++ b/apps/web/src/ecology/trustBadges.tsx
@@ -2,25 +2,37 @@ import type { CSSProperties } from "react";
 
 export type TrustBadge =
   | "DERIVED_SUPPORTED"
-  | "PUBLIC_GENERALIZED"
+  | "OBSERVED_SUPPORTED"
   | "EVIDENCE_RESOLVED"
-  | "LIMITATIONS_PRESENT"
-  | "REDACTION_APPLIED";
+  | "PUBLIC_GENERALIZED"
+  | "PUBLIC_SAFE"
+  | "RESTRICTED_SOURCE"
+  | "REDACTION_RECEIPT_PRESENT"
+  | "CATALOG_CLOSED"
+  | "RELEASED";
 
 const badgeLabel: Record<TrustBadge, string> = {
   DERIVED_SUPPORTED: "Derived-supported",
-  PUBLIC_GENERALIZED: "Public generalized",
+  OBSERVED_SUPPORTED: "Observed-supported",
   EVIDENCE_RESOLVED: "Evidence resolved",
-  LIMITATIONS_PRESENT: "Limitations noted",
-  REDACTION_APPLIED: "Redaction applied"
+  PUBLIC_GENERALIZED: "Public generalized",
+  PUBLIC_SAFE: "Public safe",
+  RESTRICTED_SOURCE: "Restricted source",
+  REDACTION_RECEIPT_PRESENT: "Redaction receipt",
+  CATALOG_CLOSED: "Catalog closed",
+  RELEASED: "Released"
 };
 
 const badgeStyle: Record<TrustBadge, CSSProperties> = {
   DERIVED_SUPPORTED: { background: "#e6f4ea", color: "#1e6b38" },
-  PUBLIC_GENERALIZED: { background: "#e8f0fe", color: "#1947a6" },
+  OBSERVED_SUPPORTED: { background: "#e7f3ff", color: "#0f4c81" },
   EVIDENCE_RESOLVED: { background: "#f3e8fd", color: "#6c2eb9" },
-  LIMITATIONS_PRESENT: { background: "#fff4e5", color: "#8b5d00" },
-  REDACTION_APPLIED: { background: "#fde8e8", color: "#9f1c1c" }
+  PUBLIC_GENERALIZED: { background: "#e8f0fe", color: "#1947a6" },
+  PUBLIC_SAFE: { background: "#edf7ed", color: "#256029" },
+  RESTRICTED_SOURCE: { background: "#fff4e5", color: "#8b5d00" },
+  REDACTION_RECEIPT_PRESENT: { background: "#fde8e8", color: "#9f1c1c" },
+  CATALOG_CLOSED: { background: "#f5f5f5", color: "#4a4a4a" },
+  RELEASED: { background: "#e6fffa", color: "#00695c" }
 };
 
 export function TrustBadges({ badges }: { badges: TrustBadge[] }) {

--- a/tests/fixtures/ecology/ui/evidence_drawer.valid.json
+++ b/tests/fixtures/ecology/ui/evidence_drawer.valid.json
@@ -1,20 +1,51 @@
 {
   "schema_version": "v1",
-  "object_type": "EvidenceDrawerPayload",
+  "object_type": "EcologyEvidenceDrawerPayload",
+  "payload_id": "kfm://drawer/ecology/demo-001",
   "claim_ref": "kfm://claim/ecology/demo-001",
   "evidence_bundle_ref": "kfm://evidence/ecology/demo-001",
   "decision_ref": "kfm://decision/ecology/demo-001",
   "release_ref": "kfm://release/ecology/demo-001",
+  "decision": "ANSWER",
+  "visible_outcome": "generalized",
+  "summary": {
+    "headline": "Kansas prairie observation available with safeguards",
+    "trust_note": "Evidence resolved and sensitivity controls applied.",
+    "taxon": "Asclepias viridis",
+    "habitat_class": "TallgrassPrairie",
+    "knowledge_character": "derived"
+  },
+  "sources": [
+    {
+      "source_ref": "kfm://source/ks-heritage-program",
+      "source_role": "SENSITIVE_OCCURRENCE",
+      "citation": "Kansas Heritage Program occurrence registry (2025 snapshot)."
+    }
+  ],
+  "evidence_refs": [
+    "kfm://evidence/ecology/demo-001#plot-01"
+  ],
   "trust_badges": [
     "DERIVED_SUPPORTED",
+    "EVIDENCE_RESOLVED",
     "PUBLIC_GENERALIZED",
-    "EVIDENCE_RESOLVED"
+    "REDACTION_RECEIPT_PRESENT"
   ],
-  "limitations": [
-    "Derived-supported, not confirmed.",
-    "Public geometry is generalized."
+  "policy_flags": [
+    "sensitivity",
+    "generalized",
+    "redacted"
   ],
   "redaction_receipt_refs": [
     "kfm://receipt/redaction/ecology/observation-plot-valid-001"
-  ]
+  ],
+  "limitations": [
+    "Derived-supported, not field-confirmed.",
+    "Public geometry is generalized to protect sensitive occurrence locations."
+  ],
+  "freshness": {
+    "generated_at": "2026-04-29T00:00:00Z",
+    "stale_after": "2026-05-29T00:00:00Z"
+  },
+  "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 }

--- a/tools/validators/ecology/run_ecology_ui_checks.sh
+++ b/tools/validators/ecology/run_ecology_ui_checks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# KFM Ecology UI payload validation runner
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+VALIDATOR="$ROOT_DIR/tools/validators/ecology/validate_ecology_bundle.py"
+
+echo "=== KFM Ecology UI Checks ==="
+echo "ROOT_DIR: $ROOT_DIR"
+echo
+
+if [[ ! -f "$VALIDATOR" ]]; then
+  echo "ERROR: validator not found at $VALIDATOR"
+  exit 1
+fi
+
+python "$VALIDATOR"   --bundle "$ROOT_DIR/tests/fixtures/ecology/ui"/*.json   --expect pass
+
+echo
+echo "✓ Ecology UI checks passed"

--- a/tools/validators/ecology/validate_ecology_bundle.py
+++ b/tools/validators/ecology/validate_ecology_bundle.py
@@ -29,6 +29,7 @@ SCHEMA_MAP = {
     "ReleaseManifest": REPO_ROOT / "schemas/contracts/v1/ecology/release_manifest.schema.json",
     "FocusModeRequest": REPO_ROOT / "schemas/contracts/v1/ecology/focus_mode_request.schema.json",
     "FocusModeResponse": REPO_ROOT / "schemas/contracts/v1/ecology/focus_mode_response.schema.json",
+    "EcologyEvidenceDrawerPayload": REPO_ROOT / "schemas/contracts/v1/ecology/ecology_evidence_drawer_payload.schema.json",
 }
 
 BUNDLE_OBJECT_TYPES = {
@@ -41,6 +42,8 @@ OUTPUT_OBJECT_TYPES = {
     "EcologicalClaim",
     "ReleaseManifest",
 }
+
+UI_OBJECT_TYPES = {"EcologyEvidenceDrawerPayload"}
 
 SPEC_HASH_RE = re.compile(r"^sha256:[a-fA-F0-9]{64}$")
 EVIDENCE_REF_RE = re.compile(r"^kfm://evidence/.+")
@@ -168,6 +171,7 @@ def _object_identifier(obj: dict[str, Any]) -> str | None:
         "plot_id",
         "occurrence_id",
         "taxon_id",
+        "payload_id",
     ):
         value = obj.get(key)
         if isinstance(value, str):
@@ -447,8 +451,9 @@ def validate_object(
     if validate_schema:
         errors.extend(_validate_schema(obj))
 
-    errors.extend(_validate_governance(obj))
-    errors.extend(_validate_registry_refs(obj, sources_registry, datasets_registry, policies_registry))
+    if obj.get("object_type") not in UI_OBJECT_TYPES:
+        errors.extend(_validate_governance(obj))
+        errors.extend(_validate_registry_refs(obj, sources_registry, datasets_registry, policies_registry))
 
     return sorted(set(errors))
 


### PR DESCRIPTION
### Motivation
- Add first-class support for the Ecology Evidence Drawer UI payload so UI payloads can be schema-validated and surfaced without being forced through governance/registry checks intended for governed data objects.
- Provide a canonical valid fixture and a CI runner so the UI payload contract is continuously validated alongside other ecology artifacts.

### Description
- Added `EcologyEvidenceDrawerPayload` to `SCHEMA_MAP` and introduced `UI_OBJECT_TYPES` and `payload_id` handling in `tools/validators/ecology/validate_ecology_bundle.py` so UI payloads are validated against schema but skip governance/registry checks.
- Created a valid UI fixture at `tests/fixtures/ecology/ui/evidence_drawer.valid.json` that conforms to the `ecology_evidence_drawer_payload.schema.json` contract.
- Added `tools/validators/ecology/run_ecology_ui_checks.sh` to run `python tools/validators/ecology/validate_ecology_bundle.py --bundle 'tests/fixtures/ecology/ui/*.json' --expect pass` for UI payloads.
- Updated `.github/workflows/ecology-validation.yml` to mark the new runner executable and run the UI checks in CI, and updated web UI files `apps/web/src/ecology/trustBadges.tsx` and `apps/web/src/ecology/EvidenceDrawer.tsx` to match the expanded badge vocabulary and the drawer payload shape.

### Testing
- Ran `python tools/validators/ecology/validate_ecology_bundle.py --bundle 'tests/fixtures/ecology/ui/*.json' --expect pass --skip-schema`, which passed against the new object extraction/flow.
- Attempting to run the full runner locally (`tools/validators/ecology/run_ecology_ui_checks.sh`) failed due to a missing `jsonschema` dependency in the local environment; CI installs `jsonschema` and `pyyaml` as part of the workflow so the runner is expected to pass in CI.
- An initial run without the validator dependency showed the expected `missing_dependency:jsonschema` error, demonstrating the dependency requirement is enforced by the validator.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17cfa3424832aa11d96a49c1c6c96)