### PR TITLE
Add Consent VC stub + deterministic Revocation Delta v1 slice

### DIFF
--- a/apps/governed_api/openapi/consent.yaml
+++ b/apps/governed_api/openapi/consent.yaml
@@ -1,0 +1,90 @@
+openapi: 3.0.3
+info:
+  title: KFM Consent API (stub)
+  version: v1
+paths:
+  /consent/issue:
+    post:
+      operationId: issueConsent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueRequest'
+      responses:
+        '200':
+          description: issued consent placeholder VC
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssueResponse'
+  /consent/revoke:
+    post:
+      operationId: revokeConsent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RevokeRequest'
+      responses:
+        '200':
+          description: generated deterministic revoke delta
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevokeResponse'
+components:
+  schemas:
+    ConsentRef:
+      type: object
+      required: [consent_vc_id, obligations_snapshot_hash]
+      properties:
+        consent_vc_id: {type: string}
+        obligations_snapshot_hash: {type: string, pattern: '^[a-f0-9]{64}$'}
+        obligations_url: {type: string}
+    RevokeDelta:
+      type: object
+      required: [object_type, schema_version, revoke_delta_id, consent_vc_id, prior_spec_hash, delta_timestamp, obligations_action, signature]
+      properties:
+        object_type: {type: string, enum: [RevokeDelta]}
+        schema_version: {type: string, enum: [v1]}
+        revoke_delta_id: {type: string}
+        consent_vc_id: {type: string}
+        prior_spec_hash: {type: string, pattern: '^[a-f0-9]{64}$'}
+        delta_timestamp: {type: string, format: date-time}
+        obligations_action: {type: string, enum: [suppress_or_recompute]}
+        signature: {type: string}
+    IssueRequest:
+      type: object
+      required: [subject_id, obligations]
+      properties:
+        subject_id: {type: string}
+        obligations: {type: object, additionalProperties: true}
+    IssueResponse:
+      type: object
+      required: [consent_vc_id, obligations_snapshot_hash, issued_at, signature]
+      properties:
+        consent_vc_id: {type: string}
+        obligations_snapshot_hash: {type: string, pattern: '^[a-f0-9]{64}$'}
+        issued_at: {type: string, format: date-time}
+        signature: {type: string}
+    RevokeRequest:
+      type: object
+      required: [consent_vc_id, prior_spec_hash, delta_timestamp]
+      properties:
+        consent_vc_id: {type: string}
+        revocation_token: {type: string}
+        revoke_vc_jwt: {type: string}
+        prior_spec_hash: {type: string, pattern: '^[a-f0-9]{64}$'}
+        delta_timestamp: {type: string, format: date-time}
+      oneOf:
+        - required: [revocation_token]
+        - required: [revoke_vc_jwt]
+    RevokeResponse:
+      type: object
+      required: [revoke_delta]
+      properties:
+        revoke_delta:
+          $ref: '#/components/schemas/RevokeDelta'

