### PR TITLE
Add Layer 2 fauna EvidenceBundle schema, validator, and eBird promotion gates

### DIFF
--- a/docs/domains/fauna/INGEST_EBIRD.md
+++ b/docs/domains/fauna/INGEST_EBIRD.md
@@ -1,0 +1,39 @@
+# eBird ingest (Layer 2)
+
+## EvidenceBundle contract
+
+Layer 2 uses `schemas/contracts/v1/fauna/evidence_bundle.schema.json` with required fields:
+`schema_version`, `object_type`, `domain`, `source`, `source_uri`, `query_predicate`, `mapping`, and `kfm:spec_hash`.
+
+## Deterministic hash recipe
+
+`kfm:spec_hash` is computed as:
+
+`sha256:` + SHA-256 of canonical JSON (sorted keys, compact separators, no timestamps).
+
+Hash input:
+- `EvidenceBundle.spec` when present, else a derived object with
+  `schema_version`, `object_type`, `domain`, `source`, `source_uri`, `query_predicate`,
+  `aggregate`, `suppression_min_n`, and `mapping`.
+
+## Validator
+
+```bash
+python3 tools/validators/fauna/validate_evidencebundle.py --file /tmp/evidencebundle.json
+```
+
+## Policy gate summary
+
+`policy/fauna/ebird.rego` denies promotion when public-safety or governance controls fail:
+- missing `source_uri`, `query_predicate`, or malformed `kfm:spec_hash`
+- suppression threshold under 10
+- unsupported aggregate
+- public layers exposing exact coordinates
+- `exact_points` not `restricted`
+- best-effort query predicate quality checks for checklist completeness and effort filters
+
+## Public-safe posture
+
+- Exact points are restricted.
+- Aggregates require `suppression_min_n >= 10`.
+- Public eBird layers must not expose exact coordinate fields.

