### PR TITLE
Update .github README to reflect inspected checkout and concrete inventory

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -9,8 +9,8 @@ created: 2026-04-29
 updated: 2026-04-29
 policy_label: public
 intended_path: .github/README.md
-evidence_mode: CORPUS_ONLY / NO_REPO_EVIDENCE until a mounted checkout is inspected
-truth_posture: CONFIRMED purpose from supplied KFM doctrine; PROPOSED directory contract; UNKNOWN active GitHub platform state
+evidence_mode: REPO_CHECKOUT_INSPECTED (filesystem only) / NO_GITHUB_PLATFORM_SETTINGS_EVIDENCE
+truth_posture: CONFIRMED purpose and on-disk .github inventory; PARTIALLY_VERIFIED workflow files in checkout; UNKNOWN GitHub platform enforcement state
 related:
   - ../README.md
   - ../docs/README.md
@@ -35,8 +35,8 @@ tags:
   - readme
   - control-surface
 notes:
-  - Draft-ready .github/README.md revision.
-  - Current repository inventory, workflow YAML, branch protection, CODEOWNERS coverage, required checks, Actions settings, environment approvals, secrets, deployment rules, and release artifact behavior remain NEEDS_VERIFICATION until checked in the active repository and GitHub platform settings.
+  - Updated against mounted repository checkout on 2026-04-29 (filesystem evidence).
+  - GitHub platform settings (branch protection, required checks, environment approvals, Actions/repo permissions, and secret posture) remain NEEDS_VERIFICATION until checked in GitHub UI/API evidence.
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
@@ -73,17 +73,17 @@ notes:
 ## Read this first
 
 > [!IMPORTANT]
-> This README is **repo-ready guidance**, not proof of active GitHub enforcement. Treat workflow names, owners, badges, branch-protection claims, required checks, environment approvals, secret posture, deployment rules, and platform settings as `NEEDS_VERIFICATION` until checked against the current repository and GitHub settings.
+> This README is **checkout-verified guidance**, but still not proof of active GitHub platform enforcement. Treat workflow names, owners, badges, branch-protection claims, required checks, environment approvals, secret posture, deployment rules, and platform settings as `NEEDS_VERIFICATION` until checked against the current repository and GitHub settings.
 
 | Field | Value |
 |---|---|
 | Status | `draft` |
 | Intended path | `.github/README.md` |
 | Owners | `@bartytime4life` |
-| Evidence mode | `CORPUS_ONLY` / `NO_REPO_EVIDENCE` until a mounted checkout is inspected |
+| Evidence mode | `REPO_CHECKOUT_INSPECTED (filesystem only)` / `NO_GITHUB_PLATFORM_SETTINGS_EVIDENCE` |
 | Authority class | GitHub-native operational control surface |
 | Policy label | `public` |
-| Truth posture | `CONFIRMED` target purpose · `PROPOSED` directory contract · `UNKNOWN` active workflow/platform state |
+| Truth posture | `CONFIRMED` target purpose and on-disk inventory · `PARTIALLY_VERIFIED` workflow files in checkout · `UNKNOWN` platform enforcement state |
 | Public posture | Cite-or-abstain; fail closed where rights, sensitivity, release state, or source terms are unresolved |
 
 | What this document does | What it does not do |
@@ -215,43 +215,68 @@ They should answer **when** and **why** GitHub calls a check. The check itself s
 
 ## Directory map
 
