### PR TITLE
Align ecology OpenAPI layer endpoint and manifest schema

### DIFF
--- a/apps/governed_api/openapi/ecology.yaml
+++ b/apps/governed_api/openapi/ecology.yaml
@@ -18,33 +18,31 @@ paths:
   /ecology/layers/{id}:
     get:
       tags: [Ecology]
-      operationId: getEcologyLayerManifest
+      operationId: getEcologyLayer
       summary: Get a governed ecology layer manifest
       description: >
-        Returns a public-safe layer manifest for a promoted ecology layer.
+        Returns a public-safe EcologyLayerManifest used to configure MapLibre layers.
       parameters:
         - name: id
           in: path
           required: true
-          description: Layer identifier suffix.
           schema:
             type: string
-            minLength: 1
       responses:
         "200":
-          description: Governed ecology layer manifest.
+          description: Ecology layer manifest
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/EcologyLayerManifest"
         "404":
-          description: Layer manifest not found.
+          description: Layer not found
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
         "451":
-          description: Denied by governance policy.
+          description: Denied by governance policy
           content:
             application/json:
               schema:
@@ -199,10 +197,8 @@ components:
           type: string
         minzoom:
           type: integer
-          minimum: 0
         maxzoom:
           type: integer
-          minimum: 0
         bounds:
           type: array
           minItems: 4
@@ -224,10 +220,8 @@ components:
           const: true
         sensitivity:
           type: string
-          enum: [public, generalize]
         rights_status:
           type: string
-          enum: [public, open]
         policy_label:
           type: string
         limitations:


### PR DESCRIPTION
### Motivation
- Keep the public OpenAPI contract in sync with the server's new governed ecology layer endpoint so MapLibre and clients can consume the manifest reliably.
- Provide a MapLibre-facing `EcologyLayerManifest` schema that matches the fields the server publishes and the UI expects.
- Relax overly strict schema constraints that previously mismatched the runtime contract.

### Description
- Renamed the `GET /ecology/layers/{id}` operationId to `getEcologyLayer` and updated the summary and description to reference `EcologyLayerManifest` for MapLibre usage.
- Simplified the path parameter for `id` to a required `string` and removed the `minLength` constraint and extra description.
- Aligned response descriptions for the `200`, `404`, and `451` responses to match the server wording and referenced `#/components/schemas/EcologyLayerManifest` for `200`.
- Updated the `EcologyLayerManifest` schema under `components.schemas` to remove `minimum: 0` from `minzoom`/`maxzoom` and to remove enum constraints from `sensitivity` and `rights_status`, while keeping the required fields and overall shape.

### Testing
- Verified the OpenAPI delta with `git diff -- apps/governed_api/openapi/ecology.yaml`, which showed the intended changes and succeeded.
- Inspected the updated file contents with `nl -ba apps/governed_api/openapi/ecology.yaml | sed -n '14,90p;130,245p'` to confirm the operation and schema sections were updated and that check succeeded.
- Confirmed the modified `apps/governed_api/openapi/ecology.yaml` was written to disk and reflects the updated contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b6dc1d1c832a81316a0c611b87b3)