### PR TITLE
Add AirNow Layer 1 offline fixture-backed intake foundation

### DIFF
--- a/data/sources/airnow/source_descriptor.airnow.v1.json
+++ b/data/sources/airnow/source_descriptor.airnow.v1.json
@@ -1,0 +1,26 @@
+{
+  "object_type": "AirNowSourceDescriptor",
+  "schema_version": "v1",
+  "source_id": "airnow",
+  "source_name": "AirNow",
+  "steward": "U.S. EPA AirNow program / participating agencies",
+  "source_role": "preliminary public air-quality observation and forecast source",
+  "access_modes": [
+    "web_services_selected_area",
+    "file_products_database_population_candidate"
+  ],
+  "endpoint_notes": {
+    "documentation_only": true,
+    "references": [
+      "https://docs.airnowapi.org/",
+      "https://docs.airnowapi.org/webservices",
+      "https://docs.airnowapi.org/faq"
+    ],
+    "live_configuration_excluded": true
+  },
+  "constraints": {
+    "no_bulk_zip_or_database_looping_via_web_services": true,
+    "preliminary_data_subject_to_change": true,
+    "not_emergency_alert_system": true
+  }
+}

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -512,3 +512,5 @@ A safe first PR for this directory should be documentation- and fixture-first:
 - [ ] Add rollback note: remove the docs PR or revert descriptor fixtures; no source data or public artifacts affected.
 
 </details>
+
+- AirNow Layer 1 intake foundation: `docs/sources/airnow/README.md`

--- a/docs/sources/airnow/README.md
+++ b/docs/sources/airnow/README.md
@@ -1,0 +1,66 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/NEEDS_VERIFICATION__airnow_layer1
+title: AirNow Layer 1 Source Intake
+type: standard
+version: v1
+status: draft
+owners: NEEDS_VERIFICATION
+created: 2026-05-02
+updated: 2026-05-02
+policy_label: public-safe
+repo_path: docs/sources/airnow/README.md
+related: [data/sources/airnow/source_descriptor.airnow.v1.json, schemas/air_quality/airnow/, tests/fixtures/air_quality/airnow/, tools/validators/air_quality/validate_airnow_layer1.py]
+tags: [kfm, airnow, intake, fixtures, offline, air_quality]
+notes: [Layer 1 is offline fixture-backed intake planning only; no live ingestion enabled.]
+[/KFM_META_BLOCK_V2] -->
+
+# AirNow Layer 1 (Offline Intake Foundation)
+
+## Purpose
+Establish a minimal, reversible, offline intake foundation for AirNow current-observation and forecast records using synthetic fixtures and fail-closed validation only.
+
+## Lifecycle placement
+RAW-source-intake planning only. This slice does not publish, tile, expose UI, or provide public API output.
+
+## AirNow product summary
+AirNow documentation identifies web services for selected-area queries and file products suitable for database population workflows. Layer 1 documents both as references only; no network execution is implemented.
+
+## Web services vs file products
+- Web services: selected-area candidate mode only.
+- File products: database-population candidate mode only.
+- Bulk ZIP/database loops via web services are prohibited.
+
+## No-network Layer 1 boundary
+- No live API calls.
+- No API keys.
+- Fixtures are synthetic and flagged `fixture_only: true`, `no_live_airnow_data: true`, `not_for_publication: true`.
+
+## Public-safety cautions
+- AirNow values are preliminary and subject to change.
+- AirNow is not an emergency alert system.
+- Outputs are public-health environmental observations/forecasts, not emergency notifications.
+
+## Governance gates
+Validator fails closed for missing provenance, unknown pollutant, invalid AQI/category, missing required timestamps, missing reporting area, preliminary flag violations, and bulk-loop manifest violations.
+
+## Validation commands
+- `python tools/validators/air_quality/validate_airnow_layer1.py tests/fixtures/air_quality/airnow/valid/observation_wichita_pm25.json`
+- `python tools/validators/air_quality/validate_airnow_layer1.py tests/fixtures/air_quality/airnow/valid/forecast_wichita_ozone.json`
+- `python tools/validators/air_quality/validate_airnow_layer1.py tests/fixtures/air_quality/airnow/valid/intake_manifest_fixture_only.json`
+- `pytest tests/air_quality/test_airnow_layer1.py`
+
+## Fixture map
+- valid observation: `tests/fixtures/air_quality/airnow/valid/observation_wichita_pm25.json`
+- valid forecast: `tests/fixtures/air_quality/airnow/valid/forecast_wichita_ozone.json`
+- valid manifest: `tests/fixtures/air_quality/airnow/valid/intake_manifest_fixture_only.json`
+- invalid unknown pollutant: `tests/fixtures/air_quality/airnow/invalid/observation_unknown_pollutant.json`
+- invalid missing forecast date: `tests/fixtures/air_quality/airnow/invalid/forecast_missing_date_forecast.json`
+- invalid bulk ZIP loop: `tests/fixtures/air_quality/airnow/invalid/intake_manifest_bulk_zip_loop.json`
+
+## Next layers
+Layer 2 may add governed ingestion orchestration and receipts against approved rights/provenance gates. Layer 1 intentionally stops at descriptor + schemas + fixtures + validator + tests.
+
+## Source references
+- https://docs.airnowapi.org/
+- https://docs.airnowapi.org/webservices
+- https://docs.airnowapi.org/faq

