### PR TITLE
Complete scripts lane entrypoints and harden `sample_ingest.sh` input

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -112,7 +112,7 @@ Good inputs are explicit, reviewable, and repo-relative.
 ```bash
 bash scripts/sample_ingest.sh example_fixture
 python3 scripts/validate_schemas.py
-make catalog-validate
+bash scripts/build_all.sh
 ```
 
 ### What bad input looks like
@@ -155,6 +155,7 @@ bash scripts/publish_everything.sh ~/Desktop/private-data
 scripts/
 ├── README.md
 ├── bootstrap.sh
+├── build_all.sh
 ├── catalog_validate.py
 ├── dev_up.sh
 ├── sample_ingest.sh

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+bash scripts/bootstrap.sh
+python3 scripts/catalog_validate.py
+python3 scripts/validate_schemas.py
+
+echo "build_all: scripts lane checks completed"

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 set -eu
 
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "dev_up: running script lane checks from $ROOT_DIR"
+python3 scripts/catalog_validate.py
+python3 scripts/validate_schemas.py
+
+echo "dev_up: baseline checks passed"
 echo "dev_up: no long-running local services are currently defined in this repository"
-echo "dev_up: use lane-specific scripts/workflows as they are introduced"

--- a/scripts/sample_ingest.sh
+++ b/scripts/sample_ingest.sh
@@ -7,6 +7,13 @@ if [ "$#" -ne 1 ]; then
 fi
 
 source_name="$1"
+case "$source_name" in
+  *[!A-Za-z0-9._-]*|"")
+    echo "sample_ingest: source_name must use [A-Za-z0-9._-] only" >&2
+    exit 2
+    ;;
+esac
+
 out_dir="data/work/sample_ingest"
 receipt_dir="data/receipts"
 


### PR DESCRIPTION
### Motivation
- Provide a single entrypoint to run the scripts-lane baseline checks and make the developer `dev_up` flow more deterministic. 
- Prevent unsafe `source_name` values in `sample_ingest.sh` that could create unexpected paths or content. 
- Keep the scripts README in sync with the actual script set.

### Description
- Added `scripts/build_all.sh` which runs `scripts/bootstrap.sh`, `scripts/catalog_validate.py`, and `scripts/validate_schemas.py` from the repository root. 
- Updated `scripts/dev_up.sh` to `cd` to the repo root and run baseline validation (`catalog_validate.py` and `validate_schemas.py`) before reporting status. 
- Hardened `scripts/sample_ingest.sh` by validating `source_name` to the allowed charset `[A-Za-z0-9._-]` and returning an error for invalid input. 
- Updated `scripts/README.md` to include `build_all.sh` in the directory tree and quickstart examples.

### Testing
- Ran `bash scripts/build_all.sh`, which executed `bootstrap.sh`, `python3 scripts/catalog_validate.py`, and `python3 scripts/validate_schemas.py`, and completed successfully. 
- Ran `bash scripts/dev_up.sh` and observed the baseline checks pass and expected status output. 
- Ran `bash scripts/sample_ingest.sh demo_source` which wrote sample ingest output and receipt files successfully and then removed the temporary artifacts during validation cleanup. 
- Ran `python3 scripts/catalog_validate.py` and `python3 scripts/validate_schemas.py` individually and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18bedcccc832a8ca826ce58515ba0)