### PR TITLE
Add fixture-backed GBIF normalization and EvidenceBundle validation slice

### DIFF
--- a/data/registry/fauna/gbif_sources.yaml
+++ b/data/registry/fauna/gbif_sources.yaml
@@ -1,0 +1,9 @@
+source_system: GBIF
+source_uri: https://www.gbif.org/occurrence/search
+license_policy:
+  public_allowed: [CC0, CC-BY]
+  public_restricted: [CC-BY-NC]
+  fail_closed_on_unknown: true
+geoprivacy:
+  deny_exact_sensitive_public: true
+  suppression_min_n: 10

--- a/docs/domains/fauna/GBIF_OCCURRENCE_INGESTION.md
+++ b/docs/domains/fauna/GBIF_OCCURRENCE_INGESTION.md
@@ -1,0 +1,57 @@
+# KFM Meta Block v2
+- Domain: fauna
+- Slice: GBIF occurrence ingestion
+- Lifecycle: RAW -> WORK/QUARANTINE -> PROCESSED -> CATALOG/TRIPLET -> PUBLISHED
+- Status: implementation slice
+
+## Purpose
+Fixture-backed GBIF occurrence normalization builds governed EvidenceBundle outputs with fail-closed rights/sensitivity posture.
+
+## Lifecycle placement
+Normalization reads RAW fixture CSV records and emits WORK/QUARANTINE-ready EvidenceBundle artifacts. Promotion remains a governed policy transition.
+
+## Field mapping
+| Darwin Core/GBIF | KFM field |
+|---|---|
+| eventDate | occurrenceDate |
+| decimalLatitude + decimalLongitude | geopoint |
+| datasetKey | kfm:dataset_key |
+| basisOfRecord | basisOfRecord |
+| coordinateUncertaintyInMeters | geospatialPrecision |
+| individualCount | abundance |
+
+## No-network testing posture
+All tests use `tests/fixtures/fauna/gbif/*`. Live GBIF calls are intentionally not used.
+
+## License rules
+- Public candidate licenses: CC0, CC-BY
+- CC-BY-NC: restricted unless explicit override flag is set
+- Unknown/missing license: QUARANTINE/fail closed
+
+## Geoprivacy rules
+- Public exact sensitive coordinates are denied.
+- Public mode rounds coordinates and emits geoprivacy receipt metadata.
+- Public aggregate suppression threshold defaults to `n >= 10`.
+
+## CLI example
+```bash
+python tools/normalizers/fauna/kfm_gbif_normalize.py \
+  --input tests/fixtures/fauna/gbif/valid/simple_occurrences.csv \
+  --query-predicate tests/fixtures/fauna/gbif/query_predicate.json \
+  --download-key TEST_DOWNLOAD_KEY \
+  --output /tmp/gbif_evidencebundle.json
+```
+
+## Validator/policy gates
+- `tools/validators/fauna/gbif_evidencebundle_validator.py` validates schema.
+- `policy/fauna/gbif_publication.rego` denies unsafe public publication postures.
+
+## Known limitations
+- Species truth is not asserted; records are treated as unreviewed occurrence claims.
+- TODO/NEEDS_VERIFICATION: confirm final schema-home convention for fauna GBIF schemas.
+
+## Promotion checklist
+- EvidenceBundle present and schema-valid.
+- `kfm:spec_hash` present and deterministic.
+- rights/sensitivity/geoprivacy checks pass.
+- no exact sensitive coordinates in public outputs.

--- a/policy/fauna/gbif_publication.rego
+++ b/policy/fauna/gbif_publication.rego
@@ -1,0 +1,27 @@
+package kfm.fauna.gbif
+
+deny[msg] if { not input.evidence_bundle_id; msg := "missing EvidenceBundle" }
+deny[msg] if { not input["kfm:spec_hash"]; msg := "missing kfm:spec_hash" }
+deny[msg] if { not input.source_uri; msg := "source_uri missing" }
+deny[msg] if { not input.download_key; msg := "download_key missing" }
+deny[msg] if { not input.query_predicate; msg := "query_predicate missing" }
+
+deny[msg] if {
+  input.outputs.publication_target == "public"
+  some r in input.outputs.normalized_records
+  r.sensitive == true
+  msg := "public exact sensitive coordinates denied"
+}
+
+deny[msg] if {
+  input.outputs.publication_target == "public"
+  some l in input.license_summary
+  not l in {"CC0","CC-BY"}
+  msg := "unknown or disallowed public license"
+}
+
+deny[msg] if {
+  input.outputs.publication_target == "public"
+  input.records_count < 10
+  msg := "public aggregate with n < 10 denied"
+}

