### PR TITLE
Add governed decision-log verification, replay, and fail-closed promotion gate

### DIFF
--- a/docs/governance/decision-log.md
+++ b/docs/governance/decision-log.md
@@ -1,0 +1,37 @@
+# Decision Log Governance Layer
+
+This layer treats `decision_log` as an immutable audit artifact. It is not policy law, not a run log, and not standalone proof.
+
+## What is validated
+
+- JSON schema conformance (`schemas/governance/decision_log.schema.json`).
+- Deterministic `spec_hash` over canonical JSON input fixture.
+- Cross-link integrity between decision log and run receipt.
+- Local fixture signature bundle presence (`fixtures://...`).
+- Policy bundle hash integrity.
+- Deterministic replay of the recorded decision.
+
+## Replay and verification CLI
+
+```bash
+python tools/validators/governance/validate_decision_log.py \
+  tests/fixtures/governance/decision_log/valid_allow.json \
+  tests/fixtures/governance/run_receipts/valid_run_receipt_with_decision_log.json \
+  tests/fixtures/governance/policy_bundles/promotion_bundle_v1.json \
+  tests/fixtures/governance/policy_inputs/promotion_allow_input.json
+```
+
+```bash
+python tools/validators/governance/replay_decision_log.py \
+  tests/fixtures/governance/policy_bundles/promotion_bundle_v1.json \
+  tests/fixtures/governance/policy_inputs/promotion_allow_input.json
+```
+
+## Promotion gate behavior
+
+`policy/governance/decision_log_gate.rego` fails closed when:
+
+- decision log is missing
+- verification report is absent/failed
+
+Promotion requires `decision_log_present=true` and `decision_log_verification_report.ok=true`.

--- a/policy/governance/decision_log_gate.rego
+++ b/policy/governance/decision_log_gate.rego
@@ -1,0 +1,19 @@
+package governance.decision_log_gate
+
+default allow := false
+
+allow if {
+  input.promotion.decision_log_present
+  input.promotion.decision_log_verification_report.ok
+}
+
+deny[msg] if {
+  not input.promotion.decision_log_present
+  msg := "decision log missing"
+}
+
+deny[msg] if {
+  input.promotion.decision_log_present
+  not input.promotion.decision_log_verification_report.ok
+  msg := "decision log verification failed"
+}

