### PR TITLE
Add Layer 22 eBird remediation and corrective-release CLI scaffolds

### DIFF
--- a/docs/domains/fauna/EBIRD_REMEDIATION.md
+++ b/docs/domains/fauna/EBIRD_REMEDIATION.md
@@ -1,0 +1,25 @@
+# EBIRD Layer 22 Remediation
+
+Layer 22 adds **copy-on-write corrective remediation governance** for public-safe eBird aggregates.
+
+## CLIs
+- `kfm-ebird-remediate`
+- `kfm-ebird-corrective-release`
+
+## Key rules
+- No network calls, no credentials, no real eBird data.
+- Apply mode requires `--apply --force`.
+- Remediation defaults to copy-on-write.
+- Public outputs must keep `public_safe=true`, `exact_points=restricted`, and suppression >= 10.
+- Blocked classes (data-affecting, hash recipe changes, governed predicate changes) require full rerun planning.
+
+## IDs
+- `remediation_id`: sha256 over canonical remediation inputs (no timestamps), first 16 hex.
+- `corrective_release_id`: sha256 over canonical corrective release inputs (no timestamps), first 16 hex.
+
+## Outputs
+Remediation writes: plan, manifest, diff report, root cause report, validation report, optional receipt.
+Corrective release writes: plan, manifest, validation report, optional approval receipt.
+
+## Safety
+Public artifacts must never include exact coordinates, restricted paths, suppression receipt details, suppressed group hashes, raw row numbers, or secrets.

--- a/tools/connectors/fauna/kfm-ebird-ingest/README.md
+++ b/tools/connectors/fauna/kfm-ebird-ingest/README.md
@@ -1,2 +1,7 @@
 # KFM eBird ingest - Layer 21
 Provides `kfm-ebird-quality` and `kfm-ebird-triage` CLIs for synthetic, offline QA governance and triage.
+
+
+## Layer 22 CLIs
+- `kfm-ebird-remediate`
+- `kfm-ebird-corrective-release`

--- a/tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-corrective-release
+++ b/tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-corrective-release
@@ -1,0 +1,1 @@
+kfm_ebird_corrective_release.py

--- a/tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-remediate
+++ b/tools/connectors/fauna/kfm-ebird-ingest/kfm-ebird-remediate
@@ -1,0 +1,1 @@
+kfm_ebird_remediate.py

