### PR TITLE
Scaffold missing watcher lane files under pipelines/watchers

### DIFF
--- a/pipelines/watchers/README.md
+++ b/pipelines/watchers/README.md
@@ -179,7 +179,17 @@ pipelines/
 └── watchers/
     ├── README.md
     ├── kansas_flora_watch/
-    │   └── README.md
+    │   ├── README.md
+    │   ├── config.example.yaml
+    │   ├── runner.py
+    │   ├── steps/
+    │   └── tests/
+    ├── soil_air_quality/
+    │   ├── README.md
+    │   ├── config.example.yaml
+    │   ├── runner.py
+    │   ├── steps/
+    │   └── tests/
     └── <domain>_<source-or-scope>_watch/
         ├── README.md
         ├── watcher.manifest.yaml        # PROPOSED after schema-home verification

--- a/pipelines/watchers/kansas_flora_watch/config.example.yaml
+++ b/pipelines/watchers/kansas_flora_watch/config.example.yaml
@@ -1,0 +1,12 @@
+watcher_id: kansas_flora_watch
+mode: dry-run
+sources:
+  - id: gbif_kansas_flora
+    type: gbif
+    enabled: true
+    modified_since: "2026-01-01"
+outputs:
+  raw_root: data/raw/flora
+  work_root: data/work/flora
+  processed_root: data/processed/flora
+  receipts_root: data/receipts/flora

--- a/pipelines/watchers/kansas_flora_watch/runner.py
+++ b/pipelines/watchers/kansas_flora_watch/runner.py
@@ -1,0 +1,40 @@
+"""Kansas flora watcher scaffolding.
+
+Roadmap-only lane: this runner provides a deterministic no-op dry-run surface
+until full ingestion wiring lands.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def build_receipt(dry_run: bool) -> dict:
+    return {
+        "watcher_id": "kansas_flora_watch",
+        "status": "noop",
+        "dry_run": dry_run,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "message": "Scaffold runner executed; implementation pending.",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--once", action="store_true", help="run one cycle")
+    parser.add_argument("--dry-run", action="store_true", help="no writes outside local receipt")
+    parser.add_argument("--receipt", default="data/work/flora/scaffold_receipt.json")
+    args = parser.parse_args()
+
+    receipt = build_receipt(dry_run=args.dry_run)
+    out = Path(args.receipt)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(receipt))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipelines/watchers/kansas_flora_watch/steps/__init__.py
+++ b/pipelines/watchers/kansas_flora_watch/steps/__init__.py
@@ -1,0 +1,1 @@
+"""Step helpers for kansas_flora_watch."""

--- a/pipelines/watchers/kansas_flora_watch/steps/acquire.py
+++ b/pipelines/watchers/kansas_flora_watch/steps/acquire.py
@@ -1,0 +1,5 @@
+"""acquire step placeholder for kansas_flora_watch."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("acquire")
+    return context

--- a/pipelines/watchers/kansas_flora_watch/steps/bundle.py
+++ b/pipelines/watchers/kansas_flora_watch/steps/bundle.py
@@ -1,0 +1,5 @@
+"""bundle step placeholder for kansas_flora_watch."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("bundle")
+    return context

--- a/pipelines/watchers/kansas_flora_watch/steps/detect.py
+++ b/pipelines/watchers/kansas_flora_watch/steps/detect.py
@@ -1,0 +1,5 @@
+"""detect step placeholder for kansas_flora_watch."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("detect")
+    return context

--- a/pipelines/watchers/kansas_flora_watch/steps/normalize.py
+++ b/pipelines/watchers/kansas_flora_watch/steps/normalize.py
@@ -1,0 +1,5 @@
+"""normalize step placeholder for kansas_flora_watch."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("normalize")
+    return context

--- a/pipelines/watchers/kansas_flora_watch/steps/publish.py
+++ b/pipelines/watchers/kansas_flora_watch/steps/publish.py
@@ -1,0 +1,5 @@
+"""publish step placeholder for kansas_flora_watch."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("publish")
+    return context

