### PR TITLE
Add USDA PLANTS flora no-network validator, fixtures, registry entry, and docs

### DIFF
--- a/data/registry/flora/sources.yaml
+++ b/data/registry/flora/sources.yaml
@@ -1,0 +1,11 @@
+- source_id: usda_plants
+  source_type: usda_plants_bulk
+  source_name: USDA PLANTS Database
+  source_uri: https://plants.sc.egov.usda.gov/downloads
+  source_role: official
+  rights_status: public
+  policy_label: public
+  default_sensitivity: public
+  notes:
+    - Official USDA/NRCS plant checklist and distribution source.
+    - No live network fetch is used in CI fixtures.

--- a/docs/domains/flora/USDA_PLANTS_INGESTION.md
+++ b/docs/domains/flora/USDA_PLANTS_INGESTION.md
@@ -1,0 +1,59 @@
+---
+doc_id: kfm://doc/flora/usda-plants-ingestion
+title: USDA PLANTS Ingestion Slice
+status: draft
+owners: [@bartytime4life]
+created: 2026-04-30
+updated: 2026-04-30
+domain: flora
+layer: ingestion
+kfm_meta_block: v2
+---
+
+# USDA PLANTS Ingestion (No-Network Governance Slice)
+
+## Purpose
+Define a deterministic, fixture-backed USDA PLANTS ingestion slice for Flora so CI can validate source posture and core data integrity without live downloads.
+
+## Lifecycle placement
+This slice currently covers **PROCESSED contract validation** fed by no-network fixtures. RAW/WORK/QUARANTINE intake and promotion to CATALOG/TRIPLET/PUBLISHED remain governed separately and are not bypassed.
+
+## Source posture
+- Source: USDA PLANTS Database (USDA/NRCS).
+- Role: official public source.
+- CI posture: fixtures only, no network access.
+
+## Validation rules
+`tools/validators/flora/usda_plants_dataset_validator.py` enforces:
+- Schema validation against `schemas/flora/usda_plants_dataset.schema.json` (fail closed if schema missing).
+- `properties["plants:symbol"]` is uppercase alphanumeric.
+- `scientificName` includes apparent authorship after genus/species.
+- `family` is non-empty.
+- `license == "USDA / U.S. Public Domain"`.
+- `rightsHolder == "United States Department of Agriculture"`.
+- Every county `fips` is exactly five digits.
+- Top-level `spec_hash` equals `properties["kfm:spec_hash"]`.
+- Finite result vocabulary: `pass` or `fail`, with explicit reason codes.
+
+## Fixture strategy
+Fixtures live under `tests/fixtures/flora/usda_plants/`:
+- `valid_minimal.json` (expected pass)
+- `invalid_missing_author.json` (expected fail: missing author token)
+- `invalid_bad_fips.json` (expected fail: county fips shape)
+
+Fixtures remain small, no-network, and avoid sensitive coordinate detail.
+
+## Promotion gates
+Promotion-facing usage must still satisfy KFM governance:
+- cite-or-abstain
+- public outputs cannot depend on RAW/WORK/QUARANTINE paths
+- separation of receipts/proofs/manifests/published objects
+- deterministic `spec_hash` handling across lanes
+
+## Not implemented yet (intentional)
+- Live USDA download/fetch connectors.
+- Scheduled intake jobs.
+- Promotion automation from fixtures to released public artifacts.
+- Expanded flora EvidenceBundle integration beyond this validator slice.
+
+These are future work items and are explicitly out of scope for this no-network implementation.

