### PR TITLE
Add fixture-backed Promotion Gate validation slice

### DIFF
--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -1,0 +1,58 @@
+name: Promotion Gate
+
+on:
+  pull_request:
+    paths:
+      - "policy/**"
+      - "schemas/contracts/v1/**"
+      - "tests/fixtures/promotion/**"
+      - "tests/promotion/**"
+      - "tools/validators/promotion/**"
+      - ".github/workflows/promotion-gate.yml"
+  push:
+    branches: [main]
+    paths:
+      - "policy/**"
+      - "schemas/contracts/v1/**"
+      - "tests/fixtures/promotion/**"
+      - "tests/promotion/**"
+      - "tools/validators/promotion/**"
+      - ".github/workflows/promotion-gate.yml"
+
+jobs:
+  promotion-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install jq and conftest
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          CONFT=conftest_0.59.0_Linux_x86_64.tar.gz
+          curl -sSL -o /tmp/${CONFT} https://github.com/open-policy-agent/conftest/releases/download/v0.59.0/${CONFT}
+          sudo tar -C /usr/local/bin -xzf /tmp/${CONFT} conftest
+
+      - name: Validate promotion fixtures
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/promotion-decisions
+          python tools/validators/promotion/validate_promotion_candidate.py tests/fixtures/promotion/valid/promotion_candidate.json > artifacts/promotion-decisions/valid.decision.json
+          python tools/validators/promotion/validate_promotion_candidate.py tests/fixtures/promotion/invalid/missing_receipt.json > artifacts/promotion-decisions/missing_receipt.decision.json || true
+          python tools/validators/promotion/validate_promotion_candidate.py tests/fixtures/promotion/invalid/restricted_public_geometry.json > artifacts/promotion-decisions/restricted_public_geometry.decision.json || true
+
+      - name: Conftest policy checks
+        run: |
+          set -euo pipefail
+          conftest test tests/fixtures/promotion/valid/promotion_candidate.json --policy policy/
+          ! conftest test tests/fixtures/promotion/invalid/missing_receipt.json --policy policy/
+          ! conftest test tests/fixtures/promotion/invalid/restricted_public_geometry.json --policy policy/
+
+      - name: Upload promotion decisions
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: promotion-decisions
+          path: artifacts/promotion-decisions/*.decision.json
+          if-no-files-found: ignore

--- a/docs/architecture/PROMOTION_GATE.md
+++ b/docs/architecture/PROMOTION_GATE.md
@@ -1,0 +1,41 @@
+# Promotion Gate
+
+## KFM Meta Block v2
+- **Status:** PROPOSED
+- **Layer:** Promotion Gate (post evidence-ci)
+- **Scope:** Fixture-backed, no-network validation + policy checks in CI
+- **Last Updated:** 2026-05-01
+
+## Purpose
+Promotion is a governed state transition that denies release unless evidence, receipts, policy posture, and registration posture pass together.
+
+## Lifecycle placement
+This gate runs between evidence-ci outputs and release manifest publication.
+
+## Inputs / outputs
+- **Inputs:** `PromotionCandidate` JSON fixtures containing evidence bundle refs, spec hash, receipt refs, rights, sensitivity, and release intent.
+- **Outputs:** `PromotionDecision` JSON (`APPROVE` or `DENY`) with explicit reason codes.
+
+## Deny rules
+- Public release from `RAW`, `WORK`, or `QUARANTINE`.
+- `target_state=PUBLISHED` without reviewer.
+- `rights_status=unknown`.
+- `sensitivity=restricted` with `public_release=true`.
+- Missing `evidencebundle_spec_hash`.
+- Missing run receipt ref or run receipt bundle ref.
+- Public release without Cosign receipt verification.
+- Public release without `gatehouse_registration_posture=registered`.
+
+## CI behavior
+Workflow `.github/workflows/promotion-gate.yml` runs validator + Conftest on fixture inputs and fails closed on invalid policy posture.
+
+## Artifact separation
+Promotion decisions are emitted as separate artifacts; they do not replace or merge with receipts, manifests, catalogs, or published objects.
+
+## Rollback / correction notes
+Denied candidates remain non-published; correction requires updated candidate posture and rerun through this gate.
+
+## Open questions
+- Canonical EvidenceBundle signature/verification adapter shape for future strict cryptographic checks.
+- Standardized Gatehouse posture vocabulary beyond `registered|pending|unknown`.
+- Whether to require schema validation in validator runtime once shared contract tooling is centralized.

--- a/policy/promotion/main.rego
+++ b/policy/promotion/main.rego
@@ -1,0 +1,52 @@
+package kfm.promotion
+
+deny contains "PROMOTION_RIGHTS_UNKNOWN" if {
+  input.rights_status == "unknown"
+}
+
+deny contains "PROMOTION_PUBLIC_FROM_PRIVATE_LIFECYCLE" if {
+  input.public_release == true
+  input.source_state == "RAW"
+}
+
+deny contains "PROMOTION_PUBLIC_FROM_PRIVATE_LIFECYCLE" if {
+  input.public_release == true
+  input.source_state == "WORK"
+}
+
+deny contains "PROMOTION_PUBLIC_FROM_PRIVATE_LIFECYCLE" if {
+  input.public_release == true
+  input.source_state == "QUARANTINE"
+}
+
+deny contains "PROMOTION_PUBLISHED_NEEDS_REVIEWER" if {
+  input.target_state == "PUBLISHED"
+  not input.reviewer
+}
+
+deny contains "PROMOTION_RESTRICTED_PUBLIC_RELEASE_BLOCKED" if {
+  input.sensitivity == "restricted"
+  input.public_release == true
+}
+
+deny contains "PROMOTION_MISSING_EVIDENCEBUNDLE_SPEC_HASH" if {
+  not input.evidencebundle_spec_hash
+}
+
+deny contains "PROMOTION_MISSING_RUN_RECEIPT" if {
+  not input.run_receipt_ref
+}
+
+deny contains "PROMOTION_MISSING_RUN_RECEIPT_BUNDLE" if {
+  not input.run_receipt_bundle_ref
+}
+
+deny contains "PROMOTION_MISSING_COSIGN_VERIFICATION" if {
+  input.public_release == true
+  input.cosign_receipt_verified != true
+}
+
+deny contains "PROMOTION_GATEHOUSE_NOT_REGISTERED" if {
+  input.public_release == true
+  input.gatehouse_registration_posture != "registered"
+}

--- a/schemas/contracts/v1/promotion_candidate.schema.json
+++ b/schemas/contracts/v1/promotion_candidate.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.dev/schemas/contracts/v1/promotion_candidate.schema.json",
+  "title": "KFM PromotionCandidate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "object_type",
+    "candidate_id",
+    "source_state",
+    "target_state",
+    "evidencebundle_ref",
+    "evidencebundle_spec_hash",
+    "run_receipt_ref",
+    "run_receipt_bundle_ref",
+    "rights_status",
+    "sensitivity",
+    "public_release",
+    "reviewer"
+  ],
+  "properties": {
+    "schema_version": {"type": "string", "const": "v1"},
+    "object_type": {"type": "string", "const": "PromotionCandidate"},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "source_state": {"type": "string", "minLength": 1},
+    "target_state": {"type": "string", "minLength": 1},
+    "evidencebundle_ref": {"type": "string", "minLength": 1},
+    "evidencebundle_spec_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "run_receipt_ref": {"type": "string", "minLength": 1},
+    "run_receipt_bundle_ref": {"type": "string", "minLength": 1},
+    "rights_status": {
+      "type": "string",
+      "enum": ["known", "licensed", "restricted", "unknown"]
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["public", "internal", "restricted"]
+    },
+    "public_release": {"type": "boolean"},
+    "reviewer": {"type": "string"},
+    "cosign_receipt_verified": {"type": "boolean"},
+    "gatehouse_registration_posture": {
+      "type": "string",
+      "enum": ["registered", "pending", "unknown"]
+    }
+  }
+}

--- a/schemas/contracts/v1/promotion_decision.schema.json
+++ b/schemas/contracts/v1/promotion_decision.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm.dev/schemas/contracts/v1/promotion_decision.schema.json",
+  "title": "KFM PromotionDecision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "object_type",
+    "decision",
+    "reasons",
+    "candidate_id",
+    "timestamp_utc",
+    "validator_version"
+  ],
+  "properties": {
+    "object_type": {"type": "string", "const": "PromotionDecision"},
+    "decision": {"type": "string", "enum": ["APPROVE", "DENY"]},
+    "reasons": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "candidate_id": {"type": "string", "minLength": 1},
+    "timestamp_utc": {"type": "string", "format": "date-time"},
+    "validator_version": {"type": "string", "minLength": 1}
+  }
+}

--- a/tests/fixtures/promotion/invalid/missing_receipt.json
+++ b/tests/fixtures/promotion/invalid/missing_receipt.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "v1",
+  "object_type": "PromotionCandidate",
+  "candidate_id": "promo:flora:2026-05-01:002",
+  "source_state": "PROCESSED",
+  "target_state": "PUBLISHED",
+  "evidencebundle_ref": "evidence://bundle/flora/2026-05-01/002",
+  "evidencebundle_spec_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "run_receipt_ref": "",
+  "run_receipt_bundle_ref": "",
+  "rights_status": "licensed",
+  "sensitivity": "public",
+  "public_release": true,
+  "reviewer": "steward@kfm.dev",
+  "cosign_receipt_verified": true,
+  "gatehouse_registration_posture": "registered"
+}

--- a/tests/fixtures/promotion/invalid/restricted_public_geometry.json
+++ b/tests/fixtures/promotion/invalid/restricted_public_geometry.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "v1",
+  "object_type": "PromotionCandidate",
+  "candidate_id": "promo:flora:2026-05-01:003",
+  "source_state": "WORK",
+  "target_state": "PUBLISHED",
+  "evidencebundle_ref": "evidence://bundle/flora/2026-05-01/003",
+  "evidencebundle_spec_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "run_receipt_ref": "receipt://runs/2026-05-01/003",
+  "run_receipt_bundle_ref": "receipt-bundle://runs/2026-05-01/003",
+  "rights_status": "unknown",
+  "sensitivity": "restricted",
+  "public_release": true,
+  "reviewer": "",
+  "cosign_receipt_verified": false,
+  "gatehouse_registration_posture": "pending"
+}

--- a/tests/fixtures/promotion/valid/promotion_candidate.json
+++ b/tests/fixtures/promotion/valid/promotion_candidate.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "v1",
+  "object_type": "PromotionCandidate",
+  "candidate_id": "promo:flora:2026-05-01:001",
+  "source_state": "PROCESSED",
+  "target_state": "PUBLISHED",
+  "evidencebundle_ref": "evidence://bundle/flora/2026-05-01/001",
+  "evidencebundle_spec_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "run_receipt_ref": "receipt://runs/2026-05-01/001",
+  "run_receipt_bundle_ref": "receipt-bundle://runs/2026-05-01/001",
+  "rights_status": "licensed",
+  "sensitivity": "public",
+  "public_release": true,
+  "reviewer": "steward@kfm.dev",
+  "cosign_receipt_verified": true,
+  "gatehouse_registration_posture": "registered"
+}

--- a/tests/promotion/test_validate_promotion_candidate.py
+++ b/tests/promotion/test_validate_promotion_candidate.py
@@ -1,0 +1,40 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "tools/validators/promotion/validate_promotion_candidate.py"
+
+
+def _run(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["python", str(VALIDATOR), str(path)], capture_output=True, text=True)
+
+
+def test_valid_candidate_approved():
+    fixture = ROOT / "tests/fixtures/promotion/valid/promotion_candidate.json"
+    result = _run(fixture)
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["object_type"] == "PromotionDecision"
+    assert payload["decision"] == "APPROVE"
+    assert payload["reasons"] == []
+
+
+def test_invalid_missing_receipt_denied():
+    fixture = ROOT / "tests/fixtures/promotion/invalid/missing_receipt.json"
+    result = _run(fixture)
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "DENY"
+    assert "missing_run_receipt_ref" in payload["reasons"]
+    assert "missing_run_receipt_bundle_ref" in payload["reasons"]
+
+
+def test_invalid_restricted_public_geometry_denied():
+    fixture = ROOT / "tests/fixtures/promotion/invalid/restricted_public_geometry.json"
+    result = _run(fixture)
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "DENY"
+    assert "restricted_sensitivity_cannot_be_public" in payload["reasons"]
+    assert "public_release_blocked_from_private_lifecycle_state" in payload["reasons"]

--- a/tools/validators/promotion/validate_promotion_candidate.py
+++ b/tools/validators/promotion/validate_promotion_candidate.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+VALIDATOR_VERSION = "promotion-gate-v1"
+BLOCKED_SOURCE_STATES = {"RAW", "WORK", "QUARANTINE"}
+
+
+def _required_field_errors(candidate: dict) -> list[str]:
+    required = [
+        "schema_version", "object_type", "candidate_id", "source_state", "target_state",
+        "evidencebundle_ref", "evidencebundle_spec_hash", "run_receipt_ref",
+        "run_receipt_bundle_ref", "rights_status", "sensitivity", "public_release", "reviewer"
+    ]
+    return [f"missing_required_field:{name}" for name in required if name not in candidate]
+
+
+def evaluate(candidate: dict) -> dict:
+    reasons = _required_field_errors(candidate)
+    if candidate.get("object_type") != "PromotionCandidate":
+        reasons.append("invalid_object_type")
+    if not candidate.get("evidencebundle_spec_hash"):
+        reasons.append("missing_evidencebundle_spec_hash")
+    if not candidate.get("run_receipt_ref"):
+        reasons.append("missing_run_receipt_ref")
+    if not candidate.get("run_receipt_bundle_ref"):
+        reasons.append("missing_run_receipt_bundle_ref")
+    if candidate.get("rights_status") == "unknown":
+        reasons.append("rights_unknown_fail_closed")
+
+    public_release = bool(candidate.get("public_release"))
+    source_state = candidate.get("source_state")
+    if public_release and source_state in BLOCKED_SOURCE_STATES:
+        reasons.append("public_release_blocked_from_private_lifecycle_state")
+
+    if candidate.get("target_state") == "PUBLISHED" and not str(candidate.get("reviewer", "")).strip():
+        reasons.append("published_target_requires_reviewer")
+
+    if candidate.get("sensitivity") == "restricted" and public_release:
+        reasons.append("restricted_sensitivity_cannot_be_public")
+
+    if public_release and candidate.get("cosign_receipt_verified") is not True:
+        reasons.append("cosign_receipt_not_verified")
+
+    if public_release and candidate.get("gatehouse_registration_posture") != "registered":
+        reasons.append("gatehouse_registration_not_registered")
+
+    decision = "DENY" if reasons else "APPROVE"
+    return {
+        "object_type": "PromotionDecision",
+        "decision": decision,
+        "reasons": reasons,
+        "candidate_id": candidate.get("candidate_id", "unknown"),
+        "timestamp_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "validator_version": VALIDATOR_VERSION,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: validate_promotion_candidate.py <promotion_candidate.json>", file=sys.stderr)
+        return 2
+    candidate = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    decision = evaluate(candidate)
+    print(json.dumps(decision, indent=2))
+    return 0 if decision["decision"] == "APPROVE" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Implement a governed promotion gate that blocks release unless canonical EvidenceBundle verification, policy posture, Cosign receipt verification, and Gatehouse registration posture all pass. 
- Provide a small, no-network validator and Rego policy so promotion decisions can be produced and exercised with fixtures before adding any live Gatehouse or network verification adapters. 
- Integrate the gate into CI as a focused slice that emits PromotionDecision artifacts and fails closed on deny posture.

### Description
- Add `PromotionCandidate` and `PromotionDecision` contract schemas at `schemas/contracts/v1/` defining required fields and deterministic `sha256:` spec hash format. 
- Add a no-network Python validator `tools/validators/promotion/validate_promotion_candidate.py` that loads a candidate, checks required fields and deny conditions, and emits a `PromotionDecision` JSON with `object_type`, `decision` (`APPROVE`|`DENY`), `reasons[]`, `candidate_id`, `timestamp_utc`, and `validator_version`. 
- Add Rego deny rules in `policy/promotion/main.rego` covering rights unknown, public release from private lifecycle states, missing receipts/spec hash, restricted/public conflict, Cosign verification, and Gatehouse registration posture. 
- Add fixtures (`tests/fixtures/promotion/valid/...`, `tests/fixtures/promotion/invalid/...`), pytest coverage `tests/promotion/test_validate_promotion_candidate.py`, CI workflow `.github/workflows/promotion-gate.yml` to run validator + Conftest, and architecture doc `docs/architecture/PROMOTION_GATE.md` describing lifecycle, deny rules, CI behavior, and open questions.

### Testing
- Ran the validator against the valid fixture with `python tools/validators/promotion/validate_promotion_candidate.py tests/fixtures/promotion/valid/promotion_candidate.json` and it produced a `PromotionDecision` with `decision: APPROVE` and exit code `0` (success). 
- Ran unit tests with `pytest tests/promotion/test_validate_promotion_candidate.py` and observed `3 passed` (success). 
- Attempted local policy engine checks with `conftest` (e.g. `conftest test tests/fixtures/promotion/valid/promotion_candidate.json --policy policy/`) but the `conftest` binary was not available in the local environment (`/bin/bash: conftest: command not found`); the workflow includes installation of Conftest so these checks will run in CI. 
- The CI workflow (`.github/workflows/promotion-gate.yml`) is configured to run the validator on fixtures, run Conftest policy checks, fail closed on denies, and upload generated PromotionDecision artifacts when present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4232f16c4832aadf4663955be2459)