### PR TITLE
Guarded Cloudflare Pages workflow + docs for USDA PLANTS external CDN deployment

### DIFF
--- a/.github/workflows/usda-plants-deploy-cloudflare-pages.yml
+++ b/.github/workflows/usda-plants-deploy-cloudflare-pages.yml
@@ -1,0 +1,86 @@
+name: USDA PLANTS Deploy Cloudflare Pages
+"on":
+  workflow_dispatch:
+    inputs:
+      snapshot_date:
+        description: Snapshot date YYYY-MM-DD
+        required: true
+        default: "2026-04-30"
+      requester_id:
+        description: Requester identifier
+        required: true
+        default: ""
+      approver_id:
+        description: Approver identifier
+        required: true
+        default: ""
+      deploy_to_cloudflare:
+        description: Deploy to Cloudflare Pages
+        required: true
+        type: choice
+        default: "false"
+        options: ["false", "true"]
+      cloudflare_project_name:
+        description: Cloudflare Pages project name
+        required: true
+        default: ""
+      run_opa:
+        description: Run OPA policy tests
+        required: true
+        type: choice
+        default: "false"
+        options: ["false", "true"]
+permissions:
+  contents: read
+jobs:
+  dry-run:
+    name: Dry-run deployment chain checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CI: "true"
+      KFM_ALLOW_NETWORK: "0"
+      KFM_ALLOW_SCHEDULED_OBSERVATION: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Dry-run tests (Step 1 chain)
+        run: |
+          pytest tests/flora/test_usda_plants_external_deployment_chain.py
+      - name: Optional OPA policy tests
+        if: ${{ inputs.run_opa == 'true' }}
+        run: |
+          if command -v opa >/dev/null 2>&1; then
+            opa test policy/flora/usda_plants_external_deployment.rego policy/flora/usda_plants_external_deployment_test.rego
+          else
+            echo "opa not found; skipping because run_opa is optional"
+          fi
+      - name: Upload dry-run manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: usda-plants-cloudflare-dry-run-${{ inputs.snapshot_date }}
+          path: |
+            out/flora/usda_plants/*${{ inputs.snapshot_date }}*.json
+            /tmp/kfm-usda-plants/out/**/*.json
+          if-no-files-found: warn
+
+  deploy:
+    name: Guarded Cloudflare Pages deploy
+    needs: [dry-run]
+    if: ${{ inputs.deploy_to_cloudflare == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: usda-plants-external-deployment
+    steps:
+      - name: Deploy static site via Cloudflare Pages Direct Upload
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy /tmp/kfm-usda-plants/out/site/flora/usda_plants/${{ inputs.snapshot_date }}
+            --project-name=${{ inputs.cloudflare_project_name }}

--- a/docs/domains/flora/USDA_PLANTS_EXTERNAL_CDN_DEPLOYMENT_LAYER.md
+++ b/docs/domains/flora/USDA_PLANTS_EXTERNAL_CDN_DEPLOYMENT_LAYER.md
@@ -1,0 +1,74 @@
+---
+kfm_meta:
+  version: 2
+  status: draft
+  domain: flora
+  layer: usda_plants_external_cdn_deployment
+  rights: public
+  deployment_state: external_deploy_guarded
+  network: disabled_for_tests
+  deploys: guarded_optional
+  sensitivity: public_static_site_only
+  source_id: usda_plants
+  geometry_authority: us_census_cartographic_boundary
+  source_uri: https://plants.sc.egov.usda.gov/downloads
+---
+
+# USDA PLANTS External CDN Deployment Layer
+
+## 1. Purpose
+Define a guarded, optional external CDN deployment path for already-built USDA PLANTS static site artifacts.
+
+## 2. Lifecycle placement
+This layer runs after static publication artifacts are built and policy-checked, and before any optional external-host promotion.
+
+## 3. External deployment vs static publication
+GitHub Pages remains the default deployment surface. Cloudflare deployment is optional and guarded.
+
+## 4. External host registry
+External host targeting is declared through the USDA PLANTS external host registry and associated deployment manifests from Step 1.
+
+## 5. External deployment request
+A manual `workflow_dispatch` request includes `snapshot_date`, `requester_id`, `approver_id`, and optional Cloudflare deployment toggle.
+
+## 6. External deployment approval
+Cloudflare deployment requires protected environment approval via `usda-plants-external-deployment`.
+
+## 7. CDN deployment execution plan
+The dry-run job validates Step 1 tests and produces artifact evidence before any deploy gate is evaluated.
+
+## 8. Cloudflare Pages guarded manifest
+`deploy_to_cloudflare` defaults false and must be explicitly set to true. Deployment uses Cloudflare Pages Direct Upload for the prebuilt site path only.
+
+## 9. Custom domain readiness
+Custom domain readiness is tracked independently from workflow execution and must be reviewed before any DNS cutover.
+
+## 10. Cache invalidation plan
+Cache invalidation follows the external deployment chain records and is executed only after successful guarded deployment approval.
+
+## 11. CDN deployment receipt
+A deployment receipt is captured in the evidence chain for traceability and rollback support.
+
+## 12. External verification report
+Post-deploy verification artifacts are documented through external verification reports without introducing live source fetches.
+
+## 13. Rollback and audit ledger
+Rollback remains artifact-addressable and governed by the external deployment audit ledger.
+
+## 14. Policy gates
+Policy gates remain enforceable in dry-run mode, with optional OPA execution under explicit operator control.
+
+## 15. Protected Cloudflare workflow
+The Cloudflare workflow is `workflow_dispatch` only, has no schedule, no push trigger, and no pull-request deployment trigger.
+
+## 16. CI and no-network posture
+Tests never deploy. This layer does not fetch USDA data. This layer does not fetch Census data. This layer does not fetch external basemaps.
+
+## 17. Credential posture
+Environment-scoped secrets must be configured by a repo admin. Secrets must never be printed or serialized. Cloudflare secrets are passed only as action inputs to the deploy action.
+
+## 18. What is intentionally not implemented
+This layer does not auto-merge, does not auto-open PRs, and does not initiate live data ingestion or geometry refresh.
+
+## 19. Future provider-OIDC/cloud deployment layer
+OIDC is preferred for providers that support it. Future provider-OIDC deployment remains a separate layer.

--- a/tests/flora/test_usda_plants_cloudflare_workflow_guardrails.py
+++ b/tests/flora/test_usda_plants_cloudflare_workflow_guardrails.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW_PATH = Path('.github/workflows/usda-plants-deploy-cloudflare-pages.yml')
+
+
+def _load_workflow() -> dict:
+    assert WORKFLOW_PATH.exists()
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding='utf-8'))
+
+
+def test_workflow_exists_and_dispatch_only():
+    wf = _load_workflow()
+    assert 'workflow_dispatch' in wf['on']
+    assert 'schedule' not in wf['on']
+    assert 'push' not in wf['on']
+    assert 'pull_request' not in wf['on']
+
+
+def test_deploy_toggle_defaults_false_and_condition_guarded():
+    wf = _load_workflow()
+    inputs = wf['on']['workflow_dispatch']['inputs']
+    assert inputs['deploy_to_cloudflare']['default'] == 'false'
+    assert inputs['deploy_to_cloudflare']['options'] == ['false', 'true']
+    assert wf['jobs']['deploy']['if'] == "${{ inputs.deploy_to_cloudflare == 'true' }}"
+
+
+def test_deploy_job_environment_and_permissions():
+    wf = _load_workflow()
+    assert wf['permissions'] == {'contents': 'read'}
+    assert wf['jobs']['dry-run']['permissions'] == {'contents': 'read'}
+    assert wf['jobs']['deploy']['permissions'] == {'contents': 'read'}
+    assert wf['jobs']['deploy']['environment'] == 'usda-plants-external-deployment'
+
+
+def test_secret_references_are_names_only_and_no_literals():
+    text = WORKFLOW_PATH.read_text(encoding='utf-8')
+    assert 'CLOUDFLARE_API_TOKEN' in text
+    assert 'CLOUDFLARE_ACCOUNT_ID' in text
+    assert 'ghp_' not in text
+    assert 'AKIA' not in text
+    assert 'secret_' not in text.lower()


