### PR TITLE
Add deterministic ingest decision engine pre-RAW gate layer

### DIFF
--- a/packages/ingest/__init__.py
+++ b/packages/ingest/__init__.py
@@ -1,0 +1,3 @@
+from .decision_engine import IngestDecisionEngine
+
+__all__ = ["IngestDecisionEngine"]

--- a/packages/ingest/decision_engine.py
+++ b/packages/ingest/decision_engine.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+ALLOWED_DECISIONS = {"INGEST", "SKIP", "QUARANTINE", "ABSTAIN", "ERROR"}
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_canonical(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _stable_for_hash(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _stable_for_hash(v) for k, v in value.items() if k not in {"created_at"}}
+    if isinstance(value, list):
+        return [_stable_for_hash(v) for v in value]
+    return value
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class IngestDecisionEngine:
+    """Deterministic, no-network ingest decision preflight gate."""
+
+    def evaluate(self, payload: dict[str, Any], created_at: str | None = None) -> dict[str, Any]:
+        created_at = created_at or _now_iso()
+        source = payload.get("source_descriptor") or {}
+        source_id = source.get("source_id")
+
+        plan = self._build_conditional_request_plan(payload, source_id, created_at)
+        probe = self._build_probe_receipt(payload, source_id, created_at, plan)
+        materiality = self._build_materiality(payload, source_id, created_at)
+
+        prev_hash = payload.get("last_known_spec_hash")
+        current_hash = payload.get("spec_hash_current") or self._compute_spec_hash_current(payload)
+
+        etag_prev = (payload.get("last_ingest_receipt") or {}).get("etag")
+        etag_curr = payload.get("etag")
+        lm_prev = (payload.get("last_ingest_receipt") or {}).get("last_modified")
+        lm_curr = payload.get("last_modified")
+        ver_prev = (payload.get("last_ingest_receipt") or {}).get("dataset_version")
+        ver_curr = payload.get("dataset_version")
+
+        change_detected = any(
+            [
+                bool(prev_hash and current_hash and prev_hash != current_hash),
+                bool(etag_prev and etag_curr and etag_prev != etag_curr),
+                bool(lm_prev and lm_curr and lm_prev != lm_curr),
+                bool(ver_prev and ver_curr and ver_prev != ver_curr),
+            ]
+        )
+
+        policy_decision, policy_reason = self._policy_check(payload)
+        decision, reason = self._synthesize_decision(change_detected, materiality["materiality"], policy_decision)
+
+        envelope = {
+            "object_type": "IngestDecisionEnvelope",
+            "schema_version": "v1",
+            "source_id": source_id,
+            "decision": decision,
+            "change_detected": change_detected,
+            "materiality": materiality["materiality"],
+            "policy_decision": policy_decision,
+            "spec_hash_previous": prev_hash,
+            "spec_hash_current": current_hash,
+            "etag_previous": etag_prev,
+            "etag_current": etag_curr,
+            "last_modified_previous": lm_prev,
+            "last_modified_current": lm_curr,
+            "decision_reason": policy_reason if policy_decision == "DENY" else reason,
+            "created_at": created_at,
+            "deterministic": True,
+        }
+        envelope["decision_id"] = sha256_canonical(_stable_for_hash(envelope))
+
+        ingest_intent = self._build_ingest_intent(payload, envelope, created_at) if decision == "INGEST" else None
+        skip_record = self._build_skip_record(envelope, created_at) if decision == "SKIP" else None
+
+        validator_report = self._validate(envelope)
+        if not validator_report["valid"]:
+            envelope["decision"] = "ERROR"
+            envelope["decision_reason"] = "validation_failed"
+
+        audit_log = self._audit_log(payload, plan, probe, materiality, envelope, ingest_intent, skip_record, created_at)
+
+        return {
+            "IngestDecisionEnvelope.v1": envelope,
+            "MaterialityAssessment.v1": materiality,
+            "SourceProbeReceipt.v1": probe,
+            "ConditionalRequestPlan.v1": plan,
+            "IngestIntent.v1": ingest_intent,
+            "SkipDecisionRecord.v1": skip_record,
+            "DecisionAuditLog.v1": audit_log,
+            "DecisionValidatorReport.v1": validator_report,
+        }
+
+    def _compute_spec_hash_current(self, payload: dict[str, Any]) -> str:
+        probe_metadata = payload.get("probe_metadata") or {}
+        return sha256_canonical(_stable_for_hash(probe_metadata))
+
+    def _build_conditional_request_plan(self, payload: dict[str, Any], source_id: str, created_at: str) -> dict[str, Any]:
+        etag = payload.get("etag")
+        last_modified = payload.get("last_modified")
+        if etag:
+            strategy = "if_none_match"
+            headers = {"If-None-Match": etag}
+        elif last_modified:
+            strategy = "if_modified_since"
+            headers = {"If-Modified-Since": last_modified}
+        else:
+            strategy = "metadata_probe"
+            headers = {}
+        out = {
+            "object_type": "ConditionalRequestPlan",
+            "schema_version": "v1",
+            "source_id": source_id,
+            "strategy": strategy,
+            "headers": headers,
+            "created_at": created_at,
+        }
+        out["plan_id"] = sha256_canonical(_stable_for_hash(out))
+        return out
+
+    def _build_probe_receipt(self, payload: dict[str, Any], source_id: str, created_at: str, plan: dict[str, Any]) -> dict[str, Any]:
+        out = {
+            "object_type": "SourceProbeReceipt",
+            "schema_version": "v1",
+            "source_id": source_id,
+            "etag": payload.get("etag"),
+            "last_modified": payload.get("last_modified"),
+            "content_length": payload.get("content_length"),
+            "dataset_version": payload.get("dataset_version"),
+            "probe_metadata": payload.get("probe_metadata") or {},
+            "request_plan_ref": plan["plan_id"],
+            "created_at": created_at,
+        }
+        out["probe_id"] = sha256_canonical(_stable_for_hash(out))
+        return out
+
+    def _build_materiality(self, payload: dict[str, Any], source_id: str, created_at: str) -> dict[str, Any]:
+        ruleset = payload.get("materiality_ruleset") or {}
+        stats = (payload.get("probe_metadata") or {}).get("summary_stats") or {}
+        delta = float(stats.get("delta", 0))
+        threshold = float(ruleset.get("threshold", 0))
+        if not ruleset:
+            mat = "UNKNOWN"
+            reason = "missing_materiality_ruleset"
+        elif ruleset.get("force_unknown"):
+            mat = "UNKNOWN"
+            reason = "ruleset_unknown"
+        elif delta > threshold:
+            mat = "MATERIAL"
+            reason = "delta_above_threshold"
+        else:
+            mat = "IMMATERIAL"
+            reason = "delta_below_or_equal_threshold"
+        out = {
+            "object_type": "MaterialityAssessment",
+            "schema_version": "v1",
+            "source_id": source_id,
+            "materiality": mat,
+            "reason": reason,
+            "threshold": threshold,
+            "observed_delta": delta,
+            "created_at": created_at,
+        }
+        out["assessment_id"] = sha256_canonical(_stable_for_hash(out))
+        return out
+
+    def _policy_check(self, payload: dict[str, Any]) -> tuple[str, str]:
+        profile = payload.get("domain_policy_profile")
+        if not profile:
+            return "DENY", "missing_policy_profile"
+        if profile.get("rights_status") in {None, "unknown"}:
+            return "DENY", "unknown_rights"
+        if profile.get("restricted_geometry"):
+            return "DENY", "restricted_geometry"
+        if profile.get("decision") == "DENY":
+            return "DENY", "policy_block"
+        return "ALLOW", "policy_allow"
+
+    def _synthesize_decision(self, changed: bool, materiality: str, policy_decision: str) -> tuple[str, str]:
+        if policy_decision == "DENY":
+            return "SKIP", "policy_block"
+        if not changed:
+            return "SKIP", "no_change"
+        if materiality == "IMMATERIAL":
+            return "SKIP", "immaterial_change"
+        if materiality == "UNKNOWN":
+            return "ABSTAIN", "unknown_materiality"
+        if materiality == "MATERIAL":
+            return "INGEST", "material_change"
+        return "ERROR", "invalid_materiality"
+
+    def _build_ingest_intent(self, payload: dict[str, Any], envelope: dict[str, Any], created_at: str) -> dict[str, Any]:
+        out = {
+            "object_type": "IngestIntent",
+            "schema_version": "v1",
+            "decision_ref": envelope["decision_id"],
+            "source_id": envelope["source_id"],
+            "ingest_mode": payload.get("ingest_mode", "snapshot"),
+            "expected_format": payload.get("expected_format", "json"),
+            "mapping_strategy": payload.get("mapping_strategy", "default"),
+            "target_lane": "RAW",
+            "requires_quarantine": bool(payload.get("domain_policy_profile", {}).get("requires_quarantine", False)),
+            "created_at": created_at,
+        }
+        out["intent_id"] = sha256_canonical(_stable_for_hash(out))
+        return out
+
+    def _build_skip_record(self, envelope: dict[str, Any], created_at: str) -> dict[str, Any]:
+        reason = envelope["decision_reason"]
+        out = {
+            "object_type": "SkipDecisionRecord",
+            "schema_version": "v1",
+            "decision_ref": envelope["decision_id"],
+            "reason": reason if reason in {"no_change", "immaterial_change", "policy_block"} else "policy_block",
+            "created_at": created_at,
+        }
+        out["skip_id"] = sha256_canonical(_stable_for_hash(out))
+        return out
+
+    def _validate(self, envelope: dict[str, Any]) -> dict[str, Any]:
+        errors = []
+        if not envelope.get("source_id"):
+            errors.append("missing_source_id")
+        if not envelope.get("policy_decision"):
+            errors.append("missing_policy_decision")
+        if envelope.get("decision") not in ALLOWED_DECISIONS:
+            errors.append("decision_enum_invalid")
+        if not envelope.get("spec_hash_current"):
+            errors.append("missing_spec_hash_current")
+        if envelope.get("change_detected") is False and envelope.get("materiality") == "MATERIAL":
+            errors.append("conflicting_signals")
+        return {
+            "object_type": "DecisionValidatorReport",
+            "schema_version": "v1",
+            "valid": len(errors) == 0,
+            "errors": errors,
+        }
+
+    def _audit_log(self, payload: dict[str, Any], plan: dict[str, Any], probe: dict[str, Any], materiality: dict[str, Any], envelope: dict[str, Any], ingest_intent: dict[str, Any] | None, skip_record: dict[str, Any] | None, created_at: str) -> dict[str, Any]:
+        out = {
+            "object_type": "DecisionAuditLog",
+            "schema_version": "v1",
+            "decision_ref": envelope["decision_id"],
+            "source_id": envelope.get("source_id"),
+            "inputs": {
+                "source_descriptor": payload.get("source_descriptor"),
+                "temporal_window": payload.get("temporal_window"),
+            },
+            "artifacts": {
+                "conditional_request_plan_ref": plan["plan_id"],
+                "source_probe_receipt_ref": probe["probe_id"],
+                "materiality_assessment_ref": materiality["assessment_id"],
+                "ingest_intent_ref": (ingest_intent or {}).get("intent_id"),
+                "skip_record_ref": (skip_record or {}).get("skip_id"),
+            },
+            "created_at": created_at,
+        }
+        out["audit_id"] = sha256_canonical(_stable_for_hash(out))
+        return out

--- a/packages/ingest/fixtures/decision_engine_cases.v1.json
+++ b/packages/ingest/fixtures/decision_engine_cases.v1.json
@@ -1,0 +1,76 @@
+[
+  {
+    "name": "unchanged_etag_skip",
+    "input": {
+      "source_descriptor": {"source_id": "src.unchanged"},
+      "last_known_spec_hash": "sha256:aaaa",
+      "spec_hash_current": "sha256:aaaa",
+      "last_ingest_receipt": {"etag": "E1", "last_modified": "Mon, 01 Jan 2024 00:00:00 GMT", "dataset_version": "1"},
+      "etag": "E1",
+      "last_modified": "Mon, 01 Jan 2024 00:00:00 GMT",
+      "dataset_version": "1",
+      "content_length": 100,
+      "domain_policy_profile": {"rights_status": "open"},
+      "materiality_ruleset": {"threshold": 10},
+      "probe_metadata": {"summary_stats": {"delta": 1}}
+    },
+    "expected_decision": "SKIP"
+  },
+  {
+    "name": "changed_etag_immaterial_skip",
+    "input": {
+      "source_descriptor": {"source_id": "src.immaterial"},
+      "last_known_spec_hash": "sha256:old",
+      "spec_hash_current": "sha256:new",
+      "last_ingest_receipt": {"etag": "E1"},
+      "etag": "E2",
+      "content_length": 100,
+      "domain_policy_profile": {"rights_status": "open"},
+      "materiality_ruleset": {"threshold": 10},
+      "probe_metadata": {"summary_stats": {"delta": 3}}
+    },
+    "expected_decision": "SKIP"
+  },
+  {
+    "name": "changed_etag_material_ingest",
+    "input": {
+      "source_descriptor": {"source_id": "src.material"},
+      "last_known_spec_hash": "sha256:old",
+      "spec_hash_current": "sha256:new",
+      "last_ingest_receipt": {"etag": "E1"},
+      "etag": "E2",
+      "content_length": 100,
+      "domain_policy_profile": {"rights_status": "open"},
+      "materiality_ruleset": {"threshold": 10},
+      "probe_metadata": {"summary_stats": {"delta": 11}},
+      "expected_format": "parquet",
+      "mapping_strategy": "schema_v2"
+    },
+    "expected_decision": "INGEST"
+  },
+  {
+    "name": "missing_policy_skip_policy_block",
+    "input": {
+      "source_descriptor": {"source_id": "src.missingpolicy"},
+      "last_known_spec_hash": "sha256:old",
+      "spec_hash_current": "sha256:new",
+      "etag": "E2",
+      "materiality_ruleset": {"threshold": 10},
+      "probe_metadata": {"summary_stats": {"delta": 15}}
+    },
+    "expected_decision": "SKIP"
+  },
+  {
+    "name": "unknown_materiality_abstain",
+    "input": {
+      "source_descriptor": {"source_id": "src.unknown"},
+      "last_known_spec_hash": "sha256:old",
+      "spec_hash_current": "sha256:new",
+      "etag": "E2",
+      "domain_policy_profile": {"rights_status": "open"},
+      "materiality_ruleset": {"force_unknown": true},
+      "probe_metadata": {"summary_stats": {"delta": 15}}
+    },
+    "expected_decision": "ABSTAIN"
+  }
+]

--- a/packages/ingest/schemas/ingest_decision_envelope.v1.schema.json
+++ b/packages/ingest/schemas/ingest_decision_envelope.v1.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "IngestDecisionEnvelope.v1",
+  "type": "object",
+  "required": [
+    "object_type","schema_version","decision_id","source_id","decision","change_detected","materiality","policy_decision","spec_hash_current","decision_reason","created_at","deterministic"
+  ],
+  "properties": {
+    "object_type": {"const": "IngestDecisionEnvelope"},
+    "schema_version": {"const": "v1"},
+    "decision": {"enum": ["INGEST","SKIP","QUARANTINE","ABSTAIN","ERROR"]},
+    "materiality": {"enum": ["MATERIAL","IMMATERIAL","UNKNOWN"]},
+    "deterministic": {"const": true}
+  }
+}

