### PR TITLE
Add USDA PLANTS no-network fixture loader, proofs, and policy gates

### DIFF
--- a/docs/domains/flora/USDA_PLANTS_NEXT_LAYER.md
+++ b/docs/domains/flora/USDA_PLANTS_NEXT_LAYER.md
@@ -1,0 +1,60 @@
+---
+doc_id: kfm://doc/flora/usda-plants-next-layer
+title: USDA PLANTS Next Layer (Fixture Loader + Receipts + Proofs + Policy)
+status: draft
+domain: flora
+layer: usda_plants_fixture_loader_receipts_proofs_policy
+rights: public
+promotion_state: not_promoted
+network: disabled
+sensitivity: public
+kfm_meta_block: v2
+created: 2026-04-30
+updated: 2026-04-30
+---
+
+# USDA PLANTS Next Layer
+
+## 1. Purpose
+This layer adds deterministic, no-network fixture loading for USDA PLANTS Flora datasets with receipts, proof manifesting, and policy gates.
+
+## 2. Lifecycle placement
+This layer bridges fixture-backed inputs toward governed PROCESSED outputs and policy/proof checks, without enabling publication.
+
+## 3. No-network fixture posture
+- This layer does not download USDA PLANTS data.
+- This layer only reads local fixture CSV files.
+- CI remains no-network and deterministic.
+
+## 4. Loader contract
+The fixture loader transforms checklist/state/county fixture CSVs into USDA PLANTS dataset JSON objects under `processed/flora/usda_plants/` with deterministic ordering and canonical spec hashing.
+
+## 5. Receipt contract
+The loader writes:
+- `receipts/flora/usda_plants/ingest_receipt.json`
+- `receipts/flora/usda_plants/validation_receipt.json`
+
+These document inputs, outputs, counts, validation details, and pass/fail status.
+
+## 6. Proof manifest contract
+`tools/proofs/flora/usda_plants_proof_manifest.py` generates `proofs/flora/usda_plants/spec_hash_manifest.json` with per-dataset `spec_hash` entries and a deterministic `manifest_hash`.
+
+## 7. Policy gate contract
+OPA policy `policy/flora/usda_plants.rego` enforces fail-closed governance checks for spec hash consistency, public policy label, licensing/rights holder, provenance presence, raw/work/quarantine closure, FIPS shape, and scientific authorship token requirements.
+
+## 8. CI expectations
+- Run fixture loader CLI.
+- Run proof manifest CLI.
+- Run pytest coverage for loader/proof slices.
+- Optionally run `opa test policy/flora/usda_plants.rego policy/flora/usda_plants_test.rego` when OPA is available.
+
+## 9. What is intentionally not implemented yet
+- This layer does not publish public map layers.
+- This layer does not promote datasets.
+- This layer does not perform live USDA endpoint fetching.
+- This layer does not execute catalog/triplet promotion workflows.
+
+## 10. Future live-USDA ingestion path
+A future governed layer may add live USDA ingestion only after source terms verification, controlled networking posture, stronger provenance contracts, expanded policy gates, and promotion controls.
+
+This layer only proves that USDA PLANTS records can move through a deterministic, governed, fixture-backed path.

--- a/policy/flora/usda_plants.rego
+++ b/policy/flora/usda_plants.rego
@@ -1,0 +1,54 @@
+package kfm.flora.usda_plants
+
+deny contains "USDA_PLANTS_MISSING_SPEC_HASH" if {
+  not input.spec_hash
+}
+
+deny contains "USDA_PLANTS_SPEC_HASH_MISMATCH" if {
+  input.spec_hash != input.properties["kfm:spec_hash"]
+}
+
+deny contains "USDA_PLANTS_NON_PUBLIC_POLICY" if {
+  input.properties.policy_label != "public"
+}
+
+deny contains "USDA_PLANTS_BAD_LICENSE" if {
+  input.properties.license != "USDA / U.S. Public Domain"
+}
+
+deny contains "USDA_PLANTS_BAD_RIGHTS_HOLDER" if {
+  input.properties.rightsHolder != "United States Department of Agriculture"
+}
+
+deny contains "USDA_PLANTS_MISSING_PROVENANCE" if {
+  not input.provenance.source_uri
+}
+
+deny contains "USDA_PLANTS_RAW_OUTPUT_REFERENCE" if {
+  some ref in input.provenance.receipt_refs
+  contains(lower(ref), "raw")
+}
+
+deny contains "USDA_PLANTS_RAW_OUTPUT_REFERENCE" if {
+  some ref in input.provenance.raw_refs
+  startswith(upper(ref), "RAW/")
+}
+
+deny contains "USDA_PLANTS_RAW_OUTPUT_REFERENCE" if {
+  some ref in input.provenance.raw_refs
+  startswith(upper(ref), "WORK/")
+}
+
+deny contains "USDA_PLANTS_RAW_OUTPUT_REFERENCE" if {
+  some ref in input.provenance.raw_refs
+  startswith(upper(ref), "QUARANTINE/")
+}
+
+deny contains "USDA_PLANTS_BAD_FIPS" if {
+  some county in input.distributions.county
+  not regex.match("^[0-9]{5}$", county.fips)
+}
+
+deny contains "USDA_PLANTS_MISSING_AUTHOR" if {
+  not regex.match("^[A-Z][a-z-]+\\s+[a-z-]+\\s+.+$", trim(input.properties.scientificName))
+}

