### PR TITLE
Add soil catalog/triplet publication slice with promotion receipt

### DIFF
--- a/policy/soil/soil_catalog_publication.rego
+++ b/policy/soil/soil_catalog_publication.rego
@@ -1,0 +1,30 @@
+package soil.catalog_publication
+
+deny contains "decision_not_pass" if {
+  input.validation_summary.decision != "pass"
+}
+
+deny contains "missing_evidence_bundle_ref" if {
+  not input.artifacts.evidence_bundle_ref
+  not input.evidence_bundle_ref
+}
+
+deny contains "missing_signatures" if {
+  not input.signatures
+}
+
+deny contains "unknown_rights_status" if {
+  input.rights_status == "unknown"
+}
+
+deny contains "missing_policy_label" if {
+  not input.policy_label
+}
+
+deny contains "restricted_sensitivity" if {
+  input.sensitivity == "restricted"
+}
+
+deny contains "private_sensitivity" if {
+  input.sensitivity == "private"
+}

--- a/tests/fixtures/soil/catalog/run_receipt_block_missing_signature.json
+++ b/tests/fixtures/soil/catalog/run_receipt_block_missing_signature.json
@@ -1,0 +1,10 @@
+{
+  "run_receipt_id": "run_receipt:soil:block:missing-signature",
+  "artifacts": {"evidence_bundle_ref": "kfm://evidence/soil.bundle.block.sig"},
+  "validation_summary": {"decision": "pass"},
+  "metrics": {"masked_pct": 4.0, "zscore_30d_max": 0.7, "station_grid_residual_max": 0.02},
+  "rights_status": "open",
+  "policy_label": "public",
+  "sensitivity": "public",
+  "signatures": []
+}

--- a/tests/fixtures/soil/catalog/run_receipt_block_review.json
+++ b/tests/fixtures/soil/catalog/run_receipt_block_review.json
@@ -1,0 +1,10 @@
+{
+  "run_receipt_id": "run_receipt:soil:block:review",
+  "artifacts": {"evidence_bundle_ref": "kfm://evidence/soil.bundle.block.review"},
+  "validation_summary": {"decision": "review"},
+  "metrics": {"masked_pct": 18.0, "zscore_30d_max": 0.6, "station_grid_residual_max": 0.03},
+  "rights_status": "open",
+  "policy_label": "public",
+  "sensitivity": "public",
+  "signatures": ["sig:review"]
+}

--- a/tests/fixtures/soil/catalog/run_receipt_block_unknown_rights.json
+++ b/tests/fixtures/soil/catalog/run_receipt_block_unknown_rights.json
@@ -1,0 +1,10 @@
+{
+  "run_receipt_id": "run_receipt:soil:block:unknown-rights",
+  "artifacts": {"evidence_bundle_ref": "kfm://evidence/soil.bundle.block.rights"},
+  "validation_summary": {"decision": "pass"},
+  "metrics": {"masked_pct": 4.0, "zscore_30d_max": 0.7, "station_grid_residual_max": 0.02},
+  "rights_status": "unknown",
+  "policy_label": "public",
+  "sensitivity": "public",
+  "signatures": ["sig:rights"]
+}

--- a/tests/fixtures/soil/catalog/run_receipt_pass_embedded_bundle.json
+++ b/tests/fixtures/soil/catalog/run_receipt_pass_embedded_bundle.json
@@ -1,0 +1,33 @@
+{
+  "evidence_bundle": {
+    "bundle_id": "soil.bundle.pass.001",
+    "rights_status": "open",
+    "policy_label": "public",
+    "sensitivity": "public"
+  },
+  "run_receipt": {
+    "run_receipt_id": "run_receipt:soil:pass:001",
+    "process": "soil.smap_mesonet.ingest",
+    "artifacts": {
+      "evidence_bundle_ref": "kfm://evidence/soil.bundle.pass.001"
+    },
+    "validation_summary": {
+      "decision": "pass",
+      "time_window": {
+        "start": "2026-04-01T00:00:00Z",
+        "end": "2026-04-30T23:59:59Z"
+      }
+    },
+    "bbox": [-101.5, 37.0, -94.9, 39.9],
+    "source_refs": ["smap:l4", "ksmesonet:stations"],
+    "metrics": {
+      "masked_pct": 4.1,
+      "zscore_30d_max": 1.2,
+      "station_grid_residual_max": 0.04
+    },
+    "rights_status": "open",
+    "policy_label": "public",
+    "sensitivity": "public",
+    "signatures": ["sig:abc123"]
+  }
+}