--- a/packages/evidence/evidencebundle_hash.py
+++ b/packages/evidence/evidencebundle_hash.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def build_hash_input(bundle: dict[str, Any]) -> dict[str, Any]:
+    spec = bundle.get("spec")
+    if isinstance(spec, dict):
+        return spec
+
+    return {
+        "schema_version": bundle.get("schema_version"),
+        "object_type": bundle.get("object_type"),
+        "domain": bundle.get("domain"),
+        "source": bundle.get("source"),
+        "source_uri": bundle.get("source_uri"),
+        "query_predicate": bundle.get("query_predicate"),
+        "aggregate": bundle.get("aggregate"),
+        "suppression_min_n": bundle.get("suppression_min_n"),
+        "mapping": bundle.get("mapping"),
+    }
+
+
+def compute_spec_hash(bundle: dict[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_json(build_hash_input(bundle)).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"

--- a/policy/fauna/ebird.rego
+++ b/policy/fauna/ebird.rego
@@ -1,0 +1,81 @@
+package kfm.fauna.ebird
+
+# Best-effort predicate checks use string containment, not a full parser.
+
+deny[msg] if {
+  not input.source_uri
+  msg := "source_uri missing"
+}
+
+deny[msg] if {
+  not input.query_predicate
+  msg := "query_predicate missing"
+}
+
+deny[msg] if {
+  not re_match("^sha256:[a-f0-9]{64}$", object.get(input, "kfm:spec_hash", ""))
+  msg := "kfm:spec_hash missing or malformed"
+}
+
+deny[msg] if {
+  input.suppression_min_n < 10
+  msg := "suppression_min_n must be >= 10"
+}
+
+deny[msg] if {
+  input.aggregate
+  not input.aggregate in {"county", "huc12"}
+  msg := "aggregate must be county or huc12"
+}
+
+deny[msg] if {
+  is_public
+  exact_field := lower(input.public_fields[_])
+  exact_field in {"decimallatitude", "decimallongitude", "latitude", "longitude", "lat", "lon", "geom", "geometry"}
+  msg := sprintf("public layer exposes exact field: %s", [exact_field])
+}
+
+deny[msg] if {
+  is_public
+  object.get(input, "exact_points", "") != "restricted"
+  msg := "exact_points must be restricted for public eBird layers"
+}
+
+deny[msg] if {
+  is_public
+  qp := lower(input.query_predicate)
+  not contains(qp, "complete==true")
+  msg := "query_predicate must require complete checklists (best-effort)"
+}
+
+deny[msg] if {
+  is_public
+  qp := lower(input.query_predicate)
+  not contains(qp, "protocol_type!='incidental'")
+  msg := "query_predicate must exclude incidental protocol_type (best-effort)"
+}
+
+deny[msg] if {
+  is_public
+  qp := lower(input.query_predicate)
+  not contains(qp, "duration_min>=5")
+  msg := "query_predicate must include duration_min>=5 (best-effort)"
+}
+
+deny[msg] if {
+  is_public
+  qp := lower(input.query_predicate)
+  not contains(qp, "distance_km<=5")
+  msg := "query_predicate must include distance_km<=5 (best-effort)"
+}
+
+deny[msg] if {
+  is_public
+  qp := lower(input.query_predicate)
+  not contains(qp, "number_observers<=10")
+  msg := "query_predicate must include number_observers<=10 (best-effort)"
+}
+
+is_public if {
+  object.get(input, "policy_label", "public") == "public"
+}

--- a/schemas/contracts/v1/fauna/evidence_bundle.schema.json
+++ b/schemas/contracts/v1/fauna/evidence_bundle.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm://schema/contracts/v1/fauna/evidence_bundle.schema.json",
+  "title": "Fauna EvidenceBundle",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "object_type",
+    "domain",
+    "source",
+    "source_uri",
+    "query_predicate",
+    "mapping",
+    "kfm:spec_hash"
+  ],
+  "properties": {
+    "schema_version": { "const": "v1" },
+    "object_type": { "const": "EvidenceBundle" },
+    "domain": { "const": "fauna" },
+    "source": { "const": "ebird" },
+    "bundle_id": { "type": "string", "minLength": 1 },
+    "policy_label": { "type": "string", "minLength": 1 },
+    "rights_status": { "type": "string", "minLength": 1 },
+    "sensitivity": { "type": "string", "minLength": 1 },
+    "source_uri": { "type": "string", "minLength": 1 },
+    "query_predicate": { "type": "string", "minLength": 1 },
+    "aggregate": { "type": "string", "enum": ["county", "huc12"] },
+    "suppression_min_n": { "type": "integer", "minimum": 1 },
+    "evidence_bundle_uri": { "type": "string", "minLength": 1 },
+    "spec": { "type": "object", "additionalProperties": true },
+    "kfm:spec_hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "mapping": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "sampling_event_identifier",
+        "observation_date",
+        "latitude",
+        "longitude",
+        "observation_count",
+        "species_taxon_id",
+        "basisOfRecord"
+      ],
+      "properties": {
+        "sampling_event_identifier": { "const": "kfm:dataset_key" },
+        "observation_date": { "const": "occurrenceDate" },
+        "latitude": { "const": "decimalLatitude" },
+        "longitude": { "const": "decimalLongitude" },
+        "observation_count": { "const": "individualCount" },
+        "species_taxon_id": { "const": "taxonKey" },
+        "basisOfRecord": { "const": "HumanObservation" }
+      }
+    }
+  }
+}

