### PR TITLE
docs: improve control-plane indexes and add ADR for authority-boundary compatibility

### DIFF
--- a/docs/adr/ADR-0012-authority-boundary-compatibility-map.md
+++ b/docs/adr/ADR-0012-authority-boundary-compatibility-map.md
@@ -1,0 +1,34 @@
+# ADR-0012: Authority Boundary Compatibility Map (`contracts/` vs `schemas/`, `policy/` vs `policies/`)
+
+- Status: proposed
+- Date: 2026-05-03
+- Deciders: KFM maintainers (pending CODEOWNERS confirmation)
+
+## Context
+
+The repository currently contains both `contracts/` and `schemas/`, and both `policy/` and `policies/`. This creates a recurring risk of accidental dual authority.
+
+## Decision (proposed)
+
+1. `schemas/` is the machine-shape authority surface. `contracts/` is semantic/narrative authority unless a later ADR grants a specific machine-contract exception.
+2. `policy/` is the active policy-authority lane in this repository revision. `policies/` is treated as compatibility/documentation-only until an explicit superseding ADR is accepted.
+3. Promotion remains a governed state transition; no directory move is treated as promotion evidence.
+
+## Compatibility map
+
+| Boundary | Current homes (CONFIRMED) | Allowed interim use | Prohibited duplication | Next decision required |
+|---|---|---|---|---|
+| Machine contract shape vs semantic contract docs | `schemas/` and `contracts/` | Cross-link both lanes and keep explicit pointers to canonical schema paths | Maintaining parallel machine-contract truth in both lanes | Accept/confirm ADR-0001 with repo-verified validators and fixtures |
+| Policy authority lane | `policy/` and `policies/` | Keep `policies/` as non-authoritative compatibility docs only | Treating both directories as simultaneous normative policy sources | Accept follow-up ADR that either retires `policies/` or formalizes migration |
+
+## Consequences
+
+- Reduces ambiguity for contributors during reorganization.
+- Preserves backward compatibility while preventing quiet authority drift.
+- Requires follow-up ADR acceptance and validation evidence before any merge/re-home operation.
+
+## Guardrails
+
+- Do not merge `contracts/` with `schemas/` in this ADR.
+- Do not merge `policy/` with `policies/` in this ADR.
+- Do not move machine contracts or policy bundles based only on this proposed note.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -76,6 +76,11 @@ This README is both a **directory landing page** and a **governance checkpoint**
 > [!WARNING]
 > A public GitHub directory listing proves file/path presence for that public snapshot only. It does not prove the active branch under review, local checkout state, hosted branch protection, required checks, secrets, deployment approvals, CI execution, emitted proof objects, dashboards, logs, or runtime behavior.
 
+### Related control-plane indexes
+
+- [`../registers/README.md`](../registers/README.md): register hub for authority ladder, drift, and verification backlog tracking.
+- [`../runbooks/README.md`](../runbooks/README.md): operator procedures for publication, correction, stale projection, and rollback actions.
+
 [Back to top](#kfm-architecture-decision-records)
 
 ---
@@ -140,6 +145,7 @@ docs/adr/
 ├── ADR-0009-sensitive-location-policy.md
 ├── ADR-0010-local-exposure-security.md
 ├── ADR-0011-catalog-proof-release-separation.md
+├── ADR-0012-authority-boundary-compatibility-map.md
 ├── ADR-0241-policy-obligation-engine-and-release-gate.md
 ├── ADR-0427-consent-vc-and-revocation-delta.md
 └── ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md

--- a/docs/registers/README.md
+++ b/docs/registers/README.md
@@ -135,6 +135,9 @@ docs/registers/
 ├── AUTHORITY_LADDER.md                   # P0: source hierarchy and conflict-resolution rules
 ├── CANONICAL_LINEAGE_EXPLORATORY.md      # P0: canon, lineage, exploratory, reference, superseded classes
 ├── DRIFT_REGISTER.md                     # P1: contradictions, overclaims, naming drift, authority gaps
+├── PMTILES_MANIFEST_REGISTER.md          # P1: map/tiles manifest lineage and drift tracking
+├── REPO_ORGANIZATION_AUDIT.md            # P1: repository structure observations and follow-up queue
+├── SOURCE_LEDGER.md                      # P0: source classes, authority role, and onboarding posture
 └── VERIFICATION_BACKLOG.md               # P1: exact evidence needed before stronger claims
 ```
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -27,6 +27,8 @@ Operator playbooks for trust-critical operational actions in Kansas Frontier Mat
 
 ## Directory map
 
+- [`../adr/README.md`](../adr/README.md): architecture decisions and authority boundaries that runbooks must obey.
+- [`../registers/README.md`](../registers/README.md): control-plane registers for drift, authority, and verification gaps.
 - [`publication.md`](./publication.md): promote and publish safely.
 - [`correction.md`](./correction.md): correct published errors with lineage.
 - [`stale_projection.md`](./stale_projection.md): handle stale derived/public projections.


### PR DESCRIPTION
### Motivation

- Reduce discoverability friction in the documentation control-plane and make registers/ADRs/runbooks easier to navigate. 
- Capture and document an existing authority ambiguity between `contracts/` vs `schemas/` and `policy/` vs `policies/` without performing any risky directory merges or moves. 
- Apply low-risk, docs-only updates to make future authoritative changes safer and easier to validate. 

### Description

- Added a proposed compatibility ADR `docs/adr/ADR-0012-authority-boundary-compatibility-map.md` that documents interim rules for `contracts/` vs `schemas/` and `policy/` vs `policies/` and includes guardrails that forbid merges/moves without ADR acceptance. 
- Updated `docs/adr/README.md` to include links to the registers and runbooks control-plane indexes and to list the new ADR in the ADR inventory. 
- Updated `docs/registers/README.md` to expand the directory tree with existing register files (`PMTILES_MANIFEST_REGISTER.md`, `REPO_ORGANIZATION_AUDIT.md`, `SOURCE_LEDGER.md`) so the register index matches the repo. 
- Updated `docs/runbooks/README.md` to cross-link to `docs/adr/README.md` and `docs/registers/README.md` to improve operator navigation; no code, schema, policy, or test files were moved or modified. 

### Testing

- Ran repository validation and inspection commands: `git status --short`, `git check-ignore -v apps/web/node_modules`, `git diff --stat`, `git diff --name-status`, and `rg -n "contracts/|schemas/|policy/|policies/" docs/adr docs/registers docs/runbooks`, and confirmed the expected file changes and that `apps/*/node_modules/` is ignored. 
- No unit tests, builds, or runtime validations were run because the changes are documentation-only and intentionally avoid touching schema/policy authority until ADRs are accepted. 
- All validation/inspection commands executed successfully and the changes were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b60fe74c832a8facc66b7c2b7c37)