--- a/schemas/air_quality/airnow/forecast.airnow.v1.schema.json
+++ b/schemas/air_quality/airnow/forecast.airnow.v1.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm/air_quality/airnow/forecast.airnow.v1.schema.json",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["object_type", "schema_version", "source_id", "reporting_area", "state_code", "latitude", "longitude", "date_issue", "date_forecast", "parameter_name", "aqi", "category", "preliminary_data"],
+  "properties": {
+    "object_type": {"const": "AirNowForecast"},
+    "schema_version": {"const": "v1"},
+    "source_id": {"const": "airnow"},
+    "reporting_area": {"type": "string", "minLength": 1},
+    "state_code": {"type": "string", "minLength": 2, "maxLength": 2},
+    "latitude": {"type": "number"},
+    "longitude": {"type": "number"},
+    "date_issue": {"type": "string", "format": "date"},
+    "date_forecast": {"type": "string", "format": "date"},
+    "parameter_name": {"type": "string", "minLength": 1},
+    "aqi": {"type": "integer", "minimum": 0, "maximum": 500},
+    "category": {"type": "object", "required": ["number", "name"], "properties": {"number": {"type": "integer"}, "name": {"type": "string"}}},
+    "action_day": {"type": "boolean"},
+    "discussion": {"type": "string"},
+    "preliminary_data": {"const": true}
+  }
+}

--- a/schemas/air_quality/airnow/intake_manifest.airnow.v1.schema.json
+++ b/schemas/air_quality/airnow/intake_manifest.airnow.v1.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm/air_quality/airnow/intake_manifest.airnow.v1.schema.json",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["object_type", "manifest_id", "source_id", "intake_mode", "requested_area", "requested_at", "source_doc_refs", "fixture_refs", "rights_status", "sensitivity", "lifecycle_stage", "no_network", "bulk_loop_prohibited"],
+  "properties": {
+    "object_type": {"const": "AirNowIntakeManifest"},
+    "manifest_id": {"type": "string", "minLength": 1},
+    "source_id": {"const": "airnow"},
+    "intake_mode": {"enum": ["fixture_only", "selected_area_web_service_candidate", "file_product_candidate"]},
+    "requested_area": {"type": "string", "minLength": 1},
+    "requested_at": {"type": "string", "format": "date-time"},
+    "source_doc_refs": {"type": "array", "items": {"type": "string", "format": "uri"}},
+    "fixture_refs": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "rights_status": {"type": "string", "minLength": 1},
+    "sensitivity": {"type": "string", "minLength": 1},
+    "lifecycle_stage": {"type": "string", "minLength": 1},
+    "no_network": {"const": true},
+    "bulk_loop_prohibited": {"const": true}
+  }
+}

