### PR TITLE
Add complete ecology timeslice fixture set

### DIFF
--- a/tests/fixtures/ecology/timeslice/evidence_bundle.valid.json
+++ b/tests/fixtures/ecology/timeslice/evidence_bundle.valid.json
@@ -1,0 +1,15 @@
+{
+  "fixture_id": "evidence_bundle.timeslice_ks_spring_2024.valid",
+  "fixture_family": "ecology_timeslice",
+  "status": "valid",
+  "bundle_id": "kfm://evidencebundle/ecology/timeslice/ks/spring-2024/v1",
+  "evidence_refs": [
+    "kfm://evidence/occurrence/obs-ks-2024-0001",
+    "kfm://evidence/habitat/grassland_30m/v1",
+    "kfm://evidence/assignment/obs-ks-2024-0001"
+  ],
+  "closure": {
+    "all_refs_resolved": true,
+    "checked_at": "2024-06-16T00:00:00Z"
+  }
+}

--- a/tests/fixtures/ecology/timeslice/expected/evidence_drawer_payload.expected.json
+++ b/tests/fixtures/ecology/timeslice/expected/evidence_drawer_payload.expected.json
@@ -1,0 +1,10 @@
+{
+  "fixture_ref": "evidence_bundle.timeslice_ks_spring_2024.valid",
+  "drawer": {
+    "citations": ["kfm://evidence/occurrence/obs-ks-2024-0001"],
+    "freshness": "as_of_2024-06-15",
+    "rights": "allowed-with-attribution",
+    "policy": "public-safe",
+    "release_state": "test-only"
+  }
+}

--- a/tests/fixtures/ecology/timeslice/expected/runtime_abstain.expected.json
+++ b/tests/fixtures/ecology/timeslice/expected/runtime_abstain.expected.json
@@ -1,0 +1,1 @@
+{"outcome":"ABSTAIN","reason_code":"MISSING_EVIDENCE","fixture_ref":"habitat_assignment.unresolved_evidence_ref.invalid"}

--- a/tests/fixtures/ecology/timeslice/expected/runtime_answer.expected.json
+++ b/tests/fixtures/ecology/timeslice/expected/runtime_answer.expected.json
@@ -1,0 +1,1 @@
+{"outcome":"ANSWER","reason_code":"EVIDENCE_COMPLETE","fixture_ref":"habitat_assignment.obs-ks-2024-0001.valid"}

--- a/tests/fixtures/ecology/timeslice/expected/runtime_deny.expected.json
+++ b/tests/fixtures/ecology/timeslice/expected/runtime_deny.expected.json
@@ -1,0 +1,1 @@
+{"outcome":"DENY","reason_code":"UNKNOWN_RIGHTS","fixture_ref":"habitat_assignment.unknown_rights.invalid"}

--- a/tests/fixtures/ecology/timeslice/expected/runtime_error.expected.json
+++ b/tests/fixtures/ecology/timeslice/expected/runtime_error.expected.json
@@ -1,0 +1,1 @@
+{"outcome":"ERROR","reason_code":"MALFORMED_INPUT","fixture_ref":"fauna_occurrence.missing_precision.invalid"}

--- a/tests/fixtures/ecology/timeslice/fail/README.md
+++ b/tests/fixtures/ecology/timeslice/fail/README.md
@@ -1,0 +1,4 @@
+# Ecology Timeslice Fail Fixtures
+
+This directory contains intentionally failing fixtures for ecology timeslice validation.
+Use it for malformed, policy-denied, or unresolved-evidence cases.

--- a/tests/fixtures/ecology/timeslice/fauna_occurrence_public_safe.valid.json
+++ b/tests/fixtures/ecology/timeslice/fauna_occurrence_public_safe.valid.json
@@ -1,0 +1,18 @@
+{
+  "fixture_id": "fauna_occurrence.dickcissel_public_safe.valid",
+  "fixture_family": "ecology_timeslice",
+  "status": "valid",
+  "occurrence": {
+    "taxon": "Spiza americana",
+    "observation_id": "obs-ks-2024-0001",
+    "observed_at": "2024-05-12T14:10:00Z",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [-97.4501, 38.6123],
+      "precision_m": 250,
+      "served_as": "generalized"
+    }
+  },
+  "source_ref": "kfm://source/ks_mesonet/public_sample/v1",
+  "provenance_ref": "kfm://provenance/obs-ks-2024-0001"
+}