--- a/tests/policy/fauna/ebird_test.rego
+++ b/tests/policy/fauna/ebird_test.rego
@@ -1,0 +1,62 @@
+package kfm.fauna.ebird_test
+
+import data.kfm.fauna.ebird
+
+valid_input := {
+  "schema_version": "v1",
+  "object_type": "EvidenceBundle",
+  "domain": "fauna",
+  "source": "ebird",
+  "source_uri": "https://example.org/ebird.csv",
+  "query_predicate": "complete==TRUE && protocol_type!='Incidental' && duration_min>=5 && distance_km<=5 && number_observers<=10",
+  "kfm:spec_hash": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "aggregate": "huc12",
+  "suppression_min_n": 10,
+  "policy_label": "public",
+  "exact_points": "restricted",
+  "public_fields": ["huc12", "count"]
+}
+
+test_valid_passes if {
+  count(ebird.deny with input as valid_input) == 0
+}
+
+test_missing_source_uri_denied if {
+  some msg in ebird.deny with input as object.remove(valid_input, "source_uri")
+  contains(msg, "source_uri")
+}
+
+test_missing_query_predicate_denied if {
+  some msg in ebird.deny with input as object.remove(valid_input, "query_predicate")
+  contains(msg, "query_predicate")
+}
+
+test_missing_spec_hash_denied if {
+  some msg in ebird.deny with input as object.remove(valid_input, "kfm:spec_hash")
+  contains(msg, "spec_hash")
+}
+
+test_malformed_spec_hash_denied if {
+  some msg in ebird.deny with input as object.union(valid_input, {"kfm:spec_hash": "sha256:xyz"})
+  contains(msg, "malformed")
+}
+
+test_suppression_below_10_denied if {
+  some msg in ebird.deny with input as object.union(valid_input, {"suppression_min_n": 9})
+  contains(msg, "suppression_min_n")
+}
+
+test_public_exact_fields_denied if {
+  some msg in ebird.deny with input as object.union(valid_input, {"public_fields": ["decimalLatitude", "huc12"]})
+  contains(msg, "exact field")
+}
+
+test_public_exact_points_not_restricted_denied if {
+  some msg in ebird.deny with input as object.union(valid_input, {"exact_points": "public"})
+  contains(msg, "exact_points")
+}
+
+test_query_predicate_constraints_denied if {
+  bad := object.union(valid_input, {"query_predicate": "complete==TRUE"})
+  count(ebird.deny with input as bad) >= 1
+}

