### PR TITLE
Add governed ecology layer manifest integration and OpenAPI contract

### DIFF
--- a/apps/governed_api/openapi/ecology.yaml
+++ b/apps/governed_api/openapi/ecology.yaml
@@ -15,6 +15,41 @@ tags:
     description: Governed ecology publication surfaces
 
 paths:
+  /ecology/layers/{id}:
+    get:
+      tags: [Ecology]
+      operationId: getEcologyLayerManifest
+      summary: Get a governed ecology layer manifest
+      description: >
+        Returns a public-safe layer manifest for a promoted ecology layer.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Layer identifier suffix.
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        "200":
+          description: Governed ecology layer manifest.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EcologyLayerManifest"
+        "404":
+          description: Layer manifest not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "451":
+          description: Denied by governance policy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
   /ecology/timeslices/{id}:
     get:
       tags: [Ecology]
@@ -110,6 +145,96 @@ paths:
 
 components:
   schemas:
+    EcologyLayerManifest:
+      type: object
+      additionalProperties: false
+      required:
+        - schema_version
+        - object_type
+        - layer_id
+        - title
+        - source_type
+        - tiles_url
+        - source_layer
+        - stac_catalog_ref
+        - stac_collection_ref
+        - evidence_bundle_ref
+        - promotion_decision_ref
+        - run_receipt_ref
+        - minzoom
+        - maxzoom
+        - allowed_fields
+        - public_safe
+      properties:
+        schema_version:
+          type: string
+          const: v1
+        object_type:
+          type: string
+          const: EcologyLayerManifest
+        layer_id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        source_type:
+          type: string
+          enum: [vector, raster, raster-dem, geojson]
+        tiles_url:
+          type: string
+        source_layer:
+          type: string
+        stac_catalog_ref:
+          type: string
+        stac_collection_ref:
+          type: string
+        stac_item_ref:
+          type: string
+        evidence_bundle_ref:
+          type: string
+        promotion_decision_ref:
+          type: string
+        run_receipt_ref:
+          type: string
+        minzoom:
+          type: integer
+          minimum: 0
+        maxzoom:
+          type: integer
+          minimum: 0
+        bounds:
+          type: array
+          minItems: 4
+          maxItems: 4
+          items:
+            type: number
+        time_start:
+          type: string
+          format: date-time
+        time_end:
+          type: string
+          format: date-time
+        allowed_fields:
+          type: array
+          items:
+            type: string
+        public_safe:
+          type: boolean
+          const: true
+        sensitivity:
+          type: string
+          enum: [public, generalize]
+        rights_status:
+          type: string
+          enum: [public, open]
+        policy_label:
+          type: string
+        limitations:
+          type: array
+          items:
+            type: string
+
     EcologyTimesliceResponse:
       type: object
       additionalProperties: false