--- a/schemas/air_quality/airnow/intake_receipt.airnow.v1.schema.json
+++ b/schemas/air_quality/airnow/intake_receipt.airnow.v1.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm/air_quality/airnow/intake_receipt.airnow.v1.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["object_type", "receipt_id", "manifest_id", "input_hash", "normalized_record_count", "quarantined_record_count", "validation_outcome", "finite_outcome", "warnings", "errors", "created_at"],
+  "properties": {
+    "object_type": {"const": "AirNowIntakeReceipt"},
+    "receipt_id": {"type": "string", "minLength": 1},
+    "manifest_id": {"type": "string", "minLength": 1},
+    "input_hash": {"type": "string", "minLength": 1},
+    "normalized_record_count": {"type": "integer", "minimum": 0},
+    "quarantined_record_count": {"type": "integer", "minimum": 0},
+    "validation_outcome": {"enum": ["PASS", "FAIL"]},
+    "finite_outcome": {"enum": ["ANSWER", "ABSTAIN", "DENY", "ERROR"]},
+    "warnings": {"type": "array", "items": {"type": "string"}},
+    "errors": {"type": "array", "items": {"type": "string"}},
+    "created_at": {"type": "string", "format": "date-time"}
+  }
+}

--- a/schemas/air_quality/airnow/observation.airnow.v1.schema.json
+++ b/schemas/air_quality/airnow/observation.airnow.v1.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm/air_quality/airnow/observation.airnow.v1.schema.json",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["object_type", "schema_version", "source_id", "reporting_area", "state_code", "latitude", "longitude", "date_observed", "hour_observed", "local_time_zone", "parameter_name", "aqi", "category", "provenance", "preliminary_data"],
+  "properties": {
+    "object_type": {"const": "AirNowObservation"},
+    "schema_version": {"const": "v1"},
+    "source_id": {"const": "airnow"},
+    "reporting_area": {"type": "string", "minLength": 1},
+    "state_code": {"type": "string", "minLength": 2, "maxLength": 2},
+    "latitude": {"type": "number"},
+    "longitude": {"type": "number"},
+    "date_observed": {"type": "string", "format": "date"},
+    "hour_observed": {"type": "integer", "minimum": 0, "maximum": 23},
+    "local_time_zone": {"type": "string", "minLength": 1},
+    "parameter_name": {"type": "string", "minLength": 1},
+    "aqi": {"type": "integer", "minimum": 0, "maximum": 500},
+    "category": {"type": "object", "required": ["number", "name"], "properties": {"number": {"type": "integer"}, "name": {"type": "string"}}},
+    "unit": {"type": "string"},
+    "value": {"type": "number"},
+    "provenance": {"type": "object", "required": ["source_doc_url"], "properties": {"source_doc_url": {"type": "string", "format": "uri"}}},
+    "preliminary_data": {"const": true}
+  }
+}

--- a/schemas/air_quality/airnow/source_descriptor.airnow.v1.schema.json
+++ b/schemas/air_quality/airnow/source_descriptor.airnow.v1.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kfm/air_quality/airnow/source_descriptor.airnow.v1.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["object_type", "schema_version", "source_id", "source_name", "steward", "source_role", "access_modes", "endpoint_notes", "constraints"],
+  "properties": {
+    "object_type": {"const": "AirNowSourceDescriptor"},
+    "schema_version": {"const": "v1"},
+    "source_id": {"const": "airnow"},
+    "source_name": {"const": "AirNow"},
+    "steward": {"type": "string", "minLength": 1},
+    "source_role": {"type": "string", "minLength": 1},
+    "access_modes": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "endpoint_notes": {"type": "object"},
+    "constraints": {"type": "object"}
+  }
+}

