### PR TITLE
chore: ignore workspace node_modules directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ baseline-report.txt
 __pycache__/
 *.pyc
 *.pyo
+
+# JavaScript dependencies (keep untracked local installs out of repo status)
+node_modules/
+apps/*/node_modules/


### PR DESCRIPTION
### Motivation
- Reduce noise from local JavaScript installs by ignoring `node_modules/` and per-app `apps/*/node_modules/` in the repository ignore rules (CONFIRMED).

### Description
- Added two entries to `.gitignore`: `node_modules/` and `apps/*/node_modules/` to prevent local dependency folders from appearing as untracked files.

### Testing
- Validated with `git status --short` to confirm no unexpected untracked changes and with `git check-ignore -v apps/web/node_modules` to verify the new rule matched, and both checks succeeded (CONFIRMED).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b371f2a0832a932dad1572df6646)