### PR TITLE
Refactor AirNow Layer22 snapshot preservation finalization CLI entrypoint

### DIFF
--- a/tools/air_quality/airnow_layer22_snapshot_preservation_finalization.py
+++ b/tools/air_quality/airnow_layer22_snapshot_preservation_finalization.py
@@ -1,8 +1,33 @@
-import argparse, json, sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from kfm.air_quality.airnow.snapshot_preservation_finalization.run_snapshot_preservation_finalization import run_snapshot_preservation_finalization
+"""CLI runner for AirNow Layer 22 snapshot preservation finalization."""
 
-def main():
- p=argparse.ArgumentParser(); p.add_argument('--manifest',required=True); p.add_argument('--out-dir',required=True); p.add_argument('--created-at',required=True); a=p.parse_args(); r=run_snapshot_preservation_finalization(a.manifest,a.out_dir,a.created_at); print(json.dumps(r,indent=2,sort_keys=True)); sys.exit(0 if r.get('validation_outcome')=='PASS' and r.get('finite_outcome')=='ANSWER' else 1)
-if __name__=='__main__': main()
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from kfm.air_quality.airnow.snapshot_preservation_finalization.run_snapshot_preservation_finalization import (
+    run_snapshot_preservation_finalization,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument("--created-at", required=True)
+    args = parser.parse_args()
+
+    receipt = run_snapshot_preservation_finalization(
+        args.manifest,
+        args.out_dir,
+        args.created_at,
+    )
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    is_pass = receipt.get("validation_outcome") == "PASS" and receipt.get("finite_outcome") == "ANSWER"
+    return 0 if is_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Improve clarity and maintainability of the Layer 22 CLI entrypoint while preserving the existing finalization workflow behavior and governance exit semantics.

### Description
- Replace the single-line entrypoint with a small, typed `main() -> int` CLI runner that imports and invokes `run_snapshot_preservation_finalization`, prints the JSON receipt to stdout, and returns `0` only when `validation_outcome == "PASS"` and `finite_outcome == "ANSWER"`.

### Testing
- Compiled the CLI with `python -m py_compile tools/air_quality/airnow_layer22_snapshot_preservation_finalization.py` and ran the smoke validations: the valid manifest run `--manifest tests/fixtures/air_quality/airnow/layer22/manifests/snapshot_preservation_finalization_valid_manifest.json` exited `0`, and the network and execution manifests exited nonzero as expected when run with `--created-at 2026-01-01T00:00:00Z` and an `--out-dir` target.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64fdf4a18832aa09c41531b0a56d3)