### PR TITLE
Add Layer 5 kfm-ebird-promote: governed promotion of public-safe eBird aggregates

### DIFF
--- a/data/published/fauna/layers/ebird_agg_county.json
+++ b/data/published/fauna/layers/ebird_agg_county.json
@@ -1,11 +1,5 @@
 {
-  "id": "ebird_agg_county",
-  "domain": "fauna",
-  "source": "ebird",
   "aggregate": "county",
-  "suppression_min_n": 10,
-  "policy_label": "public_aggregate",
-  "exact_points": "restricted",
   "allowlist_fields": [
     "county_fips",
     "taxonKey",
@@ -18,9 +12,6 @@
     "kfm:spec_hash",
     "evidence_bundle_uri"
   ],
-  "minzoom": 0,
-  "maxzoom": 12,
-  "public_safe": true,
   "denied_fields": [
     "decimalLatitude",
     "decimalLongitude",
@@ -28,8 +19,24 @@
     "longitude",
     "lat",
     "lon",
+    "raw_latitude",
+    "raw_longitude",
     "point",
     "geom",
     "geometry"
-  ]
+  ],
+  "domain": "fauna",
+  "exact_points": "restricted",
+  "id": "ebird_agg_county",
+  "latest_catalog_record_path": "/tmp/tmp1fd597jq/data/published/fauna/ebird/county/5c63e496170fb9de/catalog_record.json",
+  "latest_evidence_drawer_path": "/tmp/tmp1fd597jq/data/published/fauna/ebird/county/5c63e496170fb9de/evidence_drawer.json",
+  "latest_output_path": "/tmp/tmp1fd597jq/data/published/fauna/ebird/county/5c63e496170fb9de/aggregates.jsonl",
+  "latest_output_sha256": "sha256:191399e41158d4fa38c410f31b649f003ea3cfe2f05e78b02bba4509598ca744",
+  "latest_run_id": "5c63e496170fb9de",
+  "maxzoom": 12,
+  "minzoom": 0,
+  "policy_label": "public_aggregate",
+  "public_safe": true,
+  "source": "ebird",
+  "suppression_min_n": 10
 }

--- a/data/published/fauna/layers/ebird_agg_huc12.json
+++ b/data/published/fauna/layers/ebird_agg_huc12.json
@@ -1,11 +1,5 @@
 {
-  "id": "ebird_agg_huc12",
-  "domain": "fauna",
-  "source": "ebird",
   "aggregate": "huc12",
-  "suppression_min_n": 10,
-  "policy_label": "public_aggregate",
-  "exact_points": "restricted",
   "allowlist_fields": [
     "huc12",
     "taxonKey",
@@ -18,9 +12,6 @@
     "kfm:spec_hash",
     "evidence_bundle_uri"
   ],
-  "minzoom": 0,
-  "maxzoom": 12,
-  "public_safe": true,
   "denied_fields": [
     "decimalLatitude",
     "decimalLongitude",
@@ -28,8 +19,24 @@
     "longitude",
     "lat",
     "lon",
+    "raw_latitude",
+    "raw_longitude",
     "point",
     "geom",
     "geometry"
-  ]
+  ],
+  "domain": "fauna",
+  "exact_points": "restricted",
+  "id": "ebird_agg_huc12",
+  "latest_catalog_record_path": "/tmp/tmp2w1zsr7k/data/published/fauna/ebird/huc12/01aac40e97f350d5/catalog_record.json",
+  "latest_evidence_drawer_path": "/tmp/tmp2w1zsr7k/data/published/fauna/ebird/huc12/01aac40e97f350d5/evidence_drawer.json",
+  "latest_output_path": "/tmp/tmp2w1zsr7k/data/published/fauna/ebird/huc12/01aac40e97f350d5/aggregates.jsonl",
+  "latest_output_sha256": "sha256:b3ce36df193f995eaf9540675f31b72875699f720841184db9932d612e33acc1",
+  "latest_run_id": "01aac40e97f350d5",
+  "maxzoom": 12,
+  "minzoom": 0,
+  "policy_label": "public_aggregate",
+  "public_safe": true,
+  "source": "ebird",
+  "suppression_min_n": 10
 }

