### PR TITLE
Add deterministic SoilGrids GeoTIFF→COG normalization layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,3 +476,59 @@ KFM publication should be reversible and correctable.
 - [ ] License text is not summarized until the actual repository license is verified.
 
 </details>
+
+## SoilGrids COG normalization (Layer 2)
+
+CLI example:
+
+```bash
+python soilgrids_cog_normalize.py \
+  --input raw/soc_0-5cm_mean_subset.tif \
+  --output-dir processed/cog \
+  --compression DEFLATE \
+  --predictor 2 \
+  --blocksize 512 \
+  --bigtiff IF_SAFER \
+  --threads 1
+```
+
+Python example:
+
+```python
+from soilgrids_cog_normalize import normalize_to_cog
+
+receipt = normalize_to_cog(
+    input_path="raw/soc_0-5cm_mean_subset.tif",
+    output_dir="processed/cog",
+    compression="DEFLATE",
+    predictor=2,
+    blocksize=512,
+    bigtiff="IF_SAFER",
+    threads=1,
+)
+```
+
+Expected receipt shape (`CogReceipt.v1`) includes:
+
+```json
+{
+  "schema": "CogReceipt.v1",
+  "status": "success | error",
+  "input_path": "...",
+  "output_path": "...",
+  "spec_hash": "...",
+  "creation_options": {
+    "FORMAT": "COG",
+    "COMPRESS": "DEFLATE",
+    "PREDICTOR": "2",
+    "BLOCKSIZE": "512",
+    "BIGTIFF": "IF_SAFER",
+    "NUM_THREADS": "1"
+  },
+  "validation": {
+    "input_valid": true,
+    "output_valid": true
+  },
+  "errors": []
+}
+```