--- a/tests/validators/fauna/test_validate_evidencebundle.py
+++ b/tests/validators/fauna/test_validate_evidencebundle.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from packages.evidence.evidencebundle_hash import compute_spec_hash
+
+SCRIPT = Path("tools/validators/fauna/validate_evidencebundle.py")
+
+
+def _bundle() -> dict[str, object]:
+    doc: dict[str, object] = {
+        "schema_version": "v1",
+        "object_type": "EvidenceBundle",
+        "domain": "fauna",
+        "source": "ebird",
+        "source_uri": "https://example.org/ebird.csv",
+        "query_predicate": "complete==TRUE && protocol_type!='Incidental' && duration_min>=5 && distance_km<=5 && number_observers<=10",
+        "aggregate": "huc12",
+        "suppression_min_n": 10,
+        "mapping": {
+            "sampling_event_identifier": "kfm:dataset_key",
+            "observation_date": "occurrenceDate",
+            "latitude": "decimalLatitude",
+            "longitude": "decimalLongitude",
+            "observation_count": "individualCount",
+            "species_taxon_id": "taxonKey",
+            "basisOfRecord": "HumanObservation",
+        },
+    }
+    doc["kfm:spec_hash"] = compute_spec_hash(doc)
+    return doc
+
+
+def _run(doc: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bundle.json"
+        path.write_text(json.dumps(doc), encoding="utf-8")
+        return subprocess.run(["python3", str(SCRIPT), str(path)], check=False, capture_output=True, text=True)
+
+
+def test_valid_evidencebundle_validates() -> None:
+    proc = _run(_bundle())
+    assert proc.returncode == 0
+
+
+def test_hash_mismatch_fails() -> None:
+    doc = _bundle()
+    doc["kfm:spec_hash"] = "sha256:" + "0" * 64
+    proc = _run(doc)
+    assert proc.returncode == 1
+    assert "does not match" in proc.stderr
+
+
+def test_missing_source_uri_fails() -> None:
+    doc = _bundle()
+    doc.pop("source_uri")
+    proc = _run(doc)
+    assert proc.returncode == 1
+
+
+def test_missing_query_predicate_fails() -> None:
+    doc = _bundle()
+    doc.pop("query_predicate")
+    proc = _run(doc)
+    assert proc.returncode == 1
+
+
+def test_malformed_spec_hash_fails() -> None:
+    doc = _bundle()
+    doc["kfm:spec_hash"] = "abc"
+    proc = _run(doc)
+    assert proc.returncode == 1

--- a/tools/connectors/fauna/kfm-ebird-ingest/README.md
+++ b/tools/connectors/fauna/kfm-ebird-ingest/README.md
@@ -1,16 +1,8 @@
-# kfm-ebird-ingest (Layer 1 scaffold)
+# kfm-ebird-ingest (Layer 2 scaffold)
 
-This connector is the first scaffold layer for KFM eBird ingest. It intentionally does **not** implement full EBD parsing, downloading, publishing, or public exact-point outputs.
+This connector remains dry-run only and does not ingest, download, or publish exact points.
 
-## CLI
-
-Run via:
-
-```bash
-python tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py --help
-```
-
-### Example
+## Dry-run
 
 ```bash
 kfm-ebird-ingest \
@@ -19,35 +11,25 @@ kfm-ebird-ingest \
   --filter "complete==TRUE && protocol_type!='Incidental' && duration_min>=5 && distance_km<=5 && number_observers<=10" \
   --aggregate huc12 \
   --suppression 10 \
-  --emit evidencebundle.json \
+  --emit /tmp/evidencebundle.json \
   --dry-run
 ```
 
-## Behavior
+## Validator
 
-- Required arguments are validated (`--ebd-file`, `--filter`, `--aggregate`, `--emit`).
-- `--aggregate` must be `county` or `huc12`.
-- `--suppression` must be at least 10.
-- `--source-uri` defaults to `file://<ebd-file>`.
-- In `--dry-run`, the command emits an EvidenceBundle JSON scaffold to `--emit` and does not read the EBD file.
+```bash
+python3 tools/validators/fauna/validate_evidencebundle.py /tmp/evidencebundle.json
+```
 
-## EvidenceBundle (v1)
+## Hash recipe
 
-Dry-run output contains:
+The emitted `kfm:spec_hash` uses canonical JSON and SHA-256 from `packages/evidence/evidencebundle_hash.py`.
+If `spec` exists it is hashed directly; otherwise hash input is derived from governance-critical fields.
 
-- `source_uri`
-- `query_predicate`
-- `mapping`
-- `kfm:spec_hash`
+## Governance gates
 
-`kfm:spec_hash` is a `sha256:` hash over a canonicalized normalized spec JSON (sorted keys, compact separators, and no volatile timestamp fields).
-
-## eBird mapping
-
-- `sampling_event_identifier` -> `kfm:dataset_key`
-- `observation_date` -> `occurrenceDate`
-- `latitude` -> `decimalLatitude`
-- `longitude` -> `decimalLongitude`
-- `observation_count` -> `individualCount`
-- `species_taxon_id` -> `taxonKey`
-- `basisOfRecord` -> `HumanObservation`
+Promotion checks in `policy/fauna/ebird.rego` enforce:
+- public-safe posture (`exact_points=restricted`, no exact coordinate fields)
+- suppression floor `>=10`
+- aggregate only `county|huc12`
+- best-effort checklist QA constraints in query predicates

--- a/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py
+++ b/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
-"""Scaffold CLI for KFM eBird ingest Layer 1."""
+"""Scaffold CLI for KFM eBird ingest Layer 2."""
 
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import sys
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 from typing import Any
+
+from packages.evidence.evidencebundle_hash import compute_spec_hash
 
 FIELD_MAPPING = {
     "sampling_event_identifier": "kfm:dataset_key",
@@ -27,63 +32,31 @@ def fail(message: str) -> None:
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        prog="kfm-ebird-ingest",
-        description="Layer 1 scaffold for KFM eBird ingest adapter.",
-    )
+    parser = argparse.ArgumentParser(prog="kfm-ebird-ingest", description="Layer 2 scaffold for KFM eBird ingest adapter.")
     parser.add_argument("--ebd-file", required=True, help="Path to eBird EBD file")
-    parser.add_argument(
-        "--source-uri",
-        help="Optional source URI. Defaults to file://<ebd-file>",
-    )
+    parser.add_argument("--source-uri", help="Optional source URI. Defaults to file://<ebd-file>")
     parser.add_argument("--filter", required=True, dest="predicate", help="Filter predicate")
-    parser.add_argument(
-        "--aggregate",
-        required=True,
-        choices=("county", "huc12"),
-        help="Aggregation grain",
-    )
-    parser.add_argument(
-        "--suppression",
-        type=int,
-        default=10,
-        help="Suppression threshold (minimum 10)",
-    )
+    parser.add_argument("--aggregate", required=True, choices=("county", "huc12"), help="Aggregation grain")
+    parser.add_argument("--suppression", type=int, default=10, help="Suppression threshold (minimum 10)")
     parser.add_argument("--emit", required=True, help="Output path for scaffold artifact")
     parser.add_argument("--dry-run", action="store_true", help="Emit scaffold EvidenceBundle only")
     return parser.parse_args(argv)
 
 
-def canonical_json(value: dict[str, Any]) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-
-
-def compute_spec_hash(spec: dict[str, Any]) -> str:
-    digest = hashlib.sha256(canonical_json(spec).encode("utf-8")).hexdigest()
-    return f"sha256:{digest}"
-
-
-def build_spec(args: argparse.Namespace, source_uri: str) -> dict[str, Any]:
-    return {
-        "adapter": "kfm-ebird-ingest",
-        "aggregate": args.aggregate,
-        "mapping": FIELD_MAPPING,
-        "query_predicate": args.predicate,
-        "source_uri": source_uri,
-        "suppression": args.suppression,
-        "version": "v1",
-    }
-
-
-def build_evidence_bundle(spec: dict[str, Any], spec_hash: str) -> dict[str, Any]:
-    return {
+def build_evidence_bundle(args: argparse.Namespace, source_uri: str) -> dict[str, Any]:
+    bundle: dict[str, Any] = {
         "schema_version": "v1",
         "object_type": "EvidenceBundle",
-        "source_uri": spec["source_uri"],
-        "query_predicate": spec["query_predicate"],
-        "mapping": spec["mapping"],
-        "kfm:spec_hash": spec_hash,
+        "domain": "fauna",
+        "source": "ebird",
+        "source_uri": source_uri,
+        "query_predicate": args.predicate,
+        "aggregate": args.aggregate,
+        "suppression_min_n": args.suppression,
+        "mapping": FIELD_MAPPING,
     }
+    bundle["kfm:spec_hash"] = compute_spec_hash(bundle)
+    return bundle
 
 
 def main() -> None:
@@ -94,11 +67,9 @@ def main() -> None:
     source_uri = args.source_uri or Path(args.ebd_file).resolve().as_uri()
 
     if not args.dry_run:
-        fail("Layer 1 scaffold supports --dry-run only; full ingest not implemented")
+        fail("Layer scaffold supports --dry-run only; full ingest not implemented")
 
-    spec = build_spec(args, source_uri)
-    spec_hash = compute_spec_hash(spec)
-    bundle = build_evidence_bundle(spec, spec_hash)
+    bundle = build_evidence_bundle(args, source_uri)
 
     emit_path = Path(args.emit)
     emit_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/tests/test_kfm_ebird_ingest_cli.py
+++ b/tools/tests/test_kfm_ebird_ingest_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 SCRIPT = "tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py"
 LAYER_REGISTRY = Path("data/published/fauna/layers/ebird_agg_huc12.json")
+VALIDATOR = "tools/validators/fauna/validate_evidencebundle.py"
 
 
 def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
@@ -74,3 +75,27 @@ def test_layer_registry_suppression_and_coordinate_safety() -> None:
     merged_fields = " ".join(layer["allowlist_fields"])
     for forbidden in ("decimalLatitude", "decimalLongitude", "latitude", "longitude"):
         assert forbidden not in merged_fields
+
+
+def test_dry_run_output_validates_with_evidencebundle_validator(tmp_path: Path) -> None:
+    out = tmp_path / "evidencebundle.json"
+    result = run_cli(
+        "--ebd-file",
+        "/tmp/ebd-EBD.txt",
+        "--filter",
+        "complete==TRUE && protocol_type!='Incidental' && duration_min>=5 && distance_km<=5 && number_observers<=10",
+        "--aggregate",
+        "huc12",
+        "--emit",
+        str(out),
+        "--dry-run",
+    )
+    assert result.returncode == 0
+
+    validate = subprocess.run(
+        [sys.executable, VALIDATOR, str(out)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert validate.returncode == 0

--- a/tools/validators/fauna/validate_evidencebundle.py
+++ b/tools/validators/fauna/validate_evidencebundle.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from jsonschema import Draft202012Validator
+from packages.evidence.evidencebundle_hash import compute_spec_hash
+
+SCHEMA_PATH = Path("schemas/contracts/v1/fauna/evidence_bundle.schema.json")
+SPEC_HASH_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+
+
+def fail(message: str) -> None:
+    print(f"DENY: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate a fauna EvidenceBundle.")
+    parser.add_argument("path", nargs="?", help="EvidenceBundle JSON path")
+    parser.add_argument("--file", dest="file_path", help="EvidenceBundle JSON path")
+    return parser.parse_args(argv)
+
+
+def main() -> None:
+    args = parse_args(sys.argv[1:])
+    target = args.file_path or args.path
+    if not target:
+        fail("usage: validate_evidencebundle.py [--file] <evidencebundle.json>")
+
+    path = Path(target)
+    if not path.exists():
+        fail(f"missing EvidenceBundle: {path}")
+
+    if not SCHEMA_PATH.exists():
+        fail(f"missing schema: {SCHEMA_PATH}")
+
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.path))
+    if errors:
+        for err in errors:
+            loc = ".".join(str(p) for p in err.path) or "<root>"
+            print(f"DENY: schema error at {loc}: {err.message}", file=sys.stderr)
+        sys.exit(1)
+
+    if not doc.get("source_uri"):
+        fail("source_uri missing")
+    if not doc.get("query_predicate"):
+        fail("query_predicate missing")
+
+    spec_hash = doc.get("kfm:spec_hash")
+    if not spec_hash:
+        fail("kfm:spec_hash missing")
+    if not isinstance(spec_hash, str) or not SPEC_HASH_RE.match(spec_hash):
+        fail("kfm:spec_hash malformed")
+
+    expected_hash = compute_spec_hash(doc)
+    if spec_hash != expected_hash:
+        fail("kfm:spec_hash does not match canonical spec hash")
+
+    print(f"ALLOW: valid fauna EvidenceBundle: {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Implement Layer 2 governance for the eBird ingest adapter to enforce schema, deterministic spec hashing, and promotion gates without adding ingestion or public exact-point publishing behavior.
- Provide a shared, deterministic `kfm:spec_hash` recipe so connectors and validators can verify spec integrity across tools. 
- Add policy-level checks that prevent unsafe public publication of exact coordinates and enforce suppression and checklist QA constraints.

### Description
- Add a fauna EvidenceBundle v1 JSON Schema at `schemas/contracts/v1/fauna/evidence_bundle.schema.json` with required fields and strict eBird mapping constraints. 
- Add a canonicalization and hash helper at `packages/evidence/evidencebundle_hash.py` that builds the hash input from `spec` or a derived object and returns `sha256:<hex>` over canonical JSON. 
- Update the connector dry-run to emit a schema-compliant EvidenceBundle and compute `kfm:spec_hash` via the shared helper in `tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_ingest.py`. 
- Add a validator CLI `tools/validators/fauna/validate_evidencebundle.py` that validates the schema, enforces required fields, recomputes and verifies `kfm:spec_hash`, and exits non-zero on denial, plus OPA policy `policy/fauna/ebird.rego`, policy tests `tests/policy/fauna/ebird_test.rego`, validator tests `tests/validators/fauna/test_validate_evidencebundle.py`, and documentation updates in `docs/domains/fauna/INGEST_EBIRD.md` and connector `README.md`.

### Testing
- Ran connector and validator unit tests with `pytest -q tools/tests/test_kfm_ebird_ingest_cli.py tests/validators/fauna/test_validate_evidencebundle.py` and all tests passed (`10 passed`).
- Validator tests exercise: valid bundle acceptance, hash mismatch, missing `source_uri`, missing `query_predicate`, and malformed `kfm:spec_hash` failures. 
- Added Rego policy tests at `tests/policy/fauna/ebird_test.rego` but did not run OPA/Conftest policy execution in CI here to avoid adding brittle global binary requirements; run locally with `opa test` or `conftest test` if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c7197794832aa772429cfea00375)