### PR TITLE
Add no-network re-entry deployment authorization refresh preview foundation

### DIFF
--- a/docs/domains/atmosphere/AIR_REENTRY_DEPLOYMENT_AUTHORIZATION_REFRESH_SLICE.md
+++ b/docs/domains/atmosphere/AIR_REENTRY_DEPLOYMENT_AUTHORIZATION_REFRESH_SLICE.md
@@ -1,0 +1,10 @@
+# AIR Re-Entry Deployment Authorization Refresh Slice
+
+## KFM Meta Block v2
+- status: candidate-only fixture preview
+- network: disabled by design
+- production authorization: blocked
+
+This layer consumes re-entry deployment-readiness refresh artifacts and prepares fixture/candidate deployment authorization refresh evidence only. It does not deploy, publish, notify, or mutate `data/published/air/` or `data/published/air/read_model/`.
+
+Lifecycle extends through `REENTRY_DEPLOYMENT_AUTHORIZATION_REFRESH` and remains additive, fail-closed, and artifact-separated.

--- a/policy/air/air_reentry_deployment_authorization_refresh.rego
+++ b/policy/air/air_reentry_deployment_authorization_refresh.rego
@@ -1,0 +1,9 @@
+package kfm.air.reentry_deployment_authorization_refresh
+
+default allow = false
+
+deny[msg] { not input.ReentryDeploymentReadinessRefreshPostcheckReport; msg := "missing readiness postcheck" }
+deny[msg] { input.ReentryDeploymentReadinessRefreshPostcheckReport.result == "deny"; msg := "readiness denied" }
+deny[msg] { input.ReentryDeploymentRefreshExecutionReceipt.execution_mode == "production"; msg := "production execution blocked" }
+deny[msg] { some p in input.artifact_refs; contains(lower(p),"data/published/air/"); msg := "published path forbidden" }
+allow { count(deny)==0 }

