### PR TITLE
Add soil QA thresholds validator and promotion gate with fixtures and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,13 @@ jobs:
             echo "No Python tests found; skipping pytest." | tee -a "$KFM_CI_ARTIFACT_DIR/python-ci.md"
           fi
 
+          if [ -d tests/soil ]; then
+            echo "Running soil validator pytest slice" | tee -a "$KFM_CI_ARTIFACT_DIR/python-ci.md"
+            python -m pytest -q tests/soil | tee -a "$KFM_CI_ARTIFACT_DIR/python-ci.md"
+          else
+            echo "No tests/soil slice found; skipping soil validator pytest." | tee -a "$KFM_CI_ARTIFACT_DIR/python-ci.md"
+          fi
+
           cat "$KFM_CI_ARTIFACT_DIR/python-ci.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Python CI artifact
@@ -1209,4 +1216,3 @@ jobs:
           if bad:
               sys.exit(1)
           PY
-

--- a/policy/soil/soil_publication.rego
+++ b/policy/soil/soil_publication.rego
@@ -1,0 +1,29 @@
+package soil.publication
+
+deny contains "decision_not_pass" if {
+  input.validation_summary.decision == "quarantine"
+}
+
+deny contains "decision_not_pass" if {
+  input.validation_summary.decision == "review"
+}
+
+deny contains "masked_pct_gt_30" if {
+  input.metrics.masked_pct > 30
+}
+
+deny contains "zscore_flag_true" if {
+  input.flags.zscore_flag == true
+}
+
+deny contains "residual_sustained_true" if {
+  input.flags.residual_sustained == true
+}
+
+deny contains "missing_evidence_bundle_ref" if {
+  not input.evidence_bundle_ref
+}
+
+deny contains "missing_signatures" if {
+  not input.signatures
+}

--- a/tests/fixtures/soil/invalid/run_receipt_fail_masked_pct.json
+++ b/tests/fixtures/soil/invalid/run_receipt_fail_masked_pct.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0.0",
+  "validation_summary": {"decision": "quarantine"},
+  "metrics": {"masked_pct": 34.7, "zscore_30d_max": 0.5, "station_grid_residual_max": 0.04},
+  "flags": {"zscore_flag": false, "residual_sustained": false},
+  "decision": "quarantine",
+  "evidence_bundle_ref": "kfm://evidence/soil/run-004",
+  "signatures": ["sig-1"],
+  "policy_label": "public"
+}

--- a/tests/fixtures/soil/invalid/run_receipt_quarantine_residual.json
+++ b/tests/fixtures/soil/invalid/run_receipt_quarantine_residual.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0.0",
+  "validation_summary": {"decision": "quarantine"},
+  "metrics": {"masked_pct": 8, "zscore_30d_max": 1.2, "station_grid_residual_max": 0.13},
+  "flags": {"zscore_flag": false, "residual_sustained": true},
+  "decision": "quarantine",
+  "evidence_bundle_ref": "kfm://evidence/soil/run-003",
+  "signatures": ["sig-1"],
+  "policy_label": "public"
+}

--- a/tests/fixtures/soil/invalid/run_receipt_quarantine_zscore.json
+++ b/tests/fixtures/soil/invalid/run_receipt_quarantine_zscore.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0.0",
+  "validation_summary": {"decision": "quarantine"},
+  "metrics": {"masked_pct": 10, "zscore_30d_max": 2.4, "station_grid_residual_max": 0.05},
+  "flags": {"zscore_flag": true, "residual_sustained": false},
+  "decision": "quarantine",
+  "evidence_bundle_ref": "kfm://evidence/soil/run-002",
+  "signatures": ["sig-1"],
+  "policy_label": "public"
+}

--- a/tests/fixtures/soil/policy/run_receipt_review_masked_pct.json
+++ b/tests/fixtures/soil/policy/run_receipt_review_masked_pct.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0.0",
+  "validation_summary": {"decision": "review"},
+  "metrics": {"masked_pct": 22.1, "zscore_30d_max": 1.0, "station_grid_residual_max": 0.08},
+  "flags": {"zscore_flag": false, "residual_sustained": false},
+  "decision": "review",
+  "evidence_bundle_ref": "kfm://evidence/soil/run-005",
+  "signatures": ["sig-1"],
+  "policy_label": "public"
+}

--- a/tests/fixtures/soil/valid/run_receipt_pass.json
+++ b/tests/fixtures/soil/valid/run_receipt_pass.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0.0",
+  "validation_summary": {"decision": "pass"},
+  "metrics": {
+    "masked_pct": 12.4,
+    "zscore_30d_max": 1.8,
+    "station_grid_residual_max": 0.07
+  },
+  "flags": {
+    "zscore_flag": false,
+    "residual_sustained": false
+  },
+  "decision": "pass",
+  "evidence_bundle_ref": "kfm://evidence/soil/run-001",
+  "signatures": ["sig-1"],
+  "policy_label": "public"
+}