--- a/tests/fixtures/ecology/timeslice/habitat_assignment.valid.json
+++ b/tests/fixtures/ecology/timeslice/habitat_assignment.valid.json
@@ -1,0 +1,18 @@
+{
+  "fixture_id": "habitat_assignment.obs-ks-2024-0001.valid",
+  "fixture_family": "ecology_timeslice",
+  "status": "valid",
+  "assignment": {
+    "occurrence_ref": "obs-ks-2024-0001",
+    "surface_ref": "kfm://surface/habitat/grassland_30m/v1",
+    "cell_id": "5070:154493:433921",
+    "habitat_class": "Temperate_Grassland",
+    "confidence": 0.84,
+    "method": "point_to_grid_overlay.v1",
+    "spec_hash": "sha256:7f0fd9cbff9d8b59a44b2b87fa8b9bc251dbd3475da716ea648dbaec4cf0e5b9"
+  },
+  "evidence_refs": [
+    "kfm://evidence/occurrence/obs-ks-2024-0001",
+    "kfm://evidence/habitat/grassland_30m/v1"
+  ]
+}

--- a/tests/fixtures/ecology/timeslice/habitat_surface_descriptor.valid.json
+++ b/tests/fixtures/ecology/timeslice/habitat_surface_descriptor.valid.json
@@ -1,0 +1,15 @@
+{
+  "fixture_id": "habitat_surface_descriptor.grassland_30m.valid",
+  "fixture_family": "ecology_timeslice",
+  "status": "valid",
+  "surface": {
+    "surface_id": "kfm://surface/habitat/grassland_30m/v1",
+    "resolution_m": 30,
+    "grid_crs": "EPSG:5070",
+    "source_epoch": "2024-04-01"
+  },
+  "rights": {
+    "redistribution": "allowed-with-attribution",
+    "license": "CC-BY-4.0"
+  }
+}

--- a/tests/fixtures/ecology/timeslice/invalid/fauna_occurrence_missing_precision.invalid.json
+++ b/tests/fixtures/ecology/timeslice/invalid/fauna_occurrence_missing_precision.invalid.json
@@ -1,0 +1,13 @@
+{
+  "fixture_id": "fauna_occurrence.missing_precision.invalid",
+  "status": "invalid",
+  "reason": "precision_m is required for public-safe serving",
+  "occurrence": {
+    "observation_id": "obs-ks-2024-0099",
+    "taxon": "Spiza americana",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [-97.45, 38.61]
+    }
+  }
+}

--- a/tests/fixtures/ecology/timeslice/invalid/fauna_occurrence_missing_provenance.invalid.json
+++ b/tests/fixtures/ecology/timeslice/invalid/fauna_occurrence_missing_provenance.invalid.json
@@ -1,0 +1,10 @@
+{
+  "fixture_id": "fauna_occurrence.missing_provenance.invalid",
+  "status": "invalid",
+  "reason": "provenance_ref missing",
+  "occurrence": {
+    "observation_id": "obs-ks-2024-0100",
+    "taxon": "Spiza americana",
+    "observed_at": "2024-05-13T15:30:00Z"
+  }
+}

--- a/tests/fixtures/ecology/timeslice/invalid/habitat_assignment_unknown_rights.invalid.json
+++ b/tests/fixtures/ecology/timeslice/invalid/habitat_assignment_unknown_rights.invalid.json
@@ -1,0 +1,13 @@
+{
+  "fixture_id": "habitat_assignment.unknown_rights.invalid",
+  "status": "invalid",
+  "reason": "unknown rights blocks publication-shaped outputs",
+  "assignment": {
+    "occurrence_ref": "obs-ks-2024-0001",
+    "surface_ref": "kfm://surface/habitat/grassland_30m/v1",
+    "habitat_class": "Temperate_Grassland"
+  },
+  "rights": {
+    "redistribution": "unknown"
+  }
+}