--- a/tests/air_quality/test_airnow_layer1.py
+++ b/tests/air_quality/test_airnow_layer1.py
@@ -1,0 +1,69 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "tools" / "validators" / "air_quality" / "validate_airnow_layer1.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "air_quality" / "airnow"
+
+
+def _run(path: Path):
+    return subprocess.run([sys.executable, str(VALIDATOR), str(path)], capture_output=True, text=True)
+
+
+def test_valid_observation_passes():
+    out = _run(FIXTURES / "valid" / "observation_wichita_pm25.json")
+    assert out.returncode == 0
+
+
+def test_valid_forecast_passes():
+    out = _run(FIXTURES / "valid" / "forecast_wichita_ozone.json")
+    assert out.returncode == 0
+
+
+def test_valid_manifest_passes():
+    out = _run(FIXTURES / "valid" / "intake_manifest_fixture_only.json")
+    assert out.returncode == 0
+
+
+def test_unknown_pollutant_fails():
+    out = _run(FIXTURES / "invalid" / "observation_unknown_pollutant.json")
+    assert out.returncode != 0
+
+
+def test_missing_forecast_date_fails():
+    out = _run(FIXTURES / "invalid" / "forecast_missing_date_forecast.json")
+    assert out.returncode != 0
+
+
+def test_bulk_zip_loop_manifest_fails():
+    out = _run(FIXTURES / "invalid" / "intake_manifest_bulk_zip_loop.json")
+    assert out.returncode != 0
+
+
+def test_category_aqi_mismatch_fails(tmp_path: Path):
+    src = json.loads((FIXTURES / "valid" / "observation_wichita_pm25.json").read_text())
+    src["aqi"] = 180
+    test_file = tmp_path / "category_mismatch.json"
+    test_file.write_text(json.dumps(src))
+    out = _run(test_file)
+    assert out.returncode != 0
+
+
+def test_preliminary_data_false_fails(tmp_path: Path):
+    src = json.loads((FIXTURES / "valid" / "forecast_wichita_ozone.json").read_text())
+    src["preliminary_data"] = False
+    test_file = tmp_path / "prelim_false.json"
+    test_file.write_text(json.dumps(src))
+    out = _run(test_file)
+    assert out.returncode != 0
+
+
+def test_no_network_false_fails(tmp_path: Path):
+    src = json.loads((FIXTURES / "valid" / "intake_manifest_fixture_only.json").read_text())
+    src["no_network"] = False
+    test_file = tmp_path / "no_network_false.json"
+    test_file.write_text(json.dumps(src))
+    out = _run(test_file)
+    assert out.returncode != 0

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -510,3 +510,5 @@ When branch reality changes, update:
 </details>
 
 [Back to top](#top)
+
+- AirNow Layer 1 fixtures: `tests/fixtures/air_quality/airnow/`

--- a/tests/fixtures/air_quality/airnow/invalid/forecast_missing_date_forecast.json
+++ b/tests/fixtures/air_quality/airnow/invalid/forecast_missing_date_forecast.json
@@ -1,0 +1,17 @@
+{
+  "object_type": "AirNowForecast",
+  "schema_version": "v1",
+  "source_id": "airnow",
+  "fixture_only": true,
+  "no_live_airnow_data": true,
+  "not_for_publication": true,
+  "reporting_area": "Wichita",
+  "state_code": "KS",
+  "latitude": 37.6872,
+  "longitude": -97.3301,
+  "date_issue": "2026-04-20",
+  "parameter_name": "OZONE",
+  "aqi": 110,
+  "category": {"number": 3, "name": "Unhealthy for Sensitive Groups"},
+  "preliminary_data": true
+}

--- a/tests/fixtures/air_quality/airnow/invalid/intake_manifest_bulk_zip_loop.json
+++ b/tests/fixtures/air_quality/airnow/invalid/intake_manifest_bulk_zip_loop.json
@@ -1,0 +1,18 @@
+{
+  "object_type": "AirNowIntakeManifest",
+  "manifest_id": "airnow-manifest-invalid-zip-loop-001",
+  "source_id": "airnow",
+  "fixture_only": true,
+  "no_live_airnow_data": true,
+  "not_for_publication": true,
+  "intake_mode": "bulk_zip_loop",
+  "requested_area": "ALL_US_ZIP_CODES",
+  "requested_at": "2026-04-20T12:00:00Z",
+  "source_doc_refs": ["https://docs.airnowapi.org/webservices"],
+  "fixture_refs": [],
+  "rights_status": "public_docs_reference_only",
+  "sensitivity": "exact-sensitive-overlay-deny",
+  "lifecycle_stage": "raw_source_intake_planning_only",
+  "no_network": true,
+  "bulk_loop_prohibited": false
+}

--- a/tests/fixtures/air_quality/airnow/invalid/observation_unknown_pollutant.json
+++ b/tests/fixtures/air_quality/airnow/invalid/observation_unknown_pollutant.json
@@ -1,0 +1,20 @@
+{
+  "object_type": "AirNowObservation",
+  "schema_version": "v1",
+  "source_id": "airnow",
+  "fixture_only": true,
+  "no_live_airnow_data": true,
+  "not_for_publication": true,
+  "reporting_area": "Wichita",
+  "state_code": "KS",
+  "latitude": 37.6872,
+  "longitude": -97.3301,
+  "date_observed": "2026-04-20",
+  "hour_observed": 11,
+  "local_time_zone": "CST",
+  "parameter_name": "LEAD",
+  "aqi": 75,
+  "category": {"number": 2, "name": "Moderate"},
+  "provenance": {"source_doc_url": "https://docs.airnowapi.org/webservices"},
+  "preliminary_data": true
+}

--- a/tests/fixtures/air_quality/airnow/valid/forecast_wichita_ozone.json
+++ b/tests/fixtures/air_quality/airnow/valid/forecast_wichita_ozone.json
@@ -1,0 +1,20 @@
+{
+  "object_type": "AirNowForecast",
+  "schema_version": "v1",
+  "source_id": "airnow",
+  "fixture_only": true,
+  "no_live_airnow_data": true,
+  "not_for_publication": true,
+  "reporting_area": "Wichita",
+  "state_code": "KS",
+  "latitude": 37.6872,
+  "longitude": -97.3301,
+  "date_issue": "2026-04-20",
+  "date_forecast": "2026-04-21",
+  "parameter_name": "OZONE",
+  "aqi": 88,
+  "category": {"number": 2, "name": "Moderate"},
+  "action_day": false,
+  "discussion": "Synthetic fixture for offline validation only.",
+  "preliminary_data": true
+}

--- a/tests/fixtures/air_quality/airnow/valid/intake_manifest_fixture_only.json
+++ b/tests/fixtures/air_quality/airnow/valid/intake_manifest_fixture_only.json
@@ -1,0 +1,25 @@
+{
+  "object_type": "AirNowIntakeManifest",
+  "manifest_id": "airnow-manifest-fixture-001",
+  "source_id": "airnow",
+  "fixture_only": true,
+  "no_live_airnow_data": true,
+  "not_for_publication": true,
+  "intake_mode": "fixture_only",
+  "requested_area": "Wichita,KS",
+  "requested_at": "2026-04-20T12:00:00Z",
+  "source_doc_refs": [
+    "https://docs.airnowapi.org/",
+    "https://docs.airnowapi.org/webservices",
+    "https://docs.airnowapi.org/faq"
+  ],
+  "fixture_refs": [
+    "tests/fixtures/air_quality/airnow/valid/observation_wichita_pm25.json",
+    "tests/fixtures/air_quality/airnow/valid/forecast_wichita_ozone.json"
+  ],
+  "rights_status": "public_docs_reference_only",
+  "sensitivity": "exact-sensitive-overlay-deny",
+  "lifecycle_stage": "raw_source_intake_planning_only",
+  "no_network": true,
+  "bulk_loop_prohibited": true
+}

--- a/tests/fixtures/air_quality/airnow/valid/observation_wichita_pm25.json
+++ b/tests/fixtures/air_quality/airnow/valid/observation_wichita_pm25.json
@@ -1,0 +1,22 @@
+{
+  "object_type": "AirNowObservation",
+  "schema_version": "v1",
+  "source_id": "airnow",
+  "fixture_only": true,
+  "no_live_airnow_data": true,
+  "not_for_publication": true,
+  "reporting_area": "Wichita",
+  "state_code": "KS",
+  "latitude": 37.6872,
+  "longitude": -97.3301,
+  "date_observed": "2026-04-20",
+  "hour_observed": 14,
+  "local_time_zone": "CST",
+  "parameter_name": "PM2.5",
+  "aqi": 42,
+  "category": {"number": 1, "name": "Good"},
+  "unit": "UG/M3",
+  "value": 10.2,
+  "provenance": {"source_doc_url": "https://docs.airnowapi.org/webservices"},
+  "preliminary_data": true
+}

--- a/tools/validators/README.md
+++ b/tools/validators/README.md
@@ -553,3 +553,5 @@ Before hardening this README from `draft` to `review` or `published`, verify:
 </details>
 
 [Back to top](#top)
+
+- AirNow Layer 1 validator: `tools/validators/air_quality/validate_airnow_layer1.py`

--- a/tools/validators/air_quality/validate_airnow_layer1.py
+++ b/tools/validators/air_quality/validate_airnow_layer1.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_DIR = ROOT / "schemas" / "air_quality" / "airnow"
+
+POLLUTANTS = {
+    "OZONE", "O3", "PM2.5", "PM25", "PM10", "NO2", "SO2", "CO"
+}
+CATEGORY_BANDS = {
+    1: ("Good", 0, 50),
+    2: ("Moderate", 51, 100),
+    3: ("Unhealthy for Sensitive Groups", 101, 150),
+    4: ("Unhealthy", 151, 200),
+    5: ("Very Unhealthy", 201, 300),
+    6: ("Hazardous", 301, 500),
+}
+
+
+def _schema_for(obj_type: str) -> Path:
+    return {
+        "AirNowObservation": SCHEMA_DIR / "observation.airnow.v1.schema.json",
+        "AirNowForecast": SCHEMA_DIR / "forecast.airnow.v1.schema.json",
+        "AirNowIntakeManifest": SCHEMA_DIR / "intake_manifest.airnow.v1.schema.json",
+        "AirNowSourceDescriptor": SCHEMA_DIR / "source_descriptor.airnow.v1.schema.json",
+        "AirNowIntakeReceipt": SCHEMA_DIR / "intake_receipt.airnow.v1.schema.json",
+    }[obj_type]
+
+
+def validate_doc(doc: dict, input_path: str) -> dict:
+    errors, warnings = [], []
+    obj_type = doc.get("object_type")
+    if obj_type not in {"AirNowObservation", "AirNowForecast", "AirNowIntakeManifest", "AirNowSourceDescriptor", "AirNowIntakeReceipt"}:
+        errors.append("object_type.unsupported")
+    else:
+        schema = json.loads(_schema_for(obj_type).read_text())
+        schema_errors = sorted(Draft202012Validator(schema).iter_errors(doc), key=lambda e: list(e.path))
+        for e in schema_errors:
+            errors.append(f"schema.{'/'.join(str(p) for p in e.path) or '<root>'}:{e.message}")
+
+    if doc.get("fixture_only") is not True:
+        errors.append("fixture_only.must_be_true")
+    if doc.get("no_live_airnow_data") is not True:
+        errors.append("no_live_airnow_data.must_be_true")
+    if doc.get("not_for_publication") is not True:
+        errors.append("not_for_publication.must_be_true")
+
+    if obj_type in {"AirNowObservation", "AirNowForecast"}:
+        if doc.get("preliminary_data") is not True:
+            errors.append("preliminary_data.must_be_true")
+        pollutant = str(doc.get("parameter_name", "")).upper()
+        if pollutant not in POLLUTANTS:
+            errors.append("parameter_name.unknown_pollutant")
+        aqi = doc.get("aqi")
+        if not isinstance(aqi, int) or not (0 <= aqi <= 500):
+            errors.append("aqi.out_of_range")
+        category = doc.get("category") or {}
+        number, name = category.get("number"), category.get("name")
+        band = CATEGORY_BANDS.get(number)
+        if band is None:
+            errors.append("category.number.invalid")
+        else:
+            expected_name, low, high = band
+            if name != expected_name:
+                errors.append("category.name.mismatch")
+            if isinstance(aqi, int) and not (low <= aqi <= high):
+                errors.append("category.aqi_band_mismatch")
+
+    if obj_type == "AirNowIntakeManifest":
+        if doc.get("no_network") is not True:
+            errors.append("manifest.no_network.must_be_true")
+        if doc.get("bulk_loop_prohibited") is not True:
+            errors.append("manifest.bulk_loop_prohibited.must_be_true")
+        if "bulk" in str(doc.get("intake_mode", "")).lower() or "zip" in str(doc.get("intake_mode", "")).lower():
+            errors.append("manifest.intake_mode.bulk_zip_loop_prohibited")
+
+    return {
+        "object_type": "ValidationReport",
+        "schema_version": "v1",
+        "validator": "validate_airnow_layer1.py",
+        "input_path": input_path,
+        "validation_outcome": "PASS" if not errors else "FAIL",
+        "finite_outcome": "ANSWER" if not errors else "DENY",
+        "warnings": sorted(warnings),
+        "errors": sorted(errors),
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: validate_airnow_layer1.py <json-file>", file=sys.stderr)
+        return 2
+    p = Path(sys.argv[1])
+    doc = json.loads(p.read_text())
+    report = validate_doc(doc, str(p))
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["validation_outcome"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a minimal, reversible Layer 1 intake foundation for AirNow observations and forecasts that is strictly offline and fixture-driven to avoid any live API calls or key usage.
- Enforce fail-closed validation for provenance, pollutant allowlist, AQI/category consistency, and manifest rules so unverified or bulk-looping intake attempts are denied.
- Create a clear, reviewable starting surface (descriptor, schemas, fixtures, validator, tests, docs) to enable later governed ingestion layers without enabling live ingestion in this slice.

### Description
- Added a source descriptor at `data/sources/airnow/source_descriptor.airnow.v1.json` documenting identity, steward, source role, access modes, documentation-only endpoints, and explicit constraints against bulk web-service looping.
- Added JSON Schemas under `schemas/air_quality/airnow/` for `source_descriptor.airnow.v1`, `observation.airnow.v1`, `forecast.airnow.v1`, `intake_manifest.airnow.v1`, and `intake_receipt.airnow.v1` implementing the required fields and no-network / preliminary-data constraints.
- Added synthetic fixture files (valid and invalid) under `tests/fixtures/air_quality/airnow/` and a pytest suite at `tests/air_quality/test_airnow_layer1.py` exercising pass/fail cases; all fixtures are flagged `fixture_only`, `no_live_airnow_data`, and `not_for_publication`.
- Added a deterministic validator CLI `tools/validators/air_quality/validate_airnow_layer1.py` which uses `jsonschema` + additional rule checks (pollutant allowlist, AQI 0..500, category number/name/band consistency, `preliminary_data == true`, `no_network == true`, `bulk_loop_prohibited == true`, and rejection of intake modes implying bulk ZIP looping) and emits a JSON `ValidationReport` and nonzero exit on failures.
- Added documentation `docs/sources/airnow/README.md` with a KFM Meta Block V2, lifecycle boundaries, validation commands, fixture map, and updated navigation lines in `docs/sources/README.md`, `tools/validators/README.md`, and `tests/fixtures/README.md`.
- NEEDS_VERIFICATION: repository schema-home conventions are ambiguous in this repo (see existing `jsonschema/README.md` guidance and other schema locations), so schema placement should be verified by maintainers before promoting schema-home authority.

### Testing
- Ran validator against valid fixtures with `python tools/validators/air_quality/validate_airnow_layer1.py tests/fixtures/air_quality/airnow/valid/observation_wichita_pm25.json` and `python tools/validators/air_quality/validate_airnow_layer1.py tests/fixtures/air_quality/airnow/valid/forecast_wichita_ozone.json` and `python tools/validators/air_quality/airnow/valid/intake_manifest_fixture_only.json`, each producing a `validation_outcome: PASS` `ValidationReport` and zero exit code.
- Ran the pytest suite with `pytest tests/air_quality/test_airnow_layer1.py` and observed `9 passed` (all tests passed locally).
- Validator output is deterministic JSON and the CLI returns nonzero exit codes for the provided invalid fixtures (unknown pollutant, missing forecast date, bulk-zip-loop manifest, AQI/category mismatch, preliminary_data false, and manifest no_network false).
- Note: the validator depends on the `jsonschema` Python package (the repo contains many references to `jsonschema`); ensure CI dependency surfaces align with this validator before enabling CI-enforced checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fa601ea0832aa57a7a34024270e3)