--- a/policy/flora/usda_plants_test.rego
+++ b/policy/flora/usda_plants_test.rego
@@ -1,0 +1,53 @@
+package kfm.flora.usda_plants_test
+
+import data.kfm.flora.usda_plants
+
+base := {
+  "spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "properties": {
+    "kfm:spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "policy_label": "public",
+    "license": "USDA / U.S. Public Domain",
+    "rightsHolder": "United States Department of Agriculture",
+    "scientificName": "Achillea millefolium L."
+  },
+  "provenance": {
+    "source_uri": "https://plants.sc.egov.usda.gov/downloads",
+    "raw_refs": ["tests/fixtures/flora/usda_plants/raw/checklist.csv"],
+    "receipt_refs": ["receipts/flora/usda_plants/ingest_receipt.json"]
+  },
+  "distributions": {"county": [{"fips": "20091"}]}
+}
+
+test_valid_has_no_denies if {
+  count(usda_plants.deny with input as base) == 0
+}
+
+test_missing_spec_hash_denied if {
+  "USDA_PLANTS_MISSING_SPEC_HASH" in usda_plants.deny with input as object.remove(base, ["spec_hash"])
+}
+
+test_mismatched_spec_hash_denied if {
+  mismatched := object.union(base, {"properties": object.union(base.properties, {"kfm:spec_hash": "sha256:bbbb"})})
+  "USDA_PLANTS_SPEC_HASH_MISMATCH" in usda_plants.deny with input as mismatched
+}
+
+test_bad_license_denied if {
+  bad := object.union(base, {"properties": object.union(base.properties, {"license": "CC-BY"})})
+  "USDA_PLANTS_BAD_LICENSE" in usda_plants.deny with input as bad
+}
+
+test_bad_fips_denied if {
+  bad := object.union(base, {"distributions": {"county": [{"fips": "20A91"}]}})
+  "USDA_PLANTS_BAD_FIPS" in usda_plants.deny with input as bad
+}
+
+test_missing_author_denied if {
+  bad := object.union(base, {"properties": object.union(base.properties, {"scientificName": "Achillea millefolium"})})
+  "USDA_PLANTS_MISSING_AUTHOR" in usda_plants.deny with input as bad
+}
+
+test_raw_output_reference_denied if {
+  bad := object.union(base, {"provenance": object.union(base.provenance, {"raw_refs": ["RAW/flora/usda.csv"]})})
+  "USDA_PLANTS_RAW_OUTPUT_REFERENCE" in usda_plants.deny with input as bad
+}

--- a/tests/fixtures/flora/usda_plants/raw/checklist.csv
+++ b/tests/fixtures/flora/usda_plants/raw/checklist.csv
@@ -1,0 +1,3 @@
+symbol,scientificName,nationalCommonName,family,nativeStatus,growthHabit,wetlandStatus
+ACMI2,Achillea millefolium L.,common yarrow,Asteraceae,Native,Forb/Herb,UPL
+SORGH2,Sorghastrum nutans (L.) Nash,Indiangrass,Poaceae,Native,Graminoid,UPL

--- a/tests/fixtures/flora/usda_plants/raw/county_distribution.csv
+++ b/tests/fixtures/flora/usda_plants/raw/county_distribution.csv
@@ -1,0 +1,3 @@
+symbol,fips,presence
+ACMI2,20091,present
+SORGH2,20045,present

