### PR TITLE
Mark README-only pipeline lanes as roadmap-only

### DIFF
--- a/docs/tracking/pipeline-roadmap-only-lanes.md
+++ b/docs/tracking/pipeline-roadmap-only-lanes.md
@@ -1,0 +1,15 @@
+# Pipeline roadmap-only lanes
+
+These lanes are intentionally marked **roadmap-only** until runnable entrypoints and tests are added:
+
+- `pipelines/habitat_layer_build/`
+- `pipelines/kansas_biodiversity_etl/dedupe/`
+- `pipelines/kansas_biodiversity_etl/normalize/`
+- `pipelines/usgs-gage-watch/`
+- `pipelines/watchers/kansas_flora_watch/`
+- `pipelines/watchers/soil_air_quality/`
+
+Exit criteria:
+1. Add minimal runnable entrypoint(s).
+2. Add lane-local fixtures/tests or validator wiring.
+3. Replace README placeholders with verified commands/paths.

--- a/pipelines/habitat_layer_build/README.md
+++ b/pipelines/habitat_layer_build/README.md
@@ -16,6 +16,9 @@ notes: [Drafted from attached KFM habitat, pipeline, MapLibre UI, and documentat
 <a id="top"></a>
 
 # Habitat Layer Build Pipeline
+> [!WARNING]
+> **Implementation status: roadmap-only.** This lane is currently documentation-only in this repository snapshot (README-only directory). Track implementation in `docs/tracking/pipeline-roadmap-only-lanes.md` before treating commands, scripts, or tests here as available.
+
 
 Builds **reviewable habitat layer candidates** from governed habitat inputs without bypassing source roles, validation, catalog closure, release review, or EvidenceBundle-backed publication.
 

--- a/pipelines/kansas_biodiversity_etl/dedupe/README.md
+++ b/pipelines/kansas_biodiversity_etl/dedupe/README.md
@@ -14,6 +14,9 @@ notes: [draft README generated from attached KFM doctrine; mounted target repo n
 [/KFM_META_BLOCK_V2] -->
 
 # Kansas Biodiversity ETL — Dedupe
+> [!WARNING]
+> **Implementation status: roadmap-only.** This lane is currently documentation-only in this repository snapshot (README-only directory). Track implementation in `docs/tracking/pipeline-roadmap-only-lanes.md` before treating commands, scripts, or tests here as available.
+
 
 Deduplicate Kansas biodiversity candidate records without erasing evidence, source role, sensitivity, rights, or review state.
 

--- a/pipelines/kansas_biodiversity_etl/normalize/README.md
+++ b/pipelines/kansas_biodiversity_etl/normalize/README.md
@@ -16,6 +16,9 @@ notes: [Target path is confirmed on public main; the current leaf README was emp
 <a id="top"></a>
 
 # Kansas Biodiversity ETL — Normalize
+> [!WARNING]
+> **Implementation status: roadmap-only.** This lane is currently documentation-only in this repository snapshot (README-only directory). Track implementation in `docs/tracking/pipeline-roadmap-only-lanes.md` before treating commands, scripts, or tests here as available.
+
 
 Convert harvested Kansas biodiversity occurrence inputs into deterministic, source-traceable, policy-aware normalized candidates without publishing or weakening the KFM trust path.
 

--- a/pipelines/usgs-gage-watch/README.md
+++ b/pipelines/usgs-gage-watch/README.md
@@ -31,6 +31,9 @@ notes: [
 <a id="top"></a>
 
 # USGS Gage → HUC Overlay Watcher
+> [!WARNING]
+> **Implementation status: roadmap-only.** This lane is currently documentation-only in this repository snapshot (README-only directory). Track implementation in `docs/tracking/pipeline-roadmap-only-lanes.md` before treating commands, scripts, or tests here as available.
+
 
 Ingest **live USGS gage streams** and bind each sample to **HUC12/10/8 overlays** and a **mainstem crosswalk**, emitting **receipts** and **KFM sidecars** for governed promotion.
 

--- a/pipelines/watchers/kansas_flora_watch/README.md
+++ b/pipelines/watchers/kansas_flora_watch/README.md
@@ -33,6 +33,9 @@ notes: [
 <a id="top"></a>
 
 # Kansas Flora Watcher
+> [!WARNING]
+> **Implementation status: roadmap-only.** This lane is currently documentation-only in this repository snapshot (README-only directory). Track implementation in `docs/tracking/pipeline-roadmap-only-lanes.md` before treating commands, scripts, or tests here as available.
+
 
 One-way, fail-closed ingestion of Kansas flora records into KFM EvidenceBundles, catalog records, receipts, and promotion-gate review.
 

--- a/pipelines/watchers/soil_air_quality/README.md
+++ b/pipelines/watchers/soil_air_quality/README.md
@@ -29,6 +29,9 @@ notes: [
 <a id="top"></a>
 
 # Soil & Air Quality Watchers
+> [!WARNING]
+> **Implementation status: roadmap-only.** This lane is currently documentation-only in this repository snapshot (README-only directory). Track implementation in `docs/tracking/pipeline-roadmap-only-lanes.md` before treating commands, scripts, or tests here as available.
+
 
 Evidence-first polling connectors for soil and air-quality data sources.  
 These watchers ingest, diff, and attest external data into KFM as **EvidenceBundles**, not publishable claims.


### PR DESCRIPTION
### Motivation
- The pipelines gap analysis identified several lanes that contain only `README.md` and risk being mistaken for runnable code, so their implementation status should be explicit. 
- Making roadmap-only status discoverable reduces accidental reliance on non-runnable docs and centralizes tracking for implementation work. 
- Providing clear exit criteria helps steer follow-up work to add entrypoints, tests, and verified commands.

### Description
- Inserted a prominent `roadmap-only` warning banner at the top of six pipeline README files to indicate they are documentation-only in this snapshot. 
- Added a central tracking document at `docs/tracking/pipeline-roadmap-only-lanes.md` that lists the affected lanes and defines exit criteria (add entrypoints, add tests/fixtures or validator wiring, replace README placeholders). 
- Targeted README files updated are under `pipelines/habitat_layer_build/`, `pipelines/kansas_biodiversity_etl/dedupe/`, `pipelines/kansas_biodiversity_etl/normalize/`, `pipelines/usgs-gage-watch/`, `pipelines/watchers/kansas_flora_watch/`, and `pipelines/watchers/soil_air_quality/`. 
- Changes are documentation-only and do not add executable code or tests.

### Testing
- Ran the insertion script (`python` snippet used to inject banners) and it completed without error. 
- Verified presence of the inserted marker using `rg -n "roadmap-only"` across the modified README files and the new tracking document, and the pattern was found in all expected locations. 
- Displayed file excerpts with `nl -ba` to confirm the banner lines were placed as intended, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fa7b15fc832ab50883ae873afba8)