### PR TITLE
Build apps/web/src governed architecture scaffold

### DIFF
--- a/apps/web/src/__tests__/architecture-smoke.test.js
+++ b/apps/web/src/__tests__/architecture-smoke.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { createGovernedApiClient } from "../api/governedClient.js";
+import { EVIDENCE_DRAWER_FIXTURE } from "../fixtures/publicSafeFixtures.js";
+import { releasedLayerDescriptors } from "../map/layers/fromGovernedManifest.js";
+import { createViewSessionState } from "../state/viewSessionState.js";
+
+describe("web architecture scaffolding", () => {
+  it("exposes a governed API client surface", () => {
+    const client = createGovernedApiClient();
+    expect(typeof client.getLayerManifest).toBe("function");
+    expect(typeof client.getEvidenceDrawerPayload).toBe("function");
+    expect(typeof client.getFocusOutcome).toBe("function");
+  });
+
+  it("filters map layers to released-only descriptors", () => {
+    const descriptors = releasedLayerDescriptors({
+      layers: [
+        { id: "one", type: "fill", source: { kind: "released" } },
+        { id: "two", type: "line", source: { kind: "work" } }
+      ]
+    });
+    expect(descriptors).toHaveLength(1);
+    expect(descriptors[0].id).toBe("one");
+  });
+
+  it("keeps fixture payload public-safe", () => {
+    expect(EVIDENCE_DRAWER_FIXTURE.claimId).toContain("claim.");
+    expect(EVIDENCE_DRAWER_FIXTURE.sources).toHaveLength(1);
+  });
+
+  it("initializes ephemeral view state", () => {
+    const state = createViewSessionState();
+    expect(state.evidenceDrawerOpen).toBe(false);
+  });
+});