--- a/schemas/contracts/v1/air/reentry_change_control_handoff_refresh.schema.json
+++ b/schemas/contracts/v1/air/reentry_change_control_handoff_refresh.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "domain": {
+      "const": "atmosphere.air"
+    },
+    "schema_version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "handoff_id",
+    "domain",
+    "created_at",
+    "as_of",
+    "deployment_authorization_refresh_ref",
+    "release_manager_refresh_decision_ref",
+    "deployment_readiness_refresh_manifest_ref",
+    "static_hosting_manifest_refresh_candidate_ref",
+    "cache_invalidation_refresh_plan_ref",
+    "deployment_rollback_refresh_plan_ref",
+    "deployment_readiness_refresh_report_ref",
+    "synthetic_probe_refresh_report_ref",
+    "deployment_readiness_refresh_audit_report_ref",
+    "manual_steps",
+    "preconditions",
+    "hold_points",
+    "rollback_triggers",
+    "evidence_refs",
+    "forbidden_actions",
+    "safety_checks",
+    "status"
+  ],
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_deployment_authorization_refresh.schema.json
+++ b/schemas/contracts/v1/air/reentry_deployment_authorization_refresh.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "domain": {
+      "const": "atmosphere.air"
+    },
+    "schema_version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "authorization_id",
+    "domain",
+    "created_at",
+    "as_of",
+    "release_manager_refresh_decision_ref",
+    "deployment_readiness_refresh_manifest_ref",
+    "deployment_readiness_refresh_report_ref",
+    "deployment_readiness_refresh_decision_ref",
+    "deployment_readiness_refresh_postcheck_report_ref",
+    "deployment_readiness_refresh_audit_report_ref",
+    "deployment_readiness_refresh_ledger_manifest_ref",
+    "client_delivery_refresh_manifest_ref",
+    "authorized_environment",
+    "authorization_decision",
+    "approvers",
+    "required_conditions",
+    "safety_checks",
+    "signature",
+    "signature_type",
+    "fixture_backed",
+    "status"
+  ],
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_audit_report.schema.json
+++ b/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_audit_report.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_decision.schema.json
+++ b/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_decision.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_event.schema.json
+++ b/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_event.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_ledger_entry.schema.json
+++ b/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_ledger_entry.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_ledger_manifest.schema.json
+++ b/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_ledger_manifest.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_manifest.schema.json
+++ b/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_manifest.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "domain": {
+      "const": "atmosphere.air"
+    },
+    "schema_version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "authorization_refresh_manifest_id",
+    "domain",
+    "generated_at",
+    "as_of",
+    "release_manager_refresh_decision_ref",
+    "deployment_authorization_refresh_ref",
+    "change_control_handoff_refresh_ref",
+    "release_cutover_checklist_refresh_ref",
+    "local_deployment_refresh_simulation_ref",
+    "deployment_refresh_execution_receipt_ref",
+    "post_deploy_verification_refresh_plan_ref",
+    "post_deploy_verification_refresh_report_ref",
+    "deployment_readiness_refresh_manifest_ref",
+    "client_delivery_refresh_manifest_ref",
+    "artifact_refs",
+    "source_chain_refs",
+    "next_lifecycle_target",
+    "safety_checks",
+    "status"
+  ],
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_postcheck_report.schema.json
+++ b/schemas/contracts/v1/air/reentry_deployment_authorization_refresh_postcheck_report.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_deployment_refresh_execution_receipt.schema.json
+++ b/schemas/contracts/v1/air/reentry_deployment_refresh_execution_receipt.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "domain": {
+      "const": "atmosphere.air"
+    },
+    "schema_version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "execution_receipt_id",
+    "domain",
+    "created_at",
+    "as_of",
+    "execution_mode",
+    "deployment_authorization_refresh_ref",
+    "change_control_handoff_refresh_ref",
+    "release_cutover_checklist_refresh_ref",
+    "local_deployment_refresh_simulation_ref",
+    "actor",
+    "steps_observed",
+    "artifact_refs",
+    "hashes",
+    "result",
+    "status"
+  ],
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_local_deployment_refresh_simulation.schema.json
+++ b/schemas/contracts/v1/air/reentry_local_deployment_refresh_simulation.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "domain": {
+      "const": "atmosphere.air"
+    },
+    "schema_version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "simulation_id",
+    "domain",
+    "generated_at",
+    "as_of",
+    "deployment_authorization_refresh_ref",
+    "change_control_handoff_refresh_ref",
+    "release_cutover_checklist_refresh_ref",
+    "source_client_delivery_refresh_refs",
+    "simulated_routes",
+    "simulated_cache_entries",
+    "simulated_probe_results",
+    "simulated_rollback_result",
+    "safety_checks",
+    "status"
+  ],
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_post_deploy_verification_refresh_plan.schema.json
+++ b/schemas/contracts/v1/air/reentry_post_deploy_verification_refresh_plan.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "domain": {
+      "const": "atmosphere.air"
+    },
+    "schema_version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "verification_plan_id",
+    "domain",
+    "created_at",
+    "as_of",
+    "deployment_authorization_refresh_ref",
+    "deployment_refresh_execution_receipt_ref",
+    "synthetic_probe_refresh_spec_ref",
+    "public_slo_objectives",
+    "verification_steps",
+    "expected_evidence",
+    "rollback_triggers",
+    "incident_triggers",
+    "forbidden_actions",
+    "safety_checks",
+    "status"
+  ],
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_post_deploy_verification_refresh_report.schema.json
+++ b/schemas/contracts/v1/air/reentry_post_deploy_verification_refresh_report.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "domain": {
+      "const": "atmosphere.air"
+    },
+    "schema_version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "verification_report_id",
+    "domain",
+    "generated_at",
+    "as_of",
+    "post_deploy_verification_refresh_plan_ref",
+    "deployment_refresh_execution_receipt_ref",
+    "checks",
+    "probe_results",
+    "slo_expectations",
+    "rollback_trigger_evaluation",
+    "incident_trigger_evaluation",
+    "result"
+  ],
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_release_cutover_checklist_refresh.schema.json
+++ b/schemas/contracts/v1/air/reentry_release_cutover_checklist_refresh.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "domain": {
+      "const": "atmosphere.air"
+    },
+    "schema_version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "checklist_id",
+    "domain",
+    "created_at",
+    "as_of",
+    "deployment_authorization_refresh_ref",
+    "change_control_handoff_refresh_ref",
+    "deployment_readiness_refresh_manifest_ref",
+    "checks",
+    "hold_points",
+    "go_no_go",
+    "rollback_preconditions",
+    "post_cutover_checks",
+    "safety_checks",
+    "status"
+  ],
+  "type": "object"
+}

--- a/schemas/contracts/v1/air/reentry_release_manager_refresh_decision.schema.json
+++ b/schemas/contracts/v1/air/reentry_release_manager_refresh_decision.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "domain": {
+      "const": "atmosphere.air"
+    },
+    "schema_version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "decision_id",
+    "domain",
+    "decided_at",
+    "as_of",
+    "decided_by",
+    "role",
+    "subject_refs",
+    "deployment_readiness_refresh_manifest_ref",
+    "deployment_readiness_refresh_report_ref",
+    "deployment_readiness_refresh_decision_ref",
+    "decision",
+    "rationale",
+    "required_actions",
+    "signature",
+    "signature_type",
+    "fixture_backed",
+    "status"
+  ],
+  "type": "object"
+}

--- a/tests/air/test_air_reentry_deployment_authorization_refresh_slice.py
+++ b/tests/air/test_air_reentry_deployment_authorization_refresh_slice.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[2]
+
+def test_files_exist():
+ for p in [
+  'policy/air/air_reentry_deployment_authorization_refresh.rego',
+  'tools/deployments/air/record_air_reentry_release_manager_refresh_decision.py',
+  'tools/validators/air/validate_air_reentry_deployment_authorization_refresh.py',
+  'docs/domains/atmosphere/AIR_REENTRY_DEPLOYMENT_AUTHORIZATION_REFRESH_SLICE.md',
+ ]:
+  assert (ROOT/p).exists()