--- a/tests/fixtures/flora/usda_plants/raw/state_distribution.csv
+++ b/tests/fixtures/flora/usda_plants/raw/state_distribution.csv
@@ -1,0 +1,3 @@
+symbol,state,presence
+ACMI2,KS,present
+SORGH2,KS,present

--- a/tests/flora/test_usda_plants_fixture_loader.py
+++ b/tests/flora/test_usda_plants_fixture_loader.py
@@ -1,0 +1,62 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.validators.flora.usda_plants_dataset_validator import validate_dataset
+
+
+def _run_loader(out_dir: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/ingest/flora/usda_plants_fixture_loader.py",
+            "--checklist",
+            "tests/fixtures/flora/usda_plants/raw/checklist.csv",
+            "--states",
+            "tests/fixtures/flora/usda_plants/raw/state_distribution.csv",
+            "--counties",
+            "tests/fixtures/flora/usda_plants/raw/county_distribution.csv",
+            "--snapshot-date",
+            "2026-04-30",
+            "--out-dir",
+            str(out_dir),
+        ],
+        check=True,
+    )
+
+
+def test_loader_emits_and_validates(tmp_path: Path) -> None:
+    out_dir = tmp_path / "out"
+    _run_loader(out_dir)
+
+    processed_dir = out_dir / "processed/flora/usda_plants"
+    datasets = sorted(processed_dir.glob("*.json"))
+    assert len(datasets) == 2
+    assert (out_dir / "receipts/flora/usda_plants/ingest_receipt.json").exists()
+    assert (out_dir / "receipts/flora/usda_plants/validation_receipt.json").exists()
+
+    for dataset_path in datasets:
+        payload = json.loads(dataset_path.read_text(encoding="utf-8"))
+        result = validate_dataset(payload)
+        assert result["result"] == "pass"
+
+
+def test_loader_is_deterministic(tmp_path: Path) -> None:
+    out_a = tmp_path / "a"
+    out_b = tmp_path / "b"
+    _run_loader(out_a)
+    _run_loader(out_b)
+
+    rels = [
+        "processed/flora/usda_plants/ACMI2.json",
+        "processed/flora/usda_plants/SORGH2.json",
+        "receipts/flora/usda_plants/ingest_receipt.json",
+        "receipts/flora/usda_plants/validation_receipt.json",
+    ]
+    for rel in rels:
+        left = json.loads((out_a / rel).read_text(encoding="utf-8"))
+        right = json.loads((out_b / rel).read_text(encoding="utf-8"))
+        left.pop("generated_at", None)
+        right.pop("generated_at", None)
+        assert left == right

--- a/tests/flora/test_usda_plants_proof_manifest.py
+++ b/tests/flora/test_usda_plants_proof_manifest.py
@@ -1,0 +1,61 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_loader(out_dir: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/ingest/flora/usda_plants_fixture_loader.py",
+            "--checklist",
+            "tests/fixtures/flora/usda_plants/raw/checklist.csv",
+            "--states",
+            "tests/fixtures/flora/usda_plants/raw/state_distribution.csv",
+            "--counties",
+            "tests/fixtures/flora/usda_plants/raw/county_distribution.csv",
+            "--snapshot-date",
+            "2026-04-30",
+            "--out-dir",
+            str(out_dir),
+        ],
+        check=True,
+    )
+
+
+def _run_manifest(processed: Path, out_path: Path) -> dict:
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/proofs/flora/usda_plants_proof_manifest.py",
+            "--processed-dir",
+            str(processed),
+            "--out",
+            str(out_path),
+        ],
+        check=True,
+    )
+    return json.loads(out_path.read_text(encoding="utf-8"))
+
+
+def test_manifest_generation_and_determinism(tmp_path: Path) -> None:
+    out_a = tmp_path / "a"
+    out_b = tmp_path / "b"
+    _run_loader(out_a)
+    _run_loader(out_b)
+
+    manifest_a = _run_manifest(out_a / "processed/flora/usda_plants", out_a / "proofs/flora/usda_plants/spec_hash_manifest.json")
+    manifest_b = _run_manifest(out_b / "processed/flora/usda_plants", out_b / "proofs/flora/usda_plants/spec_hash_manifest.json")
+
+    assert manifest_a["dataset_count"] == 2
+    assert manifest_a["manifest_hash"].startswith("sha256:")
+    assert all(item["spec_hash"].startswith("sha256:") for item in manifest_a["datasets"])
+
+    manifest_a.pop("generated_at", None)
+    manifest_b.pop("generated_at", None)
+    for item in manifest_a["datasets"]:
+        item["path"] = Path(item["path"]).name
+    for item in manifest_b["datasets"]:
+        item["path"] = Path(item["path"]).name
+    assert manifest_a == manifest_b