--- a/tests/fixtures/soil/catalog/run_receipt_pass_minimal.json
+++ b/tests/fixtures/soil/catalog/run_receipt_pass_minimal.json
@@ -1,0 +1,10 @@
+{
+  "run_receipt_id": "run_receipt:soil:pass:minimal",
+  "artifacts": {"evidence_bundle_ref": "kfm://evidence/soil.bundle.pass.minimal"},
+  "validation_summary": {"decision": "pass"},
+  "metrics": {"masked_pct": 3.0, "zscore_30d_max": 0.8, "station_grid_residual_max": 0.02},
+  "rights_status": "open",
+  "policy_label": "public",
+  "sensitivity": "public",
+  "signatures": ["sig:min"]
+}

--- a/tests/soil/test_soil_catalog_builder.py
+++ b/tests/soil/test_soil_catalog_builder.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/catalog/soil/build_catalog.py"
+FIXTURE_ROOT = ROOT / "tests/fixtures/soil/catalog"
+
+
+def run_builder(receipt: Path, out_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--receipt", str(receipt), "--out-root", str(out_root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_pass_embedded_fixture_generates_outputs(tmp_path: Path) -> None:
+    result = run_builder(FIXTURE_ROOT / "run_receipt_pass_embedded_bundle.json", tmp_path)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["promotion_allowed"] is True
+
+    sid = "soil.bundle.pass.001"
+    expected = [
+        tmp_path / "catalog/stac/soil" / f"{sid}.json",
+        tmp_path / "catalog/dcat/soil" / f"{sid}.jsonld",
+        tmp_path / "catalog/prov/soil" / f"{sid}.jsonld",
+        tmp_path / "triplets/soil" / f"{sid}.nt",
+        tmp_path / "receipts/soil" / f"{sid}.promotion_receipt.json",
+    ]
+    for path in expected:
+        assert path.exists(), f"missing {path}"
+
+    for catalog in expected[:4]:
+        if catalog.suffix in {".json", ".jsonld"}:
+            json.loads(catalog.read_text(encoding="utf-8"))
+
+    promotion = json.loads(expected[4].read_text(encoding="utf-8"))
+    generated = promotion["generated_artifacts"]
+    assert set(generated.keys()) == {"stac", "dcat", "prov", "triplets"}
+    for value in generated.values():
+        assert "sha256" in value and len(value["sha256"]) == 64
+
+
+def test_triples_deterministic_across_runs(tmp_path: Path) -> None:
+    out_a = tmp_path / "a"
+    out_b = tmp_path / "b"
+    assert run_builder(FIXTURE_ROOT / "run_receipt_pass_embedded_bundle.json", out_a).returncode == 0
+    assert run_builder(FIXTURE_ROOT / "run_receipt_pass_embedded_bundle.json", out_b).returncode == 0
+    sid = "soil.bundle.pass.001"
+    nt_a = (out_a / "triplets/soil" / f"{sid}.nt").read_text(encoding="utf-8")
+    nt_b = (out_b / "triplets/soil" / f"{sid}.nt").read_text(encoding="utf-8")
+    assert nt_a == nt_b
+
+
+def test_blocked_fixtures_nonzero_and_no_outputs(tmp_path: Path) -> None:
+    for name in [
+        "run_receipt_block_review.json",
+        "run_receipt_block_missing_signature.json",
+        "run_receipt_block_unknown_rights.json",
+    ]:
+        out = tmp_path / name.replace(".json", "")
+        result = run_builder(FIXTURE_ROOT / name, out)
+        assert result.returncode != 0
+        assert not (out / "catalog").exists()
+        assert not (out / "triplets").exists()

--- a/tools/catalog/soil/build_catalog.py
+++ b/tools/catalog/soil/build_catalog.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+KANSAS_BBOX = [-102.1, 36.9, -94.6, 40.1]
+ALLOWED_RIGHTS = {"open", "public", "public_aggregate", "public_safe", "public_reviewed"}
+
+
+def _safe_id(value: str) -> str:
+    clean = re.sub(r"[^A-Za-z0-9._-]", "_", value or "")
+    return clean or "bundle"
+
+
+def _atomic_write(path: Path, payload: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, dir=str(path.parent)) as tmp:
+        tmp.write(payload)
+        tmp_name = tmp.name
+    os.replace(tmp_name, path)
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(8192)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _load_and_normalize(path: Path) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(obj, dict):
+        raise ValueError("receipt file must be a JSON object")
+    if "run_receipt" in obj:
+        run_receipt = obj.get("run_receipt")
+        if not isinstance(run_receipt, dict):
+            raise ValueError("run_receipt wrapper must contain object")
+        evidence_bundle = obj.get("evidence_bundle") if isinstance(obj.get("evidence_bundle"), dict) else None
+        return run_receipt, evidence_bundle
+    return obj, obj.get("evidence_bundle") if isinstance(obj.get("evidence_bundle"), dict) else None
+
+
+def _extract(run_receipt: dict[str, Any], evidence_bundle: dict[str, Any] | None) -> dict[str, Any]:
+    decision = ((run_receipt.get("validation_summary") or {}).get("decision"))
+    if decision != "pass":
+        raise ValueError("blocked: validation_summary.decision must be pass")
+
+    artifacts = run_receipt.get("artifacts") if isinstance(run_receipt.get("artifacts"), dict) else {}
+    evidence_ref = artifacts.get("evidence_bundle_ref") or run_receipt.get("evidence_bundle_ref")
+    if not evidence_ref:
+        raise ValueError("blocked: missing evidence_bundle_ref")
+
+    signatures = run_receipt.get("signatures")
+    if not isinstance(signatures, list) or len(signatures) == 0:
+        raise ValueError("blocked: missing signatures")
+
+    rights_status = str(run_receipt.get("rights_status") or (evidence_bundle or {}).get("rights_status") or "").strip()
+    if not rights_status or rights_status == "unknown" or rights_status not in ALLOWED_RIGHTS:
+        raise ValueError("blocked: unknown or disallowed rights_status")
+
+    policy_label = str(run_receipt.get("policy_label") or (evidence_bundle or {}).get("policy_label") or "").strip()
+    if not policy_label:
+        raise ValueError("blocked: missing policy_label")
+
+    sensitivity = str(run_receipt.get("sensitivity") or (evidence_bundle or {}).get("sensitivity") or "public").strip()
+    if sensitivity in {"restricted", "private"}:
+        raise ValueError("blocked: sensitivity not public-safe")
+
+    bundle_id = str((evidence_bundle or {}).get("bundle_id") or run_receipt.get("bundle_id") or evidence_ref)
+    if not bundle_id:
+        raise ValueError("blocked: missing bundle_id")
+
+    return {
+        "decision": decision,
+        "evidence_ref": str(evidence_ref),
+        "bundle_id": bundle_id,
+        "safe_bundle_id": _safe_id(bundle_id),
+        "rights_status": rights_status,
+        "policy_label": policy_label,
+        "sensitivity": sensitivity,
+    }
+
+
+def _bbox_and_geometry(run_receipt: dict[str, Any]) -> tuple[list[float], dict[str, Any], str | None]:
+    bbox = run_receipt.get("bbox")
+    geometry_source = None
+    if not (isinstance(bbox, list) and len(bbox) == 4):
+        bbox = KANSAS_BBOX
+        geometry_source = "PROPOSED_fixture_fallback"
+    minx, miny, maxx, maxy = [float(x) for x in bbox]
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[minx, miny], [maxx, miny], [maxx, maxy], [minx, maxy], [minx, miny]]],
+    }
+    return [minx, miny, maxx, maxy], geometry, geometry_source
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--receipt", required=True)
+    parser.add_argument("--out-root", required=True)
+    args = parser.parse_args(argv)
+
+    receipt_path = Path(args.receipt)
+    out_root = Path(args.out_root)
+
+    try:
+        run_receipt, evidence_bundle = _load_and_normalize(receipt_path)
+        meta = _extract(run_receipt, evidence_bundle)
+        bbox, geometry, geometry_source = _bbox_and_geometry(run_receipt)
+
+        val = run_receipt.get("validation_summary") if isinstance(run_receipt.get("validation_summary"), dict) else {}
+        metrics = run_receipt.get("metrics") if isinstance(run_receipt.get("metrics"), dict) else {}
+
+        props: dict[str, Any] = {
+            "kfm:domain": "soil",
+            "kfm:evidence_bundle_ref": meta["evidence_ref"],
+            "kfm:run_receipt_ref": run_receipt.get("run_receipt_ref") or run_receipt.get("run_receipt_id"),
+            "kfm:decision": "pass",
+            "kfm:rights_status": meta["rights_status"],
+            "kfm:policy_label": meta["policy_label"],
+            "kfm:sensitivity": meta["sensitivity"],
+            "soil:source": run_receipt.get("soil_source", "SMAP_L4+Mesonet"),
+            "soil:aggregation": run_receipt.get("soil_aggregation", "county"),
+            "soil:masked_pct": metrics.get("masked_pct"),
+            "soil:zscore_30d_max": metrics.get("zscore_30d_max"),
+            "soil:station_grid_residual_max": metrics.get("station_grid_residual_max"),
+        }
+        if geometry_source:
+            props["kfm:geometry_source"] = geometry_source
+        tw = val.get("time_window") if isinstance(val.get("time_window"), dict) else {}
+        if tw.get("start") and tw.get("end"):
+            props["start_datetime"] = tw["start"]
+            props["end_datetime"] = tw["end"]
+        else:
+            props["datetime"] = run_receipt.get("datetime") or run_receipt.get("timestamp")
+
+        sid = meta["safe_bundle_id"]
+        stac_path = out_root / "catalog" / "stac" / "soil" / f"{sid}.json"
+        dcat_path = out_root / "catalog" / "dcat" / "soil" / f"{sid}.jsonld"
+        prov_path = out_root / "catalog" / "prov" / "soil" / f"{sid}.jsonld"
+        nt_path = out_root / "triplets" / "soil" / f"{sid}.nt"
+        receipt_out = out_root / "receipts" / "soil" / f"{sid}.promotion_receipt.json"
+
+        stac = {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "id": sid,
+            "collection": "soil-moisture",
+            "bbox": bbox,
+            "geometry": geometry,
+            "properties": props,
+            "assets": {
+                "receipt": {"href": str(receipt_out), "type": "application/json"},
+                "evidence_bundle": {"href": meta["evidence_ref"], "type": "application/json"},
+            },
+        }
+
+        dcat = {
+            "@context": {
+                "dcat": "http://www.w3.org/ns/dcat#",
+                "dct": "http://purl.org/dc/terms/",
+                "prov": "http://www.w3.org/ns/prov#",
+                "kfm": "https://kfm.example/ns/",
+                "soil": "https://kfm.example/soil/",
+            },
+            "@type": "dcat:Dataset",
+            "@id": f"kfm://bundle/{quote(meta['bundle_id'], safe='')}",
+            "dct:title": f"KFM Soil Moisture Dataset {sid}",
+            "dct:identifier": meta["bundle_id"],
+            "dct:license": meta["rights_status"],
+            "dct:accessRights": meta["policy_label"],
+            "dct:temporal": {"start": tw.get("start"), "end": tw.get("end")},
+            "dcat:theme": "soil moisture",
+            "prov:wasGeneratedBy": run_receipt.get("process") or "soil.smap_mesonet.ingest",
+        }
+
+        prov = {
+            "@context": {"prov": "http://www.w3.org/ns/prov#", "kfm": "https://kfm.example/ns/"},
+            "@graph": [
+                {"@id": f"kfm://bundle/{quote(meta['bundle_id'], safe='')}", "@type": "prov:Entity", "kfm:evidence_bundle_ref": meta["evidence_ref"]},
+                {"@id": f"kfm://activity/{quote(str(run_receipt.get('process') or 'soil.smap_mesonet.ingest'), safe='')}", "@type": "prov:Activity", "prov:used": run_receipt.get("source_refs", [])},
+                {"@id": "kfm://agent/kfm-ci-steward", "@type": "prov:Agent"},
+                {"@id": "kfm://relation/generated", "prov:entity": f"kfm://bundle/{quote(meta['bundle_id'], safe='')}", "prov:activity": f"kfm://activity/{quote(str(run_receipt.get('process') or 'soil.smap_mesonet.ingest'), safe='')}"},
+                {"@id": "kfm://relation/associated", "prov:activity": f"kfm://activity/{quote(str(run_receipt.get('process') or 'soil.smap_mesonet.ingest'), safe='')}", "prov:agent": "kfm://agent/kfm-ci-steward"},
+            ],
+        }
+
+        b_uri = f"<kfm://bundle/{quote(meta['bundle_id'], safe='')}>"
+        facts = [
+            f"{b_uri} <kfm://predicate/hasDecision> \"pass\" .",
+            f"{b_uri} <kfm://predicate/hasDomain> \"soil\" .",
+            f"{b_uri} <kfm://predicate/hasEvidenceBundleRef> \"{meta['evidence_ref']}\" .",
+            f"{b_uri} <kfm://predicate/hasMetricMaskedPct> \"{metrics.get('masked_pct')}\" .",
+            f"{b_uri} <kfm://predicate/hasMetricResidual> \"{metrics.get('station_grid_residual_max')}\" .",
+            f"{b_uri} <kfm://predicate/hasMetricZscore30dMax> \"{metrics.get('zscore_30d_max')}\" .",
+            f"{b_uri} <kfm://predicate/hasPolicyLabel> \"{meta['policy_label']}\" .",
+            f"{b_uri} <kfm://predicate/hasRightsStatus> \"{meta['rights_status']}\" .",
+            f"{b_uri} <kfm://predicate/wasGeneratedBy> \"{run_receipt.get('process') or 'soil.smap_mesonet.ingest'}\" .",
+        ]
+        facts.sort()
+
+        _atomic_write(stac_path, json.dumps(stac, sort_keys=True, indent=2) + "\n")
+        _atomic_write(dcat_path, json.dumps(dcat, sort_keys=True, indent=2) + "\n")
+        _atomic_write(prov_path, json.dumps(prov, sort_keys=True, indent=2) + "\n")
+        _atomic_write(nt_path, "\n".join(facts) + "\n")
+
+        generated = {
+            "stac": {"path": str(stac_path), "sha256": _sha256_file(stac_path)},
+            "dcat": {"path": str(dcat_path), "sha256": _sha256_file(dcat_path)},
+            "prov": {"path": str(prov_path), "sha256": _sha256_file(prov_path)},
+            "triplets": {"path": str(nt_path), "sha256": _sha256_file(nt_path)},
+        }
+
+        promotion_receipt = {
+            "schema_version": "kfm.v1",
+            "receipt_type": "PromotionReceipt",
+            "from_state": "PROCESSED",
+            "to_states": ["CATALOG", "TRIPLET"],
+            "decision": "pass",
+            "bundle_id": meta["bundle_id"],
+            "source_run_receipt_ref": run_receipt.get("run_receipt_ref") or run_receipt.get("run_receipt_id") or _sha256_file(receipt_path),
+            "generated_artifacts": generated,
+            "policy_checks": {"rights_status": meta["rights_status"], "policy_label": meta["policy_label"], "sensitivity": meta["sensitivity"]},
+            "created": dt.datetime.now(dt.timezone.utc).isoformat(),
+        }
+        _atomic_write(receipt_out, json.dumps(promotion_receipt, sort_keys=True, indent=2) + "\n")
+
+        summary = {
+            "promotion_allowed": True,
+            "bundle_id": meta["bundle_id"],
+            "outputs": {
+                **generated,
+                "promotion_receipt": {"path": str(receipt_out), "sha256": _sha256_file(receipt_out)},
+            },
+            "state_transition": "PROCESSED->CATALOG/TRIPLET",
+        }
+        print(json.dumps(summary, sort_keys=True))
+        return 0
+    except Exception as exc:
+        print(f"catalog generation blocked: {exc}", file=sys.stderr)
+        print(json.dumps({"promotion_allowed": False, "error": str(exc), "state_transition": "PROCESSED->CATALOG/TRIPLET"}, sort_keys=True))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide the next deterministic Soil layer that converts a PASSING `run_receipt`/`EvidenceBundle` into governed catalog and triplet artifacts for publication. 
- Enforce KFM fail-closed promotion invariants (decision, evidence binding, signatures, rights, policy label, sensitivity) so only auditable, rights-checked artifacts are produced. 
- Produce STAC, DCAT JSON-LD, PROV JSON-LD, RDF N-Triples, and a promotion/state-transition receipt with artifact SHA-256s for downstream proof and release workflows. 

