### PR TITLE
Add missing example UI config files under configs/ui

### DIFF
--- a/configs/ui/accessibility.example.json
+++ b/configs/ui/accessibility.example.json
@@ -1,0 +1,15 @@
+{
+  "schema": "kfm.ui.accessibility.v1",
+  "non_color_trust_indicators": true,
+  "keyboard_navigation": {
+    "enabled": true,
+    "skip_links": true
+  },
+  "motion": {
+    "respect_prefers_reduced_motion": true,
+    "map_animation": "minimal"
+  },
+  "text_alternatives": {
+    "required_for_icons": true
+  }
+}

--- a/configs/ui/environments/local.example.json
+++ b/configs/ui/environments/local.example.json
@@ -1,0 +1,7 @@
+{
+  "schema": "kfm.ui.environment.v1",
+  "name": "local",
+  "feature_flag_overrides": {
+    "enable_diagnostics_surface": true
+  }
+}

--- a/configs/ui/environments/public.example.json
+++ b/configs/ui/environments/public.example.json
@@ -1,0 +1,7 @@
+{
+  "schema": "kfm.ui.environment.v1",
+  "name": "public",
+  "feature_flag_overrides": {
+    "enable_diagnostics_surface": false
+  }
+}

--- a/configs/ui/environments/review.example.json
+++ b/configs/ui/environments/review.example.json
@@ -1,0 +1,8 @@
+{
+  "schema": "kfm.ui.environment.v1",
+  "name": "review",
+  "feature_flag_overrides": {
+    "enable_export_surface": true,
+    "enable_diagnostics_surface": true
+  }
+}

--- a/configs/ui/evidence-drawer.example.json
+++ b/configs/ui/evidence-drawer.example.json
@@ -1,0 +1,12 @@
+{
+  "schema": "kfm.ui.evidence_drawer.v1",
+  "section_order": ["summary", "citations", "sources", "review", "release", "corrections"],
+  "visibility": {
+    "citations": true,
+    "source_roles": true,
+    "review_state": true,
+    "release_state": true,
+    "corrections": true
+  },
+  "empty_state": "No supporting evidence is currently available."
+}

--- a/configs/ui/feature-flags.example.json
+++ b/configs/ui/feature-flags.example.json
@@ -1,0 +1,11 @@
+{
+  "schema": "kfm.ui.feature_flags.v1",
+  "flags": {
+    "enable_focus_mode": true,
+    "enable_compare_surface": true,
+    "enable_export_surface": true,
+    "enable_diagnostics_surface": true,
+    "allow_policy_bypass": false,
+    "allow_unreleased_artifacts": false
+  }
+}

--- a/configs/ui/focus-mode.example.json
+++ b/configs/ui/focus-mode.example.json
@@ -1,0 +1,8 @@
+{
+  "schema": "kfm.ui.focus_mode.v1",
+  "outcomes": ["ANSWER", "ABSTAIN", "DENY", "ERROR"],
+  "show_reason_codes": true,
+  "inherit_scope": true,
+  "show_citations": true,
+  "allow_direct_model_endpoint": false
+}

--- a/configs/ui/maplibre.example.json
+++ b/configs/ui/maplibre.example.json
@@ -1,0 +1,14 @@
+{
+  "schema": "kfm.ui.maplibre.defaults.v1",
+  "renderer": "maplibre",
+  "style_manifest_ref": "kfm.style.public.default",
+  "allowed_source_types": ["vector", "raster", "geojson"],
+  "initial_viewport": {
+    "zoom": 4,
+    "center": [-98.5795, 39.8283]
+  },
+  "interactions": {
+    "drag_rotate": false,
+    "keyboard": true
+  }
+}

--- a/configs/ui/shell.defaults.example.json
+++ b/configs/ui/shell.defaults.example.json
@@ -1,0 +1,16 @@
+{
+  "schema": "kfm.ui.shell.defaults.v1",
+  "config_id": "kfm.ui.shell.defaults.public",
+  "status": "draft",
+  "default_surface": "Explore",
+  "surface_order": ["Explore", "Dossier", "Story", "Compare", "Focus", "Review", "Export", "Diagnostics"],
+  "panels": {
+    "evidence_drawer": { "visible": true, "position": "right" },
+    "time_controls": { "visible": true },
+    "trust_states": { "visible": true }
+  },
+  "responsive": {
+    "mobile_breakpoint_px": 768,
+    "tablet_breakpoint_px": 1024
+  }
+}

--- a/configs/ui/surfaces.example.json
+++ b/configs/ui/surfaces.example.json
@@ -1,0 +1,13 @@
+{
+  "schema": "kfm.ui.surfaces.v1",
+  "surfaces": [
+    { "id": "Explore", "enabled": true, "audience": "public" },
+    { "id": "Dossier", "enabled": true, "audience": "public" },
+    { "id": "Story", "enabled": true, "audience": "public" },
+    { "id": "Compare", "enabled": true, "audience": "public" },
+    { "id": "Focus", "enabled": true, "audience": "public" },
+    { "id": "Review", "enabled": true, "audience": "steward" },
+    { "id": "Export", "enabled": true, "audience": "steward" },
+    { "id": "Diagnostics", "enabled": true, "audience": "admin" }
+  ]
+}

--- a/configs/ui/trust-states.example.json
+++ b/configs/ui/trust-states.example.json
@@ -1,0 +1,14 @@
+{
+  "schema": "kfm.ui.trust_states.v1",
+  "states": {
+    "MISSING_EVIDENCE": "Evidence is required before this claim can be relied on.",
+    "SOURCE_STALE": "Sources are outdated and should be refreshed.",
+    "DENIED_BY_POLICY": "This action is blocked by policy.",
+    "GENERALIZED_GEOMETRY": "Geometry has been generalized for safety.",
+    "RESTRICTED_ACCESS": "Access is restricted for this content.",
+    "CONFLICTED_SUPPORT": "Available sources conflict and need review.",
+    "CITATION_FAILED": "Citation resolution failed.",
+    "RELEASE_WITHDRAWN": "The release was withdrawn and is not valid.",
+    "RUNTIME_ERROR": "A runtime error occurred while preparing this output."
+  }
+}


### PR DESCRIPTION
### Motivation
- The `configs/ui/README.md` documents a set of example config files but the example JSON files were not present, leaving the directory incomplete for reviewers and consumers.
- Provide public-safe, non-secret example configurations to standardize shell/surface defaults and make downstream UI integration and review easier.

### Description
- Added example UI configuration files for shell defaults, surfaces registry, trust states, MapLibre defaults, evidence drawer, focus mode, feature flags, and accessibility under `configs/ui/`.
- Added environment-specific example overrides for `local`, `review`, and `public` under `configs/ui/environments/`.
- Each file includes a minimal `schema` field and representative keys to match the shapes suggested in the README (e.g., `surface_order`, `section_order`, `outcomes`, `flags`, and `feature_flag_overrides`).

### Testing
- Ran `python -m json.tool` against all new files in `configs/ui/` and `configs/ui/environments/`, and the validation completed successfully with no JSON syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f218e14dcc832aaccdb89387080fe2)