--- a/docs/adr/ADR-0427-consent-vc-and-revocation-delta.md
+++ b/docs/adr/ADR-0427-consent-vc-and-revocation-delta.md
@@ -1,0 +1,42 @@
+# ADR-0427: Consent VC + Revocation Delta v1
+
+## KFM Meta Block v2
+- status: draft
+- verification: PROPOSED
+- owners: governance/policy/runtime
+- date: 2026-05-01
+- scope: consent issuance placeholder, deterministic revocation delta, downstream suppression/recompute signaling
+
+## Context
+KFM needs a fail-closed governance slice that can issue consent as a verifiable-credential placeholder, carry consent obligations into evidence and receipts, and deterministically derive revocation deltas without any live network or Sigstore dependency.
+
+## Decision
+Define and implement a local-only Consent VC + Revocation Delta v1 posture with deterministic stubs:
+
+- `consent_vc_id`: stable issued credential identifier (`consent_vc_<hex>`).
+- `obligations_snapshot_hash`: sha256 of canonical JSON obligations snapshot.
+- `revoke_delta_id`: deterministic HMAC identifier from token-derived key and revocation inputs.
+
+Deterministic revocation derivation:
+1. derive key using HKDF-like HMAC:
+   - `prk = HMAC("kfm:revoke:v1", revocation_token)`
+   - `k = HMAC(prk, "kfm:revoke:v1:id")`
+2. message = `prior_spec_hash + "|" + delta_timestamp`
+3. `revoke_delta_id = "rvk_" + HMAC(k, message).hex()`
+
+No-network posture:
+- issuance/revocation use local deterministic signing stub only.
+- no remote identity, Sigstore, OIDC, DID, or VC status-list calls.
+- all tests run from local fixtures.
+
+## Consequences
+- preserves proof/receipt/evidence/revoke-manifest separation.
+- enables deterministic testability and replay.
+- keeps `revocation_token` private (never serialized in public outputs).
+
+## Privacy and rollback notes
+- Revocation tokens are treated as secrets and are excluded from EvidenceBundle, run_receipt, and RevokeDelta artifacts.
+- rollback is performed by replaying prior non-revoked specs and emitting a new receipt that references the applicable `revoke_delta_id` and suppression/recompute action.
+
+## NEEDS_VERIFICATION
+- Canonical schema authority for generic `EvidenceBundle.v1.json` and `run_receipt.v1.json` in this repo appears absent/ambiguous; this ADR introduces v1 canonical files under `schemas/evidence` and `schemas/receipts` as PROPOSED pending cross-lane ratification.

--- a/policy/consent/ecology.v1.md
+++ b/policy/consent/ecology.v1.md
@@ -1,0 +1,7 @@
+# Ecology Consent Obligations v1 (PROPOSED)
+
+- aggregation = HUC12
+- exports = GEDCOM, CSV
+- retention = P24M
+- public exact coordinates disallowed
+- revoke action = suppress_or_recompute

--- a/schemas/consent/revoke_delta.v1.json
+++ b/schemas/consent/revoke_delta.v1.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "revoke_delta.v1",
+  "type": "object",
+  "required": ["object_type", "schema_version", "revoke_delta_id", "consent_vc_id", "prior_spec_hash", "delta_timestamp", "obligations_action", "signature"],
+  "properties": {
+    "object_type": {"type": "string", "const": "RevokeDelta"},
+    "schema_version": {"type": "string", "const": "v1"},
+    "revoke_delta_id": {"type": "string", "pattern": "^rvk_[a-f0-9]{64}$"},
+    "consent_vc_id": {"type": "string"},
+    "prior_spec_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "delta_timestamp": {"type": "string", "format": "date-time"},
+    "obligations_action": {"type": "string", "const": "suppress_or_recompute"},
+    "signature": {"type": "string"}
+  },
+  "additionalProperties": false
+}