--- a/schemas/governance/decision_log.schema.json
+++ b/schemas/governance/decision_log.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm/schemas/governance/decision_log.schema.json",
+  "title": "KFM Decision Log",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "decision_id",
+    "timestamp",
+    "policy_query",
+    "input_ref",
+    "policy_bundle",
+    "result",
+    "obligations",
+    "explain_trace",
+    "signature"
+  ],
+  "properties": {
+    "decision_id": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "policy_query": {"type": "string", "minLength": 1},
+    "input_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["run_receipt_id", "kfm"],
+      "properties": {
+        "run_receipt_id": {"type": "string", "minLength": 1},
+        "kfm": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["spec_hash"],
+          "properties": {
+            "spec_hash": {"type": "string", "pattern": "^sha256-[a-f0-9]{64}$"}
+          }
+        }
+      }
+    },
+    "policy_bundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "bundle_spec_hash"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "bundle_spec_hash": {"type": "string", "pattern": "^sha256-[a-f0-9]{64}$"}
+      }
+    },
+    "result": {"type": "string", "enum": ["allow", "deny"]},
+    "obligations": {"type": "array", "items": {"type": "string"}},
+    "explain_trace": {"type": "string"},
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dsse"],
+      "properties": {
+        "dsse": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["payloadType", "cosign_bundle_url"],
+          "properties": {
+            "payloadType": {"const": "application/vnd.dsse.envelope"},
+            "cosign_bundle_url": {"type": "string", "pattern": "^fixtures://"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/governance/decision_log_verification_report.schema.json
+++ b/schemas/governance/decision_log_verification_report.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kfm/schemas/governance/decision_log_verification_report.schema.json",
+  "title": "Decision Log Verification Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["ok", "decision_id", "checks", "errors"],
+  "properties": {
+    "ok": {"type": "boolean"},
+    "decision_id": {"type": "string"},
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "ok"],
+        "properties": {
+          "name": {"type": "string"},
+          "ok": {"type": "boolean"},
+          "detail": {"type": "string"}
+        }
+      }
+    },
+    "errors": {"type": "array", "items": {"type": "string"}},
+    "replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "expected_result": {"type": "string", "enum": ["allow", "deny"]},
+        "actual_result": {"type": "string", "enum": ["allow", "deny"]},
+        "result_match": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/tests/fixtures/governance/decision_log/bundles/example.bundle
+++ b/tests/fixtures/governance/decision_log/bundles/example.bundle
@@ -1,0 +1,1 @@
+{"fixture":"bundle"}

--- a/tests/fixtures/governance/decision_log/invalid_missing_signature.json
+++ b/tests/fixtures/governance/decision_log/invalid_missing_signature.json
@@ -1,0 +1,19 @@
+{
+  "decision_id": "decision-001",
+  "timestamp": "2026-05-01T12:34:56Z",
+  "policy_query": "promotion.allow?input",
+  "input_ref": {
+    "run_receipt_id": "kfm://run/example",
+    "kfm": {
+      "spec_hash": "sha256-13a9f577955862a7a3f271b4509593f37635dbb47ba3a29d1ff9dcd9e7cf0e4a"
+    }
+  },
+  "policy_bundle": {
+    "name": "kfm/promotion",
+    "version": "v1.0.0",
+    "bundle_spec_hash": "sha256-9716042fd4a58221d5c0b98f747077c28afa7e63fad05faeced83f95422ea105"
+  },
+  "explain_trace": "fixture trace",
+  "result": "allow",
+  "obligations": []
+}

--- a/tests/fixtures/governance/decision_log/invalid_policy_bundle_mismatch.json
+++ b/tests/fixtures/governance/decision_log/invalid_policy_bundle_mismatch.json
@@ -1,0 +1,25 @@
+{
+  "decision_id": "decision-001",
+  "timestamp": "2026-05-01T12:34:56Z",
+  "policy_query": "promotion.allow?input",
+  "input_ref": {
+    "run_receipt_id": "kfm://run/example",
+    "kfm": {
+      "spec_hash": "sha256-13a9f577955862a7a3f271b4509593f37635dbb47ba3a29d1ff9dcd9e7cf0e4a"
+    }
+  },
+  "policy_bundle": {
+    "name": "kfm/promotion",
+    "version": "v1.0.0",
+    "bundle_spec_hash": "sha256-1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "explain_trace": "fixture trace",
+  "signature": {
+    "dsse": {
+      "payloadType": "application/vnd.dsse.envelope",
+      "cosign_bundle_url": "fixtures://governance/decision_log/bundles/example.bundle"
+    }
+  },
+  "result": "allow",
+  "obligations": []
+}

--- a/tests/fixtures/governance/decision_log/invalid_run_receipt_mismatch.json
+++ b/tests/fixtures/governance/decision_log/invalid_run_receipt_mismatch.json
@@ -1,0 +1,25 @@
+{
+  "decision_id": "decision-001",
+  "timestamp": "2026-05-01T12:34:56Z",
+  "policy_query": "promotion.allow?input",
+  "input_ref": {
+    "run_receipt_id": "kfm://run/other",
+    "kfm": {
+      "spec_hash": "sha256-13a9f577955862a7a3f271b4509593f37635dbb47ba3a29d1ff9dcd9e7cf0e4a"
+    }
+  },
+  "policy_bundle": {
+    "name": "kfm/promotion",
+    "version": "v1.0.0",
+    "bundle_spec_hash": "sha256-9716042fd4a58221d5c0b98f747077c28afa7e63fad05faeced83f95422ea105"
+  },
+  "explain_trace": "fixture trace",
+  "signature": {
+    "dsse": {
+      "payloadType": "application/vnd.dsse.envelope",
+      "cosign_bundle_url": "fixtures://governance/decision_log/bundles/example.bundle"
+    }
+  },
+  "result": "allow",
+  "obligations": []
+}

--- a/tests/fixtures/governance/decision_log/invalid_spec_hash_mismatch.json
+++ b/tests/fixtures/governance/decision_log/invalid_spec_hash_mismatch.json
@@ -1,0 +1,25 @@
+{
+  "decision_id": "decision-001",
+  "timestamp": "2026-05-01T12:34:56Z",
+  "policy_query": "promotion.allow?input",
+  "input_ref": {
+    "run_receipt_id": "kfm://run/example",
+    "kfm": {
+      "spec_hash": "sha256-0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  "policy_bundle": {
+    "name": "kfm/promotion",
+    "version": "v1.0.0",
+    "bundle_spec_hash": "sha256-9716042fd4a58221d5c0b98f747077c28afa7e63fad05faeced83f95422ea105"
+  },
+  "explain_trace": "fixture trace",
+  "signature": {
+    "dsse": {
+      "payloadType": "application/vnd.dsse.envelope",
+      "cosign_bundle_url": "fixtures://governance/decision_log/bundles/example.bundle"
+    }
+  },
+  "result": "allow",
+  "obligations": []
+}

--- a/tests/fixtures/governance/decision_log/invalid_tampered_result.json
+++ b/tests/fixtures/governance/decision_log/invalid_tampered_result.json
@@ -1,0 +1,25 @@
+{
+  "decision_id": "decision-001",
+  "timestamp": "2026-05-01T12:34:56Z",
+  "policy_query": "promotion.allow?input",
+  "input_ref": {
+    "run_receipt_id": "kfm://run/example",
+    "kfm": {
+      "spec_hash": "sha256-13a9f577955862a7a3f271b4509593f37635dbb47ba3a29d1ff9dcd9e7cf0e4a"
+    }
+  },
+  "policy_bundle": {
+    "name": "kfm/promotion",
+    "version": "v1.0.0",
+    "bundle_spec_hash": "sha256-9716042fd4a58221d5c0b98f747077c28afa7e63fad05faeced83f95422ea105"
+  },
+  "explain_trace": "fixture trace",
+  "signature": {
+    "dsse": {
+      "payloadType": "application/vnd.dsse.envelope",
+      "cosign_bundle_url": "fixtures://governance/decision_log/bundles/example.bundle"
+    }
+  },
+  "result": "deny",
+  "obligations": []
+}

--- a/tests/fixtures/governance/decision_log/valid_allow.json
+++ b/tests/fixtures/governance/decision_log/valid_allow.json
@@ -1,0 +1,25 @@
+{
+  "decision_id": "decision-001",
+  "timestamp": "2026-05-01T12:34:56Z",
+  "policy_query": "promotion.allow?input",
+  "input_ref": {
+    "run_receipt_id": "kfm://run/example",
+    "kfm": {
+      "spec_hash": "sha256-13a9f577955862a7a3f271b4509593f37635dbb47ba3a29d1ff9dcd9e7cf0e4a"
+    }
+  },
+  "policy_bundle": {
+    "name": "kfm/promotion",
+    "version": "v1.0.0",
+    "bundle_spec_hash": "sha256-9716042fd4a58221d5c0b98f747077c28afa7e63fad05faeced83f95422ea105"
+  },
+  "explain_trace": "fixture trace",
+  "signature": {
+    "dsse": {
+      "payloadType": "application/vnd.dsse.envelope",
+      "cosign_bundle_url": "fixtures://governance/decision_log/bundles/example.bundle"
+    }
+  },
+  "result": "allow",
+  "obligations": []
+}

--- a/tests/fixtures/governance/decision_log/valid_deny_with_obligations.json
+++ b/tests/fixtures/governance/decision_log/valid_deny_with_obligations.json
@@ -1,0 +1,27 @@
+{
+  "decision_id": "decision-002",
+  "timestamp": "2026-05-01T12:34:56Z",
+  "policy_query": "promotion.allow?input",
+  "input_ref": {
+    "run_receipt_id": "kfm://run/example-deny",
+    "kfm": {
+      "spec_hash": "sha256-664db546fbcc91395c49eb5a3e9f42e2c1e3d7c2e31f3e16841339b93800c615"
+    }
+  },
+  "policy_bundle": {
+    "name": "kfm/promotion",
+    "version": "v1.0.0",
+    "bundle_spec_hash": "sha256-9716042fd4a58221d5c0b98f747077c28afa7e63fad05faeced83f95422ea105"
+  },
+  "explain_trace": "fixture trace",
+  "signature": {
+    "dsse": {
+      "payloadType": "application/vnd.dsse.envelope",
+      "cosign_bundle_url": "fixtures://governance/decision_log/bundles/example.bundle"
+    }
+  },
+  "result": "deny",
+  "obligations": [
+    "manual_review"
+  ]
+}

--- a/tests/fixtures/governance/policy_bundles/promotion_bundle_v1.json
+++ b/tests/fixtures/governance/policy_bundles/promotion_bundle_v1.json
@@ -1,0 +1,16 @@
+{
+  "id": "kfm/promotion",
+  "version": "v1.0.0",
+  "rules": [
+    {
+      "if": {
+        "review_complete": true,
+        "risk_score_max": 20
+      },
+      "then": "allow"
+    },
+    {
+      "else": "deny"
+    }
+  ]
+}

--- a/tests/fixtures/governance/policy_inputs/promotion_allow_input.json
+++ b/tests/fixtures/governance/policy_inputs/promotion_allow_input.json
@@ -1,0 +1,5 @@
+{
+  "env": "prod",
+  "risk_score": 10,
+  "review_complete": true
+}

--- a/tests/fixtures/governance/policy_inputs/promotion_deny_input.json
+++ b/tests/fixtures/governance/policy_inputs/promotion_deny_input.json
@@ -1,0 +1,5 @@
+{
+  "env": "prod",
+  "risk_score": 99,
+  "review_complete": true
+}

--- a/tests/fixtures/governance/run_receipts/valid_run_receipt_with_decision_log.json
+++ b/tests/fixtures/governance/run_receipts/valid_run_receipt_with_decision_log.json
@@ -1,0 +1,6 @@
+{
+  "run_receipt_id": "kfm://run/example",
+  "spec_hash": "sha256-13a9f577955862a7a3f271b4509593f37635dbb47ba3a29d1ff9dcd9e7cf0e4a",
+  "policy_bundle_hash": "sha256-9716042fd4a58221d5c0b98f747077c28afa7e63fad05faeced83f95422ea105",
+  "input_path": "tests/fixtures/governance/policy_inputs/promotion_allow_input.json"
+}

--- a/tests/fixtures/governance/run_receipts/valid_run_receipt_with_decision_log_deny.json
+++ b/tests/fixtures/governance/run_receipts/valid_run_receipt_with_decision_log_deny.json
@@ -1,0 +1,6 @@
+{
+  "run_receipt_id": "kfm://run/example-deny",
+  "spec_hash": "sha256-664db546fbcc91395c49eb5a3e9f42e2c1e3d7c2e31f3e16841339b93800c615",
+  "policy_bundle_hash": "sha256-9716042fd4a58221d5c0b98f747077c28afa7e63fad05faeced83f95422ea105",
+  "input_path": "tests/fixtures/governance/policy_inputs/promotion_deny_input.json"
+}

--- a/tests/governance/test_decision_log_replay.py
+++ b/tests/governance/test_decision_log_replay.py
@@ -1,0 +1,17 @@
+import json
+import subprocess
+
+
+def test_replay_allow_result():
+    r = subprocess.run(
+        [
+            "python",
+            "tools/validators/governance/replay_decision_log.py",
+            "tests/fixtures/governance/policy_bundles/promotion_bundle_v1.json",
+            "tests/fixtures/governance/policy_inputs/promotion_allow_input.json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert json.loads(r.stdout)["result"] == "allow"

--- a/tests/governance/test_decision_log_validator.py
+++ b/tests/governance/test_decision_log_validator.py
@@ -1,0 +1,36 @@
+import subprocess
+from pathlib import Path
+
+CMD = ["python", "tools/validators/governance/validate_decision_log.py"]
+BUNDLE = "tests/fixtures/governance/policy_bundles/promotion_bundle_v1.json"
+
+
+def run(path: str, run_receipt: str, policy_input: str):
+    return subprocess.run(CMD + [path, run_receipt, BUNDLE, policy_input], capture_output=True, text=True)
+
+
+def test_valid_fixtures_pass():
+    cases = [
+        (
+            "tests/fixtures/governance/decision_log/valid_allow.json",
+            "tests/fixtures/governance/run_receipts/valid_run_receipt_with_decision_log.json",
+            "tests/fixtures/governance/policy_inputs/promotion_allow_input.json",
+        ),
+        (
+            "tests/fixtures/governance/decision_log/valid_deny_with_obligations.json",
+            "tests/fixtures/governance/run_receipts/valid_run_receipt_with_decision_log_deny.json",
+            "tests/fixtures/governance/policy_inputs/promotion_deny_input.json",
+        ),
+    ]
+    for decision_log, run_receipt, policy_input in cases:
+        assert run(decision_log, run_receipt, policy_input).returncode == 0, decision_log
+
+
+def test_invalid_fixtures_fail():
+    for p in Path("tests/fixtures/governance/decision_log").glob("invalid_*.json"):
+        r = run(
+            str(p),
+            "tests/fixtures/governance/run_receipts/valid_run_receipt_with_decision_log.json",
+            "tests/fixtures/governance/policy_inputs/promotion_allow_input.json",
+        )
+        assert r.returncode != 0, p

--- a/tools/validators/governance/replay_decision_log.py
+++ b/tools/validators/governance/replay_decision_log.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json,sys
+from pathlib import Path
+
+def replay(bundle: dict, policy_input: dict) -> str:
+    for rule in bundle.get("rules", []):
+        cond = rule.get("if")
+        if cond:
+            if "review_complete" in cond and policy_input.get("review_complete") != cond["review_complete"]:
+                continue
+            if "risk_score_max" in cond and policy_input.get("risk_score", 10**9) > cond["risk_score_max"]:
+                continue
+            return rule.get("then", "deny")
+        if "else" in rule:
+            return rule["else"]
+    return "deny"
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: replay_decision_log.py <policy_bundle.json> <policy_input.json>")
+        return 2
+    bundle = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    policy_input = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+    print(json.dumps({"result": replay(bundle, policy_input)}, sort_keys=True, separators=(",", ":")))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/governance/validate_decision_log.py
+++ b/tools/validators/governance/validate_decision_log.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+
+
+
+def replay(bundle: dict, policy_input: dict) -> str:
+    for rule in bundle.get("rules", []):
+        cond = rule.get("if")
+        if cond:
+            if "review_complete" in cond and policy_input.get("review_complete") != cond["review_complete"]:
+                continue
+            if "risk_score_max" in cond and policy_input.get("risk_score", 10**9) > cond["risk_score_max"]:
+                continue
+            return rule.get("then", "deny")
+        if "else" in rule:
+            return rule["else"]
+    return "deny"
+
+
+def canonical_hash(path: Path) -> str:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    blob = json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256-" + hashlib.sha256(blob).hexdigest()
+
+
+def fixture_to_path(url: str) -> Path:
+    return Path("tests") / url.replace("fixtures://", "fixtures/")
+
+
+def validate(decision_log_path: Path, run_receipt_path: Path, bundle_path: Path, input_path: Path) -> dict:
+    checks, errors = [], []
+    schema = json.loads(Path("schemas/governance/decision_log.schema.json").read_text(encoding="utf-8"))
+    log = json.loads(decision_log_path.read_text(encoding="utf-8"))
+    receipt = json.loads(run_receipt_path.read_text(encoding="utf-8"))
+    policy_bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+
+    schema_ok = True
+    for e in Draft202012Validator(schema).iter_errors(log):
+        schema_ok = False
+        errors.append(f"schema:{e.message}")
+    checks.append({"name": "schema", "ok": schema_ok})
+
+    spec_ok = log.get("input_ref", {}).get("kfm", {}).get("spec_hash") == canonical_hash(input_path)
+    checks.append({"name": "spec_hash_determinism", "ok": spec_ok})
+    if not spec_ok:
+        errors.append("spec_hash mismatch")
+
+    receipt_ok = (
+        log.get("input_ref", {}).get("run_receipt_id") == receipt.get("run_receipt_id")
+        and log.get("input_ref", {}).get("kfm", {}).get("spec_hash") == receipt.get("spec_hash")
+    )
+    checks.append({"name": "run_receipt_link", "ok": receipt_ok})
+    if not receipt_ok:
+        errors.append("run_receipt mismatch")
+
+    bundle_ok = log.get("policy_bundle", {}).get("bundle_spec_hash") == canonical_hash(bundle_path)
+    checks.append({"name": "policy_bundle_hash", "ok": bundle_ok})
+    if not bundle_ok:
+        errors.append("policy_bundle hash mismatch")
+
+    sig_url = log.get("signature", {}).get("dsse", {}).get("cosign_bundle_url", "")
+    signature_ok = bool(sig_url) and fixture_to_path(sig_url).exists()
+    checks.append({"name": "signature_bundle_presence", "ok": signature_ok})
+    if not signature_ok:
+        errors.append("signature bundle missing")
+
+    replay_result = replay(policy_bundle, json.loads(input_path.read_text(encoding="utf-8")))
+    replay_ok = replay_result == log.get("result")
+    checks.append({"name": "policy_replay", "ok": replay_ok})
+    if not replay_ok:
+        errors.append("replay result mismatch")
+
+    ok = all(c["ok"] for c in checks)
+    return {
+        "ok": ok,
+        "decision_id": log.get("decision_id", ""),
+        "checks": checks,
+        "errors": errors,
+        "replay": {
+            "expected_result": log.get("result"),
+            "actual_result": replay_result,
+            "result_match": replay_ok,
+        },
+    }
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print("usage: validate_decision_log.py <decision_log.json> <run_receipt.json> <policy_bundle.json> <policy_input.json>")
+        raise SystemExit(2)
+    out = validate(Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]), Path(sys.argv[4]))
+    print(json.dumps(out, sort_keys=True, separators=(",", ":")))
+    raise SystemExit(0 if out["ok"] else 1)


### PR DESCRIPTION
### Motivation
- Treat `decision_log` as an immutable governed audit artifact that must be verified and replayed before promotion, not as policy law or standalone proof. 
- Provide an offline, fixture-backed verification layer that detects tampering, enforces deterministic hashing/linking, and prevents promotion when verification fails.

### Description
- Add JSON schemas `schemas/governance/decision_log.schema.json` and `schemas/governance/decision_log_verification_report.schema.json` that define the decision-log contract and the verification report shape. 
- Implement an offline validator CLI `tools/validators/governance/validate_decision_log.py` that enforces schema conformance, deterministic `spec_hash` checks, run-receipt cross-links, policy-bundle hash verification, fixture-only signature presence, deterministic replay parity, and emits a verification report (non-zero exit on failure). 
- Implement a deterministic replay CLI `tools/validators/governance/replay_decision_log.py` that replays fixture-backed policy bundles against recorded inputs to produce an expected `allow/deny` result. 
- Add a fail-closed promotion gate policy `policy/governance/decision_log_gate.rego` that only allows promotion when `decision_log_present` is true and the verification report `ok` is true. 
- Add fixture corpus under `tests/fixtures/governance/*`, tests `tests/governance/test_decision_log_validator.py` and `tests/governance/test_decision_log_replay.py`, and docs `docs/governance/decision-log.md` describing usage and boundaries; all updated artifacts are strictly offline and fixture-backed with no network/Sigstore dependencies.

### Testing
- Ran `pytest -q tests/governance/test_decision_log_validator.py tests/governance/test_decision_log_replay.py` and all tests passed (`3 passed`).
- Validator CLI returns non-zero exit codes on verification failures and zero on success, as exercised by the test fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f551508320832a9fae485f9b0f354c)