--- a/tests/fixtures/flora/usda_plants/invalid_bad_fips.json
+++ b/tests/fixtures/flora/usda_plants/invalid_bad_fips.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0.0",
+  "object_type": "usda_plants_dataset",
+  "id": "kfm.dataset.flora.usda_plants.ACESA",
+  "domain": "flora",
+  "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "source": {
+    "source_id": "usda_plants",
+    "source_type": "usda_plants_bulk",
+    "source_name": "USDA PLANTS Database",
+    "source_descriptor_ref": "registry:flora:usda_plants",
+    "source_uri": "https://plants.sc.egov.usda.gov/downloads"
+  },
+  "properties": {
+    "plants:symbol": "ACESA",
+    "scientificName": "Acer saccharum Marsh.",
+    "family": "Sapindaceae",
+    "license": "USDA / U.S. Public Domain",
+    "rightsHolder": "United States Department of Agriculture",
+    "datasetID": "USDA_PLANTS",
+    "policy_label": "public",
+    "kfm:spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "distributions": {
+    "state": [{ "state": "KS", "presence": "reported" }],
+    "county": [{ "fips": "2004", "presence": "reported", "first_observed": null }]
+  },
+  "provenance": {
+    "source_uri": "https://plants.sc.egov.usda.gov/downloads",
+    "snapshot_date": "2026-01-15",
+    "raw_refs": ["raw://flora/usda_plants/checklist.csv"],
+    "receipt_refs": ["receipt://flora/usda_plants/intake-2026-01-15"]
+  },
+  "validation": { "validator_id": "usda_plants_dataset_validator@v1", "result": "not_run", "reason_codes": [] }
+}

--- a/tests/fixtures/flora/usda_plants/invalid_missing_author.json
+++ b/tests/fixtures/flora/usda_plants/invalid_missing_author.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0.0",
+  "object_type": "usda_plants_dataset",
+  "id": "kfm.dataset.flora.usda_plants.ACESA",
+  "domain": "flora",
+  "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "source": {
+    "source_id": "usda_plants",
+    "source_type": "usda_plants_bulk",
+    "source_name": "USDA PLANTS Database",
+    "source_descriptor_ref": "registry:flora:usda_plants",
+    "source_uri": "https://plants.sc.egov.usda.gov/downloads"
+  },
+  "properties": {
+    "plants:symbol": "ACESA",
+    "scientificName": "Acer saccharum",
+    "family": "Sapindaceae",
+    "license": "USDA / U.S. Public Domain",
+    "rightsHolder": "United States Department of Agriculture",
+    "datasetID": "USDA_PLANTS",
+    "policy_label": "public",
+    "kfm:spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "distributions": {
+    "state": [{ "state": "KS", "presence": "reported" }],
+    "county": [{ "fips": "20045", "presence": "reported", "first_observed": null }]
+  },
+  "provenance": {
+    "source_uri": "https://plants.sc.egov.usda.gov/downloads",
+    "snapshot_date": "2026-01-15",
+    "raw_refs": ["raw://flora/usda_plants/checklist.csv"],
+    "receipt_refs": ["receipt://flora/usda_plants/intake-2026-01-15"]
+  },
+  "validation": { "validator_id": "usda_plants_dataset_validator@v1", "result": "not_run", "reason_codes": [] }
+}

--- a/tests/fixtures/flora/usda_plants/valid_minimal.json
+++ b/tests/fixtures/flora/usda_plants/valid_minimal.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0.0",
+  "object_type": "usda_plants_dataset",
+  "id": "kfm.dataset.flora.usda_plants.ACESA",
+  "domain": "flora",
+  "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "source": {
+    "source_id": "usda_plants",
+    "source_type": "usda_plants_bulk",
+    "source_name": "USDA PLANTS Database",
+    "source_descriptor_ref": "registry:flora:usda_plants",
+    "source_uri": "https://plants.sc.egov.usda.gov/downloads"
+  },
+  "properties": {
+    "plants:symbol": "ACESA",
+    "scientificName": "Acer saccharum Marsh.",
+    "family": "Sapindaceae",
+    "license": "USDA / U.S. Public Domain",
+    "rightsHolder": "United States Department of Agriculture",
+    "datasetID": "USDA_PLANTS",
+    "policy_label": "public",
+    "kfm:spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "distributions": {
+    "state": [{ "state": "KS", "presence": "reported" }],
+    "county": [{ "fips": "20045", "presence": "reported", "first_observed": null }]
+  },
+  "provenance": {
+    "source_uri": "https://plants.sc.egov.usda.gov/downloads",
+    "snapshot_date": "2026-01-15",
+    "raw_refs": ["raw://flora/usda_plants/checklist.csv"],
+    "receipt_refs": ["receipt://flora/usda_plants/intake-2026-01-15"]
+  },
+  "validation": { "validator_id": "usda_plants_dataset_validator@v1", "result": "not_run", "reason_codes": [] }
+}