--- a/tools/ingest/flora/usda_plants_fixture_loader.py
+++ b/tools/ingest/flora/usda_plants_fixture_loader.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sys
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.validators.flora.usda_plants_dataset_validator import validate_dataset
+
+SOURCE_URI = "https://plants.sc.egov.usda.gov/downloads"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_json_bytes(obj: Any) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _spec_hash_for_dataset(dataset: dict[str, Any]) -> str:
+    base = deepcopy(dataset)
+    base.pop("spec_hash", None)
+    props = base.get("properties")
+    if isinstance(props, dict):
+        props.pop("kfm:spec_hash", None)
+    digest = hashlib.sha256(_canonical_json_bytes(base)).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _split_growth_habit(raw: str) -> list[str]:
+    if not raw:
+        return []
+    return [part.strip() for part in raw.replace(";", "|").split("|") if part.strip()]
+
+
+def load_usda_plants_fixtures(checklist: Path, states: Path, counties: Path, snapshot_date: str, out_dir: Path) -> dict[str, Path]:
+    with checklist.open("r", encoding="utf-8", newline="") as f:
+        checklist_rows = list(csv.DictReader(f))
+    with states.open("r", encoding="utf-8", newline="") as f:
+        state_rows = list(csv.DictReader(f))
+    with counties.open("r", encoding="utf-8", newline="") as f:
+        county_rows = list(csv.DictReader(f))
+
+    state_by_symbol: dict[str, list[dict[str, str]]] = {}
+    for row in state_rows:
+        state_by_symbol.setdefault(row["symbol"].strip(), []).append({"state": row["state"].strip(), "presence": row["presence"].strip()})
+
+    county_by_symbol: dict[str, list[dict[str, Any]]] = {}
+    for row in county_rows:
+        county_by_symbol.setdefault(row["symbol"].strip(), []).append(
+            {"fips": row["fips"].strip(), "presence": row["presence"].strip(), "first_observed": None}
+        )
+
+    processed_dir = out_dir / "processed/flora/usda_plants"
+    receipt_dir = out_dir / "receipts/flora/usda_plants"
+    proof_dir = out_dir / "proofs/flora/usda_plants"
+    processed_dir.mkdir(parents=True, exist_ok=True)
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    proof_dir.mkdir(parents=True, exist_ok=True)
+
+    output_refs: list[str] = []
+    validation_results: list[dict[str, Any]] = []
+    dataset_paths: list[Path] = []
+
+    for row in sorted(checklist_rows, key=lambda r: r["symbol"].strip()):
+        symbol = row["symbol"].strip()
+        dataset: dict[str, Any] = {
+            "schema_version": "1.0.0",
+            "object_type": "usda_plants_dataset",
+            "id": f"kfm.dataset.flora.usda_plants.{symbol}",
+            "domain": "flora",
+            "spec_hash": "",
+            "source": {
+                "source_id": "usda_plants",
+                "source_type": "usda_plants_bulk",
+                "source_name": "USDA PLANTS Database",
+                "source_descriptor_ref": "data/registry/flora/sources.yaml#usda_plants",
+                "source_uri": SOURCE_URI,
+            },
+            "properties": {
+                "plants:symbol": symbol,
+                "scientificName": row["scientificName"].strip(),
+                "nationalCommonName": row["nationalCommonName"].strip(),
+                "family": row["family"].strip(),
+                "nativeStatus": row["nativeStatus"].strip(),
+                "growthHabit": _split_growth_habit(row["growthHabit"].strip()),
+                "wetlandStatus": row["wetlandStatus"].strip(),
+                "license": "USDA / U.S. Public Domain",
+                "rightsHolder": "United States Department of Agriculture",
+                "datasetID": "USDA_PLANTS",
+                "policy_label": "public",
+                "kfm:spec_hash": "",
+            },
+            "distributions": {
+                "state": sorted(state_by_symbol.get(symbol, []), key=lambda i: i["state"]),
+                "county": sorted(county_by_symbol.get(symbol, []), key=lambda i: i["fips"]),
+            },
+            "provenance": {
+                "source_uri": SOURCE_URI,
+                "snapshot_date": snapshot_date,
+                "raw_refs": [str(checklist), str(states), str(counties)],
+                "receipt_refs": [
+                    "receipts/flora/usda_plants/ingest_receipt.json",
+                    "receipts/flora/usda_plants/validation_receipt.json",
+                ],
+            },
+            "validation": {
+                "validator_id": "usda_plants_dataset_validator@v1",
+                "result": "pass",
+                "reason_codes": [],
+            },
+        }
+        spec_hash = _spec_hash_for_dataset(dataset)
+        dataset["spec_hash"] = spec_hash
+        dataset["properties"]["kfm:spec_hash"] = spec_hash
+
+        path = processed_dir / f"{symbol}.json"
+        _write_json(path, dataset)
+        dataset_paths.append(path)
+        output_refs.append(str(path.relative_to(out_dir)))
+
+        result = validate_dataset(dataset)
+        validation_results.append({"path": str(path.relative_to(out_dir)), "result": result["result"], "reason_codes": result["reason_codes"]})
+
+    pass_count = sum(1 for r in validation_results if r["result"] == "pass")
+    fail_count = len(validation_results) - pass_count
+
+    ingest_receipt = {
+        "schema_version": "1.0.0",
+        "object_type": "usda_plants_ingest_receipt",
+        "receipt_id": "kfm.receipt.flora.usda_plants.ingest.v1",
+        "generated_at": _utc_now_iso(),
+        "snapshot_date": snapshot_date,
+        "source_id": "usda_plants",
+        "source_uri": SOURCE_URI,
+        "input_refs": [str(checklist), str(states), str(counties)],
+        "output_refs": sorted(output_refs),
+        "record_counts": {
+            "checklist_rows": len(checklist_rows),
+            "state_distribution_rows": len(state_rows),
+            "county_distribution_rows": len(county_rows),
+            "emitted_datasets": len(output_refs),
+        },
+        "status": "pass" if fail_count == 0 else "fail",
+        "reason_codes": [] if fail_count == 0 else ["VALIDATION_FAILED"],
+    }
+
+    validation_receipt = {
+        "schema_version": "1.0.0",
+        "object_type": "usda_plants_validation_receipt",
+        "receipt_id": "kfm.receipt.flora.usda_plants.validation.v1",
+        "generated_at": _utc_now_iso(),
+        "validator_id": "usda_plants_dataset_validator@v1",
+        "validated_refs": sorted(output_refs),
+        "results": sorted(validation_results, key=lambda i: i["path"]),
+        "summary": {"pass_count": pass_count, "fail_count": fail_count},
+        "status": "pass" if fail_count == 0 else "fail",
+    }
+
+    _write_json(receipt_dir / "ingest_receipt.json", ingest_receipt)
+    _write_json(receipt_dir / "validation_receipt.json", validation_receipt)
+
+    return {
+        "processed_dir": processed_dir,
+        "ingest_receipt": receipt_dir / "ingest_receipt.json",
+        "validation_receipt": receipt_dir / "validation_receipt.json",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Load USDA PLANTS fixture CSVs into deterministic dataset JSON artifacts")
+    parser.add_argument("--checklist", required=True, type=Path)
+    parser.add_argument("--states", required=True, type=Path)
+    parser.add_argument("--counties", required=True, type=Path)
+    parser.add_argument("--snapshot-date", required=True)
+    parser.add_argument("--out-dir", required=True, type=Path)
+    args = parser.parse_args()
+    load_usda_plants_fixtures(args.checklist, args.states, args.counties, args.snapshot_date, args.out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/proofs/flora/usda_plants_proof_manifest.py
+++ b/tools/proofs/flora/usda_plants_proof_manifest.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_json_bytes(obj: Any) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def generate_manifest(processed_dir: Path, out: Path) -> dict[str, Any]:
+    datasets = []
+    for path in sorted(processed_dir.glob("*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        datasets.append(
+            {
+                "id": payload.get("id"),
+                "plants_symbol": payload.get("properties", {}).get("plants:symbol"),
+                "path": path.name,
+                "spec_hash": payload.get("spec_hash"),
+            }
+        )
+
+    manifest: dict[str, Any] = {
+        "schema_version": "1.0.0",
+        "object_type": "usda_plants_spec_hash_manifest",
+        "generated_at": _utc_now_iso(),
+        "algorithm": "sha256",
+        "canonicalization": "json_sorted_keys_compact_separators_excluding_self_hash_fields",
+        "dataset_count": len(datasets),
+        "datasets": datasets,
+    }
+    manifest_hash = hashlib.sha256(_canonical_json_bytes(manifest)).hexdigest()
+    manifest["manifest_hash"] = f"sha256:{manifest_hash}"
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate USDA PLANTS deterministic spec_hash proof manifest")
+    parser.add_argument("--processed-dir", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+    generate_manifest(args.processed_dir, args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a deterministic, no-network slice that converts USDA PLANTS-shaped fixture CSVs into governed PROCESSED dataset objects with receipts and proofs.
- Enforce fail-closed governance checks (spec-hash, licensing, provenance, FIPS shape, authorship) before any future promotion or publication.
- Make CI-safe deterministic artifacts and manifests so downstream cataloging/proof steps can be exercised without live USDA access.

### Description
- Added a fixture loader `tools/ingest/flora/usda_plants_fixture_loader.py` that reads checklist/state/county CSVs, emits per-symbol JSON under `processed/flora/usda_plants/`, computes canonical `spec_hash` excluding self-hash fields, attaches `properties["kfm:spec_hash"]`, and writes `receipts/flora/usda_plants/ingest_receipt.json` and `validation_receipt.json`.
- Added a proof manifest generator `tools/proofs/flora/usda_plants_proof_manifest.py` that enumerates processed datasets, records each `spec_hash`, and computes a deterministic `manifest_hash` using JSON with sorted keys and compact separators.
- Added OPA policy `policy/flora/usda_plants.rego` implementing required deny reasons (`USDA_PLANTS_MISSING_SPEC_HASH`, `USDA_PLANTS_SPEC_HASH_MISMATCH`, `USDA_PLANTS_NON_PUBLIC_POLICY`, `USDA_PLANTS_BAD_LICENSE`, `USDA_PLANTS_BAD_RIGHTS_HOLDER`, `USDA_PLANTS_MISSING_PROVENANCE`, `USDA_PLANTS_RAW_OUTPUT_REFERENCE`, `USDA_PLANTS_BAD_FIPS`, `USDA_PLANTS_MISSING_AUTHOR`) and unit tests in `policy/flora/usda_plants_test.rego` covering the specified scenarios.
- Added pytest tests `tests/flora/test_usda_plants_fixture_loader.py` and `tests/flora/test_usda_plants_proof_manifest.py` that assert artifact emission, validation with the existing `tools/validators/flora/usda_plants_dataset_validator.py`, deterministic outputs across runs, and manifest correctness.
- Added CSV fixtures for two benign Kansas examples under `tests/fixtures/flora/usda_plants/raw/` and draft documentation `docs/domains/flora/USDA_PLANTS_NEXT_LAYER.md` with KFM meta block v2 and explicit non-goals.

### Testing
- Ran the loader CLI `python tools/ingest/flora/usda_plants_fixture_loader.py --checklist tests/fixtures/flora/usda_plants/raw/checklist.csv --states tests/fixtures/flora/usda_plants/raw/state_distribution.csv --counties tests/fixtures/flora/usda_plants/raw/county_distribution.csv --snapshot-date 2026-04-30 --out-dir /tmp/kfm-usda-plants/out` which completed successfully.
- Ran the manifest CLI `python tools/proofs/flora/usda_plants_proof_manifest.py --processed-dir /tmp/kfm-usda-plants/out/processed/flora/usda_plants --out /tmp/kfm-usda-plants/out/proofs/flora/usda_plants/spec_hash_manifest.json` which completed successfully.
- Ran pytest for the new tests with `pytest tests/flora/test_usda_plants_fixture_loader.py tests/flora/test_usda_plants_proof_manifest.py` and all tests passed (3 passed).
- Attempted `opa test policy/flora/usda_plants.rego policy/flora/usda_plants_test.rego` but `opa` was not installed in the execution environment, so Rego tests are provided but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f395fcca1c832aad0e3f3d5a49b87e)