--- a/soilgrids_cog_normalize.py
+++ b/soilgrids_cog_normalize.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+MODULE_VERSION = "1.0.0"
+REMOTE_PREFIXES = ("http://", "https://", "s3://", "gs://", "/vsicurl/", "/vsis3/", "/vsigs/")
+
+try:
+    from osgeo import gdal  # type: ignore
+except Exception:
+    gdal = None
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        data = {"level": record.levelname.lower(), "message": record.getMessage()}
+        if isinstance(record.args, dict):
+            data.update(record.args)
+        if hasattr(record, "payload"):
+            data.update(record.payload)
+        return json.dumps(data, sort_keys=True)
+
+
+def _logger() -> logging.Logger:
+    logger = logging.getLogger("soilgrids_cog_normalize")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(JsonFormatter())
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def canonical_creation_options(compression: str, predictor: int | str, blocksize: int | str, bigtiff: str, threads: int | str) -> dict[str, str]:
+    opts = {
+        "FORMAT": "COG",
+        "COMPRESS": str(compression).upper(),
+        "PREDICTOR": str(predictor),
+        "BLOCKSIZE": str(blocksize),
+        "BIGTIFF": str(bigtiff).upper(),
+        "NUM_THREADS": str(threads),
+    }
+    return {k: opts[k] for k in sorted(opts)}
+
+
+def compute_spec_hash(input_path: Path, input_sha256: str, creation_options: dict[str, str], source_spec_hash: str | None) -> str:
+    payload = {
+        "creation_options": {k: creation_options[k] for k in sorted(creation_options)},
+        "input_path": str(input_path.resolve()),
+        "input_sha256": input_sha256,
+        "module_version": MODULE_VERSION,
+        "source_receipt_spec_hash": source_spec_hash,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def _parse_source_receipt(path: Path | None) -> dict[str, Any]:
+    if not path:
+        return {"path": None, "schema": None, "spec_hash": None}
+    data = json.loads(path.read_text())
+    return {"path": str(path), "schema": data.get("schema"), "spec_hash": data.get("spec_hash")}
+
+
+def _translate_subprocess(input_path: Path, output_path: Path, creation_options: dict[str, str]) -> None:
+    cmd = ["gdal_translate", str(input_path), str(output_path), "-of", "COG"]
+    for k, v in creation_options.items():
+        if k == "FORMAT":
+            continue
+        cmd.extend(["-co", f"{k}={v}"])
+    subprocess.run(cmd, check=True, capture_output=True)
+
+
+def _open_ds(path: Path):
+    if gdal is None:
+        raise RuntimeError("GDAL Python bindings unavailable")
+    ds = gdal.Open(str(path))
+    if ds is None:
+        raise ValueError(f"cannot open raster: {path}")
+    return ds
+
+
+def _raster_semantics(ds: Any) -> dict[str, Any]:
+    width, height, bands = ds.RasterXSize, ds.RasterYSize, ds.RasterCount
+    gt = list(ds.GetGeoTransform() or [])
+    proj = ds.GetProjectionRef() or ""
+    band_types, nodata, checksums = [], [], []
+    for i in range(1, bands + 1):
+        b = ds.GetRasterBand(i)
+        band_types.append(int(b.DataType))
+        nodata.append(b.GetNoDataValue())
+        checksums.append(int(b.Checksum()))
+    return {
+        "width": width,
+        "height": height,
+        "bands": bands,
+        "geotransform": gt,
+        "projection": proj,
+        "band_types": band_types,
+        "nodata": nodata,
+        "checksums": checksums,
+    }
+
+
+def compute_semantic_raster_hash(sem: dict[str, Any]) -> str:
+    return hashlib.sha256(json.dumps(sem, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def normalize_to_cog(input_path: str | Path, output_dir: str | Path, source_receipt: str | Path | None = None,
+                     compression: str = "DEFLATE", predictor: int = 2, blocksize: int = 512,
+                     bigtiff: str = "IF_SAFER", threads: str | int = 1, overwrite: bool = False,
+                     allow_non_epsg4326: bool = False, keep_temp: bool = False, receipt_dir: str | Path | None = None,
+                     translate_runner: Callable[[Path, Path, dict[str, str]], None] | None = None) -> dict[str, Any]:
+    run_id = hashlib.sha256(f"{Path(input_path)}|{datetime.now(timezone.utc).isoformat()}".encode()).hexdigest()[:16]
+    logger = _logger()
+    input_p, out_dir = Path(input_path), Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    receipt_out_dir = Path(receipt_dir) if receipt_dir else out_dir
+    receipt_out_dir.mkdir(parents=True, exist_ok=True)
+    receipt = {"schema": "CogReceipt.v1", "run_id": run_id, "created_at_utc": datetime.now(timezone.utc).isoformat(), "status": "error", "source": "soilgrids_cog_normalize", "errors": []}
+    tmp_path = None
+    try:
+        logger.info("event", extra={"payload": {"event": "cog.normalize.started", "run_id": run_id, "input_path": str(input_p), "status": "started"}})
+        if str(input_p).startswith(REMOTE_PREFIXES):
+            raise ValueError("remote input paths are not allowed")
+        if not input_p.exists() or input_p.is_dir():
+            raise ValueError("input path missing or is directory")
+        if input_p.stat().st_size == 0:
+            raise ValueError("input file is empty")
+        creation_options = canonical_creation_options(compression, predictor, blocksize, bigtiff, threads)
+        src = _parse_source_receipt(Path(source_receipt)) if source_receipt else {"path": None, "schema": None, "spec_hash": None}
+        in_sha = sha256_file(input_p)
+        spec_hash = compute_spec_hash(input_p, in_sha, creation_options, src["spec_hash"])
+        final_output = out_dir / f"{input_p.stem}_cog_{spec_hash[:12]}.tif"
+        if final_output.exists() and not overwrite:
+            raise FileExistsError("output exists and overwrite is false")
+        ds = _open_ds(input_p)
+        in_sem = _raster_semantics(ds)
+        if in_sem["width"] <= 0 or in_sem["height"] <= 0 or in_sem["bands"] <= 0:
+            raise ValueError("invalid raster dimensions/bands")
+        if not in_sem["geotransform"]:
+            raise ValueError("missing geotransform")
+        if not in_sem["projection"]:
+            raise ValueError("missing CRS")
+        if ("4326" not in in_sem["projection"]) and not allow_non_epsg4326:
+            raise ValueError("CRS is not EPSG:4326")
+        logger.info("event", extra={"payload": {"event": "cog.input.validated", "run_id": run_id, "status": "ok", "spec_hash": spec_hash}})
+        fd, tmp_name = tempfile.mkstemp(suffix=".tif", prefix=".tmp_cog_", dir=str(out_dir))
+        os.close(fd)
+        tmp_path = Path(tmp_name)
+        runner = translate_runner
+        if runner is None:
+            if gdal is not None:
+                def _runner(inp: Path, outp: Path, opts: dict[str, str]) -> None:
+                    src_ds = _open_ds(inp)
+                    co = [f"{k}={v}" for k, v in opts.items() if k != "FORMAT"]
+                    res = gdal.Translate(str(outp), src_ds, format="COG", creationOptions=co)
+                    if res is None:
+                        raise RuntimeError("gdal.Translate failed")
+                runner = _runner
+            else:
+                runner = _translate_subprocess
+        logger.info("event", extra={"payload": {"event": "cog.translate.started", "run_id": run_id, "status": "started"}})
+        runner(input_p, tmp_path, creation_options)
+        logger.info("event", extra={"payload": {"event": "cog.translate.completed", "run_id": run_id, "status": "ok"}})
+        out_ds = _open_ds(tmp_path)
+        out_sem = _raster_semantics(out_ds)
+        if (out_sem["width"], out_sem["height"], out_sem["bands"]) != (in_sem["width"], in_sem["height"], in_sem["bands"]):
+            raise ValueError("output dimensions mismatch")
+        if out_sem["projection"] != in_sem["projection"]:
+            raise ValueError("output CRS mismatch")
+        if any(abs(a - b) > 1e-12 for a, b in zip(out_sem["geotransform"], in_sem["geotransform"])):
+            raise ValueError("output geotransform mismatch")
+        meta = out_ds.GetMetadata("IMAGE_STRUCTURE") or {}
+        if meta.get("LAYOUT") != "COG":
+            drv = out_ds.GetDriver().ShortName
+            if drv != "COG":
+                raise ValueError("output is not recognizable COG layout")
+        first_band = out_ds.GetRasterBand(1)
+        if first_band.GetBlockSize()[0] <= 0:
+            raise ValueError("output not tiled")
+        ov_counts = [out_ds.GetRasterBand(i).GetOverviewCount() for i in range(1, out_ds.RasterCount + 1)]
+        small = min(in_sem["width"], in_sem["height"]) < int(blocksize) * 2
+        if not small and any(c == 0 for c in ov_counts):
+            raise ValueError("missing overviews")
+        shutil.move(str(tmp_path), str(final_output))
+        tmp_path = None
+        out_sha = sha256_file(final_output)
+        receipt.update({"status": "success", "input_path": str(input_p.resolve()), "input_sha256": in_sha, "input_bytes": input_p.stat().st_size,
+                        "output_path": str(final_output.resolve()), "output_sha256": out_sha, "output_bytes": final_output.stat().st_size,
+                        "semantic_raster_hash": compute_semantic_raster_hash(out_sem), "spec_hash": spec_hash,
+                        "creation_options": creation_options, "gdal": {"version": (gdal.VersionInfo() if gdal else "subprocess"), "driver": "COG"},
+                        "raster": {"width": in_sem["width"], "height": in_sem["height"], "bands": in_sem["bands"], "crs": "EPSG:4326" if "4326" in in_sem["projection"] else in_sem["projection"], "geotransform": in_sem["geotransform"], "nodata": in_sem["nodata"]},
+                        "source_receipt": src,
+                        "validation": {"input_valid": True, "output_valid": True, "is_tiled": True, "overview_count_by_band": ov_counts,
+                                       "dimension_match": True, "crs_match": True, "geotransform_match": True, "nodata_match": in_sem["nodata"] == out_sem["nodata"]}})
+        logger.info("event", extra={"payload": {"event": "cog.output.validated", "run_id": run_id, "status": "ok", "output_path": str(final_output)}})
+    except Exception as exc:
+        receipt["errors"].append(str(exc))
+        logger.error("event", extra={"payload": {"event": "cog.normalize.failed", "run_id": run_id, "status": "error", "error": str(exc)}})
+        if tmp_path and tmp_path.exists() and not keep_temp:
+            tmp_path.unlink()
+    receipt_path = receipt_out_dir / f"cog_receipt_{run_id}.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True))
+    logger.info("event", extra={"payload": {"event": "cog.receipt.written", "run_id": run_id, "status": receipt['status'], "receipt_path": str(receipt_path)}})
+    return receipt
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", required=True)
+    p.add_argument("--output-dir", required=True)
+    p.add_argument("--source-receipt")
+    p.add_argument("--compression", default="DEFLATE")
+    p.add_argument("--predictor", type=int, default=2)
+    p.add_argument("--blocksize", type=int, default=512)
+    p.add_argument("--bigtiff", default="IF_SAFER")
+    p.add_argument("--threads", default="1")
+    p.add_argument("--overwrite", action="store_true")
+    p.add_argument("--allow-non-epsg4326", action="store_true")
+    p.add_argument("--keep-temp", action="store_true")
+    p.add_argument("--receipt-dir")
+    args = p.parse_args()
+    receipt = normalize_to_cog(**vars(args))
+    if receipt["status"] == "success":
+        print(str((Path(args.receipt_dir) if args.receipt_dir else Path(args.output_dir)) / f"cog_receipt_{receipt['run_id']}.json"))
+        return 0
+    print(json.dumps(receipt), file=os.sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_soilgrids_cog_normalize.py
+++ b/tests/test_soilgrids_cog_normalize.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+import json
+import soilgrids_cog_normalize as m
+
+
+def _fake_translate(inp: Path, outp: Path, opts: dict[str, str]):
+    outp.write_bytes(inp.read_bytes() or b'x')
+
+
+def _patch_open(monkeypatch):
+    class Band:
+        DataType = 1
+        def __init__(self): self.nodata=None
+        def GetNoDataValue(self): return self.nodata
+        def Checksum(self): return 7
+        def GetOverviewCount(self): return 1
+        def GetBlockSize(self): return (512, 512)
+    class Driver: ShortName = 'COG'
+    class DS:
+        RasterXSize=10; RasterYSize=10; RasterCount=1
+        def GetGeoTransform(self): return (0,1,0,0,0,-1)
+        def GetProjectionRef(self): return 'EPSG:4326'
+        def GetRasterBand(self, i): return Band()
+        def GetMetadata(self, domain=None): return {'LAYOUT':'COG'}
+        def GetDriver(self): return Driver()
+    monkeypatch.setattr(m, '_open_ds', lambda p: DS())
+
+
+def test_rejects_missing_input(tmp_path):
+    r = m.normalize_to_cog(tmp_path/'x.tif', tmp_path)
+    assert r['status'] == 'error'
+
+def test_rejects_remote_paths(tmp_path):
+    r = m.normalize_to_cog('https://x.tif', tmp_path)
+    assert r['status'] == 'error'
+
+def test_rejects_empty_input(tmp_path):
+    inp = tmp_path/'e.tif'; inp.write_bytes(b'')
+    r = m.normalize_to_cog(inp, tmp_path)
+    assert r['status'] == 'error'
+
+def test_canonical_creation_options_stable():
+    a = m.canonical_creation_options('deflate',2,512,'if_safer',1)
+    b = m.canonical_creation_options('DEFLATE','2','512','IF_SAFER','1')
+    assert a == b
+
+def test_spec_hash_stable(tmp_path):
+    inp = tmp_path/'a.tif'; inp.write_bytes(b'abc')
+    opts = m.canonical_creation_options('DEFLATE',2,512,'IF_SAFER',1)
+    h1 = m.compute_spec_hash(inp, m.sha256_file(inp), opts, None)
+    h2 = m.compute_spec_hash(inp, m.sha256_file(inp), opts, None)
+    assert h1 == h2
+
+def test_output_filename_contains_spec_hash(tmp_path, monkeypatch):
+    _patch_open(monkeypatch)
+    inp = tmp_path/'a.tif'; inp.write_bytes(b'abc')
+    r = m.normalize_to_cog(inp, tmp_path, translate_runner=_fake_translate)
+    assert r['status']=='success'
+    assert r['spec_hash'][:12] in Path(r['output_path']).name
+
+def test_receipt_written_on_success(tmp_path, monkeypatch):
+    _patch_open(monkeypatch)
+    inp = tmp_path/'a.tif'; inp.write_bytes(b'abc')
+    r = m.normalize_to_cog(inp, tmp_path, translate_runner=_fake_translate)
+    rp = tmp_path / f"cog_receipt_{r['run_id']}.json"
+    assert rp.exists()
+
+def test_receipt_written_on_failure(tmp_path):
+    r = m.normalize_to_cog(tmp_path/'none.tif', tmp_path)
+    rp = tmp_path / f"cog_receipt_{r['run_id']}.json"
+    assert rp.exists()
+
+def test_no_overwrite_without_flag(tmp_path, monkeypatch):
+    _patch_open(monkeypatch)
+    inp = tmp_path/'a.tif'; inp.write_bytes(b'abc')
+    r1 = m.normalize_to_cog(inp, tmp_path, translate_runner=_fake_translate)
+    r2 = m.normalize_to_cog(inp, tmp_path, translate_runner=_fake_translate)
+    assert r1['status']=='success'
+    assert r2['status']=='error'
+
+def test_atomic_write_no_partial_final_on_failure(tmp_path, monkeypatch):
+    _patch_open(monkeypatch)
+    inp = tmp_path/'a.tif'; inp.write_bytes(b'abc')
+    def bad(i,o,opts):
+        o.write_bytes(b'partial')
+        raise RuntimeError('fail')
+    r = m.normalize_to_cog(inp, tmp_path, translate_runner=bad)
+    assert r['status']=='error'
+    assert not list(tmp_path.glob('*_cog_*.tif'))
+
+def test_mock_gdal_runner_called_with_expected_options(tmp_path, monkeypatch):
+    _patch_open(monkeypatch)
+    inp = tmp_path/'a.tif'; inp.write_bytes(b'abc')
+    seen = {}
+    def runner(i,o,opts):
+        seen.update(opts)
+        o.write_bytes(b'abc')
+    m.normalize_to_cog(inp, tmp_path, translate_runner=runner)
+    assert seen['NUM_THREADS'] == '1'
+    assert seen['COMPRESS'] == 'DEFLATE'
+
+def test_semantic_raster_hash_stable_for_fixture(tmp_path, monkeypatch):
+    _patch_open(monkeypatch)
+    sem = m._raster_semantics(m._open_ds(tmp_path/'x'))
+    assert m.compute_semantic_raster_hash(sem) == m.compute_semantic_raster_hash(sem)


### PR DESCRIPTION
### Motivation
- Provide a deterministic, offline Layer 2 that converts Layer 1 GeoTIFFs into Cloud-Optimized GeoTIFFs (COGs) suitable for downstream STAC registration. 
- Ensure reproducibility and auditability by canonicalizing creation options, computing spec and output hashes, and failing closed on validation issues. 
- Support environments with or without the GDAL Python bindings via an injectable subprocess fallback so tests and CI remain offline and deterministic. 

### Description
- Add `soilgrids_cog_normalize.py` with `normalize_to_cog(...)` implementing input validation, canonical creation options (`canonical_creation_options`), `spec_hash` computation, `semantic_raster_hash`, atomic temp-file writes, GDAL Python driver or subprocess `gdal_translate` fallback, output validation, structured JSON logging, and CLI entrypoint. 
- Make the GDAL runnner injectable via `translate_runner` for deterministic tests and allow explicit canonical options including `NUM_THREADS=1` by default. 
- Ensure naming convention for final output as `<input_stem>_cog_<spec_hash_12>.tif` and always emit a `CogReceipt.v1` JSON receipt on success or failure. 
- Add README snippet documenting the CLI example, Python usage, and expected `CogReceipt.v1` shape. 

### Testing
- Add `tests/test_soilgrids_cog_normalize.py` with 12 deterministic pytest tests covering missing input, remote path rejection, empty input, canonical options, stable spec hash, filename/spec-hash inclusion, receipt emission on success/failure, overwrite protection, atomic-write behavior, mockable GDAL runner invocation, and semantic raster hash stability. 
- Ran `pytest -q tests/test_soilgrids_cog_normalize.py`, which completed successfully with `12 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60363c420832a8f65d8355125c38b)