### PR TITLE
Require shared route fields in ecology evidence bundle response schema

### DIFF
--- a/schemas/contracts/v1/runtime/ecology_evidence_bundle_response.schema.json
+++ b/schemas/contracts/v1/runtime/ecology_evidence_bundle_response.schema.json
@@ -4,16 +4,29 @@
   "title": "Ecology EvidenceBundle Response",
   "type": "object",
   "additionalProperties": true,
-  "required": ["status", "data", "meta"],
+  "required": [
+    "status",
+    "data",
+    "meta"
+  ],
   "properties": {
-    "status": {"const": "ok"},
+    "status": {
+      "const": "ok"
+    },
     "meta": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["resolver", "evidence_drawer_required"],
+      "required": [
+        "resolver",
+        "evidence_drawer_required"
+      ],
       "properties": {
-        "resolver": {"const": "ecology_evidencebundle"},
-        "evidence_drawer_required": {"type": "boolean"}
+        "resolver": {
+          "const": "ecology_evidencebundle"
+        },
+        "evidence_drawer_required": {
+          "type": "boolean"
+        }
       }
     },
     "data": {
@@ -31,21 +44,40 @@
             "evidence"
           ],
           "properties": {
-            "evidence_bundle_id": {"type": "string"},
-            "candidate_id": {"type": "string"},
-            "spec_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
-            "decision": {"const": "cite"},
-            "status": {"type": "string"},
-            "proof_pack_ref": {"type": "string"},
+            "evidence_bundle_id": {
+              "type": "string"
+            },
+            "candidate_id": {
+              "type": "string"
+            },
+            "spec_hash": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "decision": {
+              "const": "cite"
+            },
+            "status": {
+              "type": "string"
+            },
+            "proof_pack_ref": {
+              "type": "string"
+            },
             "evidence": {
               "type": "object",
               "additionalProperties": true,
               "properties": {
-                "receipts": {"type": "array"},
-                "catalog_refs": {"type": "object"}
+                "receipts": {
+                  "type": "array"
+                },
+                "catalog_refs": {
+                  "type": "object"
+                }
               }
             },
-            "uncertainty": {"type": "object"}
+            "uncertainty": {
+              "type": "object"
+            }
           }
         },
         {
@@ -60,15 +92,36 @@
             "error_code"
           ],
           "properties": {
-            "evidence_bundle_id": {"type": "string"},
-            "candidate_id": {"type": "string"},
-            "decision": {"const": "abstain"},
-            "status": {"type": "string"},
-            "reason": {"type": "string"},
-            "error_code": {"type": "string"},
-            "claim_text": {"type": "string"}
+            "evidence_bundle_id": {
+              "type": "string"
+            },
+            "candidate_id": {
+              "type": "string"
+            },
+            "decision": {
+              "const": "abstain"
+            },
+            "status": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "error_code": {
+              "type": "string"
+            },
+            "claim_text": {
+              "type": "string"
+            }
           }
         }
+      ],
+      "type": "object",
+      "required": [
+        "evidence_bundle_id",
+        "candidate_id",
+        "decision",
+        "status"
       ]
     }
   }


### PR DESCRIPTION
### Motivation
- The runtime schema for ecology evidence bundle responses allowed payloads to pass validation even when shared route fields like `candidate_id` were missing because each `oneOf` branch only enforced branch-specific fields.
- Tests exercising the ecology routes expect these shared fields to be required and surfaced a failing contract validation for a payload missing `candidate_id`.

### Description
- Updated `schemas/contracts/v1/runtime/ecology_evidence_bundle_response.schema.json` to set `data.type` to `object` and add top-level `required` entries for the shared route fields `evidence_bundle_id`, `candidate_id`, `decision`, and `status` on `data`.
- Preserved the existing `oneOf` branch-specific `required` properties for the `cite` and `abstain` decision variants so decision-specific validation remains intact.
- Adjusted formatting in the JSON for clarity while keeping `additionalProperties` behavior unchanged.

### Testing
- Ran `pytest -q apps/governed_api/ecology/tests` before the change which showed a failing test for missing `candidate_id` in the contract validation.
- Re-ran `pytest -q apps/governed_api/ecology/tests` after the schema update and the suite completed successfully with `15 passed, 2 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18e590168832ab1baa6ecb3b7975f)