### PR TITLE
Add README files for habitat_layer_build subdirectories

### DIFF
--- a/pipelines/habitat_layer_build/config/README.md
+++ b/pipelines/habitat_layer_build/config/README.md
@@ -1,0 +1,5 @@
+# habitat_layer_build config
+
+Contains configuration templates for the habitat layer build lane.
+
+- `layer_build.example.yaml`: canonical example config used by tests and local dry runs.

--- a/pipelines/habitat_layer_build/fixtures/README.md
+++ b/pipelines/habitat_layer_build/fixtures/README.md
@@ -1,0 +1,6 @@
+# habitat_layer_build fixtures
+
+Fixture inputs for validator and pipeline behavior tests.
+
+- `good/`: valid candidate payloads expected to pass validation.
+- `bad/`: invalid payloads expected to fail with explicit errors.

--- a/pipelines/habitat_layer_build/fixtures/bad/README.md
+++ b/pipelines/habitat_layer_build/fixtures/bad/README.md
@@ -1,0 +1,3 @@
+# Invalid fixture set
+
+This folder contains intentionally invalid habitat layer candidate examples used for negative tests.

--- a/pipelines/habitat_layer_build/fixtures/good/README.md
+++ b/pipelines/habitat_layer_build/fixtures/good/README.md
@@ -1,0 +1,3 @@
+# Valid fixture set
+
+This folder contains valid habitat layer candidate examples.

--- a/pipelines/habitat_layer_build/outputs/README.md
+++ b/pipelines/habitat_layer_build/outputs/README.md
@@ -1,0 +1,6 @@
+# habitat_layer_build outputs
+
+Scratch output directory for local or CI runs of this lane.
+
+- Keep only placeholder files in git (`.gitkeep`).
+- Do not commit generated run artifacts from pipeline execution.


### PR DESCRIPTION
### Motivation
- Provide missing documentation for the habitat layer build lane subdirectories so fixture intent, config usage, and output commit hygiene are explicit and helpful for contributors and CI.

### Description
- Add small README files under `pipelines/habitat_layer_build/config/README.md`, `pipelines/habitat_layer_build/fixtures/README.md`, `pipelines/habitat_layer_build/fixtures/good/README.md`, `pipelines/habitat_layer_build/fixtures/bad/README.md`, and `pipelines/habitat_layer_build/outputs/README.md` describing the example config, fixture expectations (good vs bad), and that only placeholder outputs should be committed.

### Testing
- Ran `pytest -q pipelines/habitat_layer_build/tests/test_habitat_layer_build.py` which succeeded (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fd7f3db4832aa432afee03fdb3fb)