### Description
- Add a CLI `tools/catalog/soil/build_catalog.py` that accepts either a top-level `run_receipt` or a wrapper with `{ "evidence_bundle", "run_receipt" }` and emits deterministic artifacts or fails closed. 
- The builder generates `catalog/stac/soil/<safe_bundle_id>.json`, `catalog/dcat/soil/<safe_bundle_id>.jsonld`, `catalog/prov/soil/<safe_bundle_id>.jsonld`, `triplets/soil/<safe_bundle_id>.nt`, and `receipts/soil/<safe_bundle_id>.promotion_receipt.json`, using atomic writes and real SHA-256 digests. 
- Implements deterministic N-Triples ordering, a Kansas bbox fallback (`[-102.1, 36.9, -94.6, 40.1]`) marked as `kfm:geometry_source = "PROPOSED_fixture_fallback"`, and stable filename sanitization for bundle ids. 
- Add publication policy rules in `policy/soil/soil_catalog_publication.rego` to deny publication when `decision != "pass"`, missing evidence/signatures/policy_label, unknown rights, or restricted/private sensitivity. 
- Add fixtures under `tests/fixtures/soil/catalog/` (pass embedded, pass minimal, and blocked variants) and a pytest suite `tests/soil/test_soil_catalog_builder.py` that exercises CLI behavior and determinism. 

### Testing
- Executed the builder against the embedded bundle fixture with `python tools/catalog/soil/build_catalog.py --receipt tests/fixtures/soil/catalog/run_receipt_pass_embedded_bundle.json --out-root /tmp/kfm_soil_catalog`, which exited `0` and produced all required artifacts and a promotion receipt with SHA-256s. 
- Ran the pytest slice `tests/soil` including the new `tests/soil/test_soil_catalog_builder.py` together with existing soil validators, and all tests passed (`8 passed`). 
- Verified blocked fixtures exit nonzero and do not create `catalog` or `triplets` outputs as asserted by the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f413f56e54832aaf91a65c15ef0d51)