-This is a **proposed verification target**, not a claim that these files are active in the current repository. Replace it with a generated inventory after the real checkout is mounted and inspected.
+This map reflects the mounted repository checkout as inspected on **2026-04-29**. It confirms file presence only; behavior and platform enforcement still require GitHub settings evidence.
 
 ```text
 .github/
-├── README.md                         # this file
-├── CODEOWNERS                        # NEEDS_VERIFICATION
-├── PULL_REQUEST_TEMPLATE.md          # NEEDS_VERIFICATION
-├── SECURITY.md                       # NEEDS_VERIFICATION
-├── dependabot.yml                    # NEEDS_VERIFICATION
+├── README.md
+├── CODEOWNERS
+├── PULL_REQUEST_TEMPLATE.md
+├── SECURITY.md
+├── dependabot.yml
 ├── ISSUE_TEMPLATE/
-│   ├── bug_report.md                 # PROPOSED / NEEDS_VERIFICATION
-│   ├── documentation_drift.md         # PROPOSED / NEEDS_VERIFICATION
-│   ├── source_intake.md               # PROPOSED / NEEDS_VERIFICATION
-│   ├── policy_or_release_gap.md       # PROPOSED / NEEDS_VERIFICATION
-│   └── security_sensitive.md          # PROPOSED / NEEDS_VERIFICATION
+│   ├── README.md
+│   ├── bug_report.md
+│   ├── config.yml
+│   ├── documentation_drift.md
+│   ├── policy_or_release_gap.md
+│   └── source_intake.md
 ├── actions/
-│   └── README.md                      # PROPOSED / GitHub-specific glue only
+│   ├── README.md
+│   ├── metadata-validate/
+│   │   ├── README.md
+│   │   └── action.yml
+│   ├── opa-gate/
+│   │   ├── README.md
+│   │   └── action.yml
+│   ├── provenance-guard/
+│   │   ├── README.md
+│   │   └── action.yml
+│   ├── sbom-produce-and-sign/
+│   │   ├── README.md
+│   │   └── action.yml
+│   └── src/
+│       └── README.md
+├── linters/
+│   ├── README.md
+│   ├── markdownlint.json
+│   └── mlc.config.json
 ├── watchers/
-│   └── README.md                      # PROPOSED / workflow watcher notes only
-├── workflows/
-│   ├── README.md                      # PROPOSED / workflow inventory and gates
-│   ├── verification-baseline.yml      # PROPOSED / read-only baseline checks
-│   ├── docs-lint.yml                  # PROPOSED / delegates to docs tooling
-│   ├── contracts.yml                  # PROPOSED / delegates to contract tooling
-│   ├── policy.yml                     # PROPOSED / delegates to policy tooling
-│   ├── tests.yml                      # PROPOSED / delegates to repo tests
-│   └── release-dry-run.yml            # PROPOSED / no public release by itself
-└── linters/
-    ├── markdownlint.json              # PROPOSED / GitHub-facing config
-    └── mlc.config.json                # PROPOSED / link-check config
+│   ├── README.md
+│   ├── RECEIPT_PROOF_SEPARATION.md
+│   ├── WATCHER_PROPOSAL_TEMPLATE.md
+│   └── templates/
+│       └── watcher-run-receipt.example.yaml
+└── workflows/
+    ├── .gitkeep
+    ├── README.md
+    ├── contracts.yml
+    ├── docs-lint.yml
+    ├── ecology-timeslice.yml
+    ├── ecology-validation.yml
+    ├── evidence-chain.yml
+    ├── policy.yml
+    ├── provenance-gates.yml
+    ├── release-dry-run.yml
+    ├── tests.yml
+    └── verification-baseline.yml
 ```
 
 > [!TIP]
-> After the real repository is mounted, replace the proposed tree with an inventory generated from the checkout.
+> Regenerate this section from the active checkout whenever `.github/` files are added, removed, or moved.
 
 ```bash
-# Read-only inventory. Run from repository root after mounting the real checkout.
+# Read-only inventory from repository root.
 find .github -maxdepth 3 -type f | sort
 ```
 


### PR DESCRIPTION
### Motivation
- Make the `.github/README.md` reflect the actual on-disk control-surface inventory discovered in the mounted repository checkout. 
- Clarify evidence posture so disk-level findings are distinguished from GitHub platform enforcement (branch protection, required checks, environment approvals, etc.).
- Replace a proposed/provisional directory map with a concrete, checkout-verified tree so maintainers have an accurate starting point for verification.

### Description
- Updated the KFM meta block fields `evidence_mode`, `truth_posture`, and `notes` to record `REPO_CHECKOUT_INSPECTED (filesystem only)` and `PARTIALLY_VERIFIED` workflow status. 
- Revised the “Read this first” framing text to say the README is checkout-verified guidance while keeping GitHub platform settings labeled `NEEDS_VERIFICATION`.
- Replaced the prior proposed `Directory map` with a concrete `.github/` tree (issue templates, actions, watchers, linters, and workflows) that matches the mounted checkout and added a suggestion to regenerate the section from the active checkout. 
- Preserved original document structure and formatting and committed the change with the message `Update .github README to match checked-out control surface`.

### Testing
- Ran `find .github -maxdepth 3 -type f | sort` to enumerate files and used the result to build the directory map, which completed successfully. 
- Inspected the file with `sed -n '1,260p' .github/README.md` and displayed parts with `nl -ba .github/README.md | sed -n '1,120p'` to verify content changes, both succeeded. 
- Performed the in-place update script via `python - <<'PY' ... PY` to programmatically patch the README and confirmed it ran without error. 
- Staged and committed the update with `git add .github/README.md` and `git commit -m "Update .github README to match checked-out control surface"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f267ee7c34832a80dcd6584a56b756)