--- a/tests/soil/test_soil_promotion_gate.py
+++ b/tests/soil/test_soil_promotion_gate.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/validators/soil/promotion_gate.py"
+FIXTURE_ROOT = ROOT / "tests/fixtures/soil"
+
+
+def run_gate(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_soil_promotion_gate_pass_fixture() -> None:
+    result = run_gate(FIXTURE_ROOT / "valid/run_receipt_pass.json")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["promotion_allowed"] is True
+
+
+def test_soil_promotion_gate_review_fixture_blocked() -> None:
+    result = run_gate(FIXTURE_ROOT / "policy/run_receipt_review_masked_pct.json")
+    assert result.returncode != 0
+    payload = json.loads(result.stdout)
+    assert payload["promotion_allowed"] is False
+
+
+def test_soil_promotion_gate_quarantine_and_fail_fixtures_blocked() -> None:
+    blocked_fixtures = [
+        "invalid/run_receipt_quarantine_zscore.json",
+        "invalid/run_receipt_quarantine_residual.json",
+        "invalid/run_receipt_fail_masked_pct.json",
+    ]
+    for fixture in blocked_fixtures:
+        result = run_gate(FIXTURE_ROOT / fixture)
+        assert result.returncode != 0, fixture

--- a/tests/soil/test_soil_qa_thresholds.py
+++ b/tests/soil/test_soil_qa_thresholds.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/validators/soil/qa_thresholds.py"
+FIXTURE_ROOT = ROOT / "tests/fixtures/soil"
+
+
+def run_validator(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_soil_qa_pass_fixture_exits_zero() -> None:
+    result = run_validator(FIXTURE_ROOT / "valid/run_receipt_pass.json")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "pass"
+
+
+def test_soil_qa_invalid_fixtures_exit_nonzero() -> None:
+    invalid_fixtures = [
+        "invalid/run_receipt_quarantine_zscore.json",
+        "invalid/run_receipt_quarantine_residual.json",
+        "invalid/run_receipt_fail_masked_pct.json",
+    ]
+    for fixture in invalid_fixtures:
+        result = run_validator(FIXTURE_ROOT / fixture)
+        assert result.returncode != 0, fixture

--- a/tools/validators/soil/promotion_gate.py
+++ b/tools/validators/soil/promotion_gate.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ALLOWED_POLICY_LABELS = {"public", "publication", "public_safe", "public_reviewed"}
+
+
+def evaluate_gate(receipt: dict[str, object]) -> dict[str, object]:
+    reasons: list[str] = []
+
+    validation_summary = receipt.get("validation_summary")
+    if not isinstance(validation_summary, dict):
+        reasons.append("missing validation_summary")
+    elif validation_summary.get("decision") != "pass":
+        reasons.append("validation_summary.decision must be pass")
+
+    if not receipt.get("evidence_bundle_ref"):
+        reasons.append("missing evidence_bundle_ref")
+    if not receipt.get("signatures"):
+        reasons.append("missing signatures")
+
+    policy_label = receipt.get("policy_label")
+    if policy_label is not None and str(policy_label) not in ALLOWED_POLICY_LABELS:
+        reasons.append(f"policy_label not allowed: {policy_label}")
+
+    allowed = len(reasons) == 0
+    return {
+        "validator": "soil.promotion_gate",
+        "promotion_allowed": allowed,
+        "gate": "pass" if allowed else "block",
+        "message": "promotion allowed" if allowed else "Gate C review required",
+        "reasons": reasons,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1:
+        print(json.dumps({"error": "usage: promotion_gate.py <run_receipt.json>"}))
+        return 2
+    path = Path(args[0])
+    if not path.exists():
+        print(json.dumps({"error": f"missing file: {path}"}))
+        return 2
+
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(receipt, dict):
+            raise ValueError("run receipt must be a JSON object")
+        result = evaluate_gate(receipt)
+    except Exception as exc:  # PROPOSED: deterministic fail-closed parsing behavior.
+        print(json.dumps({"validator": "soil.promotion_gate", "promotion_allowed": False, "error": str(exc)}))
+        return 2
+
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["promotion_allowed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/soil/qa_thresholds.py
+++ b/tools/validators/soil/qa_thresholds.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PASS = "pass"
+REVIEW = "review"
+QUARANTINE = "quarantine"
+FAIL = "fail"
+
+
+def _to_float(value: object, field: str) -> float:
+    if not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be numeric")
+    return float(value)
+
+
+def evaluate_receipt(receipt: dict[str, object]) -> dict[str, object]:
+    errors: list[str] = []
+    notes: list[str] = []
+
+    if "schema_version" not in receipt:
+        errors.append("missing schema_version")
+    if "validation_summary" not in receipt:
+        errors.append("missing validation_summary")
+    if "flags" not in receipt:
+        errors.append("missing flags")
+    if "decision" not in receipt:
+        errors.append("missing decision")
+
+    metrics_obj = receipt.get("metrics")
+    if not isinstance(metrics_obj, dict):
+        errors.append("missing metrics object")
+        metrics_obj = {}
+
+    try:
+        masked_pct = _to_float(metrics_obj.get("masked_pct"), "metrics.masked_pct")
+    except ValueError as exc:
+        errors.append(str(exc))
+        masked_pct = None
+
+    try:
+        zscore_30d_max = _to_float(metrics_obj.get("zscore_30d_max"), "metrics.zscore_30d_max")
+    except ValueError as exc:
+        errors.append(str(exc))
+        zscore_30d_max = None
+
+    try:
+        station_grid_residual_max = _to_float(
+            metrics_obj.get("station_grid_residual_max"),
+            "metrics.station_grid_residual_max",
+        )
+    except ValueError as exc:
+        errors.append(str(exc))
+        station_grid_residual_max = None
+
+    flags_obj = receipt.get("flags") if isinstance(receipt.get("flags"), dict) else {}
+    residual_sustained = bool(flags_obj.get("residual_sustained", False))
+
+    decision = PASS
+    if errors:
+        decision = FAIL
+    else:
+        assert masked_pct is not None and zscore_30d_max is not None and station_grid_residual_max is not None
+        if abs(zscore_30d_max) > 2.0:
+            decision = QUARANTINE
+            notes.append("zscore threshold exceeded")
+        if station_grid_residual_max > 0.10 and residual_sustained:
+            decision = QUARANTINE
+            notes.append("station-grid residual sustained threshold exceeded")
+        if masked_pct > 30.0:
+            decision = QUARANTINE
+            notes.append("masked_pct exceeded fail threshold")
+        elif 15.0 <= masked_pct <= 30.0 and decision == PASS:
+            decision = REVIEW
+            notes.append("masked_pct in review range")
+
+    summary = {
+        "validator": "soil.qa_thresholds",
+        "status": PASS if decision == PASS else "blocked",
+        "decision": decision,
+        "errors": errors,
+        "notes": notes,
+    }
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1:
+        print(json.dumps({"error": "usage: qa_thresholds.py <run_receipt.json>"}))
+        return 2
+
+    receipt_path = Path(args[0])
+    if not receipt_path.exists():
+        print(json.dumps({"error": f"missing file: {receipt_path}"}))
+        return 2
+
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if not isinstance(receipt, dict):
+            raise ValueError("run receipt must be a JSON object")
+        summary = evaluate_receipt(receipt)
+    except Exception as exc:  # PROPOSED: keep deterministic fail-closed exception surface.
+        print(json.dumps({"validator": "soil.qa_thresholds", "status": "error", "error": str(exc)}))
+        return 2
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0 if summary["decision"] == PASS else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a deterministic, fixture-backed QA slice for soil run receipts that enforces KFM fail-closed promotion posture for soil-derived artifacts.  
- Surface a promotion-gate that blocks publication unless receipts carry passing validation, EvidenceBundle linkage, signatures, and an allowable publication label.

### Description
- Add `tools/validators/soil/qa_thresholds.py`, a CLI that reads a `run_receipt` JSON, validates required fields (`schema_version`, `validation_summary`, `metrics.*`, `flags`, `decision`), enforces thresholds (`|zscore_30d_max| > 2.0` => quarantine, sustained `station_grid_residual_max > 0.10` => quarantine, `masked_pct > 30` => quarantine, `masked_pct` in `15–30` => review), emits machine-readable JSON, and exits nonzero for blocked outcomes.  
- Add `tools/validators/soil/promotion_gate.py`, a CLI promotion gate that requires `validation_summary.decision == "pass"`, `evidence_bundle_ref` presence, `signatures`, and an allowlist for `policy_label` to permit promotion, emitting a Gate C review message and exiting nonzero when blocked.  
- Add Rego policy `policy/soil/soil_publication.rego` with compact deny rules that block public promotion for quarantine/review decisions, `masked_pct > 30`, `zscore_flag` or `residual_sustained` true, or missing evidence/signatures.  
- Add deterministic fixtures under `tests/fixtures/soil/` for pass, quarantine (zscore), quarantine (residual), fail (masked_pct), and review masked_pct; add subprocess-based pytest coverage in `tests/soil/` exercising CLI behavior.  
- Update CI: `.github/workflows/ci.yml` runs `pytest -q tests/soil` slice when `tests/soil` exists to make the validator slice visible in Python CI reports.

### Testing
- Ran CLI validator smoke tests: `python tools/validators/soil/qa_thresholds.py tests/fixtures/soil/valid/run_receipt_pass.json` exited `0` and returned `"decision": "pass"`, and each invalid fixture produced nonzero exit codes as expected.  
- Ran gate CLI checks: `python tools/validators/soil/promotion_gate.py tests/fixtures/soil/valid/run_receipt_pass.json` exited `0`, and the review/quarantine/fail fixtures produced nonzero exits and returned `"promotion_allowed": false` for blocked cases.  
- Ran unit/CLI integration via pytest: `pytest -q tests/soil` → `5 passed` (succeeded).  
- All automated tests and validator CLI checks included in this change passed in the branch run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f412bf49f0832a8df054732f99bbf2)