### PR TITLE
Add ecology module README scaffolding under apps/web/src/ecology

### DIFF
--- a/apps/web/src/ecology/__tests__/README.md
+++ b/apps/web/src/ecology/__tests__/README.md
@@ -1,0 +1,3 @@
+# Ecology UI Tests
+
+UI contract and no-bypass tests.

--- a/apps/web/src/ecology/api/README.md
+++ b/apps/web/src/ecology/api/README.md
@@ -1,0 +1,3 @@
+# Ecology API
+
+Governed API client wrappers only.

--- a/apps/web/src/ecology/components/README.md
+++ b/apps/web/src/ecology/components/README.md
@@ -1,0 +1,3 @@
+# Ecology Components
+
+Local ecology presentation components.

--- a/apps/web/src/ecology/components/evidence/README.md
+++ b/apps/web/src/ecology/components/evidence/README.md
@@ -1,0 +1,3 @@
+# Ecology Evidence Components
+
+Evidence Drawer ecology renderers.

--- a/apps/web/src/ecology/components/focus/README.md
+++ b/apps/web/src/ecology/components/focus/README.md
@@ -1,0 +1,3 @@
+# Ecology Focus Components
+
+Focus outcome renderers/copy maps.

--- a/apps/web/src/ecology/fixtures/README.md
+++ b/apps/web/src/ecology/fixtures/README.md
@@ -1,0 +1,3 @@
+# Ecology Fixtures
+
+Public-safe UI fixtures.

--- a/apps/web/src/ecology/layers/README.md
+++ b/apps/web/src/ecology/layers/README.md
@@ -1,0 +1,3 @@
+# Ecology Layers
+
+Ecology layer descriptors/adapters.

--- a/apps/web/src/ecology/types/README.md
+++ b/apps/web/src/ecology/types/README.md
@@ -1,0 +1,3 @@
+# Ecology Types
+
+UI-local DTO mirrors/type guards.


### PR DESCRIPTION
### Motivation
- Provide a local "ecology" feature-area scaffold under `apps/web/src/ecology` for API wrappers, layer adapters, presentation components, DTO types, public fixtures, and UI tests.
- Add concise `README.md` placeholders to each requested subdirectory to document intended usage boundaries and keep the interface contract explicit.

### Description
- Created the directories `apps/web/src/ecology/api`, `apps/web/src/ecology/layers`, `apps/web/src/ecology/components/evidence`, `apps/web/src/ecology/components/focus`, `apps/web/src/ecology/types`, `apps/web/src/ecology/fixtures`, and `apps/web/src/ecology/__tests__` and added `README.md` files in each.
- Each `README.md` contains a short purpose statement such as "Governed API client wrappers only" or "UI contract and no-bypass tests" to guide future implementation.
- Files added are `apps/web/src/ecology/api/README.md`, `apps/web/src/ecology/layers/README.md`, `apps/web/src/ecology/components/README.md`, `apps/web/src/ecology/components/evidence/README.md`, `apps/web/src/ecology/components/focus/README.md`, `apps/web/src/ecology/types/README.md`, `apps/web/src/ecology/fixtures/README.md`, and `apps/web/src/ecology/__tests__/README.md`.

### Testing
- Validated file presence with `git status --short` which listed the created paths.
- Verified file contents by printing them with `nl -ba` for each new `README.md` and observed the expected placeholder text.
- The directory and file creation commands executed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bf0b061c832a9822b8c734920645)