--- a/packages/ingest/tests/test_decision_engine.py
+++ b/packages/ingest/tests/test_decision_engine.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+from packages.ingest.decision_engine import IngestDecisionEngine, canonical_json, sha256_canonical
+
+
+FIXTURES = Path("packages/ingest/fixtures/decision_engine_cases.v1.json")
+
+
+def test_decision_paths_and_artifacts():
+    engine = IngestDecisionEngine()
+    cases = json.loads(FIXTURES.read_text())
+    for case in cases:
+        out = engine.evaluate(case["input"], created_at="2026-01-01T00:00:00Z")
+        assert out["IngestDecisionEnvelope.v1"]["decision"] == case["expected_decision"]
+        assert out["IngestDecisionEnvelope.v1"]["deterministic"] is True
+        assert out["DecisionValidatorReport.v1"]["object_type"] == "DecisionValidatorReport"
+        if case["expected_decision"] == "INGEST":
+            assert out["IngestIntent.v1"] is not None
+            assert out["SkipDecisionRecord.v1"] is None
+        elif case["expected_decision"] == "SKIP":
+            assert out["SkipDecisionRecord.v1"] is not None
+
+
+def test_canonical_hash_stability():
+    data_a = {"b": 2, "a": 1}
+    data_b = {"a": 1, "b": 2}
+    assert canonical_json(data_a) == canonical_json(data_b)
+    assert sha256_canonical(data_a) == sha256_canonical(data_b)
+
+
+def test_conflicting_signal_fails_closed():
+    engine = IngestDecisionEngine()
+    payload = {
+        "source_descriptor": {"source_id": "src.conflict"},
+        "last_known_spec_hash": "sha256:same",
+        "spec_hash_current": "sha256:same",
+        "domain_policy_profile": {"rights_status": "open"},
+        "materiality_ruleset": {"threshold": 1},
+        "probe_metadata": {"summary_stats": {"delta": 10}},
+    }
+    out = engine.evaluate(payload, created_at="2026-01-01T00:00:00Z")
+    assert out["DecisionValidatorReport.v1"]["valid"] is False
+    assert "conflicting_signals" in out["DecisionValidatorReport.v1"]["errors"]
+    assert out["IngestDecisionEnvelope.v1"]["decision"] == "ERROR"


