### PR TITLE
Add USDA PLANTS flora no-network slice to roadmap-only tracking

### DIFF
--- a/docs/tracking/README.md
+++ b/docs/tracking/README.md
@@ -164,6 +164,7 @@ docs/tracking/
 | `pipelines/kansas_biodiversity_etl/normalize/` | `ROADMAP_ONLY` | Runnable entrypoint + lane-local fixtures/tests or validator wiring. |
 | `pipelines/usgs-gage-watch/` | `ROADMAP_ONLY` | Runnable entrypoint + lane-local fixtures/tests or validator wiring. |
 | `pipelines/watchers/kansas_flora_watch/` | `ROADMAP_ONLY` | Runnable entrypoint + lane-local fixtures/tests or validator wiring. |
+| `pipelines/watchers/usda_plants_flora_no_network_slice/` | `ROADMAP_ONLY` | Runnable entrypoint + lane-local fixtures/tests or validator wiring. |
 | `pipelines/watchers/soil_air_quality/` | `ROADMAP_ONLY` | Runnable entrypoint + lane-local fixtures/tests or validator wiring. |
 
 The shared exit criteria are:

--- a/docs/tracking/pipeline-roadmap-only-lanes.md
+++ b/docs/tracking/pipeline-roadmap-only-lanes.md
@@ -7,6 +7,7 @@ These lanes are intentionally marked **roadmap-only** until runnable entrypoints
 - `pipelines/kansas_biodiversity_etl/normalize/`
 - `pipelines/usgs-gage-watch/`
 - `pipelines/watchers/kansas_flora_watch/`
+- `pipelines/watchers/usda_plants_flora_no_network_slice/`
 - `pipelines/watchers/soil_air_quality/`
 
 Exit criteria:


### PR DESCRIPTION
### Motivation
- Track the planned USDA PLANTS flora no-network slice as a roadmap-only lane so the pipeline is visible to reviewers until runnable entrypoints, fixtures, and tests exist.

### Description
- Added `pipelines/watchers/usda_plants_flora_no_network_slice/` to `docs/tracking/pipeline-roadmap-only-lanes.md` and the companion tracker table in `docs/tracking/README.md` with the same `ROADMAP_ONLY` status and exit criteria.

### Testing
- This is a docs-only change so no unit tests were run; automated verification commands `git diff -- docs/tracking/pipeline-roadmap-only-lanes.md docs/tracking/README.md`, `git add && git commit`, and file inspections (`nl -ba ...`) were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f385f7d360832a9bf25da6a1d8528b)