### PR TITLE
Add Layer 1 scaffold for KFM eBird ingest adapter

### DIFF
--- a/data/published/fauna/layers/ebird_agg_huc12.json
+++ b/data/published/fauna/layers/ebird_agg_huc12.json
@@ -1,0 +1,21 @@
+{
+  "id": "ebird_agg_huc12",
+  "domain": "fauna",
+  "source": "ebird",
+  "aggregate": "huc12",
+  "suppression_min_n": 10,
+  "policy_label": "public_aggregate",
+  "exact_points": "restricted",
+  "allowlist_fields": [
+    "huc12",
+    "taxonKey",
+    "occurrenceDate_month",
+    "checklist_count",
+    "observation_count_sum",
+    "species_count",
+    "kfm:spec_hash",
+    "evidence_bundle_uri"
+  ],
+  "minzoom": 0,
+  "maxzoom": 12
+}

--- a/tools/connectors/fauna/kfm-ebird-ingest/README.md
+++ b/tools/connectors/fauna/kfm-ebird-ingest/README.md
@@ -1,0 +1,53 @@
+# kfm-ebird-ingest (Layer 1 scaffold)
+
+This connector is the first scaffold layer for KFM eBird ingest. It intentionally does **not** implement full EBD parsing, downloading, publishing, or public exact-point outputs.
+
+## CLI
+
+Run via:
+
+```bash
+python tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py --help
+```
+
+### Example
+
+```bash
+kfm-ebird-ingest \
+  --ebd-file /data/ebd-EBD.txt \
+  --source-uri "https://ebird.org/data?request_id=..." \
+  --filter "complete==TRUE && protocol_type!='Incidental' && duration_min>=5 && distance_km<=5 && number_observers<=10" \
+  --aggregate huc12 \
+  --suppression 10 \
+  --emit evidencebundle.json \
+  --dry-run
+```
+
+## Behavior
+
+- Required arguments are validated (`--ebd-file`, `--filter`, `--aggregate`, `--emit`).
+- `--aggregate` must be `county` or `huc12`.
+- `--suppression` must be at least 10.
+- `--source-uri` defaults to `file://<ebd-file>`.
+- In `--dry-run`, the command emits an EvidenceBundle JSON scaffold to `--emit` and does not read the EBD file.
+
+## EvidenceBundle (v1)
+
+Dry-run output contains:
+
+- `source_uri`
+- `query_predicate`
+- `mapping`
+- `kfm:spec_hash`
+
+`kfm:spec_hash` is a `sha256:` hash over a canonicalized normalized spec JSON (sorted keys, compact separators, and no volatile timestamp fields).
+
+## eBird mapping
+
+- `sampling_event_identifier` -> `kfm:dataset_key`
+- `observation_date` -> `occurrenceDate`
+- `latitude` -> `decimalLatitude`
+- `longitude` -> `decimalLongitude`
+- `observation_count` -> `individualCount`
+- `species_taxon_id` -> `taxonKey`
+- `basisOfRecord` -> `HumanObservation`

--- a/tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-ingest
+++ b/tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-ingest
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python "$(dirname "$0")/kfm_ebird_ingest.py" "$@"