### PR DESCRIPTION
### Motivation
- Provide a deterministic pre-ingest decision brain that evaluates freshness, structural drift, and material change and produces governed artifacts before any data movement.
- Enforce fail-closed policy checks and validator guarantees so the intake gate never silently admits ungoverned or conflicting signals.
- Enable deterministic replayability and auditability by canonicalizing inputs and deriving all IDs with stable SHA256 hashes.

### Description
- Implemented `packages/ingest/decision_engine.py` which builds a `ConditionalRequestPlan`, `SourceProbeReceipt`, `MaterialityAssessment`, synthesizes a deterministic `IngestDecisionEnvelope`, and emits either `IngestIntent` (for `INGEST`) or `SkipDecisionRecord` (for `SKIP`), plus `DecisionAuditLog` and `DecisionValidatorReport`.
- Added canonical JSON and deterministic ID helpers (`canonical_json`, `sha256_canonical`, `_stable_for_hash`) that sort keys, remove volatile `created_at` from hash inputs, and produce stable `sha256:` IDs.
- Implemented conditional probe planning (`If-None-Match` / `If-Modified-Since` / `metadata_probe`), change detection (spec hash, ETag, Last-Modified, dataset version), materiality evaluation (`MATERIAL`/`IMMATERIAL`/`UNKNOWN`), policy fail-closed checks, and decision synthesis per the specified decision rules.
- Added package exports, a JSON schema stub for `IngestDecisionEnvelope.v1`, deterministic fixtures covering the required scenarios, and tests exercising artifact emission and validator behaviour.

### Testing
- Ran `pytest -q packages/ingest/tests/test_decision_engine.py` which passed: `3 passed`.
- Tests cover the fixture decision paths (unchanged ETag SKIP, changed ETag immaterial SKIP, changed ETag material INGEST, missing policy block, unknown materiality ABSTAIN), canonical-hash stability, and fail-closed conflicting-signal validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f6269ca0832a8a1412f5da16c908)