### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ baseline-report.txt
 __pycache__/
 *.pyc
 *.pyo
+
+# JavaScript dependencies (matches node_modules directories repo-wide)
+node_modules/


### PR DESCRIPTION
### Motivation
- Prevent committing JavaScript dependency directories by ignoring `node_modules/` across the repository.

### Description
- Update the `.gitignore` to add a comment and the `node_modules/` pattern and include a separating blank line for readability.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b371f2a0832a932dad1572df6646)