### PR TITLE
docs: add suggested follow-up actions to changed-file audit

### DIFF
--- a/docs/architecture/changed-file-audit-2026-04-30.md
+++ b/docs/architecture/changed-file-audit-2026-04-30.md
@@ -63,3 +63,10 @@ This audit inspects files changed on 2026-04-30 from git history and validates c
 - Revert this file with:
   - `git revert <commit>` (if committed), or
   - `git rm docs/architecture/changed-file-audit-2026-04-30.md` before commit.
+
+## Suggested follow-up actions
+
+1. In CI or a provisioned local environment, install governed API test dependencies and run `pytest tests/governed_api -q`.
+2. Run schema validation for `data/published/ecology/dry-run/layer_manifest.json` against `schemas/contracts/v1/ecology/layer_manifest.schema.json`.
+3. Execute the web build/runtime checks (for example `npm --prefix apps/web test` and `npm --prefix apps/web run build`) and capture artifact links.
+4. Confirm `.github/workflows/*.yml` outcomes from today’s pipeline run artifacts and attach job IDs to this audit.


### PR DESCRIPTION
### Motivation
- Make remediation steps explicit for the `NEEDS_VERIFICATION` items in the 2026-04-30 changed-file audit so follow-up verification can be executed consistently.

### Description
- Add a `Suggested follow-up actions` section to `docs/architecture/changed-file-audit-2026-04-30.md` listing four concrete next steps: run governed API tests (`pytest tests/governed_api -q`), validate the ecology layer manifest against its schema, execute web test/build checks (`npm --prefix apps/web test` and `npm --prefix apps/web run build`), and confirm CI workflow job outcomes.

### Testing
- Ran repository hygiene and status checks which passed, including `git diff --check` and `git status --short`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dadb5e70832abf089f09f24b3fd9)