--- a/docs/domains/fauna/INGEST_EBIRD.md
+++ b/docs/domains/fauna/INGEST_EBIRD.md
@@ -25,3 +25,15 @@ No public exact-point publication is implemented in this layer.
 - Restricted suppression receipt stores hashed suppressed group identifiers.
 - Region assignment order: observation field, then optional synthetic GeoJSON spatial join.
 - WARNING: public outputs must never contain exact coordinates.
+
+## Layer 5: Governed Promotion
+`kfm-ebird-promote` validates a Layer 4 aggregate + manifest + EvidenceBundle, computes deterministic `run_id`, and writes:
+- `aggregates.(jsonl|csv)`
+- `aggregate_manifest.json`
+- `evidencebundle.json`
+- `catalog_record.json`
+- `triplets.jsonl`
+- `evidence_drawer.json`
+- `promotion_receipt.json`
+
+Promotion is aggregate-only and never publishes exact coordinates, restricted observations, quarantines, or suppression-group details.

--- a/policy/fauna/ebird.rego
+++ b/policy/fauna/ebird.rego
@@ -31,3 +31,8 @@ deny[msg] if { is_public_aggregate_row; input.checklist_count < input.suppressio
 
 is_public_layer if { object.get(input, "policy_label", "") == "public" or object.get(input, "policy_label", "") == "public_aggregate" }
 is_public_aggregate_row if { object.get(input, "object_type", "") == "AggregateOccurrence" }
+
+
+deny[msg] if { object.get(input,"object_type","")=="PromotionReceipt"; object.get(input,"policy_label","")!="public_aggregate"; msg:="promotion receipt policy_label must be public_aggregate" }
+deny[msg] if { object.get(input,"object_type","")=="PromotionReceipt"; object.get(input,"public_safe",false)!=true; msg:="promotion receipt public_safe must be true" }
+deny[msg] if { object.get(input,"object_type","")=="CatalogRecord"; object.get(input,"exact_points","")!="restricted"; msg:="catalog record exact_points must be restricted" }

--- a/tests/connectors/fauna/test_kfm_ebird_promote.py
+++ b/tests/connectors/fauna/test_kfm_ebird_promote.py
@@ -1,0 +1,61 @@
+import json, subprocess, tempfile
+from pathlib import Path
+from hashlib import sha256
+
+SCRIPT=Path('tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_promote.py')
+
+
+def shafile(p: Path)->str:
+    return 'sha256:'+sha256(p.read_bytes()).hexdigest()
+
+def make_row(agg='huc12'):
+    r={"schema_version":"v1","object_type":"AggregateOccurrence","domain":"fauna","source":"ebird","policy_label":"public_aggregate","aggregate":agg,"taxonKey":"sp1","occurrenceDate_month":"2025-01","checklist_count":10,"observation_count_sum":12,"observation_count_unknown_count":0,"species_count":1,"suppression_min_n":10,"kfm:spec_hash":"sha256:e2d03a9bbb06efed2bf6203fe04a35eba6fc11033d613a23fdbdcccd3c2e7fa7","evidence_bundle_uri":"file://eb.json"}
+    r['huc12' if agg=='huc12' else 'county_fips']='123456789012' if agg=='huc12' else '20001'
+    return r
+
+def run(td, agg='huc12', extra=None, dry=False):
+    eb=Path('tests/fixtures/fauna/ebird/evidencebundle.valid.json')
+    aggf=Path(td)/'agg.jsonl'; row=make_row(agg); aggf.write_text(json.dumps(row)+'\n')
+    man={"kfm:spec_hash":row['kfm:spec_hash'],"suppression_min_n":10,"output_sha256":shafile(aggf),"evidencebundle_sha256":shafile(eb),"counts":{"groups_published":1}}
+    manf=Path(td)/'man.json'; manf.write_text(json.dumps(man))
+    pub=Path(td)/'data/published/fauna/ebird'/agg; cat=Path(td)/'catalog'; reg=Path('data/published/fauna/layers/ebird_agg_'+agg+'.json')
+    cmd=['python3',str(SCRIPT),'--aggregate-file',str(aggf),'--aggregate-manifest',str(manf),'--evidencebundle',str(eb),'--aggregate',agg,'--publish-dir',str(pub),'--catalog-dir',str(cat),'--layer-registry',str(reg)]
+    if dry: cmd.append('--dry-run')
+    if extra: cmd.extend(extra)
+    return subprocess.run(cmd,capture_output=True,text=True)
+
+
+def test_promote_huc12_success_and_receipt_safety():
+    with tempfile.TemporaryDirectory() as td:
+        p=run(td); assert p.returncode==0, p.stderr
+        run_dir=next((Path(td)/'data/published/fauna/ebird/huc12').iterdir())
+        rec=json.loads((run_dir/'promotion_receipt.json').read_text())
+        assert rec['public_safe'] is True
+        assert 'suppressed_groups' not in rec
+        assert 'suppressed_groups' not in rec.get('counts', {})
+
+
+def test_promote_county_success():
+    with tempfile.TemporaryDirectory() as td:
+        p=run(td,agg='county'); assert p.returncode==0, p.stderr
+
+
+def test_dry_run_no_writes_and_deterministic_run_id():
+    with tempfile.TemporaryDirectory() as td:
+        p1=run(td,dry=True); p2=run(td,dry=True)
+        assert p1.returncode==0 and p2.returncode==0
+        j1=json.loads(p1.stdout[p1.stdout.find('{'):]); j2=json.loads(p2.stdout[p2.stdout.find('{'):]); assert j1['run_id']==j2['run_id']
+        assert not (Path(td)/'data/published/fauna/ebird/huc12').exists()
+
+
+def test_failures():
+    with tempfile.TemporaryDirectory() as td:
+        p=run(td, extra=['--overwrite']); assert p.returncode==0
+        p2=run(td); assert p2.returncode!=0
+    with tempfile.TemporaryDirectory() as td:
+        p=run(td, extra=['--evidencebundle','tests/fixtures/fauna/ebird/restricted_observations.jsonl']); assert p.returncode!=0
+    with tempfile.TemporaryDirectory() as td:
+        bad=Path(td)/'bad.jsonl'; r=make_row(); r['decimalLatitude']=1; bad.write_text(json.dumps(r)+'\n')
+        eb=Path('tests/fixtures/fauna/ebird/evidencebundle.valid.json'); man=Path(td)/'m.json'; man.write_text(json.dumps({"kfm:spec_hash":r['kfm:spec_hash'],"suppression_min_n":10,"output_sha256":shafile(bad),"evidencebundle_sha256":shafile(eb)}))
+        cmd=['python3',str(SCRIPT),'--aggregate-file',str(bad),'--aggregate-manifest',str(man),'--evidencebundle',str(eb),'--aggregate','huc12','--publish-dir',str(Path(td)/'data/published/x'),'--catalog-dir',str(Path(td)/'c')]
+        assert subprocess.run(cmd,capture_output=True,text=True).returncode!=0

--- a/tools/connectors/fauna/kfm-ebird-ingest/README.md
+++ b/tools/connectors/fauna/kfm-ebird-ingest/README.md
@@ -26,3 +26,21 @@ kfm-ebird-ingest \
 
 ## Layer 4 aggregation
 Use `kfm-ebird-aggregate` to create public-safe county/HUC12 aggregates, restricted suppression receipts, and aggregate manifests. Public outputs must never contain exact coordinates. Suppression rule: `checklist_count >= suppression_min_n`.
+
+## Layer 5 Promotion (`kfm-ebird-promote`)
+Promotes Layer 4 public-safe aggregates into governed public/catalog artifacts.
+
+Example:
+```bash
+kfm-ebird-promote \
+  --aggregate-file tests/fixtures/fauna/ebird/ebird_agg_huc12.public.jsonl \
+  --aggregate-manifest tests/fixtures/fauna/ebird/ebird_agg_huc12_manifest.json \
+  --evidencebundle tests/fixtures/fauna/ebird/evidencebundle.valid.json \
+  --aggregate huc12
+```
+
+Safety guarantees:
+- never publishes exact coordinates/geometry
+- requires `policy_label=public_aggregate`, `exact_points=restricted`, and `public_safe=true`
+- refuses to publish suppression receipts or restricted raw rows
+- deterministic run id from canonical hash inputs

--- a/tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-promote
+++ b/tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-promote
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python "$(dirname "$0")/kfm_ebird_promote.py" "$@"

--- a/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_promote.py
+++ b/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_promote.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse,csv,hashlib,json,sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from packages.evidence.evidencebundle_hash import canonical_json
+from tools.validators.fauna.validate_evidencebundle import main as validate_bundle_main
+
+DENIED_FIELDS=["decimalLatitude","decimalLongitude","latitude","longitude","lat","lon","raw_latitude","raw_longitude","point","geom","geometry"]
+
+
+def fail(msg:str)->None:
+    print(f"ERROR: {msg}", file=sys.stderr); raise SystemExit(2)
+
+def sha256_file(path:Path)->str:
+    d=hashlib.sha256();
+    with path.open('rb') as f:
+        for c in iter(lambda:f.read(65536), b''): d.update(c)
+    return f"sha256:{d.hexdigest()}"
+
+def parse_rows(path:Path, fmt:str)->list[dict[str,Any]]:
+    if fmt=='jsonl':
+        return [json.loads(l) for l in path.read_text(encoding='utf-8').splitlines() if l.strip()]
+    with path.open('r', encoding='utf-8', newline='') as f:
+        return list(csv.DictReader(f))
+
+def write_rows(path:Path, fmt:str, rows:list[dict[str,Any]])->None:
+    if fmt=='jsonl':
+        path.write_text(''.join(json.dumps(r,sort_keys=True)+"\n" for r in rows), encoding='utf-8'); return
+    fields=list(rows[0].keys()) if rows else []
+    with path.open('w', encoding='utf-8', newline='') as f:
+        w=csv.DictWriter(f, fieldnames=fields); w.writeheader(); w.writerows(rows)
+
+def parse_args(argv:list[str])->argparse.Namespace:
+    p=argparse.ArgumentParser(prog='kfm-ebird-promote')
+    p.add_argument('--aggregate-file', required=True); p.add_argument('--aggregate-manifest', required=True)
+    p.add_argument('--evidencebundle', required=True); p.add_argument('--aggregate', required=True, choices=('county','huc12'))
+    p.add_argument('--publish-dir'); p.add_argument('--catalog-dir'); p.add_argument('--layer-registry')
+    p.add_argument('--promotion-receipt'); p.add_argument('--format', choices=('jsonl','csv'), default='jsonl')
+    p.add_argument('--run-id'); p.add_argument('--dry-run', action='store_true'); p.add_argument('--overwrite', action='store_true')
+    return p.parse_args(argv)
+
+def main()->None:
+    a=parse_args(sys.argv[1:])
+    pub=Path(a.publish_dir or f"data/published/fauna/ebird/{a.aggregate}")
+    cat=Path(a.catalog_dir or f"data/catalog/fauna/ebird/{a.aggregate}")
+    regp=Path(a.layer_registry or f"data/published/fauna/layers/ebird_agg_{a.aggregate}.json")
+    rec_override=Path(a.promotion_receipt) if a.promotion_receipt else None
+    aggf,manf,ebf=Path(a.aggregate_file),Path(a.aggregate_manifest),Path(a.evidencebundle)
+    for p in [aggf,manf,ebf,regp]:
+        if not p.exists(): fail(f"Missing input file: {p}")
+    if 'data/published' not in pub.as_posix(): fail('--publish-dir must be under data/published')
+
+    old=sys.argv
+    try:
+        sys.argv=['validate_evidencebundle.py', str(ebf)]; validate_bundle_main()
+    except SystemExit as e:
+        if e.code!=0: fail('EvidenceBundle validation failed')
+    finally: sys.argv=old
+
+    bundle=json.loads(ebf.read_text(encoding='utf-8')); manifest=json.loads(manf.read_text(encoding='utf-8')); registry=json.loads(regp.read_text(encoding='utf-8'))
+    rows=parse_rows(aggf,a.format)
+    eb_sha,man_sha,agg_sha=sha256_file(ebf),sha256_file(manf),sha256_file(aggf)
+    spec=bundle.get('kfm:spec_hash')
+    if not spec: fail('Missing kfm:spec_hash in EvidenceBundle')
+    if manifest.get('output_sha256') and manifest['output_sha256']!=agg_sha: fail('Aggregate file hash mismatch manifest output_sha256')
+    if manifest.get('evidencebundle_sha256') and manifest['evidencebundle_sha256']!=eb_sha: fail('EvidenceBundle hash mismatch manifest evidencebundle_sha256')
+    if manifest.get('kfm:spec_hash') and manifest['kfm:spec_hash']!=spec: fail('kfm:spec_hash mismatch between manifest and EvidenceBundle')
+
+    min_n=int(manifest.get('suppression_min_n', bundle.get('suppression_min_n',10)))
+    if min_n<10: fail('suppression_min_n must be >= 10')
+    denied_low={x.lower() for x in DENIED_FIELDS}
+    for i,r in enumerate(rows):
+        if r.get('policy_label')!='public_aggregate': fail(f'row {i} policy_label must be public_aggregate')
+        if str(r.get('kfm:spec_hash'))!=spec: fail('kfm:spec_hash mismatch across aggregate rows and EvidenceBundle')
+        for k in r.keys():
+            if k.lower() in denied_low: fail(f'aggregate row contains denied field: {k}')
+        if int(r.get('checklist_count',0))<min_n: fail('aggregate row checklist_count below suppression_min_n')
+    if registry.get('exact_points')!='restricted': fail('layer registry exact_points must be restricted')
+    if registry.get('public_safe') is not True: fail('layer registry public_safe must be true')
+    if any(f.lower() in denied_low for f in registry.get('allowlist_fields',[])): fail('layer registry allowlist contains denied fields')
+
+    run_id=a.run_id or hashlib.sha256(canonical_json({"aggregate":a.aggregate,"aggregate_file_sha256":agg_sha,"aggregate_manifest_sha256":man_sha,"evidencebundle_sha256":eb_sha,"kfm_spec_hash":spec}).encode()).hexdigest()[:16]
+    layer_id=f"ebird_agg_{a.aggregate}"
+    run_dir=pub/run_id
+    out_file=run_dir/f"aggregates.{a.format}"; out_manifest=run_dir/'aggregate_manifest.json'; out_bundle=run_dir/'evidencebundle.json'
+    out_catalog=run_dir/'catalog_record.json'; out_triplets=run_dir/'triplets.jsonl'; out_drawer=run_dir/'evidence_drawer.json'; out_receipt=rec_override or run_dir/'promotion_receipt.json'
+    for p in [out_file,out_manifest,out_bundle,out_catalog,out_triplets,out_drawer,out_receipt]:
+        if p.exists() and not a.overwrite: fail(f'target exists (use --overwrite): {p}')
+    if a.dry_run:
+        print(json.dumps({"run_id":run_id,"plan":{"publish_dir":str(run_dir),"catalog_dir":str(cat)},"valid":True},indent=2)); return
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    write_rows(out_file,a.format,rows)
+    out_manifest.write_text(json.dumps({k:v for k,v in manifest.items() if 'suppressed' not in k and 'suppression_receipt' not in k},indent=2,sort_keys=True)+"\n",encoding='utf-8')
+    out_bundle.write_text(json.dumps(bundle,indent=2,sort_keys=True)+"\n",encoding='utf-8')
+    out_sha=sha256_file(out_file)
+    displayed=[f for f in registry.get('allowlist_fields',[]) if f not in {'kfm:spec_hash','evidence_bundle_uri'}]
+    common_counts={k:manifest.get('counts',{}).get(k) for k in ["rows_seen","rows_assigned","rows_unassigned","rows_invalid","groups_seen","groups_published","groups_suppressed","observation_count_unknown"] if manifest.get('counts',{}).get(k) is not None}
+    rec={"schema_version":"v1","object_type":"CatalogRecord","domain":"fauna","source":"ebird","layer_id":layer_id,"aggregate":a.aggregate,"policy_label":"public_aggregate","public_safe":True,"exact_points":"restricted","run_id":run_id,"kfm:spec_hash":spec,"evidence_bundle_uri":bundle.get('source_uri',str(out_bundle)),"source_uri":bundle.get('source_uri'),"query_predicate":bundle.get('query_predicate'),"suppression_min_n":min_n,"output_path":str(out_file),"output_sha256":out_sha,"aggregate_manifest_path":str(out_manifest),"aggregate_manifest_sha256":sha256_file(out_manifest),"evidencebundle_path":str(out_bundle),"evidencebundle_sha256":sha256_file(out_bundle),"layer_registry_path":str(regp),"layer_registry_sha256":sha256_file(regp),"output_fields":list(rows[0].keys()) if rows else registry.get('allowlist_fields',[]),"denied_public_fields_checked":DENIED_FIELDS,**common_counts}
+    if 'rights_status' in bundle: rec['rights_status']=bundle['rights_status']
+    if 'citation' in bundle: rec['citation']=bundle['citation']
+    if 'citation_uri' in bundle: rec['citation_uri']=bundle['citation_uri']
+    out_catalog.write_text(json.dumps(rec,indent=2,sort_keys=True)+"\n",encoding='utf-8')
+    triplets=[{"subject":layer_id,"predicate":p,"object":o,"evidence_bundle_uri":rec['evidence_bundle_uri'],"kfm:spec_hash":spec,"policy_label":"public_aggregate"} for p,o in [("hasDomain","fauna"),("hasSource","ebird"),("hasAggregate",a.aggregate),("hasPolicyLabel","public_aggregate"),("hasExactPoints","restricted"),("hasSuppressionMinN",min_n),("hasSpecHash",spec),("hasEvidenceBundle",str(out_bundle)),("hasAggregateManifest",str(out_manifest)),("hasOutputHash",out_sha),("derivedFrom","EvidenceBundle"),("promotedBy","kfm-ebird-promote"),("hasRunId",run_id)]]
+    out_triplets.write_text(''.join(json.dumps(t,sort_keys=True)+"\n" for t in triplets),encoding='utf-8')
+    drawer={"schema_version":"v1","object_type":"EvidenceDrawer","domain":"fauna","source":"ebird","layer_id":layer_id,"aggregate":a.aggregate,"policy_label":"public_aggregate","public_safe":True,"exact_points":"restricted","source_uri":bundle.get('source_uri'),"query_predicate":bundle.get('query_predicate'),"kfm:spec_hash":spec,"evidence_bundle_uri":rec['evidence_bundle_uri'],"suppression_min_n":min_n,"mapping":bundle.get('mapping',{}),"displayed_fields":displayed,"hidden_fields":DENIED_FIELDS,"denied_public_fields_checked":DENIED_FIELDS}
+    out_drawer.write_text(json.dumps(drawer,indent=2,sort_keys=True)+"\n",encoding='utf-8')
+    receipt={"schema_version":"v1","object_type":"PromotionReceipt","domain":"fauna","source":"ebird","policy_label":"public_aggregate","public_safe":True,"run_id":run_id,"aggregate":a.aggregate,"layer_id":layer_id,"kfm:spec_hash":spec,"suppression_min_n":min_n,"validations_passed":["evidencebundle","aggregate_rows","manifest_hashes","registry_safety"],"input_hashes":{"aggregate_file_sha256":agg_sha,"aggregate_manifest_sha256":man_sha,"evidencebundle_sha256":eb_sha},"output_hashes":{"aggregates_sha256":out_sha,"catalog_record_sha256":sha256_file(out_catalog),"triplets_sha256":sha256_file(out_triplets),"evidence_drawer_sha256":sha256_file(out_drawer)},"published_paths":{"run_dir":str(run_dir),"aggregates":str(out_file)},"catalog_paths":{"catalog_record":str(out_catalog),"triplets":str(out_triplets),"evidence_drawer":str(out_drawer)},"denied_public_fields_checked":DENIED_FIELDS,"promoted_at":datetime.now(timezone.utc).isoformat(),"counts":common_counts}
+    out_receipt.parent.mkdir(parents=True,exist_ok=True); out_receipt.write_text(json.dumps(receipt,indent=2,sort_keys=True)+"\n",encoding='utf-8')
+    cat.mkdir(parents=True,exist_ok=True)
+    idx=cat/'index.json'; data=json.loads(idx.read_text()) if idx.exists() else {"entries":{}}
+    data['entries'][run_id]={"layer_id":layer_id,"aggregate":a.aggregate,"run_id":run_id,"kfm:spec_hash":spec,"catalog_record_path":str(out_catalog),"public_output_path":str(out_file),"evidence_drawer_path":str(out_drawer),"promotion_receipt_path":str(out_receipt),"output_sha256":out_sha,"promoted_at":receipt['promoted_at']}
+    idx.write_text(json.dumps(data,indent=2,sort_keys=True)+"\n",encoding='utf-8')
+    registry.update({"latest_run_id":run_id,"latest_catalog_record_path":str(out_catalog),"latest_evidence_drawer_path":str(out_drawer),"latest_output_path":str(out_file),"latest_output_sha256":out_sha,"denied_fields":DENIED_FIELDS,"public_safe":True,"exact_points":"restricted"})
+    regp.write_text(json.dumps(registry,indent=2,sort_keys=True)+"\n",encoding='utf-8')
+
+if __name__=='__main__': main()


### PR DESCRIPTION
### Motivation
- Implement a Layer 5 promotion step to govern moving already-public-safe Layer 4 aggregates into the KFM catalog/published lane with immutable hashes, receipts, triplets, and Evidence Drawer/API DTO contracts.
- Enforce public-safety posture and deterministic provenance (`kfm:spec_hash`, input/output sha256, suppression rules) before writing any public artifacts.

### Description
- Add a new CLI `kfm-ebird-promote` (launcher + `tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_promote.py`) that validates inputs, computes a deterministic `run_id`, and emits governed artifacts under `<publish-dir>/<run_id>/` including `aggregates.(jsonl|csv)`, `aggregate_manifest.json`, `evidencebundle.json`, `catalog_record.json`, `triplets.jsonl`, `evidence_drawer.json`, and `promotion_receipt.json`.
- Implement validations for file existence, EvidenceBundle schema (reusing existing validator), manifest/aggregate/evidencebundle hash consistency, `kfm:spec_hash` coherence, suppression_min_n >= 10 and checklist_count checks, denied exact-coordinate/geometry fields, and layer-registry safety checks; support `--dry-run`, `--overwrite`, `--run-id`, and deterministic run-id calculation when not provided.
- Update catalog index and layer registry pointers/metadata, expand policy rules (`policy/fauna/ebird.rego`) to cover PromotionReceipt and CatalogRecord invariants, and add documentation describing the Layer 5 workflow and safety guarantees.
- Add connector tests for happy and failing paths (`tests/connectors/fauna/test_kfm_ebird_promote.py`) and a small launcher; keep fixtures small and avoid publishing suppressed/raw details.

### Testing
- Ran: `pytest -q tests/connectors/fauna/test_kfm_ebird_promote.py tests/connectors/fauna/test_kfm_ebird_aggregate.py tests/validators/fauna/test_validate_evidencebundle.py`, and the test suite passed: `11 passed`.
- An earlier attempt to run a `.rego` file directly via `pytest` was not applicable and was not included in the final test run because `.rego` files are not pytest targets.
- The `--dry-run` behavior, overwrite protection, deterministic `run_id`, validation failures for denied coordinate fields, and successful HUC12/county promotions are covered by the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d1495b0c832a8e8702339626336f)