### PR TITLE
Add governed API fixtures and boundary-focused tests

### DIFF
--- a/tests/governed_api/fixtures/README.md
+++ b/tests/governed_api/fixtures/README.md
@@ -1,0 +1,7 @@
+# Governed API fixtures
+
+Small, deterministic JSON fixtures used by governed API boundary tests.
+
+- `evidence_ref.valid.json` models a resolvable evidence reference.
+- `evidence_ref.missing_bundle.invalid.json` models an unresolved reference.
+- `runtime_*.valid.json` model finite runtime envelope outcomes.

--- a/tests/governed_api/fixtures/evidence_ref.missing_bundle.invalid.json
+++ b/tests/governed_api/fixtures/evidence_ref.missing_bundle.invalid.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "v1",
+  "object_type": "EvidenceRef",
+  "evidence_ref": "kfm://evidence/ref/ecology/missing-bundle",
+  "resolved": false
+}

--- a/tests/governed_api/fixtures/evidence_ref.valid.json
+++ b/tests/governed_api/fixtures/evidence_ref.valid.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "v1",
+  "object_type": "EvidenceRef",
+  "evidence_ref": "kfm://evidence/ref/ecology/no-network-fixture",
+  "bundle_id": "kfm://evidence/ecology/example-pass-timeslice",
+  "resolved": true
+}

--- a/tests/governed_api/fixtures/runtime_abstain.valid.json
+++ b/tests/governed_api/fixtures/runtime_abstain.valid.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "v1",
+  "object_type": "RuntimeResponseEnvelope",
+  "outcome": "ABSTAIN",
+  "request_id": "req-abstain-001",
+  "reasons": ["insufficient_evidence"]
+}

--- a/tests/governed_api/fixtures/runtime_answer.valid.json
+++ b/tests/governed_api/fixtures/runtime_answer.valid.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "v1",
+  "object_type": "RuntimeResponseEnvelope",
+  "outcome": "ANSWER",
+  "request_id": "req-answer-001",
+  "evidence_bundle_ref": "kfm://evidence/ecology/example-pass-timeslice"
+}

--- a/tests/governed_api/fixtures/runtime_deny.valid.json
+++ b/tests/governed_api/fixtures/runtime_deny.valid.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "v1",
+  "object_type": "RuntimeResponseEnvelope",
+  "outcome": "DENY",
+  "request_id": "req-deny-001",
+  "policy_ref": "policy/ecology/publication.rego",
+  "reasons": ["restricted_sensitivity"]
+}

--- a/tests/governed_api/fixtures/runtime_error.valid.json
+++ b/tests/governed_api/fixtures/runtime_error.valid.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "v1",
+  "object_type": "RuntimeResponseEnvelope",
+  "outcome": "ERROR",
+  "request_id": "req-error-001",
+  "message": "Required artifact is missing: evidence_bundle.json"
+}

--- a/tests/governed_api/test_evidence_bundle_resolution_boundary.py
+++ b/tests/governed_api/test_evidence_bundle_resolution_boundary.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_evidence_ref_fixture_marks_resolved_bundle() -> None:
+    evidence_ref = load_fixture("evidence_ref.valid.json")
+
+    assert evidence_ref["object_type"] == "EvidenceRef"
+    assert evidence_ref["resolved"] is True
+    assert evidence_ref["bundle_id"].startswith("kfm://evidence/")
+
+
+def test_evidence_ref_missing_bundle_fixture_is_invalid_for_resolution() -> None:
+    evidence_ref = load_fixture("evidence_ref.missing_bundle.invalid.json")
+
+    assert evidence_ref["object_type"] == "EvidenceRef"
+    assert evidence_ref["resolved"] is False
+    assert "bundle_id" not in evidence_ref

--- a/tests/governed_api/test_governed_api_app_registration.py
+++ b/tests/governed_api/test_governed_api_app_registration.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from apps.governed_api.server import app
+
+
+def test_governed_api_routes_registered() -> None:
+    routes = {route.path for route in app.routes}
+
+    assert "/healthz" in routes
+    assert "/ecology/timeslices/{id}" in routes
+    assert "/ecology/evidence/{bundle_id:path}" in routes
+    assert "/ecology/catalog/stac" in routes

--- a/tests/governed_api/test_governed_api_no_direct_model_client.py
+++ b/tests/governed_api/test_governed_api_no_direct_model_client.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+DIRECT_MODEL_TOKENS = (
+    "openai",
+    "anthropic",
+    "ollama",
+    "localhost:11434",
+    "/v1/chat",
+    "/v1/responses",
+)
+
+
+def test_governed_api_server_has_no_direct_model_client_references() -> None:
+    server_source = Path("apps/governed_api/server.py").read_text(encoding="utf-8").lower()
+
+    assert all(token not in server_source for token in DIRECT_MODEL_TOKENS)

--- a/tests/governed_api/test_governed_api_no_raw_store_bypass.py
+++ b/tests/governed_api/test_governed_api_no_raw_store_bypass.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+FORBIDDEN_PATH_TOKENS = (
+    "data/raw",
+    "/raw/",
+    "data/work",
+    "/work/",
+    "data/quarantine",
+    "/quarantine/",
+)
+
+
+def test_governed_api_server_avoids_raw_work_quarantine_paths() -> None:
+    server_source = Path("apps/governed_api/server.py").read_text(encoding="utf-8").lower()
+
+    assert all(token not in server_source for token in FORBIDDEN_PATH_TOKENS)