--- a/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_corrective_release.py
+++ b/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_corrective_release.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, hashlib, sys
+from pathlib import Path
+from datetime import datetime, timezone
+VERSION='0.22.0'
+
+def now(): return datetime.now(timezone.utc).isoformat()
+def fail(m): print(f'ERROR: {m}',file=sys.stderr); raise SystemExit(2)
+def sh(p:Path): return hashlib.sha256(p.read_bytes()).hexdigest()
+
+def parse(argv):
+  p=argparse.ArgumentParser(prog='kfm-ebird-corrective-release')
+  p.add_argument('--version',action='version',version=VERSION)
+  p.add_argument('--mode',default='plan',choices=['plan','build','validate','approve-local','rollback-plan','report'])
+  p.add_argument('--aggregate',default='huc12',choices=['huc12','county','both'])
+  for a in ['remediation-plan','remediation-receipt','remediation-manifest','public-correction-notice','release-receipt','package-manifest','deployment-receipt','public-out-dir']:
+    p.add_argument(f'--{a}')
+  p.add_argument('--published-root',default='data/published/fauna/ebird');p.add_argument('--catalog-root',default='data/catalog/fauna/ebird');p.add_argument('--layer-registry-dir',default='data/published/fauna/layers')
+  p.add_argument('--out-dir',default='data/catalog/fauna/ebird/corrective-releases/run');p.add_argument('--decision',choices=['approve','block','needs-review'])
+  p.add_argument('--dry-run',action='store_true');p.add_argument('--force',action='store_true')
+  return p.parse_args(argv)
+
+def main():
+  a=parse(sys.argv[1:])
+  if a.mode=='build' and not a.remediation_plan: fail('build requires --remediation-plan')
+  if a.mode=='approve-local' and (not a.force or not a.remediation_receipt): fail('approve-local requires --force and --remediation-receipt')
+  out=Path(a.out_dir); out.mkdir(parents=True,exist_ok=True)
+  rp=json.loads(Path(a.remediation_plan).read_text()) if a.remediation_plan and Path(a.remediation_plan).exists() else {}
+  rid=rp.get('remediation_id','unknown')
+  blocked = bool(json.loads(Path(a.remediation_manifest).read_text()).get('counts',{}).get('actions_blocked_requires_rerun',0)) if a.remediation_manifest and Path(a.remediation_manifest).exists() else False
+  obj={"aggregate_targets":a.aggregate,"remediation_id":rid}
+  for f in ['remediation_receipt','remediation_manifest','public_correction_notice','release_receipt','package_manifest','deployment_receipt']:
+    v=getattr(a,f)
+    if v and Path(v).exists(): obj[f+'_sha256']=sh(Path(v))
+  cid=hashlib.sha256(json.dumps(obj,sort_keys=True,separators=(',',':')).encode()).hexdigest()[:16]
+  plan={"schema_version":"v1","object_type":"EbirdCorrectiveReleasePlan","domain":"fauna","source":"ebird","adapter":"kfm-ebird","policy_label":"corrective_release","public_safe_final_outputs":True,"exact_points":"restricted","corrective_release_id":cid,"remediation_id":rid,"aggregate_targets":[a.aggregate],"corrective_release_type":"blocked_requires_full_rerun" if blocked else "mixed_public_safe","blocked_actions":["requires_full_rerun"] if blocked else [],"generated_at":now()}
+  (out/'corrective_release_plan.json').write_text(json.dumps(plan,indent=2)+'\n')
+  (out/'corrective_release_manifest.json').write_text(json.dumps({"schema_version":"v1","object_type":"EbirdCorrectiveReleaseManifest","domain":"fauna","source":"ebird","adapter":"kfm-ebird","policy_label":"corrective_release","public_safe_final_outputs":True,"exact_points":"restricted","corrective_release_id":cid,"remediation_id":rid,"input_artifacts":[],"output_artifacts":[],"generated_at":now()},indent=2)+'\n')
+  (out/'corrective_release_validation_report.json').write_text(json.dumps({"schema_version":"v1","object_type":"EbirdCorrectiveReleaseValidationReport","corrective_release_id":cid,"status":"fail" if blocked else "pass"},indent=2)+'\n')
+  if a.mode=='approve-local':
+    dec='blocked' if blocked else ('approved' if a.decision=='approve' else 'needs_review')
+    (out/'corrective_release_receipt.json').write_text(json.dumps({"schema_version":"v1","object_type":"EbirdCorrectiveReleaseReceipt","domain":"fauna","source":"ebird","adapter":"kfm-ebird","policy_label":"public_aggregate","public_safe":True,"exact_points":"restricted","corrective_release_id":cid,"remediation_id":rid,"decision":dec,"blockers":["blocked_actions"] if blocked else [],"generated_at":now()},indent=2)+'\n')
+  print(cid)
+
+if __name__=='__main__': main()

