### PR TITLE
Add build script and docs for apps/web

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -448,3 +448,9 @@ It should not silently imply absence. Restricted or generalized objects should s
 </details>
 
 <p align="right"><a href="#top">Back to top ↑</a></p>
+
+
+## Build
+
+- `npm run check` validates the JavaScript entrypoint syntax.
+- `npm run build` creates a static `dist/` bundle (index, src, public).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,8 @@
   "description": "Governed web shell scaffold for Kansas Frontier Matrix",
   "scripts": {
     "dev": "python3 -m http.server 4173",
-    "check": "node --check src/main.js"
+    "check": "node --check src/main.js",
+    "build": "node scripts_build.mjs",
+    "build:clean": "rm -rf dist"
   }
 }

--- a/apps/web/scripts_build.mjs
+++ b/apps/web/scripts_build.mjs
@@ -1,0 +1,19 @@
+import { mkdir, cp, rm, stat } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(fileURLToPath(import.meta.url));
+const dist = resolve(root, 'dist');
+const src = resolve(root, 'src');
+const publicDir = resolve(root, 'public');
+
+async function exists(path) {
+  try { await stat(path); return true; } catch { return false; }
+}
+
+await rm(dist, { recursive: true, force: true });
+await mkdir(dist, { recursive: true });
+await cp(resolve(root, 'index.html'), resolve(dist, 'index.html'));
+await cp(src, resolve(dist, 'src'), { recursive: true });
+if (await exists(publicDir)) await cp(publicDir, resolve(dist, 'public'), { recursive: true });
+console.log('Built static web app into apps/web/dist');


### PR DESCRIPTION
### Motivation
- Provide a minimal, dependency-free local build for the web scaffold so developers and CI can produce a static `dist/` output without adding a heavier toolchain.

### Description
- Add `apps/web/scripts_build.mjs`, add `build` and `build:clean` scripts to `apps/web/package.json`, and document `npm run check` and `npm run build` in `apps/web/README.md`.

### Testing
- Ran `cd apps/web && npm run check` (succeeded) and `cd apps/web && npm run build` (succeeded and produced `apps/web/dist`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18cc75748832a8273d97b6498ce31)