### PR DESCRIPTION
### Motivation
- Provide a guarded, optional Cloudflare Pages deployment path for prebuilt USDA PLANTS static site artifacts while keeping GitHub Pages as the default and maintaining a no-network/no-deploy posture in CI.
- Ensure deployments require explicit operator intent and protected-environment approval and that secrets are only used as environment-scoped inputs and never serialized.

### Description
- Added `.github/workflows/usda-plants-deploy-cloudflare-pages.yml` as `workflow_dispatch`-only with inputs including `snapshot_date`, `requester_id`, `approver_id`, `deploy_to_cloudflare` (defaults to `"false"`), `cloudflare_project_name`, and `run_opa`, and with top-level `permissions: contents: read`.
- Implemented a `dry-run` job that always runs first to execute Step 1 chain tests via `pytest tests/flora/test_usda_plants_external_deployment_chain.py`, optionally runs OPA tests when requested, and uploads dry-run manifests as an artifact.
- Implemented a `deploy` job gated by `if: ${{ inputs.deploy_to_cloudflare == 'true' }}`, requiring the protected environment `usda-plants-external-deployment`, and using `cloudflare/wrangler-action` to run the equivalent of `pages deploy <site-path> --project-name=<cloudflare_project_name>` against the prebuilt path `/tmp/kfm-usda-plants/out/site/flora/usda_plants/${{ inputs.snapshot_date }}` while passing secrets only via action inputs (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`).
- Added documentation `docs/domains/flora/USDA_PLANTS_EXTERNAL_CDN_DEPLOYMENT_LAYER.md` with the required KFM Meta Block v2 and all requested sections, explicitly stating guardrails (no USDA/Census/basemap fetches in this layer, tests never deploy, no auto-merge, env-scoped secrets, OIDC preference for future provider integrations).
- Added `tests/flora/test_usda_plants_cloudflare_workflow_guardrails.py` to validate workflow existence, `workflow_dispatch` trigger only, absence of schedule/push/PR triggers, `deploy_to_cloudflare` default, deploy job condition and environment, minimal permissions, and that secret names (not literal secret values) are referenced.

### Testing
- Ran `pytest tests/flora/test_usda_plants_cloudflare_workflow_guardrails.py tests/flora/test_usda_plants_external_deployment_chain.py` and observed all tests pass (`5 passed`).
- Attempted optional OPA test `opa test policy/flora/usda_plants_external_deployment.rego policy/flora/usda_plants_external_deployment_test.rego` but the `opa` binary was not available in the environment so OPA tests were skipped.
- Verified that the workflow contains no schedule/push/PR triggers, `deploy_to_cloudflare` defaults to `false`, the deploy job is conditioned on that input and targets `usda-plants-external-deployment`, and that Cloudflare secrets are referenced by name only and not serialized.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c3005d68832a80b63fc39b6d1818)