--- a/schemas/evidence/gbif_evidencebundle.schema.json
+++ b/schemas/evidence/gbif_evidencebundle.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["evidence_bundle_id","source_system","source_uri","download_key","query_predicate","kfm:spec_hash","records_count","dataset_keys","license_summary","rights_posture","sensitivity_posture","geoprivacy_transform","created_at","inputs","outputs","limitations"],
+  "properties": {
+    "evidence_bundle_id": {"type":"string"},
+    "source_system": {"const":"GBIF"},
+    "source_uri": {"type":"string"},
+    "download_key": {"type":"string"},
+    "query_predicate": {"type":["object","array","string"]},
+    "kfm:spec_hash": {"type":"string","pattern":"^sha256:[a-f0-9]{64}$"},
+    "records_count": {"type":"integer","minimum":0},
+    "dataset_keys": {"type":"array","items":{"type":"string"}},
+    "license_summary": {"type":"array","items":{"type":"string"}},
+    "rights_posture": {"type":"string"},
+    "sensitivity_posture": {"type":"string"},
+    "geoprivacy_transform": {"type":"object"},
+    "created_at": {"type":"string"},
+    "inputs": {"type":"object"},
+    "outputs": {"type":"object"},
+    "limitations": {"type":"array","items":{"type":"string"}}
+  }
+}

--- a/schemas/fauna/gbif_occurrence_record.schema.json
+++ b/schemas/fauna/gbif_occurrence_record.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GBIF Occurrence Record",
+  "type": "object",
+  "required": ["gbifID","datasetKey","eventDate","decimalLatitude","decimalLongitude","basisOfRecord","coordinateUncertaintyInMeters","license"],
+  "properties": {
+    "gbifID": {"type": "string"},
+    "datasetKey": {"type": "string"},
+    "scientificName": {"type": "string"},
+    "acceptedScientificName": {"type": "string"},
+    "eventDate": {"type": "string"},
+    "decimalLatitude": {"type": ["string","number"]},
+    "decimalLongitude": {"type": ["string","number"]},
+    "basisOfRecord": {"type": "string"},
+    "coordinateUncertaintyInMeters": {"type": ["string","number"]},
+    "individualCount": {"type": ["string","number","null"]},
+    "license": {"type": "string"}
+  },
+  "anyOf": [
+    {"required": ["scientificName"]},
+    {"required": ["acceptedScientificName"]}
+  ]
+}

--- a/tests/fauna/test_gbif_evidencebundle_validator.py
+++ b/tests/fauna/test_gbif_evidencebundle_validator.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+import subprocess, sys
+from pathlib import Path
+
+NORMALIZER = "tools/normalizers/fauna/kfm_gbif_normalize.py"
+VALIDATOR = "tools/validators/fauna/gbif_evidencebundle_validator.py"
+FIX = Path("tests/fixtures/fauna/gbif")
+
+
+def test_schema_validation_passes_for_valid_output(tmp_path: Path) -> None:
+    out = tmp_path / "eb.json"
+    r = subprocess.run([sys.executable, NORMALIZER, "--input", str(FIX / "valid/simple_occurrences.csv"), "--query-predicate", str(FIX / "query_predicate.json"), "--download-key", "TEST", "--output", str(out)], text=True, capture_output=True)
+    assert r.returncode == 0, r.stderr
+    v = subprocess.run([sys.executable, VALIDATOR, str(out)], text=True, capture_output=True)
+    assert v.returncode == 0, v.stderr

