### PR TITLE
docs(connectors): verify owner note and update metadata date

### DIFF
--- a/connectors/README.md
+++ b/connectors/README.md
@@ -6,7 +6,7 @@ version: v1
 status: draft
 owners: @bartytime4life
 created: NEEDS_VERIFICATION__YYYY-MM-DD
-updated: NEEDS_VERIFICATION__YYYY-MM-DD
+updated: 2026-04-29
 policy_label: NEEDS_VERIFICATION__public_safe_or_restricted
 related: [../README.md, ../.github/CODEOWNERS, ../data/README.md, ../data/registry/README.md, ../contracts/README.md, ../schemas/README.md, ../policy/README.md, ../tools/validators/README.md, ../tools/validators/connector_gate/README.md, ./pipelines/README.md, ./pipelines/ecology/README.md]
 tags: [kfm, connectors, source-admission, ingestion, source-descriptor, receipts, fail-closed]
@@ -30,7 +30,7 @@ Source-admission and connector-orientation surface for bringing external source 
 > [!NOTE]
 > **Status:** `experimental` / `draft`  
 > **Intended path:** `connectors/README.md`  
-> **Owners:** `@bartytime4life` by broad fallback unless connector-specific CODEOWNERS verification says otherwise.  
+> **Owners:** `@bartytime4life` (verified against current `.github/CODEOWNERS` broad fallback on 2026-04-29).  
 > **Evidence mode:** README contract and orientation. Active implementation depth remains **NEEDS_VERIFICATION** until checked in the real repository.  
 > **Repo fit:** parent README for source-facing connector stubs, no-network connector fixtures, and pipeline-oriented admission work before governed lifecycle handoff.
 


### PR DESCRIPTION
### Motivation
- Update the `connectors/README.md` metadata to record the verification date and make the owner note explicit about verification against the repository `CODEOWNERS` fallback.

### Description
- Set the meta block `updated` field to `2026-04-29` and change the owners line to: `@bartytime4life (verified against current .github/CODEOWNERS broad fallback on 2026-04-29)`.

### Testing
- Ran repository and content checks including `git rev-parse --show-toplevel`, `find connectors -maxdepth 4`, existence checks for linked docs, and a Python consistency check for the meta block and `related` paths, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f286809270832a92a35bcaaadd00b5)