--- a/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_remediate.py
+++ b/tools/connectors/fauna/kfm-ebird-ingest/kfm_ebird_remediate.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, hashlib, sys
+from pathlib import Path
+from datetime import datetime, timezone
+
+VERSION='0.22.0'
+SAFE_TYPES={"metadata_only","public_text_only","pointer_only","checksum_only","package_manifest_only"}
+BLOCKED_TYPES={"data_affecting","aggregate_value_change","suppression_threshold_change","governed_filter_change","evidencebundle_hash_recipe_change","kfm_spec_hash_change","taxon_crosswalk_semantics_change","region_crosswalk_semantics_change","public_output_field_contract_change","restricted_artifact_change","suppression_receipt_change","raw_ebd_change"}
+
+
+def fail(msg):
+    print(f'ERROR: {msg}',file=sys.stderr); raise SystemExit(2)
+
+def sha(path:Path)->str:
+    d=hashlib.sha256();d.update(path.read_bytes());return d.hexdigest()
+
+def now(): return datetime.now(timezone.utc).isoformat()
+
+def parse(argv):
+    p=argparse.ArgumentParser(prog='kfm-ebird-remediate')
+    p.add_argument('--version',action='version',version=VERSION)
+    p.add_argument('--mode',default='plan',choices=['plan','apply','verify','close-triage','rollback-plan','public-notice','report'])
+    p.add_argument('--aggregate',default='huc12',choices=['huc12','county','both'])
+    for a in ['triage-queue','triage-manifest','quality-report','quality-anomaly-report','quality-metadata-gap-report','quality-crosswalk-drift-report','release-receipt','public-portal-manifest','public-download-manifest','public-federation-index','public-analytics-index','package-manifest','deployment-receipt','assurance-scan-report','support-workflow-pack','patch-file','public-out-dir','target-root']:
+        p.add_argument(f'--{a}')
+    p.add_argument('--out-dir',default='data/catalog/fauna/ebird/remediation/run')
+    p.add_argument('--owner-role',default='data-steward')
+    p.add_argument('--dry-run',action='store_true');p.add_argument('--apply',action='store_true');p.add_argument('--force',action='store_true')
+    return p.parse_args(argv)
+
+def load_patches(path):
+    if not path: return []
+    p=Path(path); txt=p.read_text()
+    recs=[json.loads(l) for l in txt.splitlines() if l.strip()] if p.suffix=='.jsonl' else None
+    if recs is None:
+        raw=json.loads(txt); recs=raw if isinstance(raw,list) else [raw]
+    return recs
+
+def contains_denied(val:str)->bool:
+    s=val.lower(); denied=['decimallatitude','decimallongitude','geometry','suppression_receipt','raw_row_number','/restricted/','token=','apikey=']
+    return any(d in s for d in denied)
+
+def remediation_id(args,input_hashes):
+    obj={"aggregate_targets":args.aggregate,"owner_role":args.owner_role,"adapter_version":VERSION,"input_artifact_hashes":input_hashes}
+    if args.patch_file: obj['patch_file_sha256']=sha(Path(args.patch_file))
+    return hashlib.sha256(json.dumps(obj,sort_keys=True,separators=(',',':')).encode()).hexdigest()[:16]
+
+def main():
+    a=parse(sys.argv[1:])
+    if a.mode=='apply' and (not a.apply or not a.force): fail('apply mode requires --apply and --force')
+    out=Path(a.out_dir); out.mkdir(parents=True,exist_ok=True)
+    input_hashes={}
+    for k,v in vars(a).items():
+        if k.endswith(('queue','manifest','report','receipt','index','pack','file')) and isinstance(v,str) and Path(v).exists(): input_hashes[k]=sha(Path(v))
+    rid=remediation_id(a,input_hashes)
+    patches=load_patches(a.patch_file)
+    actions=[]; blocked=[]
+    for i,p in enumerate(patches,1):
+        pt=p.get('patch_type','manual_review')
+        s=json.dumps(p,sort_keys=True)
+        if contains_denied(s): fail(f'unsafe patch payload {p.get("patch_id",i)}')
+        if pt in SAFE_TYPES:
+            actions.append({"action_id":f"a{i}","action_type":f"patch_{pt.split('_')[0]}","remediation_class":pt,"allowed_to_apply":True,"reason":p.get('reason','')})
+        else:
+            blocked.append({"action_id":f"a{i}","reason":"requires full rerun","requires_full_rerun":True})
+    plan={"schema_version":"v1","object_type":"EbirdRemediationPlan","domain":"fauna","source":"ebird","adapter":"kfm-ebird","policy_label":"remediation","public_safe_final_outputs":True,"exact_points":"restricted","remediation_id":rid,"aggregate_targets":[a.aggregate],"findings_classified":[],"planned_actions":actions,"prohibited_actions":{"change_evidencebundle_hash_recipe":True,"change_governed_filter":True},"generated_at":now()}
+    (out/'remediation_plan.json').write_text(json.dumps(plan,indent=2)+"\n")
+    manifest={"schema_version":"v1","object_type":"EbirdRemediationManifest","domain":"fauna","source":"ebird","adapter":"kfm-ebird","policy_label":"remediation","public_safe_final_outputs":True,"exact_points":"restricted","remediation_id":rid,"input_artifacts":[],"output_artifacts":[],"counts":{"findings_seen":len(patches),"actions_planned":len(actions)+len(blocked),"actions_apply_allowed":len(actions),"actions_blocked_requires_rerun":len(blocked),"actions_manual_review":0,"artifacts_corrected":0,"triage_items_closed":0},"generated_at":now()}
+    (out/'remediation_manifest.json').write_text(json.dumps(manifest,indent=2)+"\n")
+    (out/'remediation_diff_report.json').write_text(json.dumps({"schema_version":"v1","object_type":"EbirdRemediationDiffReport","domain":"fauna","source":"ebird","adapter":"kfm-ebird","remediation_id":rid,"status":"pass" if not blocked else "warn","diffs":[],"blocked_diffs":blocked,"generated_at":now()},indent=2)+"\n")
+    (out/'root_cause_report.json').write_text(json.dumps({"schema_version":"v1","object_type":"EbirdRemediationRootCauseReport","domain":"fauna","source":"ebird","adapter":"kfm-ebird","remediation_id":rid,"status":"pass","root_causes":[],"generated_at":now()},indent=2)+"\n")
+    (out/'remediation_validation_report.json').write_text(json.dumps({"schema_version":"v1","object_type":"EbirdRemediationValidationReport","status":"pass","remediation_id":rid},indent=2)+"\n")
+    if a.mode=='apply':
+        (out/'remediation_receipt.json').write_text(json.dumps({"schema_version":"v1","object_type":"EbirdRemediationReceipt","domain":"fauna","source":"ebird","adapter":"kfm-ebird","policy_label":"remediation","public_safe_final_outputs":True,"exact_points":"restricted","remediation_id":rid,"force_used":True,"apply_used":True,"actions_applied":[],"validation_status":"pass","applied_at":now()},indent=2)+"\n")
+    print(rid)
+
+if __name__=='__main__': main()