--- a/pipelines/watchers/kansas_flora_watch/steps/validate_dwca.py
+++ b/pipelines/watchers/kansas_flora_watch/steps/validate_dwca.py
@@ -1,0 +1,5 @@
+"""validate_dwca step placeholder for kansas_flora_watch."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("validate_dwca")
+    return context

--- a/pipelines/watchers/kansas_flora_watch/tests/README.md
+++ b/pipelines/watchers/kansas_flora_watch/tests/README.md
@@ -1,0 +1,3 @@
+# kansas_flora_watch tests
+
+Scaffold-only test directory for the watcher lane.

--- a/pipelines/watchers/soil_air_quality/config.example.yaml
+++ b/pipelines/watchers/soil_air_quality/config.example.yaml
@@ -1,0 +1,12 @@
+watcher_id: soil_air_quality
+mode: dry-run
+sources:
+  - id: airnow
+    enabled: true
+  - id: aqs
+    enabled: false
+outputs:
+  raw_root: data/raw/soil_air
+  work_root: data/work/soil_air
+  proofs_root: data/proofs/soil_air
+  receipts_root: data/receipts/soil_air

--- a/pipelines/watchers/soil_air_quality/runner.py
+++ b/pipelines/watchers/soil_air_quality/runner.py
@@ -1,0 +1,31 @@
+"""Soil & air quality watcher scaffolding runner."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--receipt", default="data/work/soil_air/scaffold_receipt.json")
+    args = parser.parse_args()
+
+    receipt = {
+        "watcher_id": "soil_air_quality",
+        "status": "noop",
+        "dry_run": args.dry_run,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    out = Path(args.receipt)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(receipt))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipelines/watchers/soil_air_quality/steps/__init__.py
+++ b/pipelines/watchers/soil_air_quality/steps/__init__.py
@@ -1,0 +1,1 @@
+"""Step helpers for soil_air_quality watcher."""

--- a/pipelines/watchers/soil_air_quality/steps/attest_receipt.py
+++ b/pipelines/watchers/soil_air_quality/steps/attest_receipt.py
@@ -1,0 +1,5 @@
+"""attest_receipt step placeholder for soil_air_quality watcher."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("attest_receipt")
+    return context

--- a/pipelines/watchers/soil_air_quality/steps/build_bundle.py
+++ b/pipelines/watchers/soil_air_quality/steps/build_bundle.py
@@ -1,0 +1,5 @@
+"""build_bundle step placeholder for soil_air_quality watcher."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("build_bundle")
+    return context

--- a/pipelines/watchers/soil_air_quality/steps/chunk_hash.py
+++ b/pipelines/watchers/soil_air_quality/steps/chunk_hash.py
@@ -1,0 +1,5 @@
+"""chunk_hash step placeholder for soil_air_quality watcher."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("chunk_hash")
+    return context

--- a/pipelines/watchers/soil_air_quality/steps/diff.py
+++ b/pipelines/watchers/soil_air_quality/steps/diff.py
@@ -1,0 +1,5 @@
+"""diff step placeholder for soil_air_quality watcher."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("diff")
+    return context

--- a/pipelines/watchers/soil_air_quality/steps/fetch.py
+++ b/pipelines/watchers/soil_air_quality/steps/fetch.py
@@ -1,0 +1,5 @@
+"""fetch step placeholder for soil_air_quality watcher."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("fetch")
+    return context

--- a/pipelines/watchers/soil_air_quality/steps/probe_metadata.py
+++ b/pipelines/watchers/soil_air_quality/steps/probe_metadata.py
@@ -1,0 +1,5 @@
+"""probe_metadata step placeholder for soil_air_quality watcher."""
+
+def run(context: dict) -> dict:
+    context.setdefault("steps", []).append("probe_metadata")
+    return context

--- a/pipelines/watchers/soil_air_quality/tests/README.md
+++ b/pipelines/watchers/soil_air_quality/tests/README.md
@@ -1,0 +1,3 @@
+# soil_air_quality watcher tests
+
+Scaffold-only test directory for this watcher lane.


### PR DESCRIPTION
### Motivation

- Provide the missing scaffold files for watcher lanes so reviewer-visible directory shape, configs, and no-op runners exist for future implementation work.
- Preserve a fail-closed, deterministic scaffold surface (no-op runners and minimal step placeholders) so downstream policy, receipts, and promotion wiring can be layered later.
- Keep documentation accurate by updating the `pipelines/watchers` README directory tree to reflect the newly added lane scaffolds.

### Description

- Added `pipelines/watchers/kansas_flora_watch/` with `config.example.yaml`, a no-op `runner.py` that writes a local scaffold receipt, `steps/` placeholder modules (`detect`, `acquire`, `validate_dwca`, `normalize`, `bundle`, `publish`) and `tests/README.md`.
- Added `pipelines/watchers/soil_air_quality/` with `config.example.yaml`, a no-op `runner.py` that writes a local scaffold receipt, `steps/` placeholder modules (`probe_metadata`, `fetch`, `chunk_hash`, `diff`, `build_bundle`, `attest_receipt`) and `tests/README.md`.
- Updated `pipelines/watchers/README.md` to include the new lane files in the documented directory tree and preserve the watcher hub guidance.
- All step modules are minimal, export a `run(context: dict) -> dict` placeholder, and include `steps/__init__.py` for package readiness.

### Testing

- Compiled the new Python scaffold modules with `python -m py_compile pipelines/watchers/kansas_flora_watch/runner.py pipelines/watchers/kansas_flora_watch/steps/*.py pipelines/watchers/soil_air_quality/runner.py pipelines/watchers/soil_air_quality/steps/*.py`, which completed successfully.
- No additional automated tests were run as the changes are scaffolding-only and intended to be fleshed out by subsequent implementation work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fe67f43c832a9db9a5f55b1aa11f)