--- a/tools/deployments/air/record_air_reentry_release_manager_refresh_decision.py
+++ b/tools/deployments/air/record_air_reentry_release_manager_refresh_decision.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+from _reentry_deployment_readiness_refresh_common import *
+import argparse,uuid
+p=argparse.ArgumentParser();p.add_argument('--deployment-readiness-refresh-dir',action='append',required=True);p.add_argument('--decision',required=True);p.add_argument('--decided-by',required=True);p.add_argument('--role',required=True);p.add_argument('--out-dir',required=True);p.add_argument('--signature',default='fixture-signature');p.add_argument('--signature-type',default='fixture_signature');p.add_argument('--as-of');p.add_argument('--fixture-only',action='store_true');a=p.parse_args();
+if 'production' in a.decision: fail('production blocked')
+d=J(Path(a.deployment_readiness_refresh_dir[0])/'reentry_deployment_readiness_refresh_manifest.json')
+out={"schema_version":"v1","decision_id":f"rmr-{uuid.uuid5(uuid.NAMESPACE_URL,a.as_of or 'now').hex[:12]}","domain":"atmosphere.air","decided_at":ts(a.as_of),"as_of":ts(a.as_of),"decided_by":a.decided_by,"role":a.role,"subject_refs":[],"deployment_readiness_refresh_manifest_ref":"reentry_deployment_readiness_refresh_manifest.json","deployment_readiness_refresh_report_ref":"reentry_deployment_readiness_refresh_report.json","deployment_readiness_refresh_decision_ref":"reentry_deployment_readiness_refresh_decision.json","decision":a.decision,"rationale":"fixture-backed governance preview only","required_actions":[],"signature":a.signature,"signature_type":a.signature_type,"fixture_backed":True,"status":"fixture_decision"}
+W(Path(a.out_dir)/'reentry_release_manager_refresh_decision.json',out)
+print('PASS')

--- a/tools/validators/air/validate_air_reentry_deployment_authorization_refresh.py
+++ b/tools/validators/air/validate_air_reentry_deployment_authorization_refresh.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys,json
+from pathlib import Path
+BAD=["data/raw/","data/work/","data/quarantine/","data/processed/air/","data/published/air/"]
+for d in sys.argv[1:]:
+ p=Path(d)
+ if p.is_dir():
+  for f in p.rglob('*.json'):
+   t=f.read_text().lower()
+   if any(b in t for b in BAD): raise SystemExit(f'DENY: bad path in {f}')
+print('PASS')


### PR DESCRIPTION
### Motivation
- Provide a safe, no-network foundation for the AIR re-entry Deployment Authorization Refresh layer so governed re-entry artifacts can be prepared for preview without publishing or deploying.
- Enforce fail-closed, fixture-only semantics and prevent any production authorization or references to protected paths (e.g., `data/published/air/`) at the schema/policy/tooling level.
- Create a minimal, inspectable surface so subsequent PRs can implement the remaining builders, ledger, postchecks, validators, and full pass/deny fixture matrix.

### Description
- Add schema scaffolds under `schemas/contracts/v1/air/` for the authorization refresh family (authorization, manifest, decision, ledger, event, postcheck/report, simulation, execution receipt, post-deploy verification plan/report, change-control handoff, cutover checklist, and release-manager decision) with required-field stubs where applicable.
- Add a fail-closed policy scaffold `policy/air/air_reentry_deployment_authorization_refresh.rego` that denies missing/denied readiness postcheck, production execution claims, and any `data/published/air/` artifact refs.
- Add a fixture-only CLI generator `tools/deployments/air/record_air_reentry_release_manager_refresh_decision.py` which emits a release-manager refresh decision JSON into an explicit `--out-dir` and blocks any production decision strings.
- Add a small local validator `tools/validators/air/validate_air_reentry_deployment_authorization_refresh.py` that scans candidate JSON files for unsafe path leakage and fails closed, plus slice documentation `docs/domains/atmosphere/AIR_REENTRY_DEPLOYMENT_AUTHORIZATION_REFRESH_SLICE.md` and a basic existence test `tests/air/test_air_reentry_deployment_authorization_refresh_slice.py`.

### Testing
- Ran the slice unit tests with `pytest -q tests/air/test_air_reentry_deployment_authorization_refresh_slice.py tests/air/test_air_reentry_deployment_readiness_refresh_slice.py` and both tests passed (`2 passed`).
- Performed repository inspection commands and schema/file creation verification during rollout; the added tools and policy are local-only and contain explicit production-blocking checks (no network calls performed).
- No files were written to `data/published/air/` or `data/published/air/read_model/`, and no source re-entry fixtures were mutated by these changes (tooling writes only to an explicit `--out-dir`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50b18f40c832ab45f5725416711c3)