--- a/tests/fauna/test_gbif_normalize.py
+++ b/tests/fauna/test_gbif_normalize.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import json, subprocess, sys
+from pathlib import Path
+
+SCRIPT = "tools/normalizers/fauna/kfm_gbif_normalize.py"
+FIX = Path("tests/fixtures/fauna/gbif")
+
+def run_cli(*args: str):
+    return subprocess.run([sys.executable, SCRIPT, *args], text=True, capture_output=True)
+
+def test_valid_fixture_normalizes_successfully(tmp_path: Path) -> None:
+    out = tmp_path / "eb.json"
+    r = run_cli("--input", str(FIX / "valid/simple_occurrences.csv"), "--query-predicate", str(FIX / "query_predicate.json"), "--download-key", "TEST", "--output", str(out))
+    assert r.returncode == 0, r.stderr
+    doc = json.loads(out.read_text())
+    assert doc["source_system"] == "GBIF"
+    assert doc["records_count"] == 10
+
+def test_missing_dataset_key_fails(tmp_path: Path) -> None:
+    r = run_cli("--input", str(FIX / "invalid/missing_dataset_key.csv"), "--query-predicate", str(FIX / "query_predicate.json"), "--download-key", "TEST", "--output", str(tmp_path / "x.json"))
+    assert r.returncode != 0
+
+def test_unknown_license_fails_closed(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.csv"
+    bad.write_text("gbifID,datasetKey,scientificName,eventDate,decimalLatitude,decimalLongitude,basisOfRecord,coordinateUncertaintyInMeters,license\n1,ds,x,2025-01-01,1,1,HUMAN_OBSERVATION,5,Proprietary\n")
+    r = run_cli("--input", str(bad), "--query-predicate", str(FIX / "query_predicate.json"), "--download-key", "TEST", "--output", str(tmp_path / "x.json"))
+    assert r.returncode != 0
+
+def test_spec_hash_stable_when_created_at_changes(tmp_path: Path) -> None:
+    out = tmp_path / "eb.json"
+    r = run_cli("--input", str(FIX / "valid/simple_occurrences.csv"), "--query-predicate", str(FIX / "query_predicate.json"), "--download-key", "TEST", "--output", str(out))
+    assert r.returncode == 0
+    doc = json.loads(out.read_text())
+    from tools.normalizers.fauna.kfm_gbif_normalize import compute_spec_hash
+    h1 = compute_spec_hash(doc)
+    doc["created_at"] = "2099-01-01T00:00:00Z"
+    h2 = compute_spec_hash(doc)
+    assert h1 == h2
+
+def test_public_exact_sensitive_coordinate_denied(tmp_path: Path) -> None:
+    r = run_cli("--input", str(FIX / "invalid/public_exact_sensitive_coordinate.csv"), "--query-predicate", str(FIX / "query_predicate.json"), "--download-key", "TEST", "--publication-target", "public", "--output", str(tmp_path / "x.json"))
+    assert r.returncode != 0
+
+def test_public_aggregate_below_threshold_denied(tmp_path: Path) -> None:
+    small = tmp_path / "small.csv"
+    small.write_text((FIX / "valid/simple_occurrences.csv").read_text().splitlines()[0] + "\n" + "\n".join((FIX / "valid/simple_occurrences.csv").read_text().splitlines()[1:5]))
+    r = run_cli("--input", str(small), "--query-predicate", str(FIX / "query_predicate.json"), "--download-key", "TEST", "--publication-target", "public", "--output", str(tmp_path / "x.json"))
+    assert r.returncode != 0

--- a/tests/fixtures/fauna/gbif/invalid/missing_dataset_key.csv
+++ b/tests/fixtures/fauna/gbif/invalid/missing_dataset_key.csv
@@ -1,0 +1,2 @@
+gbifID,datasetKey,scientificName,eventDate,decimalLatitude,decimalLongitude,basisOfRecord,coordinateUncertaintyInMeters,license
+1,,Panthera leo,2025-01-01,38.1234,-96.9911,HUMAN_OBSERVATION,30,CC-BY

--- a/tests/fixtures/fauna/gbif/invalid/public_exact_sensitive_coordinate.csv
+++ b/tests/fixtures/fauna/gbif/invalid/public_exact_sensitive_coordinate.csv
@@ -1,0 +1,11 @@
+gbifID,datasetKey,scientificName,eventDate,decimalLatitude,decimalLongitude,basisOfRecord,coordinateUncertaintyInMeters,individualCount,license,isSensitive
+1,ds-sensitive,Felis concolor,2025-01-01,38.1234,-96.9911,HUMAN_OBSERVATION,5,1,CC-BY,true
+2,ds-sensitive,Felis concolor,2025-01-02,38.2234,-96.8911,HUMAN_OBSERVATION,5,1,CC-BY,true
+3,ds-sensitive,Felis concolor,2025-01-03,38.3234,-96.7911,HUMAN_OBSERVATION,5,1,CC-BY,true
+4,ds-sensitive,Felis concolor,2025-01-04,38.4234,-96.6911,HUMAN_OBSERVATION,5,1,CC-BY,true
+5,ds-sensitive,Felis concolor,2025-01-05,38.5234,-96.5911,HUMAN_OBSERVATION,5,1,CC-BY,true
+6,ds-sensitive,Felis concolor,2025-01-06,38.6234,-96.4911,HUMAN_OBSERVATION,5,1,CC-BY,true
+7,ds-sensitive,Felis concolor,2025-01-07,38.7234,-96.3911,HUMAN_OBSERVATION,5,1,CC-BY,true
+8,ds-sensitive,Felis concolor,2025-01-08,38.8234,-96.2911,HUMAN_OBSERVATION,5,1,CC-BY,true
+9,ds-sensitive,Felis concolor,2025-01-09,38.9234,-96.1911,HUMAN_OBSERVATION,5,1,CC-BY,true
+10,ds-sensitive,Felis concolor,2025-01-10,39.0234,-96.0911,HUMAN_OBSERVATION,5,1,CC-BY,true

--- a/tests/fixtures/fauna/gbif/query_predicate.json
+++ b/tests/fixtures/fauna/gbif/query_predicate.json
@@ -1,0 +1,1 @@
+{"country":"US","stateProvince":"Kansas"}

--- a/tests/fixtures/fauna/gbif/valid/simple_occurrences.csv
+++ b/tests/fixtures/fauna/gbif/valid/simple_occurrences.csv
@@ -1,0 +1,11 @@
+gbifID,datasetKey,scientificName,acceptedScientificName,eventDate,decimalLatitude,decimalLongitude,basisOfRecord,coordinateUncertaintyInMeters,individualCount,license,isSensitive
+1,ds-1,Panthera leo,,2025-01-01,38.1234,-96.9911,HUMAN_OBSERVATION,30,2,CC-BY,false
+2,ds-1,,Panthera tigris,2025-01-02,38.2234,-96.8911,HUMAN_OBSERVATION,50,1,CC0,false
+3,ds-2,Canis lupus,,2025-01-03,38.3234,-96.7911,HUMAN_OBSERVATION,100,3,CC-BY,false
+4,ds-2,Ursus arctos,,2025-01-04,38.4234,-96.6911,HUMAN_OBSERVATION,80,1,CC0,false
+5,ds-3,Bison bison,,2025-01-05,38.5234,-96.5911,HUMAN_OBSERVATION,20,7,CC-BY,false
+6,ds-3,Odocoileus virginianus,,2025-01-06,38.6234,-96.4911,HUMAN_OBSERVATION,20,4,CC0,false
+7,ds-4,Cervus canadensis,,2025-01-07,38.7234,-96.3911,HUMAN_OBSERVATION,20,2,CC-BY,false
+8,ds-4,Lynx rufus,,2025-01-08,38.8234,-96.2911,HUMAN_OBSERVATION,20,1,CC0,false
+9,ds-5,Vulpes vulpes,,2025-01-09,38.9234,-96.1911,HUMAN_OBSERVATION,20,2,CC-BY,false
+10,ds-5,Taxidea taxus,,2025-01-10,39.0234,-96.0911,HUMAN_OBSERVATION,20,1,CC0,false

--- a/tests/policy/fauna/gbif_publication_test.rego
+++ b/tests/policy/fauna/gbif_publication_test.rego
@@ -1,0 +1,16 @@
+package kfm.fauna.gbif
+
+import data.kfm.fauna.gbif
+
+test_deny_missing_spec_hash if {
+  count(gbif.deny with input as {"evidence_bundle_id":"x"}) > 0
+}
+
+test_deny_small_public_aggregate if {
+  count(gbif.deny with input as {
+    "evidence_bundle_id":"x","kfm:spec_hash":"sha256:abc","source_uri":"u","download_key":"d","query_predicate":{},
+    "records_count": 9,
+    "license_summary": ["CC0"],
+    "outputs": {"publication_target":"public","normalized_records":[]}
+  }) > 0
+}

--- a/tools/normalizers/fauna/kfm_gbif_normalize.py
+++ b/tools/normalizers/fauna/kfm_gbif_normalize.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ALLOWED_PUBLIC_LICENSES = {"CC0", "CC-BY"}
+RESTRICTED_PUBLIC_LICENSES = {"CC-BY-NC"}
+REQUIRED_FIELDS = {
+    "gbifID", "datasetKey", "eventDate", "decimalLatitude", "decimalLongitude",
+    "basisOfRecord", "coordinateUncertaintyInMeters", "license"
+}
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_spec_hash(bundle: dict[str, Any]) -> str:
+    stable = dict(bundle.get("spec", {}))
+    payload = _canonical_json(stable).encode("utf-8")
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _normalize_license(raw: str) -> str:
+    v = (raw or "").upper().replace(" ", "")
+    if "CC0" in v:
+        return "CC0"
+    if "CC-BY-NC" in v:
+        return "CC-BY-NC"
+    if "CC-BY" in v:
+        return "CC-BY"
+    return "UNKNOWN"
+
+
+def normalize_rows(rows: list[dict[str, str]], publication_target: str = "internal", allow_nc_override: bool = False) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    dataset_keys: set[str] = set()
+    licenses: set[str] = set()
+    sensitive_exact = False
+    for idx, row in enumerate(rows, start=1):
+        missing = [f for f in REQUIRED_FIELDS if not row.get(f)]
+        if missing:
+            raise ValueError(f"row {idx}: missing required fields: {','.join(sorted(missing))}")
+        sci = row.get("scientificName") or row.get("acceptedScientificName")
+        if not sci:
+            raise ValueError(f"row {idx}: missing scientificName/acceptedScientificName")
+
+        lic = _normalize_license(row.get("license", ""))
+        if lic == "UNKNOWN":
+            raise ValueError(f"row {idx}: unknown license")
+
+        lat = float(row["decimalLatitude"])
+        lon = float(row["decimalLongitude"])
+        sensitive = str(row.get("isSensitive", "false")).lower() == "true"
+        if publication_target == "public" and sensitive:
+            sensitive_exact = True
+
+        out.append({
+            "object_type": "KfmGbifOccurrence",
+            "gbifID": row["gbifID"],
+            "scientificName": sci,
+            "occurrenceDate": row["eventDate"],
+            "geopoint": {"lat": round(lat, 2) if publication_target == "public" else lat, "lon": round(lon, 2) if publication_target == "public" else lon},
+            "kfm:dataset_key": row["datasetKey"],
+            "basisOfRecord": row["basisOfRecord"],
+            "geospatialPrecision": float(row["coordinateUncertaintyInMeters"]),
+            "abundance": int(row["individualCount"]) if row.get("individualCount") else None,
+            "license": lic,
+            "sensitive": sensitive,
+            "evidence_review_posture": "unreviewed_occurrence_claim"
+        })
+        dataset_keys.add(row["datasetKey"])
+        licenses.add(lic)
+
+    rights_posture = "QUARANTINE"
+    if licenses.issubset(ALLOWED_PUBLIC_LICENSES):
+        rights_posture = "PUBLIC_CANDIDATE" if publication_target == "public" else "INTERNAL_OK"
+    elif licenses.issubset(ALLOWED_PUBLIC_LICENSES | RESTRICTED_PUBLIC_LICENSES):
+        rights_posture = "RESTRICTED_LICENSE"
+        if publication_target == "public" and ("CC-BY-NC" in licenses) and not allow_nc_override:
+            raise ValueError("public output blocked: CC-BY-NC requires explicit override")
+
+    if publication_target == "public" and len(out) < 10:
+        raise ValueError("public aggregate denied: n < 10")
+    if publication_target == "public" and sensitive_exact:
+        raise ValueError("public exact coordinates denied for sensitive taxa")
+
+    gate = {
+        "dataset_keys": sorted(dataset_keys),
+        "license_summary": sorted(licenses),
+        "rights_posture": rights_posture,
+        "sensitivity_posture": "SENSITIVE_PRESENT" if any(r["sensitive"] for r in out) else "NOT_SENSITIVE",
+        "geoprivacy_transform": {
+            "method": "grid_0.01deg_rounding" if publication_target == "public" else "none",
+            "receipt": f"geoprivacy://kfm/gbif/{publication_target}/v1",
+            "suppression_min_n": 10,
+        },
+    }
+    return out, gate
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", required=True)
+    p.add_argument("--query-predicate", required=True)
+    p.add_argument("--download-key", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--publication-target", choices=["internal", "public"], default="internal")
+    p.add_argument("--allow-public-nc-override", action="store_true")
+    args = p.parse_args()
+    try:
+        rows = list(csv.DictReader(Path(args.input).read_text(encoding="utf-8").splitlines()))
+        normalized, gate = normalize_rows(rows, args.publication_target, args.allow_public_nc_override)
+        query_predicate = json.loads(Path(args.query_predicate).read_text(encoding="utf-8"))
+        bundle = {
+            "evidence_bundle_id": f"gbif-{args.download_key.lower()}",
+            "source_system": "GBIF",
+            "source_uri": "https://www.gbif.org/occurrence/search",
+            "download_key": args.download_key,
+            "query_predicate": query_predicate,
+            "records_count": len(normalized),
+            "dataset_keys": gate["dataset_keys"],
+            "license_summary": gate["license_summary"],
+            "rights_posture": gate["rights_posture"],
+            "sensitivity_posture": gate["sensitivity_posture"],
+            "geoprivacy_transform": gate["geoprivacy_transform"],
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "inputs": {"input_csv": args.input},
+            "outputs": {"normalized_records": normalized, "publication_target": args.publication_target},
+            "limitations": ["GBIF occurrences are observational claims, not confirmed species truth without review."],
+            "spec": {
+                "source_system": "GBIF", "source_uri": "https://www.gbif.org/occurrence/search",
+                "download_key": args.download_key, "query_predicate": query_predicate,
+                "dataset_keys": gate["dataset_keys"], "license_summary": gate["license_summary"],
+                "rights_posture": gate["rights_posture"], "sensitivity_posture": gate["sensitivity_posture"],
+                "geoprivacy_transform": gate["geoprivacy_transform"], "records_count": len(normalized),
+            },
+        }
+        bundle["kfm:spec_hash"] = compute_spec_hash(bundle)
+        Path(args.output).write_text(json.dumps(bundle, indent=2), encoding="utf-8")
+    except Exception as exc:
+        print(f"DENY: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validators/fauna/gbif_evidencebundle_validator.py
+++ b/tools/validators/fauna/gbif_evidencebundle_validator.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA = REPO_ROOT / "schemas/evidence/gbif_evidencebundle.schema.json"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("path")
+    args = ap.parse_args()
+    doc = json.loads(Path(args.path).read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    errors = sorted(Draft202012Validator(schema).iter_errors(doc), key=lambda e: list(e.path))
+    if errors:
+        for e in errors:
+            loc = ".".join(str(p) for p in e.path) or "<root>"
+            print(f"DENY: {loc}: {e.message}", file=sys.stderr)
+        sys.exit(1)
+    print("ALLOW")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a no-network GBIF → KFM normalization slice that converts Darwin Core occurrence fixtures into governed EvidenceBundle artifacts following KFM doctrine. 
- Enforce fail-closed rights and geoprivacy posture so public outputs are only produced for permitted licenses and non-sensitive/geoprivacy-safe aggregates. 
- Enable deterministic provenance via a canonical `kfm:spec_hash` that ignores transient timestamps so spec identity is stable for CI/promotion gates. 

### Description
- Add a normalization CLI at `tools/normalizers/fauna/kfm_gbif_normalize.py` that parses CSV fixtures, maps Darwin Core fields to KFM occurrence objects (e.g., `eventDate->occurrenceDate`, lat/lon->`geopoint`, `datasetKey->kfm:dataset_key`), enforces required fields, applies license/geoprivacy gating, emits an EvidenceBundle JSON, and computes `kfm:spec_hash` from the stable `spec`. 
- Add an EvidenceBundle validator CLI at `tools/validators/fauna/gbif_evidencebundle_validator.py` that validates bundle JSON against `schemas/evidence/gbif_evidencebundle.schema.json` using `Draft202012Validator`. 
- Add input/output schemas at `schemas/fauna/gbif_occurrence_record.schema.json` and `schemas/evidence/gbif_evidencebundle.schema.json`, domain doc at `docs/domains/fauna/GBIF_OCCURRENCE_INGESTION.md`, and a registry seed at `data/registry/fauna/gbif_sources.yaml`. 
- Add pytest coverage and fixtures under `tests/fauna/*` and `tests/fixtures/fauna/gbif/*`, and a Rego publication policy at `policy/fauna/gbif_publication.rego` with unit tests in `tests/policy/fauna/gbif_publication_test.rego`. 

### Testing
- Ran `pytest -q tests/fauna/test_gbif_normalize.py tests/fauna/test_gbif_evidencebundle_validator.py` and all tests passed (`7 passed`). 
- The `spec_hash` stability is asserted by tests that change `created_at` and verify the computed `kfm:spec_hash` does not change. 
- Rego policy tests were prepared and `opa test policy/fauna/gbif_publication.rego tests/policy/fauna/gbif_publication_test.rego` was attempted but failed in the environment because the `opa` binary is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f409143558832a872096f4b979a20f)