### PR TITLE
Make pipelines gap analysis actionable with prioritized placeholder ranking

### DIFF
--- a/pipelines/PIPELINES_GAP_ANALYSIS.md
+++ b/pipelines/PIPELINES_GAP_ANALYSIS.md
@@ -1,24 +1,20 @@
 # Pipelines Gap Analysis (as of 2026-04-29)
 
-This document summarizes what appears missing or outdated in `pipelines/` based on a direct repository scan.
+This document summarizes missing or outdated items in `pipelines/` from a direct repository scan in this checkout.
 
 ## High-level findings
 
-1. **Documentation maturity is ahead of implementation maturity** in several pipeline lanes.
-   - Multiple pipeline folders only contain `README.md` and no runnable code.
-2. **Metadata placeholders are still unresolved** across many docs.
-   - Frequent placeholders include `TODO`, `TBD`, `NEEDS VERIFICATION`, and ownership/policy/date placeholders.
+1. **Documentation maturity is ahead of implementation maturity** in several lanes.
+2. **Governance placeholders are still widespread** (`TODO`, `TBD`, `NEEDS VERIFICATION`, and metadata placeholders).
 3. **Some lanes are implemented and testable**, especially:
    - `pipelines/kansas_biodiversity_etl/catalog/*`
    - `pipelines/kansas_biodiversity_etl/validate/promotion_gate_full.py`
    - `pipelines/watchers/hydrology_huc12_admin_crosswalk_watch/*`
-4. **Cross-doc consistency debt exists**: many READMEs still describe “proposed” commands/paths rather than verified repo-native commands.
+4. **Cross-doc drift exists**: multiple READMEs still describe proposed paths/commands rather than verified repo-native commands.
 
-## Missing or incomplete items by area
+## 1) Directory-level implementation gaps
 
-### 1) Directory-level implementation gaps
-
-The following directories currently contain only a `README.md` (no scripts/tests/assets), indicating likely missing runnable components:
+The following directories currently contain only `README.md` (no scripts/tests/assets at the same level), which indicates likely missing runnable components:
 
 - `pipelines/habitat_layer_build/`
 - `pipelines/kansas_biodiversity_etl/dedupe/`