--- a/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py
+++ b/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Scaffold CLI for KFM eBird ingest Layer 1."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+FIELD_MAPPING = {
+    "sampling_event_identifier": "kfm:dataset_key",
+    "observation_date": "occurrenceDate",
+    "latitude": "decimalLatitude",
+    "longitude": "decimalLongitude",
+    "observation_count": "individualCount",
+    "species_taxon_id": "taxonKey",
+    "basisOfRecord": "HumanObservation",
+}
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="kfm-ebird-ingest",
+        description="Layer 1 scaffold for KFM eBird ingest adapter.",
+    )
+    parser.add_argument("--ebd-file", required=True, help="Path to eBird EBD file")
+    parser.add_argument(
+        "--source-uri",
+        help="Optional source URI. Defaults to file://<ebd-file>",
+    )
+    parser.add_argument("--filter", required=True, dest="predicate", help="Filter predicate")
+    parser.add_argument(
+        "--aggregate",
+        required=True,
+        choices=("county", "huc12"),
+        help="Aggregation grain",
+    )
+    parser.add_argument(
+        "--suppression",
+        type=int,
+        default=10,
+        help="Suppression threshold (minimum 10)",
+    )
+    parser.add_argument("--emit", required=True, help="Output path for scaffold artifact")
+    parser.add_argument("--dry-run", action="store_true", help="Emit scaffold EvidenceBundle only")
+    return parser.parse_args(argv)
+
+
+def canonical_json(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_spec_hash(spec: dict[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_json(spec).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def build_spec(args: argparse.Namespace, source_uri: str) -> dict[str, Any]:
+    return {
+        "adapter": "kfm-ebird-ingest",
+        "aggregate": args.aggregate,
+        "mapping": FIELD_MAPPING,
+        "query_predicate": args.predicate,
+        "source_uri": source_uri,
+        "suppression": args.suppression,
+        "version": "v1",
+    }
+
+
+def build_evidence_bundle(spec: dict[str, Any], spec_hash: str) -> dict[str, Any]:
+    return {
+        "schema_version": "v1",
+        "object_type": "EvidenceBundle",
+        "source_uri": spec["source_uri"],
+        "query_predicate": spec["query_predicate"],
+        "mapping": spec["mapping"],
+        "kfm:spec_hash": spec_hash,
+    }
+
+
+def main() -> None:
+    args = parse_args(sys.argv[1:])
+    if args.suppression < 10:
+        fail("--suppression must be >= 10")
+
+    source_uri = args.source_uri or Path(args.ebd_file).resolve().as_uri()
+
+    if not args.dry_run:
+        fail("Layer 1 scaffold supports --dry-run only; full ingest not implemented")
+
+    spec = build_spec(args, source_uri)
+    spec_hash = compute_spec_hash(spec)
+    bundle = build_evidence_bundle(spec, spec_hash)
+
+    emit_path = Path(args.emit)
+    emit_path.parent.mkdir(parents=True, exist_ok=True)
+    emit_path.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Wrote dry-run EvidenceBundle scaffold: {emit_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/test_kfm_ebird_ingest_cli.py
+++ b/tools/tests/test_kfm_ebird_ingest_cli.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = "tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py"
+LAYER_REGISTRY = Path("data/published/fauna/layers/ebird_agg_huc12.json")
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, SCRIPT, *args],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_help_exits_successfully() -> None:
+    result = run_cli("--help")
+    assert result.returncode == 0
+    assert "kfm-ebird-ingest" in result.stdout
+
+
+def test_invalid_suppression_fails(tmp_path: Path) -> None:
+    out = tmp_path / "bundle.json"
+    result = run_cli(
+        "--ebd-file",
+        "placeholder.txt",
+        "--filter",
+        "complete==TRUE",
+        "--aggregate",
+        "huc12",
+        "--suppression",
+        "9",
+        "--emit",
+        str(out),
+        "--dry-run",
+    )
+    assert result.returncode != 0
+    assert "--suppression must be >= 10" in result.stderr
+
+
+def test_dry_run_emits_evidence_bundle(tmp_path: Path) -> None:
+    out = tmp_path / "bundle.json"
+    result = run_cli(
+        "--ebd-file",
+        "/tmp/ebd-EBD.txt",
+        "--source-uri",
+        "https://ebird.org/data?request_id=abc123",
+        "--filter",
+        "complete==TRUE",
+        "--aggregate",
+        "huc12",
+        "--emit",
+        str(out),
+        "--dry-run",
+    )
+    assert result.returncode == 0
+    bundle = json.loads(out.read_text(encoding="utf-8"))
+    assert bundle["source_uri"] == "https://ebird.org/data?request_id=abc123"
+    assert bundle["query_predicate"] == "complete==TRUE"
+    assert isinstance(bundle["mapping"], dict)
+    assert "kfm:spec_hash" in bundle
+    assert bundle["kfm:spec_hash"].startswith("sha256:")
+
+
+def test_layer_registry_suppression_and_coordinate_safety() -> None:
+    layer = json.loads(LAYER_REGISTRY.read_text(encoding="utf-8"))
+    assert int(layer["suppression_min_n"]) >= 10
+    merged_fields = " ".join(layer["allowlist_fields"])
+    for forbidden in ("decimalLatitude", "decimalLongitude", "latitude", "longitude"):
+        assert forbidden not in merged_fields


### PR DESCRIPTION
### Motivation
- Provide a minimal, safe Layer 1 scaffold for ingesting eBird EBDs that supports public-aggregate publication workflows without implementing full EBD processing, downloading, or exact-point outputs.
- Offer a CLI that validates invocation parameters and can emit a deterministic dry-run EvidenceBundle for review and integration testing.
- Register the new public-safe aggregate layer metadata so it can be discovered and validated by existing tooling.

### Description
- Add a new CLI implementation at `tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py` and an executable wrapper `tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-ingest` that accept the requested arguments and validate `--aggregate` and `--suppression` (must be >= 10). 
- Implement the requested eBird field mapping as `FIELD_MAPPING`, build a normalized spec object, and compute `kfm:spec_hash` as `sha256:` over canonicalized JSON (stable key order and separators) via `compute_spec_hash`.
- Implement `--dry-run` mode that writes an EvidenceBundle v1 JSON to `--emit` containing `source_uri`, `query_predicate`, `mapping`, and `kfm:spec_hash`, and fail-closed for non-dry-run invocations (scaffold-only behavior).
- Add connector documentation at `tools/connectors/fauna/kfm-ebird-ingest/README.md`, the first public-safe layer registry at `data/published/fauna/layers/ebird_agg_huc12.json`, and smoke tests at `tools/tests/test_kfm_ebird_ingest_cli.py`.
- Changed files: `tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py`, `tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-ingest`, `tools/connectors/fauna/kfm-ebird-ingest/README.md`, `data/published/fauna/layers/ebird_agg_huc12.json`, `tools/tests/test_kfm_ebird_ingest_cli.py`.

### Testing
- Ran the new smoke tests with `pytest -q tools/tests/test_kfm_ebird_ingest_cli.py` which completed successfully with `4 passed`.
- The tests exercised: `--help` exits successfully, invalid suppression (<10) fails, `--dry-run` emits an EvidenceBundle containing `source_uri`, `query_predicate`, `mapping`, and `kfm:spec_hash`, and the layer registry contains `suppression_min_n >= 10` and does not include exact coordinate fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c518c4b8832a8142610b429a6c9c)