### PR DESCRIPTION
### Motivation
- Provide a Layer 22 governance lane for safe, copy-on-write corrective remediation and corrective-release workflows for the eBird adapter without introducing network, credentials, or real eBird data dependencies. 
- Enable deterministic identifiers and guarded apply semantics so only approved metadata/text/pointer/checksum fixes can be planned and applied with explicit authorization. 
- Surface public-safe artifacts (plans, manifests, diff/validation reports, receipts, correction notices) that are amenable to policy gating and downstream corrective-release bundling. 

### Description
- Added two CLI scaffolds under `tools/connectors/fauna/kfm-ebird-ingest`: `kfm_ebird_remediate.py` (entry `kfm-ebird-remediate`) and `kfm_ebird_corrective_release.py` (entry `kfm-ebird-corrective-release`) implementing argument parsing, deterministic `remediation_id` / `corrective_release_id` computation, safe/blocked patch classification, and generation of Layer 22 artifact skeletons (plan, manifest, diff report, root-cause, validation report, receipts, and corrective-release artifacts). 
- Implemented simple patch-file loading and safety checks that reject patches containing denied fields (decimalLatitude/decimalLongitude/geometry/suppression receipts/raw row numbers/secret-looking tokens) and block data-affecting patch types, producing rerun recommendations. 
- Added documentation `docs/domains/fauna/EBIRD_REMEDIATION.md` and updated the connector README to list the new Layer 22 CLIs. 
- The implementation is intentionally offline/synthetic: no network calls, no credentials, no real EBD processing, and applies copy-on-write semantics by default; apply requires `--apply --force`. 

### Testing
- Ran smoke CLI validations and flows: `kfm-ebird-remediate --help` (success), `kfm-ebird-remediate --version` (success), `kfm-ebird-remediate --mode plan` with a small JSONL patch fixture (success, produced remediation plan/manifest/diff/etc.), and `kfm-ebird-remediate --mode apply --apply --force` (success, produced remediation receipt with `apply_used`/`force_used`). 
- Ran corrective-release smoke flows: `kfm-ebird-corrective-release --help` (success), `kfm-ebird-corrective-release --version` (success), and `kfm-ebird-corrective-release --mode build` using generated remediation artifacts (success, produced corrective-release plan/manifest/validation). 
- Full validator/policy/red-team/conformance suites and the complete set of Layer 22 unit tests/fixtures described in the spec were not implemented or run in this change and remain future work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ed673600832aa0b8c94d9737012c)