### PR TITLE
docs: clarify authority-boundary ADR and register/runbook links; add truth labels and guardrails

### DIFF
--- a/docs/adr/ADR-0012-authority-boundary-compatibility-map.md
+++ b/docs/adr/ADR-0012-authority-boundary-compatibility-map.md
@@ -14,12 +14,24 @@ The repository currently contains both `contracts/` and `schemas/`, and both `po
 2. `policy/` is the active policy-authority lane in this repository revision. `policies/` is treated as compatibility/documentation-only until an explicit superseding ADR is accepted.
 3. Promotion remains a governed state transition; no directory move is treated as promotion evidence.
 
+## Truth labels used in this ADR
+
+- **CONFIRMED:** both path pairs exist in this repository revision: `contracts/` + `schemas/`, and `policy/` + `policies/`.
+- **PROPOSED:** authority assignment and interim compatibility posture below.
+- **PROHIBITED:** any change that creates dual machine-truth or dual policy-truth without explicit superseding ADR acceptance.
+
 ## Compatibility map
 
 | Boundary | Current homes (CONFIRMED) | Allowed interim use | Prohibited duplication | Next decision required |
 |---|---|---|---|---|
 | Machine contract shape vs semantic contract docs | `schemas/` and `contracts/` | Cross-link both lanes and keep explicit pointers to canonical schema paths | Maintaining parallel machine-contract truth in both lanes | Accept/confirm ADR-0001 with repo-verified validators and fixtures |
 | Policy authority lane | `policy/` and `policies/` | Keep `policies/` as non-authoritative compatibility docs only | Treating both directories as simultaneous normative policy sources | Accept follow-up ADR that either retires `policies/` or formalizes migration |
+
+## Explicit prohibited actions (until superseded)
+
+1. Copying machine schemas between `schemas/` and `contracts/` as parallel normative stores.
+2. Treating `policy/` and `policies/` as equal runtime policy authorities.
+3. Using file moves alone as evidence of promotion, release, or review completion.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -185,6 +185,16 @@ sed -n '1,160p' docs/adr/ADR-TEMPLATE.md
 
 [Back to top](#kfm-architecture-decision-records)
 
+## Authority-boundary ADR set
+
+The following ADRs should be reviewed together during reorganization work because they constrain where authority can live:
+
+- [`ADR-0001-schema-home.md`](./ADR-0001-schema-home.md) — schema-home authority for machine-checkable contracts.
+- [`ADR-0011-catalog-proof-release-separation.md`](./ADR-0011-catalog-proof-release-separation.md) — keeps catalog, proof, and release object families distinct.
+- [`ADR-0012-authority-boundary-compatibility-map.md`](./ADR-0012-authority-boundary-compatibility-map.md) — compatibility guardrails for `contracts/` vs `schemas/` and `policy/` vs `policies/`.
+
+If a proposed move or merge conflicts with these ADRs, treat that action as blocked pending explicit supersession.
+
 ---
 
 ## Usage

--- a/docs/registers/README.md
+++ b/docs/registers/README.md
@@ -19,6 +19,23 @@ notes: [Generated as a repo-ready draft from the KFM documentation-architecture 
 
 Directory landing page for KFM’s documentation registers: the control-plane records that classify authority, canon status, drift, and verification gaps.
 
+## Confirmed register inventory (checkpoint 2026-05-03)
+
+The files below are present in this repository revision and are the primary register surfaces for docs control-plane navigation:
+
+- [`AUTHORITY_LADDER.md`](./AUTHORITY_LADDER.md)
+- [`CANONICAL_LINEAGE_EXPLORATORY.md`](./CANONICAL_LINEAGE_EXPLORATORY.md)
+- [`DRIFT_REGISTER.md`](./DRIFT_REGISTER.md)
+- [`PMTILES_MANIFEST_REGISTER.md`](./PMTILES_MANIFEST_REGISTER.md)
+- [`REPO_ORGANIZATION_AUDIT.md`](./REPO_ORGANIZATION_AUDIT.md)
+- [`SOURCE_LEDGER.md`](./SOURCE_LEDGER.md)
+- [`VERIFICATION_BACKLOG.md`](./VERIFICATION_BACKLOG.md)
+
+Related control-plane indexes:
+
+- [`../adr/README.md`](../adr/README.md)
+- [`../runbooks/README.md`](../runbooks/README.md)
+
 ![Status: experimental](https://img.shields.io/badge/status-experimental-orange)
 ![Doc: README-like](https://img.shields.io/badge/doc-README--like-blue)
 ![Truth: bounded](https://img.shields.io/badge/truth-CONFIRMED%20%7C%20PROPOSED%20%7C%20UNKNOWN-2ea043)

--- a/docs/registers/VERIFICATION_BACKLOG.md
+++ b/docs/registers/VERIFICATION_BACKLOG.md
@@ -8,7 +8,7 @@ owners: TODO-NEEDS-VERIFICATION
 created: 2026-04-28
 updated: 2026-04-28
 policy_label: TODO-NEEDS-VERIFICATION
-related: [docs/registers/AUTHORITY_LADDER.md, docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md, docs/registers/DRIFT_REGISTER.md, docs/intake/IDEA_INTAKE.md, docs/runbooks/PROMOTION_GATE.md, docs/runbooks/CORRECTION_AND_ROLLBACK.md, contracts/OBJECT_MAP.md, schemas/README.md, policy/README.md, tests/README.md]
+related: [docs/registers/AUTHORITY_LADDER.md, docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md, docs/registers/DRIFT_REGISTER.md, docs/intake/IDEA_INTAKE.md, docs/runbooks/publication.md, docs/runbooks/correction.md, docs/runbooks/rollback.md, contracts/OBJECT_MAP.md, schemas/README.md, policy/README.md, tests/README.md]
 tags: [kfm, verification, backlog, governance, evidence, control-plane]
 notes: [Draft register for docs/registers/VERIFICATION_BACKLOG.md. doc_id, owners, policy_label, active-branch path existence, and related-link validity require direct repo verification before merge. created/updated dates reflect draft generation date and should be reconciled with commit history if different.]
 [/KFM_META_BLOCK_V2] -->
@@ -68,8 +68,8 @@ It exists to prevent three failure modes:
 | Sibling | `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md` | Classifies canon, lineage, exploratory inputs, emitted artifacts, and proof families. |
 | Sibling | `docs/registers/DRIFT_REGISTER.md` | Records contradictions, naming drift, source drift, schema drift, and path drift. |
 | Upstream | `docs/intake/IDEA_INTAKE.md` | Sends `REPO VERIFY`, `EVIDENCE GAP`, and `ADR CANDIDATE` items here. |
-| Upstream | `docs/runbooks/PROMOTION_GATE.md` | Uses this backlog to block release claims that still lack proof. |
-| Upstream | `docs/runbooks/CORRECTION_AND_ROLLBACK.md` | Uses this backlog when withdrawal, supersession, or rollback exposes unresolved proof gaps. |
+| Upstream | `docs/runbooks/publication.md` | Uses this backlog to block release claims that still lack proof. |
+| Upstream | `docs/runbooks/correction.md` and `docs/runbooks/rollback.md` | Uses this backlog when withdrawal, supersession, or rollback exposes unresolved proof gaps. |
 | Downstream | `contracts/OBJECT_MAP.md` | Retires object-family ambiguity by defining semantic objects and lifecycle roles. |
 | Downstream | `schemas/README.md` | Retires executable shape and schema-home ambiguity. |
 | Downstream | `policy/README.md` | Retires fail-closed, rights, sensitivity, AI-runtime, and promotion-policy uncertainty. |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -46,6 +46,13 @@ Operator playbooks for trust-critical operational actions in Kansas Frontier Mat
 3. Preserve auditability: correction/supersession history must remain visible.
 4. Do not treat projections, summaries, or generated text as canonical truth.
 
+## Validation entrypoints (confirmed paths)
+
+- Python test discovery: [`../../pytest.ini`](../../pytest.ini)
+- Pytest suites: [`../../tests/`](../../tests/)
+- Web app tests (vitest script): [`../../apps/web/package.json`](../../apps/web/package.json)
+- Governance/policy tests: [`../../tests/policy/`](../../tests/policy/) and [`../../policy/tests/`](../../policy/tests/)
+
 ## Minimum runbook shape
 
 Each runbook in this directory should include:

--- a/docs/runbooks/reliability/README.md
+++ b/docs/runbooks/reliability/README.md
@@ -8,7 +8,7 @@ owners: NEEDS-VERIFICATION
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 policy_label: NEEDS-VERIFICATION
-related: [docs/runbooks/PROMOTION_GATE.md, docs/runbooks/CORRECTION_AND_ROLLBACK.md, docs/registers/VERIFICATION_BACKLOG.md, data/receipts/, data/proofs/, policy/]
+related: [docs/runbooks/publication.md, docs/runbooks/correction.md, docs/runbooks/rollback.md, docs/registers/VERIFICATION_BACKLOG.md, data/receipts/, data/proofs/, policy/]
 tags: [kfm, runbook, reliability, operations, observability, rollback]
 notes: [Repo-ready draft generated from attached KFM doctrine. Actual doc_id, owners, dates, policy label, adjacent paths, workflows, dashboards, emitted artifacts, and runtime maturity remain NEEDS VERIFICATION.]
 [/KFM_META_BLOCK_V2] -->
@@ -65,8 +65,8 @@ This README is a **directory landing page**, not a release record and not a repl
 | Local path | `docs/runbooks/reliability/README.md` | `PROPOSED` | Target file requested for this run. |
 | Docs landing | [`../../README.md`](../../README.md) | `NEEDS VERIFICATION` | Should orient readers to canonical docs, registers, and runbooks. |
 | Runbooks landing | [`../README.md`](../README.md) | `NEEDS VERIFICATION` | Should list operational runbooks as a family. |
-| Promotion gate | [`../PROMOTION_GATE.md`](../PROMOTION_GATE.md) | `PROPOSED / NEEDS VERIFICATION` | Release reliability depends on promotion evidence, not deployment success alone. |
-| Correction and rollback | [`../CORRECTION_AND_ROLLBACK.md`](../CORRECTION_AND_ROLLBACK.md) | `PROPOSED / NEEDS VERIFICATION` | Reliability recovery must preserve visible lineage. |
+| Promotion gate | [`../publication.md`](../publication.md) | `CONFIRMED path / content status may vary` | Release reliability depends on promotion evidence, not deployment success alone. |
+| Correction and rollback | [`../correction.md`](../correction.md) + [`../rollback.md`](../rollback.md) | `CONFIRMED path / content status may vary` | Reliability recovery must preserve visible lineage. |
 | Verification backlog | [`../../registers/VERIFICATION_BACKLOG.md`](../../registers/VERIFICATION_BACKLOG.md) | `NEEDS VERIFICATION` | Unverified reliability surfaces should become concrete checks. |
 | Policy | [`../../../policy/README.md`](../../../policy/README.md) | `NEEDS VERIFICATION` | Deny, abstain, release, sensitivity, and rights decisions should stay executable. |
 | Receipts | [`../../../data/receipts/README.md`](../../../data/receipts/README.md) | `NEEDS VERIFICATION` | Process memory belongs with emitted receipt surfaces, not in prose only. |


### PR DESCRIPTION
### Motivation

- Make authority boundaries explicit for `contracts/` vs `schemas/` and `policy/` vs `policies/` to avoid dual-authority drift. 
- Surface repository-confirmed register and validation entrypoints so runbooks and registers can point to concrete control-plane surfaces. 
- Tighten governance language with explicit prohibited actions and truth labels to reduce ambiguous promotion or migration semantics. 

### Description

- Extended `docs/adr/ADR-0012-authority-boundary-compatibility-map.md` with a "Truth labels used in this ADR" section and an "Explicit prohibited actions" list, and adjusted compatibility/guardrail wording. 
- Added an "Authority-boundary ADR set" section to `docs/adr/README.md` linking related ADRs and calling out review dependencies. 
- Updated `docs/registers/README.md` to include a confirmed register inventory checkpoint and related control-plane indexes. 
- Modified `docs/registers/VERIFICATION_BACKLOG.md`, `docs/runbooks/README.md`, and `docs/runbooks/reliability/README.md` to fix and standardize related links, rename upstream runbook targets (`publication.md`, `correction.md`, `rollback.md`), and add validation entrypoints (pytest, vitest, and policy test locations). 

### Testing

- No automated tests were executed because these are documentation-only changes and do not affect runtime code or test fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b8af2228832a85eb54ef1dbaae64)