--- a/tests/fixtures/ecology/timeslice/invalid/habitat_assignment_unresolved_evidence_ref.invalid.json
+++ b/tests/fixtures/ecology/timeslice/invalid/habitat_assignment_unresolved_evidence_ref.invalid.json
@@ -1,0 +1,14 @@
+{
+  "fixture_id": "habitat_assignment.unresolved_evidence_ref.invalid",
+  "status": "invalid",
+  "reason": "unresolved evidence ref",
+  "assignment": {
+    "occurrence_ref": "obs-ks-2024-0001",
+    "surface_ref": "kfm://surface/habitat/grassland_30m/v1",
+    "habitat_class": "Temperate_Grassland",
+    "spec_hash": "sha256:7f0fd9cbff9d8b59a44b2b87fa8b9bc251dbd3475da716ea648dbaec4cf0e5b9"
+  },
+  "evidence_refs": [
+    "kfm://evidence/does-not-exist"
+  ]
+}

--- a/tests/fixtures/ecology/timeslice/release_manifest.valid.json
+++ b/tests/fixtures/ecology/timeslice/release_manifest.valid.json
@@ -1,0 +1,14 @@
+{
+  "fixture_id": "release_manifest.timeslice_ks_spring_2024.valid",
+  "fixture_family": "ecology_timeslice",
+  "status": "valid",
+  "manifest_id": "kfm://release/ecology/timeslice/ks/spring-2024/v1",
+  "release_state": "test-only",
+  "artifact_refs": [
+    "timeslice_descriptor.kansas.spring_2024.valid",
+    "habitat_surface_descriptor.grassland_30m.valid",
+    "fauna_occurrence.dickcissel_public_safe.valid",
+    "habitat_assignment.obs-ks-2024-0001.valid",
+    "evidence_bundle.timeslice_ks_spring_2024.valid"
+  ]
+}

--- a/tests/fixtures/ecology/timeslice/timeslice_descriptor.valid.json
+++ b/tests/fixtures/ecology/timeslice/timeslice_descriptor.valid.json
@@ -1,0 +1,17 @@
+{
+  "fixture_id": "timeslice_descriptor.kansas.spring_2024.valid",
+  "fixture_family": "ecology_timeslice",
+  "status": "valid",
+  "timeslice": {
+    "label": "spring-2024",
+    "valid_time": {
+      "start": "2024-03-01T00:00:00Z",
+      "end": "2024-05-31T23:59:59Z"
+    },
+    "as_of": "2024-06-15T00:00:00Z"
+  },
+  "policy": {
+    "classification": "public-safe",
+    "sensitivity": "generalized"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a baseline, public-safe fixture lane for ecology timeslice tests so validators and runtime-proof tests can exercise time-bounded habitat/fauna flows without live source data.
- Include both positive and negative examples to exercise schema/validator and policy fail-closed behavior and to support Evidence Drawer and runtime outcome assertions.

### Description
- Add a set of valid fixtures: `timeslice_descriptor.valid.json`, `habitat_surface_descriptor.valid.json`, `fauna_occurrence_public_safe.valid.json`, `habitat_assignment.valid.json`, `evidence_bundle.valid.json`, and `release_manifest.valid.json` under `tests/fixtures/ecology/timeslice/`.
- Add invalid fixtures to cover fail cases: `fauna_occurrence_missing_precision.invalid.json`, `fauna_occurrence_missing_provenance.invalid.json`, `habitat_assignment_unresolved_evidence_ref.invalid.json`, and `habitat_assignment_unknown_rights.invalid.json` in `invalid/`.
- Add expected runtime outcome fixtures (`runtime_answer.expected.json`, `runtime_abstain.expected.json`, `runtime_deny.expected.json`, `runtime_error.expected.json`) and an Evidence Drawer expected payload (`evidence_drawer_payload.expected.json`) under `expected/`.
- Add `fail/README.md` sibling to document the fail-lane and align directory shape with existing fixture README guidance.

### Testing
- Parsed every JSON file under `tests/fixtures/ecology/timeslice` with a small Python script using the `json` module (`python - <<'PY' ... json.load(...)`), and all files parsed successfully.
- No schema or validator runs were executed in this change; further wiring into repo-native validators and CI is left for follow-up integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25aea93bc832a88f92c7731aa2e75)