--- a/tests/flora/test_usda_plants_dataset_validator.py
+++ b/tests/flora/test_usda_plants_dataset_validator.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+from tools.validators.flora.usda_plants_dataset_validator import validate_dataset
+
+FIXTURE_DIR = Path("tests/fixtures/flora/usda_plants")
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_valid_fixture_passes() -> None:
+    result = validate_dataset(_load("valid_minimal.json"))
+    assert result["result"] == "pass"
+    assert result["reason_codes"] == []
+
+
+def test_missing_author_fails() -> None:
+    result = validate_dataset(_load("invalid_missing_author.json"))
+    assert result["result"] == "fail"
+    assert "field.scientific_name.missing_author" in result["reason_codes"]
+
+
+def test_bad_fips_fails() -> None:
+    result = validate_dataset(_load("invalid_bad_fips.json"))
+    assert result["result"] == "fail"
+    assert any(code.startswith("field.county_fips.invalid") for code in result["reason_codes"])
+
+
+def test_spec_hash_mismatch_fails() -> None:
+    payload = _load("valid_minimal.json")
+    payload["properties"]["kfm:spec_hash"] = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    result = validate_dataset(payload)
+    assert result["result"] == "fail"
+    assert "field.spec_hash.mismatch" in result["reason_codes"]