@@ -27,13 +23,14 @@ The following directories currently contain only a `README.md` (no scripts/tests
 - `pipelines/watchers/kansas_flora_watch/`
 - `pipelines/watchers/soil_air_quality/`
 
-**What likely needs update**
-- Add minimal runnable entrypoints (`runner.py`, Make targets, or equivalent) and fixture/test paths that match each README.
-- If a lane is intentionally documentation-only, explicitly mark it as roadmap-only and add acceptance criteria for “implementation complete”.
+**Required updates**
+- Add minimal runnable entrypoints (for example `runner.py` or repo-native shell targets).
+- Add lane-local fixtures/tests or wire to existing validators.
+- If intentionally doc-only, mark lane as `roadmap-only` and link a tracked implementation issue.
 
-### 2) Unresolved governance metadata in READMEs
+## 2) Unresolved metadata fields in READMEs
 
-Common unresolved fields are still present in top-level and leaf docs:
+Common unresolved fields still present:
 
 - `doc_id`
 - `owners`
@@ -41,64 +38,86 @@ Common unresolved fields are still present in top-level and leaf docs:
 - `policy_label`
 - `related`
 
-**What likely needs update**
-- Resolve these fields in all production READMEs, or formally mark specific docs as draft with a tracked issue reference.
+**Required updates**
+- Resolve metadata for stable lanes.
+- Keep placeholders only in explicitly draft docs and include issue references.
 
-### 3) Highest-placeholder documents (priority)
+## 3) Highest-placeholder files to prioritize
 
-By quick placeholder-density scan, prioritize these files first:
+Placeholder-density scan (README files under `pipelines/`):
 
-1. `pipelines/watchers/hydrology_huc12_admin_crosswalk_watch/sql/README.md`
-2. `pipelines/kansas_biodiversity_etl/catalog/README.md`
-3. `pipelines/kansas_biodiversity_etl/dedupe/README.md`
-4. `pipelines/kansas_biodiversity_etl/publish/README.md`
-5. `pipelines/watchers/hydrology_huc12_admin_crosswalk_watch/README.md`
-6. `pipelines/kansas_biodiversity_etl/harvest/README.md`
-7. `pipelines/README.md`
-8. `pipelines/kansas_biodiversity_etl/validate/README.md`
+1. `pipelines/watchers/hydrology_huc12_admin_crosswalk_watch/sql/README.md` (50)
+2. `pipelines/kansas_biodiversity_etl/publish/README.md` (45)
+3. `pipelines/kansas_biodiversity_etl/catalog/README.md` (41)
+4. `pipelines/kansas_biodiversity_etl/README.md` (41)
+5. `pipelines/kansas_biodiversity_etl/dedupe/README.md` (33)
+6. `pipelines/kansas_biodiversity_etl/normalize/README.md` (31)
+7. `pipelines/README.md` (31)
+8. `pipelines/watchers/kansas_flora_watch/README.md` (28)
+9. `pipelines/kansas_biodiversity_etl/harvest/README.md` (25)
+10. `pipelines/watchers/hydrology_huc12_admin_crosswalk_watch/fixtures/README.md` (24)
+11. `pipelines/watchers/hydrology_huc12_admin_crosswalk_watch/README.md` (24)
+12. `pipelines/kansas_biodiversity_etl/validate/README.md` (23)
 
-**What likely needs update**
+**Required updates**
 - Replace placeholder commands with verified commands that run in this repo.
-- Replace placeholder paths with canonical paths in this repo.
-- Remove “NEEDS VERIFICATION” where verification can now be done locally.
+- Replace placeholder paths with canonical repo paths.
+- Remove `NEEDS VERIFICATION` markers once locally verified.
 
-### 4) Test/fixture parity gaps
+## 4) Test/fixture parity gaps
 
-Some READMEs describe negative fixtures and failure modes that do not yet have matching concrete fixture files in adjacent directories.
+Some READMEs describe failure modes and fixture expectations that are not represented by adjacent concrete fixture files.
 
-**What likely needs update**
-- For each README checklist item, either:
-  - add the fixture/test artifact, or
-  - remove/reword the claim and link to a tracking issue.
+**Required updates**
+- For each checklist claim, either:
+  - add matching fixtures/tests, or
+  - reword/remove the claim and link a tracking issue.
 
-### 5) Consistency between contracts and validators
+## 5) Contract/validator consistency gaps
 
-Where scripts do exist, there are explicit fail-closed checks and reason codes. Documentation should be tightened to reflect the exact implemented reason codes and CLI flags.
+Where scripts are implemented, behavior is fail-closed with explicit reason codes; docs should mirror actual CLI flags and reason-code vocabulary.
 
-**What likely needs update**
-- Generate documentation snippets directly from implemented validators where possible (or add a CI doc drift check).
+**Required updates**
+- Generate doc snippets from implemented validators where possible.
+- Add a CI doc-drift check for reason-code and CLI-flag mismatches.
 
-## Suggested update order
+## Suggested execution order
 
-1. **Stabilize ownership/policy metadata** in `pipelines/README.md` and each leaf README.
-2. **Pick one watcher lane and one ETL lane** and make their docs + commands executable end-to-end.
-3. **Add missing runners/tests** for doc-only lanes or explicitly mark them roadmap-only.
-4. **Add CI checks** for:
-   - unresolved placeholder tokens in non-draft docs
-   - referenced command/path existence
-   - fixture checklist drift
+1. **Metadata closure**: stabilize ownership/policy/date metadata in `pipelines/README.md` and lane READMEs.
+2. **Executable closure**: make one watcher lane and one ETL lane fully runnable end-to-end.
+3. **Doc-only lane decision**: implement or explicitly mark roadmap-only with issue links.
+4. **CI enforcement**:
+   - unresolved placeholders in non-draft docs,
+   - referenced command/path existence,
+   - fixture checklist parity.
 
-## Evidence collection commands used
+## Evidence commands run
 
 ```bash
 rg --files pipelines
-rg -n "TODO|TBD|FIXME|coming soon|placeholder|stub|missing|not implemented" pipelines
+rg -n "TODO|TBD|NEEDS VERIFICATION|NEEDS_VERIFICATION|placeholder" pipelines
 python - <<'PY'
-# placeholder-density scan
-...
+from pathlib import Path
+import re
+root=Path('pipelines')
+pat=re.compile(r'TODO|TBD|NEEDS VERIFICATION|NEEDS_VERIFICATION|placeholder',re.I)
+rows=[]
+for p in root.rglob('README.md'):
+    txt=p.read_text(errors='ignore')
+    c=len(pat.findall(txt))
+    if c: rows.append((c,p.as_posix()))
+rows.sort(reverse=True)
+for c,p in rows[:12]:
+    print(c,p)
 PY
 python - <<'PY'
-# detect directories that only contain README.md
-...
+from pathlib import Path
+root=Path('pipelines')
+for d in sorted([x for x in root.rglob('*') if x.is_dir()]):
+    kids=[k for k in d.iterdir() if not k.name.startswith('.')]
+    files=[k for k in kids if k.is_file()]
+    dirs=[k for k in kids if k.is_dir()]
+    if files and all(f.name=='README.md' for f in files) and not dirs:
+        print(d.as_posix())
 PY
 ```


### PR DESCRIPTION
### Motivation
- Turn a broad, prose gap note into an actionable remediation plan so pipeline owners can triage and close work quickly. 
- Surface highest-debt README files with an objective, count-based ranking to prioritize documentation fixes. 
- Capture reproducible evidence commands so the scan can be re-run and validated in this checkout. 

### Description
- Rewrote `pipelines/PIPELINES_GAP_ANALYSIS.md` to replace vague guidance with concrete "Required updates" and a suggested execution order. 
- Added a placeholder-density ranking (top 12 READMEs with counts) and an explicit list of doc-only pipeline directories that need runnable entrypoints or an explicit roadmap designation. 
- Included reproducible commands and small Python scans used to compute placeholder density and detect README-only directories (commands are embedded in the document). 
- Minor wording/structure cleanups to clarify metadata fields to resolve and CI enforcement recommendations. 

### Testing
- Re-ran the placeholder search with `rg -n "TODO|TBD|NEEDS VERIFICATION|NEEDS_VERIFICATION|placeholder" pipelines`, which completed successfully. 
- Executed the placeholder-density and doc-only directory scans using the included Python snippets, which produced the ranked counts and directory list used in the document. 
- Document file was staged and committed (`git commit`) on the working branch; the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f96ee26c832ab3d9c685dd0cfc8f)