### PR TITLE
Add scaffold pytest coverage for kansas_flora_watch steps and runner

### DIFF
--- a/pipelines/watchers/kansas_flora_watch/tests/README.md
+++ b/pipelines/watchers/kansas_flora_watch/tests/README.md
@@ -1,3 +1,6 @@
 # kansas_flora_watch tests
 
-Scaffold-only test directory for the watcher lane.
+Pytest coverage for the current scaffolding implementation:
+
+- `test_steps.py` verifies each step appends its step name to `context["steps"]`.
+- `test_runner.py` verifies receipt generation and CLI receipt writes for the watcher runner.

--- a/pipelines/watchers/kansas_flora_watch/tests/test_runner.py
+++ b/pipelines/watchers/kansas_flora_watch/tests/test_runner.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from pipelines.watchers.kansas_flora_watch import runner
+
+
+def test_build_receipt_shape() -> None:
+    receipt = runner.build_receipt(dry_run=True)
+
+    assert receipt["watcher_id"] == "kansas_flora_watch"
+    assert receipt["status"] == "noop"
+    assert receipt["dry_run"] is True
+    assert isinstance(receipt["timestamp"], str)
+    assert "Scaffold runner executed" in receipt["message"]
+
+
+def test_runner_writes_receipt_file(tmp_path: Path) -> None:
+    out = tmp_path / "receipt.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pipelines.watchers.kansas_flora_watch.runner",
+            "--once",
+            "--dry-run",
+            "--receipt",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert out.exists()
+
+    on_disk = json.loads(out.read_text(encoding="utf-8"))
+    from_stdout = json.loads(result.stdout)
+
+    assert on_disk["watcher_id"] == "kansas_flora_watch"
+    assert on_disk["dry_run"] is True
+    assert on_disk == from_stdout

--- a/pipelines/watchers/kansas_flora_watch/tests/test_steps.py
+++ b/pipelines/watchers/kansas_flora_watch/tests/test_steps.py
@@ -1,0 +1,33 @@
+from pipelines.watchers.kansas_flora_watch.steps import (
+    acquire,
+    bundle,
+    detect,
+    normalize,
+    publish,
+    validate_dwca,
+)
+
+
+def test_step_modules_append_name_in_order() -> None:
+    context: dict = {}
+
+    for module in (detect, acquire, validate_dwca, normalize, bundle, publish):
+        context = module.run(context)
+
+    assert context["steps"] == [
+        "detect",
+        "acquire",
+        "validate_dwca",
+        "normalize",
+        "bundle",
+        "publish",
+    ]
+
+
+def test_step_modules_reuse_existing_steps_list() -> None:
+    context = {"steps": ["already_there"]}
+
+    updated = detect.run(context)
+
+    assert updated is context
+    assert updated["steps"] == ["already_there", "detect"]


### PR DESCRIPTION
### Motivation

- Provide unit-level verification for the existing scaffolded watcher to prevent regressions as implementation proceeds. 
- Ensure the no-op runner and individual step modules have a minimal, testable contract for downstream development and CI.

### Description

- Add `pipelines/watchers/kansas_flora_watch/tests/test_steps.py` which asserts each scaffold step appends its step name to `context["steps"]` in order and that a pre-existing `steps` list is reused in-place via `detect.run`.
- Add `pipelines/watchers/kansas_flora_watch/tests/test_runner.py` which validates `runner.build_receipt(dry_run=True)` shape and exercises the CLI to write a receipt file and emit identical JSON to stdout when invoked as a module.
- Update `pipelines/watchers/kansas_flora_watch/tests/README.md` to document the new scaffold test coverage.

### Testing

- Ran `pytest -q pipelines/watchers/kansas_flora_watch/tests` and all tests passed with `4 passed`.
- The runner CLI invocation used in tests is `python -m pipelines.watchers.kansas_flora_watch.runner --once --dry-run --receipt <path>` and returned exit code `0` during testing.
- No additional automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ffaf6538832abd48e110c8df8351)