--- a/apps/web/src/ecology/EcologyMap.tsx
+++ b/apps/web/src/ecology/EcologyMap.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import { fetchEcologyStacCatalog } from "./stac";
+import { fetchEcologyLayerManifest } from "./layerManifest";
 import {
   ECOLOGY_LAYER_ID,
   ECOLOGY_SOURCE_ID,
@@ -12,16 +12,16 @@ import {
 
 type EcologyMapProps = {
   apiBase?: string;
-  tilesUrl?: string;
+  layerId?: string;
 };
 
 export function EcologyMap({
   apiBase = "/api",
-  tilesUrl = "https://example.invalid/tiles/{z}/{x}/{y}.pbf"
+  layerId = "example-pass"
 }: EcologyMapProps) {
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
-  const [status, setStatus] = useState("Loading governed ecology catalog...");
+  const [status, setStatus] = useState("Loading governed ecology layer...");
 
   useEffect(() => {
     if (!mapContainerRef.current || mapRef.current) return;
@@ -54,21 +54,27 @@ export function EcologyMap({
 
     map.on("load", async () => {
       try {
-        const catalog = await fetchEcologyStacCatalog(apiBase);
-
-        if (catalog.type !== "Catalog") {
-          throw new Error("Governed ecology STAC response was not a Catalog");
-        }
+        const manifest = await fetchEcologyLayerManifest(layerId, apiBase);
 
         if (!map.getSource(ECOLOGY_SOURCE_ID)) {
-          map.addSource(ECOLOGY_SOURCE_ID, buildEcologyVectorSource(tilesUrl));
+          map.addSource(ECOLOGY_SOURCE_ID, buildEcologyVectorSource(manifest));
         }
 
         if (!map.getLayer(ECOLOGY_LAYER_ID)) {
-          map.addLayer(buildEcologyFillLayer());
+          map.addLayer(buildEcologyFillLayer(manifest));
         }
 
-        setStatus(`Loaded ${catalog.title}`);
+        if (manifest.bounds) {
+          map.fitBounds(
+            [
+              [manifest.bounds[0], manifest.bounds[1]],
+              [manifest.bounds[2], manifest.bounds[3]]
+            ],
+            { padding: 32, duration: 0 }
+          );
+        }
+
+        setStatus(`Loaded governed layer: ${manifest.title}`);
       } catch (error) {
         setStatus(error instanceof Error ? error.message : "Failed to load ecology layer");
       }
@@ -78,7 +84,7 @@ export function EcologyMap({
       map.remove();
       mapRef.current = null;
     };
-  }, [apiBase, tilesUrl]);
+  }, [apiBase, layerId]);
 
   return (
     <section>

--- a/apps/web/src/ecology/ecologyLayer.ts
+++ b/apps/web/src/ecology/ecologyLayer.ts
@@ -1,23 +1,35 @@
+import type { EcologyLayerManifest } from "./layerManifest";
+
 export const ECOLOGY_SOURCE_ID = "kfm-ecology-timeslice-source";
 export const ECOLOGY_LAYER_ID = "kfm-ecology-timeslice-layer";
 
-export function buildEcologyVectorSource(tilesUrl: string) {
+export function buildEcologyVectorSource(manifest: EcologyLayerManifest) {
   return {
     type: "vector" as const,
-    tiles: [tilesUrl],
-    minzoom: 0,
-    maxzoom: 14
+    tiles: [manifest.tiles_url],
+    minzoom: manifest.minzoom,
+    maxzoom: manifest.maxzoom
   };
 }
 
-export function buildEcologyFillLayer() {
+export function buildEcologyFillLayer(manifest: EcologyLayerManifest) {
   return {
     id: ECOLOGY_LAYER_ID,
     type: "fill" as const,
     source: ECOLOGY_SOURCE_ID,
-    "source-layer": "ecology",
+    "source-layer": manifest.source_layer,
+    minzoom: manifest.minzoom,
+    maxzoom: manifest.maxzoom,
     paint: {
       "fill-opacity": 0.55
+    },
+    metadata: {
+      "kfm:layer_id": manifest.layer_id,
+      "kfm:evidence_bundle_ref": manifest.evidence_bundle_ref,
+      "kfm:promotion_decision_ref": manifest.promotion_decision_ref,
+      "kfm:run_receipt_ref": manifest.run_receipt_ref,
+      "kfm:allowed_fields": manifest.allowed_fields,
+      "kfm:public_safe": manifest.public_safe
     }
   };
 }

--- a/apps/web/src/ecology/layerManifest.ts
+++ b/apps/web/src/ecology/layerManifest.ts
@@ -1,0 +1,50 @@
+export type EcologyLayerManifest = {
+  schema_version: "v1";
+  object_type: "EcologyLayerManifest";
+  layer_id: string;
+  title: string;
+  description?: string;
+  source_type: "vector" | "raster" | "raster-dem" | "geojson";
+  tiles_url: string;
+  source_layer: string;
+  stac_catalog_ref: string;
+  stac_collection_ref: string;
+  stac_item_ref?: string;
+  evidence_bundle_ref: string;
+  promotion_decision_ref: string;
+  run_receipt_ref: string;
+  minzoom: number;
+  maxzoom: number;
+  bounds?: [number, number, number, number];
+  time_start?: string;
+  time_end?: string;
+  allowed_fields: string[];
+  public_safe: true;
+  sensitivity?: "public" | "generalize";
+  rights_status?: "public" | "open";
+  policy_label?: string;
+  limitations?: string[];
+};
+
+export async function fetchEcologyLayerManifest(
+  id = "example-pass",
+  apiBase = "/api"
+): Promise<EcologyLayerManifest> {
+  const response = await fetch(`${apiBase}/ecology/layers/${id}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load ecology layer manifest: ${response.status}`);
+  }
+
+  const manifest = (await response.json()) as EcologyLayerManifest;
+
+  if (manifest.object_type !== "EcologyLayerManifest") {
+    throw new Error("Invalid ecology layer manifest response");
+  }
+
+  if (manifest.public_safe !== true) {
+    throw new Error("Ecology layer manifest is not public-safe");
+  }
+
+  return manifest;
+}


### PR DESCRIPTION
### Motivation
- Provide a typed client and guarded loader so the web app can fetch published, public-safe ecology layer manifests and use them to drive map rendering.
- Move from a STAC-catalog-only flow to manifest-driven layers so tiles URL, source layer, zoom ranges, bounds and governance metadata are supplied by the server.
- Keep the OpenAPI contract in sync with server behavior by adding a route and schema for layer manifests.

### Description
- Add `apps/web/src/ecology/layerManifest.ts` which defines `EcologyLayerManifest` and exports `fetchEcologyLayerManifest` that fetches `GET /ecology/layers/{id}` and enforces `object_type` and `public_safe` guards.
- Update `apps/web/src/ecology/ecologyLayer.ts` to accept an `EcologyLayerManifest`, build the vector source from `tiles_url` and zooms, and attach governance metadata to the fill layer.
- Update `apps/web/src/ecology/EcologyMap.tsx` to fetch the layer manifest (prop `layerId`), create the source/layer from the manifest, fit map bounds when `bounds` are present, and update status messaging.
- Extend `apps/governed_api/openapi/ecology.yaml` with a `GET /ecology/layers/{id}` path and an `EcologyLayerManifest` schema to align the OpenAPI spec with the new endpoint.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b5f6f75c832a96b5ae9e238b6fd5)