--- a/tools/validators/flora/usda_plants_dataset_validator.py
+++ b/tools/validators/flora/usda_plants_dataset_validator.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path("schemas/flora/usda_plants_dataset.schema.json")
+SYMBOL_RE = re.compile(r"^[A-Z0-9]+$")
+AUTHOR_RE = re.compile(r"^[A-Z][a-z-]+\s+[a-z-]+\s+.+$")
+FIPS_RE = re.compile(r"^\d{5}$")
+
+
+def _schema_validate(payload: dict[str, Any], schema_path: Path, reasons: list[str]) -> None:
+    if not schema_path.exists():
+        reasons.append("schema.missing")
+        return
+    try:
+        from jsonschema import Draft202012Validator  # type: ignore
+    except ImportError:
+        reasons.append("dependency.jsonschema_missing")
+        return
+
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema)
+    for error in validator.iter_errors(payload):
+        path_parts = getattr(error, "absolute_path", getattr(error, "path", ()))
+        field_path = ".".join(str(part) for part in path_parts) or "root"
+        reasons.append(f"schema.invalid:{field_path}")
+
+
+def validate_dataset(payload: dict[str, Any], schema_path: Path = SCHEMA_PATH) -> dict[str, Any]:
+    reasons: list[str] = []
+    _schema_validate(payload, schema_path, reasons)
+
+    props = payload.get("properties") if isinstance(payload.get("properties"), dict) else {}
+    symbol = props.get("plants:symbol")
+    if not isinstance(symbol, str) or not SYMBOL_RE.fullmatch(symbol):
+        reasons.append("field.symbol.invalid")
+
+    scientific_name = props.get("scientificName")
+    if not isinstance(scientific_name, str) or not AUTHOR_RE.match(scientific_name.strip()):
+        reasons.append("field.scientific_name.missing_author")
+
+    family = props.get("family")
+    if not isinstance(family, str) or not family.strip():
+        reasons.append("field.family.empty")
+
+    if props.get("license") != "USDA / U.S. Public Domain":
+        reasons.append("field.license.invalid")
+
+    if props.get("rightsHolder") != "United States Department of Agriculture":
+        reasons.append("field.rights_holder.invalid")
+
+    counties = payload.get("distributions", {}).get("county", []) if isinstance(payload.get("distributions"), dict) else []
+    if isinstance(counties, list):
+        for idx, county in enumerate(counties):
+            fips = county.get("fips") if isinstance(county, dict) else None
+            if not isinstance(fips, str) or not FIPS_RE.fullmatch(fips):
+                reasons.append(f"field.county_fips.invalid:{idx}")
+    else:
+        reasons.append("field.county_fips.invalid_type")
+
+    top_spec_hash = payload.get("spec_hash")
+    prop_spec_hash = props.get("kfm:spec_hash")
+    if top_spec_hash != prop_spec_hash:
+        reasons.append("field.spec_hash.mismatch")
+
+    reasons = sorted(set(reasons))
+    return {"result": "pass" if not reasons else "fail", "reason_codes": reasons}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate USDA PLANTS dataset fixture/object")
+    parser.add_argument("dataset", type=Path, help="Path to one USDA PLANTS dataset JSON object")
+    parser.add_argument("--schema", type=Path, default=SCHEMA_PATH, help="Path to JSON schema")
+    args = parser.parse_args()
+
+    payload = json.loads(args.dataset.read_text(encoding="utf-8"))
+    result = validate_dataset(payload, args.schema)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["result"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide the next KFM layer for USDA PLANTS ingestion as a no-network, fixture-backed, CI-safe slice to validate processed flora dataset objects without live downloads. 
- Ensure deterministic gating and clear failure modes for core metadata and distribution checks required by the `usda_plants_dataset` schema. 
- Keep public-facing outputs and promotion gates separate from RAW/WORK/QUARANTINE inputs following KFM doctrine. 

### Description
- Add a validator `tools/validators/flora/usda_plants_dataset_validator.py` that validates one JSON dataset object, runs schema validation via `jsonschema` when available (and fails closed if the schema is missing), enforces field rules, and returns a finite result (`pass`/`fail`) with explicit reason codes. 
- Enforce the following checks in the validator: `plants:symbol` is uppercase alphanumeric; `scientificName` appears to include an authorship token; `family` is non-empty; `license` equals `USDA / U.S. Public Domain`; `rightsHolder` equals `United States Department of Agriculture`; each county `fips` is exactly five digits; and top-level `spec_hash` equals `properties["kfm:spec_hash"]`. 
- Add three small, no-network fixtures under `tests/fixtures/flora/usda_plants/`: `valid_minimal.json`, `invalid_missing_author.json`, and `invalid_bad_fips.json`. 
- Add pytest tests in `tests/flora/test_usda_plants_dataset_validator.py` that assert the valid fixture passes and the targeted invalid fixtures fail with the expected reason codes, plus a `spec_hash` mismatch case. 
- Add a source registry entry at `data/registry/flora/sources.yaml` with the `usda_plants` source record and add domain documentation `docs/domains/flora/USDA_PLANTS_INGESTION.md` that includes a KFM Meta Block v2, lifecycle placement, validation rules, fixture strategy, promotion gates, and explicit note that live downloads are future work.

### Testing
- Ran `pytest -q tests/flora/test_usda_plants_dataset_validator.py` and all tests passed (`4 passed`). 
- The validator emits specific reason codes for schema issues and field failures (for example `schema.missing`, `dependency.jsonschema_missing`, `field.scientific_name.missing_author`, `field.county_fips.invalid:<index>`, and `field.spec_hash.mismatch`).
- Schema validation is exercised when `jsonschema` is present and will cause a fail-closed outcome if the schema file is missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f387944964832a81b8e84100ff1ed9)