--- a/tests/governed_api/test_policy_denial_visible_at_boundary.py
+++ b/tests/governed_api/test_policy_denial_visible_at_boundary.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.governed_api.server import app
+from tests.governed_api.test_ecology_api import seed_public_safe_artifacts, write_json
+
+
+@pytest.fixture()
+def artifact_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "published" / "ecology" / "dry-run"
+    root.mkdir(parents=True)
+
+    monkeypatch.setenv("KFM_ECOLOGY_ARTIFACT_ROOT", str(root))
+
+    import apps.governed_api.server as server
+
+    monkeypatch.setattr(server, "DEFAULT_ARTIFACT_ROOT", root)
+    return root
+
+
+@pytest.fixture()
+def client(artifact_root: Path) -> TestClient:
+    return TestClient(app)
+
+
+def test_policy_denial_visible_at_boundary(client: TestClient, artifact_root: Path) -> None:
+    seed_public_safe_artifacts(artifact_root)
+
+    receipt_path = artifact_root / "run_receipt.json"
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    payload["policy_results"][0]["result"] = "deny"
+    payload["policy_results"][0]["reasons"] = ["classification_policy_block"]
+    write_json(receipt_path, payload)
+
+    response = client.get("/ecology/timeslices/example-pass")
+
+    assert response.status_code == 451
+    detail = response.json()["detail"]
+    assert detail["outcome"] == "DENY"
+    assert "classification_policy_block" in detail["reasons"]
+    assert detail["policy_ref"] == "policy/ecology/publication.rego"

--- a/tests/governed_api/test_release_sidecar_visibility.py
+++ b/tests/governed_api/test_release_sidecar_visibility.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.governed_api.server import app
+from tests.governed_api.test_ecology_api import seed_public_safe_artifacts
+
+
+@pytest.fixture()
+def artifact_root(tmp_path, monkeypatch):
+    root = tmp_path / "published" / "ecology" / "dry-run"
+    root.mkdir(parents=True)
+
+    monkeypatch.setenv("KFM_ECOLOGY_ARTIFACT_ROOT", str(root))
+
+    import apps.governed_api.server as server
+
+    monkeypatch.setattr(server, "DEFAULT_ARTIFACT_ROOT", root)
+    return root
+
+
+@pytest.fixture()
+def client(artifact_root):
+    return TestClient(app)
+
+
+def test_release_sidecar_references_visible_in_public_timeslice_response(client, artifact_root) -> None:
+    seed_public_safe_artifacts(artifact_root)
+
+    response = client.get("/ecology/timeslices/example-pass")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["evidence_bundle_ref"].startswith("kfm://evidence/")
+    assert payload["run_receipt_ref"].startswith("kfm://receipt/run/")
+    assert payload["promotion"]["decision_ref"].startswith("kfm://promotion/")

--- a/tests/governed_api/test_runtime_response_envelope_outcomes.py
+++ b/tests/governed_api/test_runtime_response_envelope_outcomes.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+VALID_OUTCOMES = {"ANSWER", "ABSTAIN", "DENY", "ERROR"}
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_runtime_response_envelope_outcome_fixtures_are_finite() -> None:
+    fixture_names = (
+        "runtime_answer.valid.json",
+        "runtime_abstain.valid.json",
+        "runtime_deny.valid.json",
+        "runtime_error.valid.json",
+    )
+
+    payloads = [load_fixture(name) for name in fixture_names]
+
+    assert {payload["outcome"] for payload in payloads} == VALID_OUTCOMES
+    for payload in payloads:
+        assert payload["object_type"] == "RuntimeResponseEnvelope"
+        assert payload["schema_version"] == "v1"
+        assert payload["request_id"].startswith("req-")


### PR DESCRIPTION
### Motivation

- Provide a focused verification lane for governed API boundary behavior to prove evidence resolution, policy mediation, finite runtime envelopes, and no-bypass public response discipline.
- Supply small, deterministic fixtures to make boundary assertions deterministic and reviewable without relying on production artifacts.
- Add compact tests that exercise route registration, release/correction sidecars, policy denial visibility, and source-level no-bypass/no-direct-model-client guarantees.

### Description

- Add `tests/governed_api/fixtures/` with deterministic JSON fixtures: `evidence_ref.valid.json`, `evidence_ref.missing_bundle.invalid.json`, and `runtime_*.valid.json` for `ANSWER`, `ABSTAIN`, `DENY`, and `ERROR` envelopes.
- Add boundary-focused tests: `test_governed_api_app_registration.py`, `test_governed_api_no_direct_model_client.py`, and `test_governed_api_no_raw_store_bypass.py` to assert route registration and absence of direct model/client and raw/work/quarantine path tokens in the server source.
- Add fixture-backed behavior tests: `test_evidence_bundle_resolution_boundary.py`, `test_policy_denial_visible_at_boundary.py`, `test_release_sidecar_visibility.py`, and `test_runtime_response_envelope_outcomes.py` to assert evidence resolution semantics, policy-deny visibility at the boundary, release sidecar references, and finite runtime outcomes.

### Testing

- Ran `python -m pytest tests/governed_api -q` to validate the new test suite and collection, and it failed during collection because the runtime environment is missing the `fastapi` dependency (ModuleNotFoundError: No module named 'fastapi').
- No further automated tests were executed in this environment due to the missing dependency preventing test collection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b5135f78832aa32d8f9214d65947)