--- a/schemas/evidence/EvidenceBundle.v1.json
+++ b/schemas/evidence/EvidenceBundle.v1.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceBundle.v1",
+  "type": "object",
+  "required": ["object_type", "schema_version", "bundle_id", "spec_hash"],
+  "properties": {
+    "object_type": {"type": "string", "const": "EvidenceBundle"},
+    "schema_version": {"type": "string", "const": "v1"},
+    "bundle_id": {"type": "string"},
+    "spec_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "consent": {
+      "type": "object",
+      "required": ["consent_vc_id", "obligations_url", "obligations_snapshot_hash"],
+      "properties": {
+        "consent_vc_id": {"type": "string"},
+        "obligations_url": {"type": "string"},
+        "obligations_snapshot_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/receipts/run_receipt.v1.json
+++ b/schemas/receipts/run_receipt.v1.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "run_receipt.v1",
+  "type": "object",
+  "required": ["object_type", "schema_version", "run_id", "spec_hash", "artifact_spec_hash"],
+  "properties": {
+    "object_type": {"type": "string", "const": "run_receipt"},
+    "schema_version": {"type": "string", "const": "v1"},
+    "run_id": {"type": "string"},
+    "spec_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "artifact_spec_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "consent_vc_id": {"type": "string"},
+    "obligations_snapshot": {
+      "type": "object",
+      "required": ["obligations_snapshot_hash"],
+      "properties": {
+        "obligations_snapshot_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      },
+      "additionalProperties": true
+    },
+    "revoke_delta_id": {"type": "string", "pattern": "^rvk_[a-f0-9]{64}$"}
+  },
+  "additionalProperties": true
+}

--- a/tests/consent/test_evidence_bundle_consent_schema.py
+++ b/tests/consent/test_evidence_bundle_consent_schema.py
@@ -1,0 +1,11 @@
+import json
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+
+def test_evidence_bundle_with_consent_validates_and_negative_case():
+    schema = json.loads(Path("schemas/evidence/EvidenceBundle.v1.json").read_text())
+    doc = json.loads(Path("tests/fixtures/consent/evidence_bundle.with_consent.valid.json").read_text())
+    assert not list(Draft202012Validator(schema).iter_errors(doc))
+    bad = json.loads(json.dumps(doc)); del bad["consent"]["consent_vc_id"]
+    assert list(Draft202012Validator(schema).iter_errors(bad))

--- a/tests/consent/test_issue_consent.py
+++ b/tests/consent/test_issue_consent.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+from tools.consent.issue_consent import issue_consent
+
+FIX = Path("tests/fixtures/consent")
+
+
+def test_issue_consent_golden():
+    req = json.loads((FIX / "issue_request.valid.json").read_text())
+    got = issue_consent(req)
+    exp = json.loads((FIX / "issue_response.golden.json").read_text())
+    assert got == exp
+    assert "revocation_token" not in json.dumps(got)

--- a/tests/consent/test_revoke_delta_determinism.py
+++ b/tests/consent/test_revoke_delta_determinism.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+import pytest
+from tools.consent.revoke_consent import revoke_consent
+
+FIX = Path("tests/fixtures/consent")
+
+
+def test_revoke_delta_deterministic_and_golden():
+    req = json.loads((FIX / "revoke_request.valid.json").read_text())
+    got = revoke_consent(req)
+    exp = json.loads((FIX / "revoke_delta.golden.json").read_text())
+    assert got == exp
+    assert revoke_consent(req)["revoke_delta_id"] == got["revoke_delta_id"]
+
+
+def test_revoke_delta_changes_with_inputs():
+    req = json.loads((FIX / "revoke_request.valid.json").read_text())
+    a = revoke_consent(req)["revoke_delta_id"]
+    req2 = dict(req); req2["revocation_token"] = "different-token"
+    b = revoke_consent(req2)["revoke_delta_id"]
+    req3 = dict(req); req3["prior_spec_hash"] = "f"*64
+    c = revoke_consent(req3)["revoke_delta_id"]
+    assert a != b
+    assert a != c
+
+
+def test_revoke_requires_token_or_jwt():
+    req = {"consent_vc_id":"x","prior_spec_hash":"a"*64,"delta_timestamp":"2026-05-01T00:00:00Z"}
+    with pytest.raises(ValueError):
+        revoke_consent(req)

--- a/tests/consent/test_run_receipt_consent_schema.py
+++ b/tests/consent/test_run_receipt_consent_schema.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+
+def test_run_receipt_with_consent_and_revoked_validate_and_negative_hash():
+    schema = json.loads(Path("schemas/receipts/run_receipt.v1.json").read_text())
+    doc1 = json.loads(Path("tests/fixtures/consent/run_receipt.with_consent.valid.json").read_text())
+    doc2 = json.loads(Path("tests/fixtures/consent/run_receipt.revoked.valid.json").read_text())
+    v = Draft202012Validator(schema)
+    assert not list(v.iter_errors(doc1))
+    assert not list(v.iter_errors(doc2))
+    bad = json.loads(json.dumps(doc1)); bad["obligations_snapshot"]["obligations_snapshot_hash"] = "oops"
+    assert list(v.iter_errors(bad))

--- a/tests/consent/test_worker_apply_revocation.py
+++ b/tests/consent/test_worker_apply_revocation.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+from tools.consent.worker_apply_revocation import apply_revocation
+
+
+def test_worker_emits_suppress_or_recompute_receipt_and_no_token_leak():
+    run = json.loads(Path("tests/fixtures/consent/run_receipt.with_consent.valid.json").read_text())
+    delta = json.loads(Path("tests/fixtures/consent/revoke_delta.golden.json").read_text())
+    out = apply_revocation(run, delta)
+    assert out["action"] == "suppress_or_recompute"
+    assert out["revoke_delta_id"] == delta["revoke_delta_id"]
+    assert "revocation_token" not in json.dumps(out)

--- a/tests/fixtures/consent/evidence_bundle.with_consent.valid.json
+++ b/tests/fixtures/consent/evidence_bundle.with_consent.valid.json
@@ -1,0 +1,11 @@
+{
+  "object_type": "EvidenceBundle",
+  "schema_version": "v1",
+  "bundle_id": "eb-1",
+  "spec_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "consent": {
+    "consent_vc_id": "consent_vc_bd26f709e3aedd7e0a9fc21b",
+    "obligations_url": "policy/consent/ecology.v1.md",
+    "obligations_snapshot_hash": "3d1c107ace15f20af58a027fc5dff8f77705cb4f36535d93f77c79104b3853b5"
+  }
+}

--- a/tests/fixtures/consent/issue_request.valid.json
+++ b/tests/fixtures/consent/issue_request.valid.json
@@ -1,0 +1,15 @@
+{
+  "subject_id": "person:abc",
+  "issued_at": "2026-05-01T00:00:00Z",
+  "obligations": {
+    "aggregation": "HUC12",
+    "exports": [
+      "GEDCOM",
+      "CSV"
+    ],
+    "retention": "P24M",
+    "public_exact_coordinates_disallowed": true,
+    "revoke_action": "suppress_or_recompute"
+  },
+  "obligations_url": "policy/consent/ecology.v1.md"
+}

--- a/tests/fixtures/consent/issue_response.golden.json
+++ b/tests/fixtures/consent/issue_response.golden.json
@@ -1,0 +1,7 @@
+{
+  "consent_vc_id": "consent_vc_bd26f709e3aedd7e0a9fc21b",
+  "obligations_snapshot_hash": "3d1c107ace15f20af58a027fc5dff8f77705cb4f36535d93f77c79104b3853b5",
+  "issued_at": "2026-05-01T00:00:00Z",
+  "obligations_url": "policy/consent/ecology.v1.md",
+  "signature": "stubsig_42371d326bdb7dc2d1c0bd0db748de42a217913ee3da5e8b22a8f6fe52de3865"
+}

--- a/tests/fixtures/consent/revoke_delta.golden.json
+++ b/tests/fixtures/consent/revoke_delta.golden.json
@@ -1,0 +1,10 @@
+{
+  "object_type": "RevokeDelta",
+  "schema_version": "v1",
+  "revoke_delta_id": "rvk_3f33c59388227375dae85657b9d480d4e41505c93c63eeca0f8d7f73ef11fb5e",
+  "consent_vc_id": "consent_vc_bd26f709e3aedd7e0a9fc21b",
+  "prior_spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "delta_timestamp": "2026-05-01T01:00:00Z",
+  "obligations_action": "suppress_or_recompute",
+  "signature": "stubsig_4f88f95725b6de2bbb056b14c03ed8d7baff51d4b1c875ddb567ac40f524bf4e"
+}

--- a/tests/fixtures/consent/revoke_request.valid.json
+++ b/tests/fixtures/consent/revoke_request.valid.json
@@ -1,0 +1,6 @@
+{
+  "consent_vc_id": "consent_vc_bd26f709e3aedd7e0a9fc21b",
+  "revocation_token": "token-fixture-001",
+  "prior_spec_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "delta_timestamp": "2026-05-01T01:00:00Z"
+}

--- a/tests/fixtures/consent/run_receipt.revoked.valid.json
+++ b/tests/fixtures/consent/run_receipt.revoked.valid.json
@@ -1,0 +1,15 @@
+{
+  "object_type": "run_receipt",
+  "schema_version": "v1",
+  "run_id": "run-001.revoked",
+  "spec_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "artifact_spec_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "consent_vc_id": "consent_vc_bd26f709e3aedd7e0a9fc21b",
+  "revoke_delta_id": "rvk_3f33c59388227375dae85657b9d480d4e41505c93c63eeca0f8d7f73ef11fb5e",
+  "obligations_snapshot": {
+    "obligations_snapshot_hash": "3d1c107ace15f20af58a027fc5dff8f77705cb4f36535d93f77c79104b3853b5"
+  },
+  "action": "suppress_or_recompute",
+  "status": "SUPPRESSED",
+  "timestamp": "2026-05-01T03:42:38Z"
+}

--- a/tests/fixtures/consent/run_receipt.with_consent.valid.json
+++ b/tests/fixtures/consent/run_receipt.with_consent.valid.json
@@ -1,0 +1,11 @@
+{
+  "object_type": "run_receipt",
+  "schema_version": "v1",
+  "run_id": "run-001",
+  "spec_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "artifact_spec_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "consent_vc_id": "consent_vc_bd26f709e3aedd7e0a9fc21b",
+  "obligations_snapshot": {
+    "obligations_snapshot_hash": "3d1c107ace15f20af58a027fc5dff8f77705cb4f36535d93f77c79104b3853b5"
+  }
+}

--- a/tools/consent/canonical_json.py
+++ b/tools/consent/canonical_json.py
@@ -1,0 +1,11 @@
+import json
+import hashlib
+from typing import Any
+
+
+def canonical_json_bytes(obj: Any) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_hex(obj: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(obj)).hexdigest()

--- a/tools/consent/issue_consent.py
+++ b/tools/consent/issue_consent.py
@@ -1,0 +1,19 @@
+import hashlib
+from datetime import datetime, timezone
+from .canonical_json import sha256_hex
+from .signing_stub import sign_payload
+
+
+def issue_consent(request: dict) -> dict:
+    issued_at = request.get("issued_at") or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    obligations_snapshot_hash = sha256_hex(request["obligations"])
+    consent_vc_id = "consent_vc_" + hashlib.sha256(f"{request['subject_id']}|{obligations_snapshot_hash}|{issued_at}".encode()).hexdigest()[:24]
+    unsigned = {
+        "consent_vc_id": consent_vc_id,
+        "obligations_snapshot_hash": obligations_snapshot_hash,
+        "issued_at": issued_at,
+        "obligations_url": request.get("obligations_url", "policy/consent/ecology.v1.md")
+    }
+    out = dict(unsigned)
+    out["signature"] = sign_payload(unsigned)
+    return out

--- a/tools/consent/revoke_consent.py
+++ b/tools/consent/revoke_consent.py
@@ -1,0 +1,29 @@
+import hmac
+import hashlib
+from .signing_stub import sign_payload
+
+
+def _derive_key(token: str) -> bytes:
+    prk = hmac.new(b"kfm:revoke:v1", token.encode("utf-8"), hashlib.sha256).digest()
+    return hmac.new(prk, b"kfm:revoke:v1:id", hashlib.sha256).digest()
+
+
+def revoke_consent(request: dict) -> dict:
+    token = request.get("revocation_token")
+    if not token and not request.get("revoke_vc_jwt"):
+        raise ValueError("revocation_token or revoke_vc_jwt is required")
+    key = _derive_key(token if token else request["revoke_vc_jwt"])
+    message = f"{request['prior_spec_hash']}|{request['delta_timestamp']}".encode("utf-8")
+    revoke_delta_id = "rvk_" + hmac.new(key, message, hashlib.sha256).hexdigest()
+    unsigned = {
+        "object_type": "RevokeDelta",
+        "schema_version": "v1",
+        "revoke_delta_id": revoke_delta_id,
+        "consent_vc_id": request["consent_vc_id"],
+        "prior_spec_hash": request["prior_spec_hash"],
+        "delta_timestamp": request["delta_timestamp"],
+        "obligations_action": "suppress_or_recompute"
+    }
+    out = dict(unsigned)
+    out["signature"] = sign_payload(unsigned)
+    return out

--- a/tools/consent/signing_stub.py
+++ b/tools/consent/signing_stub.py
@@ -1,0 +1,9 @@
+import hmac
+import hashlib
+from .canonical_json import canonical_json_bytes
+
+STUB_KEY = b"kfm-local-signing-stub-v1"
+
+
+def sign_payload(payload: dict) -> str:
+    return "stubsig_" + hmac.new(STUB_KEY, canonical_json_bytes(payload), hashlib.sha256).hexdigest()

--- a/tools/consent/worker_apply_revocation.py
+++ b/tools/consent/worker_apply_revocation.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timezone
+
+
+def apply_revocation(run_receipt: dict, revoke_delta: dict) -> dict:
+    return {
+        "object_type": "run_receipt",
+        "schema_version": "v1",
+        "run_id": run_receipt["run_id"] + ".revoked",
+        "spec_hash": run_receipt["spec_hash"],
+        "artifact_spec_hash": run_receipt["artifact_spec_hash"],
+        "consent_vc_id": revoke_delta["consent_vc_id"],
+        "revoke_delta_id": revoke_delta["revoke_delta_id"],
+        "obligations_snapshot": run_receipt.get("obligations_snapshot", {}),
+        "action": "suppress_or_recompute",
+        "status": "SUPPRESSED",
+        "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    }


### PR DESCRIPTION
### Motivation

- Provide a local, no-network governance slice to issue consent as a verifiable-credential placeholder and to deterministically derive revocation deltas while preserving a fail-closed posture.  
- Ensure EvidenceBundle and `run_receipt` can reference consent obligations and that downstream workers can locate affected artifacts to emit suppress/recompute receipts.  
- Protect privacy by keeping `revocation_token` secret and by separating proofs/receipts/evidence/revoke manifests while remaining testable offline.

### Description

- Added ADR: `docs/adr/ADR-0427-consent-vc-and-revocation-delta.md` documenting KFM Meta Block v2, deterministic revocation derivation, no-network posture, privacy and rollback notes, and `NEEDS_VERIFICATION` for schema authority.  
- Added OpenAPI stub `apps/governed_api/openapi/consent.yaml` with `POST /consent/issue` and `POST /consent/revoke` and the request/response schemas (`IssueRequest`, `IssueResponse`, `RevokeRequest`, `RevokeResponse`, `ConsentRef`, `RevokeDelta`).  
- Added proposed schemas: `schemas/evidence/EvidenceBundle.v1.json` (optional consent object), `schemas/receipts/run_receipt.v1.json` (consent and revoke linkage fields), and `schemas/consent/revoke_delta.v1.json` (`RevokeDelta` shape).  
- Implemented deterministic local tooling under `tools/consent/`: `canonical_json.py` (canonical JSON bytes + `sha256_hex`), `signing_stub.py` (local signing stub), `issue_consent.py` (deterministic `consent_vc_id` and obligations snapshot hash), `revoke_consent.py` (HKDF-like HMAC key derivation and deterministic `revoke_delta_id`), and `worker_apply_revocation.py` (emit `suppress_or_recompute` run receipt referencing `revoke_delta_id`).  
- Added ecology obligations profile `policy/consent/ecology.v1.md` (PROPOSED) expressing aggregation, exports, retention, coordinate privacy, and revoke action `suppress_or_recompute`.  
- Added fixtures under `tests/fixtures/consent/` for issue/revoke/evidence/run_receipt and golden responses, and offline tests under `tests/consent/` covering issuance, revocation determinism, schema validation, and worker behavior.  
- Implementation notes: revocation derivation uses an HKDF-like step: `prk = HMAC(b"kfm:revoke:v1", revocation_token)` then `k = HMAC(prk, b"kfm:revoke:v1:id")` and `revoke_delta_id = "rvk_" + HMAC(k, prior_spec_hash||"|"||delta_timestamp).hex()`, and `revocation_token` is never serialized into public artifacts; signing uses a deterministic local stub `stubsig_...` (explicitly a stub, no Sigstore/VC network calls).

### Testing

- Ran `pytest -q tests/consent` (offline) and all tests passed: `7 passed`.
- Automated tests include: issuance golden equality (`test_issue_consent.py`), deterministic revoke id and sensitivity checks (`test_revoke_delta_determinism.py`), schema validation positive and negative cases for `EvidenceBundle` and `run_receipt` (`test_evidence_bundle_consent_schema.py`, `test_run_receipt_consent_schema.py`), and worker application behavior and token non-leak assertion (`test_worker_apply_revocation.py`); all succeeded.  
- Determinism assertions validated that identical `revocation_token` + `prior_spec_hash` + `delta_timestamp` produce the same `revoke_delta_id`, and that changes to token or `prior_spec_hash` change the id.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f420c347c0832a992eec1367c4ea53)