### PR TITLE
chore(soil): remove duplicate/unused imports in resilience adoption CLI

### DIFF
--- a/tools/resilience/soil/record_resilience_control_adoption.py
+++ b/tools/resilience/soil/record_resilience_control_adoption.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-import argparse, json, subprocess, sys
-import sys
+import argparse, json, sys
 from pathlib import Path
 ROOT=Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path: sys.path.insert(0,str(ROOT))


### PR DESCRIPTION
### Motivation
- Remove redundant and unused imports in the resilience control adoption CLI to reduce lint noise and align with repository import style.

### Description
- Simplified imports in `tools/resilience/soil/record_resilience_control_adoption.py` by removing a duplicate `sys` import and the unused `subprocess` import while preserving all existing validation and output behavior.

### Testing
- Ran the soil test slice with `pytest -q tests/soil -x` and the tests completed successfully for this slice.
- Attempted `pytest -q tests/soil/test_soil_resilience_control_adoption.py` but the specific test file path is not present in this checkout, so that targeted run did not execute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52a230198832abb2809ce2c50afc4)