--- a/apps/web/src/api/governedClient.js
+++ b/apps/web/src/api/governedClient.js
@@ -1,0 +1,26 @@
+const JSON_HEADERS = { "content-type": "application/json" };
+
+export function createGovernedApiClient({ baseUrl = "/api" } = {}) {
+  async function request(path, init = {}) {
+    const response = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: { ...JSON_HEADERS, ...(init.headers ?? {}) }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Governed API request failed: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  return {
+    getLayerManifest: () => request("/ecology/layer-manifest"),
+    getEvidenceDrawerPayload: (claimId) => request(`/ecology/evidence/${encodeURIComponent(claimId)}`),
+    getFocusOutcome: (body) =>
+      request("/ecology/focus", {
+        method: "POST",
+        body: JSON.stringify(body)
+      })
+  };
+}

--- a/apps/web/src/app/bootstrap.js
+++ b/apps/web/src/app/bootstrap.js
@@ -1,0 +1,10 @@
+import { createShellFrame } from "../shell/shell-frame.js";
+
+export function mountApp(root = document.getElementById("app")) {
+  if (!root) {
+    throw new Error("Expected #app root to exist.");
+  }
+
+  root.replaceChildren(createShellFrame());
+  return root;
+}

--- a/apps/web/src/components/accessibility/keyboardPaths.js
+++ b/apps/web/src/components/accessibility/keyboardPaths.js
@@ -1,0 +1,4 @@
+export function nextFocusableIndex(current, count) {
+  if (count <= 0) return -1;
+  return (current + 1) % count;
+}

--- a/apps/web/src/components/evidence/EvidenceDrawerCard.js
+++ b/apps/web/src/components/evidence/EvidenceDrawerCard.js
@@ -1,0 +1,8 @@
+export function renderEvidenceDrawerCard(payload) {
+  return {
+    claimId: payload.claimId,
+    claimText: payload.claimText,
+    sources: payload.sources ?? [],
+    trustState: payload.trustState ?? "unknown"
+  };
+}

--- a/apps/web/src/components/focus/FocusOutcomePanel.js
+++ b/apps/web/src/components/focus/FocusOutcomePanel.js
@@ -1,0 +1,3 @@
+export function toFiniteFocusOutcome(runtimeResponse) {
+  return runtimeResponse?.outcome ?? "ABSTAIN";
+}

--- a/apps/web/src/components/review/reviewVisibility.js
+++ b/apps/web/src/components/review/reviewVisibility.js
@@ -1,0 +1,3 @@
+export function canViewStewardDetails(role) {
+  return role === "steward" || role === "reviewer";
+}

--- a/apps/web/src/components/story/storyPreview.js
+++ b/apps/web/src/components/story/storyPreview.js
@@ -1,0 +1,7 @@
+export function summarizeStoryPreview(story) {
+  return {
+    title: story.title,
+    citationCount: story.citations?.length ?? 0,
+    hasReleaseContext: Boolean(story.release)
+  };
+}

--- a/apps/web/src/components/trust-state/trustStateBadges.js
+++ b/apps/web/src/components/trust-state/trustStateBadges.js
@@ -1,0 +1,5 @@
+export const TRUST_STATES = ["ANSWER", "ABSTAIN", "DENY", "ERROR", "STALE", "REDACTED", "SUPERSEDED"];
+
+export function isKnownTrustState(value) {
+  return TRUST_STATES.includes(value);
+}

--- a/apps/web/src/fixtures/publicSafeFixtures.js
+++ b/apps/web/src/fixtures/publicSafeFixtures.js
@@ -1,0 +1,6 @@
+export const EVIDENCE_DRAWER_FIXTURE = {
+  claimId: "claim.demo-001",
+  claimText: "Habitat suitability increased in the selected region.",
+  sources: [{ id: "source.demo-001", title: "Synthetic release-safe source" }],
+  trustState: "ANSWER"
+};

--- a/apps/web/src/main.js
+++ b/apps/web/src/main.js
@@ -1,9 +1,3 @@
-import { createShellFrame } from "./shell/shell-frame.js";
+import { mountApp } from "./app/bootstrap.js";
 
-const appRoot = document.getElementById("app");
-
-if (!appRoot) {
-  throw new Error("Expected #app root to exist.");
-}
-
-appRoot.appendChild(createShellFrame());
+mountApp();

--- a/apps/web/src/map/adapters/maplibreAdapter.js
+++ b/apps/web/src/map/adapters/maplibreAdapter.js
@@ -1,0 +1,9 @@
+export function toMaplibreLayerDescriptor(layerBinding) {
+  return {
+    id: layerBinding.id,
+    type: layerBinding.type,
+    source: layerBinding.source,
+    paint: layerBinding.paint ?? {},
+    layout: layerBinding.layout ?? {}
+  };
+}

--- a/apps/web/src/map/layers/fromGovernedManifest.js
+++ b/apps/web/src/map/layers/fromGovernedManifest.js
@@ -1,0 +1,7 @@
+import { toMaplibreLayerDescriptor } from "../adapters/maplibreAdapter.js";
+
+export function releasedLayerDescriptors(manifest) {
+  return (manifest.layers ?? [])
+    .filter((layer) => layer.source?.kind === "released")
+    .map((layer) => toMaplibreLayerDescriptor(layer));
+}

--- a/apps/web/src/map/styles/publicSafeStyle.js
+++ b/apps/web/src/map/styles/publicSafeStyle.js
@@ -1,0 +1,10 @@
+export const publicSafeStyle = {
+  version: 8,
+  name: "kfm-public-safe",
+  sources: {},
+  layers: [],
+  metadata: {
+    trustBoundary: "public-safe",
+    policy: "governed-api-only"
+  }
+};

--- a/apps/web/src/map/time/viewTimeState.js
+++ b/apps/web/src/map/time/viewTimeState.js
@@ -1,0 +1,8 @@
+export function buildViewTimeState({ eventTime, observedTime, releaseTime, selectedTime }) {
+  return {
+    eventTime: eventTime ?? null,
+    observedTime: observedTime ?? null,
+    releaseTime: releaseTime ?? null,
+    selectedTime: selectedTime ?? releaseTime ?? observedTime ?? eventTime ?? null
+  };
+}

--- a/apps/web/src/state/viewSessionState.js
+++ b/apps/web/src/state/viewSessionState.js
@@ -1,0 +1,8 @@
+export function createViewSessionState() {
+  return {
+    selectedLayerId: null,
+    selectedFeatureId: null,
+    evidenceDrawerOpen: false,
+    focusModeOpen: false
+  };
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal, boundary-focused scaffold for the KFM web shell that enforces the proposed responsibilities for a MapLibre-first, governed-API-driven UI (app bootstrap, map adapters, evidence drawer, focus mode, trust-state, etc.).
- Establish a safe starting point for UI development with public-safe fixtures and small domain helpers so downstream work can implement rendering and role-gated behavior without leaking canonical or raw stores.

### Description

- Added an app bootstrap entrypoint (`apps/web/src/app/bootstrap.js`) and updated `apps/web/src/main.js` to mount the shell through the new boundary.  
- Implemented a lightweight governed API client at `apps/web/src/api/governedClient.js` exposing `getLayerManifest`, `getEvidenceDrawerPayload`, and `getFocusOutcome`.  
- Added MapLibre-related helpers under `apps/web/src/map/`: adapter (`adapters/maplibreAdapter.js`), manifest → descriptors (`layers/fromGovernedManifest.js`), public-safe style (`styles/publicSafeStyle.js`), and time state helper (`time/viewTimeState.js`).  
- Introduced small, focused component utilities under `apps/web/src/components/` (evidence, focus, trust-state, review, story, accessibility), an ephemeral UI state factory at `apps/web/src/state/viewSessionState.js`, a public-safe fixture at `apps/web/src/fixtures/publicSafeFixtures.js`, and a smoke test suite at `apps/web/src/__tests__/architecture-smoke.test.js` that verifies API surface shape, released-layer filtering, fixture posture, and ephemeral session defaults.

### Testing

- Ran syntax checks with `npm run check:syntax` in `apps/web` and it succeeded.  
- Attempted to run unit tests with `npm test` in `apps/web` but the run failed in this environment because the `vitest` binary is not installed (`sh: 1: vitest: not found`).  
- The repository now includes a smoke test (`apps/web/src/__tests__/architecture-smoke.test.js`) to validate the scaffold when dev dependencies are installed in a developer or CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ca8122c8832ab2f00e8833ffd178)