### PR TITLE
Docs: ADRs for authority boundaries and policy-home; add validation entrypoints and register updates

### DIFF
--- a/docs/adr/ADR-0012-authority-boundary-compatibility-map.md
+++ b/docs/adr/ADR-0012-authority-boundary-compatibility-map.md
@@ -14,12 +14,24 @@ The repository currently contains both `contracts/` and `schemas/`, and both `po
 2. `policy/` is the active policy-authority lane in this repository revision. `policies/` is treated as compatibility/documentation-only until an explicit superseding ADR is accepted.
 3. Promotion remains a governed state transition; no directory move is treated as promotion evidence.
 
+## Truth labels used in this ADR
+
+- **CONFIRMED:** both path pairs exist in this repository revision: `contracts/` + `schemas/`, and `policy/` + `policies/`.
+- **PROPOSED:** authority assignment and interim compatibility posture below.
+- **PROHIBITED:** any change that creates dual machine-truth or dual policy-truth without explicit superseding ADR acceptance.
+
 ## Compatibility map
 
 | Boundary | Current homes (CONFIRMED) | Allowed interim use | Prohibited duplication | Next decision required |
 |---|---|---|---|---|
 | Machine contract shape vs semantic contract docs | `schemas/` and `contracts/` | Cross-link both lanes and keep explicit pointers to canonical schema paths | Maintaining parallel machine-contract truth in both lanes | Accept/confirm ADR-0001 with repo-verified validators and fixtures |
-| Policy authority lane | `policy/` and `policies/` | Keep `policies/` as non-authoritative compatibility docs only | Treating both directories as simultaneous normative policy sources | Accept follow-up ADR that either retires `policies/` or formalizes migration |
+| Policy authority lane | `policy/` and `policies/` | Keep `policies/` as non-authoritative compatibility docs only | Treating both directories as simultaneous normative policy sources | Resolve via ADR-0013 (`policy/` canonical; `policies/` compatibility-only) |
+
+## Explicit prohibited actions (until superseded)
+
+1. Copying machine schemas between `schemas/` and `contracts/` as parallel normative stores.
+2. Treating `policy/` and `policies/` as equal runtime policy authorities.
+3. Using file moves alone as evidence of promotion, release, or review completion.
 
 ## Consequences
 

--- a/docs/adr/ADR-0013-policy-home-authority.md
+++ b/docs/adr/ADR-0013-policy-home-authority.md
@@ -1,0 +1,33 @@
+# ADR-0013: Policy Home Authority (`policy/` canonical, `policies/` compatibility-only)
+
+- Status: proposed
+- Date: 2026-05-03
+- Deciders: KFM maintainers (pending CODEOWNERS confirmation)
+
+## Context
+
+This repository contains both `policy/` and `policies/`. Leaving both as normative policy homes creates dual-authority risk for runtime enforcement and review.
+
+## Decision (proposed)
+
+1. `policy/` is the canonical home for executable policy authority in this revision.
+2. `policies/` is compatibility/documentation-only until a superseding ADR authorizes migration.
+3. No policy release/promotion evidence is inferred from directory moves alone.
+
+## Compatibility map
+
+| Concern | Canonical home | Interim allowed use | Prohibited |
+|---|---|---|---|
+| Executable policy bundles, tests, and enforcement-facing policy references | `policy/` | Cross-link from `policies/` docs to canonical `policy/` paths | Parallel normative policy definitions in both trees |
+| Human-facing compatibility notes | `policies/` | Keep explanatory docs that reference canonical policy artifacts | Storing authoritative executable policy only in `policies/` |
+
+## Next decision required
+
+- Accept or supersede this ADR after maintainers confirm migration/deprecation timing for `policies/`.
+- Update docs/registers backlog row `VFY-005` closure evidence once this ADR is accepted.
+
+## Guardrails
+
+- Do not merge `policy/` and `policies/` in this ADR.
+- Do not move policy bundles solely to satisfy naming symmetry.
+- Do not claim runtime-policy equivalence for both directories.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -185,6 +185,17 @@ sed -n '1,160p' docs/adr/ADR-TEMPLATE.md
 
 [Back to top](#kfm-architecture-decision-records)
 
+## Authority-boundary ADR set
+
+The following ADRs should be reviewed together during reorganization work because they constrain where authority can live:
+
+- [`ADR-0001-schema-home.md`](./ADR-0001-schema-home.md) — schema-home authority for machine-checkable contracts.
+- [`ADR-0011-catalog-proof-release-separation.md`](./ADR-0011-catalog-proof-release-separation.md) — keeps catalog, proof, and release object families distinct.
+- [`ADR-0012-authority-boundary-compatibility-map.md`](./ADR-0012-authority-boundary-compatibility-map.md) — compatibility guardrails for `contracts/` vs `schemas/` and `policy/` vs `policies/`.
+- [`ADR-0013-policy-home-authority.md`](./ADR-0013-policy-home-authority.md) — proposed canonical policy-home decision (`policy/`) and compatibility posture for `policies/`.
+
+If a proposed move or merge conflicts with these ADRs, treat that action as blocked pending explicit supersession.
+
 ---
 
 ## Usage
@@ -270,6 +281,7 @@ This inventory reflects file presence in the public GitHub snapshot checked duri
 | [`ADR-0009-sensitive-location-policy.md`](./ADR-0009-sensitive-location-policy.md) | Sensitive-location policy | File present; status `NEEDS REVIEW` before relying on it |
 | [`ADR-0010-local-exposure-security.md`](./ADR-0010-local-exposure-security.md) | Local exposure and security | File present; status `NEEDS REVIEW` before relying on it |
 | [`ADR-0011-catalog-proof-release-separation.md`](./ADR-0011-catalog-proof-release-separation.md) | Catalog/proof/release separation | File present; status `NEEDS REVIEW` before relying on it |
+| [`ADR-0013-policy-home-authority.md`](./ADR-0013-policy-home-authority.md) | Canonical policy home authority (`policy/` vs `policies/`) | File present; status `proposed`; acceptance evidence still required |
 | [`ADR-0241-policy-obligation-engine-and-release-gate.md`](./ADR-0241-policy-obligation-engine-and-release-gate.md) | Policy obligation engine and release gate | File present; status `NEEDS REVIEW` before relying on it |
 | [`ADR-0427-consent-vc-and-revocation-delta.md`](./ADR-0427-consent-vc-and-revocation-delta.md) | Consent, verifiable credentials, and revocation delta | File present; status `NEEDS REVIEW` before relying on it |
 | [`ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md`](./ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md) | PROV/STAC/DCAT catalog mapping | File present; status `NEEDS REVIEW` before relying on it |

--- a/docs/registers/README.md
+++ b/docs/registers/README.md
@@ -19,6 +19,24 @@ notes: [Generated as a repo-ready draft from the KFM documentation-architecture 
 
 Directory landing page for KFM’s documentation registers: the control-plane records that classify authority, canon status, drift, and verification gaps.
 
+## Confirmed register inventory (checkpoint 2026-05-03)
+
+The files below are present in this repository revision and are the primary register surfaces for docs control-plane navigation:
+
+- [`AUTHORITY_LADDER.md`](./AUTHORITY_LADDER.md)
+- [`CANONICAL_LINEAGE_EXPLORATORY.md`](./CANONICAL_LINEAGE_EXPLORATORY.md)
+- [`DRIFT_REGISTER.md`](./DRIFT_REGISTER.md)
+- [`PMTILES_MANIFEST_REGISTER.md`](./PMTILES_MANIFEST_REGISTER.md)
+- [`REPO_ORGANIZATION_AUDIT.md`](./REPO_ORGANIZATION_AUDIT.md)
+- [`SOURCE_LEDGER.md`](./SOURCE_LEDGER.md)
+- [`VERIFICATION_BACKLOG.md`](./VERIFICATION_BACKLOG.md)
+
+Related control-plane indexes:
+
+- [`../adr/README.md`](../adr/README.md)
+- [`../runbooks/README.md`](../runbooks/README.md)
+- [`../runbooks/validation-entrypoints.md`](../runbooks/validation-entrypoints.md)
+
 ![Status: experimental](https://img.shields.io/badge/status-experimental-orange)
 ![Doc: README-like](https://img.shields.io/badge/doc-README--like-blue)
 ![Truth: bounded](https://img.shields.io/badge/truth-CONFIRMED%20%7C%20PROPOSED%20%7C%20UNKNOWN-2ea043)
@@ -155,7 +173,7 @@ Use these checks before editing or reviewing this directory.
 find docs/registers -maxdepth 1 -type f | sort
 
 # Find unresolved review markers in this register surface.
-grep -RInE 'TODO|NEEDS VERIFICATION|UNKNOWN|CONFLICTED|PROPOSED' docs/registers || true
+rg -n 'TODO|NEEDS VERIFICATION|UNKNOWN|CONFLICTED|PROPOSED' docs/registers || true
 
 # Confirm this README has exactly one H1.
 grep -RIn '^# ' docs/registers/README.md

--- a/docs/registers/VERIFICATION_BACKLOG.md
+++ b/docs/registers/VERIFICATION_BACKLOG.md
@@ -8,7 +8,7 @@ owners: TODO-NEEDS-VERIFICATION
 created: 2026-04-28
 updated: 2026-04-28
 policy_label: TODO-NEEDS-VERIFICATION
-related: [docs/registers/AUTHORITY_LADDER.md, docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md, docs/registers/DRIFT_REGISTER.md, docs/intake/IDEA_INTAKE.md, docs/runbooks/PROMOTION_GATE.md, docs/runbooks/CORRECTION_AND_ROLLBACK.md, contracts/OBJECT_MAP.md, schemas/README.md, policy/README.md, tests/README.md]
+related: [docs/registers/AUTHORITY_LADDER.md, docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md, docs/registers/DRIFT_REGISTER.md, docs/intake/IDEA_INTAKE.md, docs/runbooks/publication.md, docs/runbooks/correction.md, docs/runbooks/rollback.md, contracts/OBJECT_MAP.md, schemas/README.md, policy/README.md, tests/README.md]
 tags: [kfm, verification, backlog, governance, evidence, control-plane]
 notes: [Draft register for docs/registers/VERIFICATION_BACKLOG.md. doc_id, owners, policy_label, active-branch path existence, and related-link validity require direct repo verification before merge. created/updated dates reflect draft generation date and should be reconciled with commit history if different.]
 [/KFM_META_BLOCK_V2] -->
@@ -68,8 +68,8 @@ It exists to prevent three failure modes:
 | Sibling | `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md` | Classifies canon, lineage, exploratory inputs, emitted artifacts, and proof families. |
 | Sibling | `docs/registers/DRIFT_REGISTER.md` | Records contradictions, naming drift, source drift, schema drift, and path drift. |
 | Upstream | `docs/intake/IDEA_INTAKE.md` | Sends `REPO VERIFY`, `EVIDENCE GAP`, and `ADR CANDIDATE` items here. |
-| Upstream | `docs/runbooks/PROMOTION_GATE.md` | Uses this backlog to block release claims that still lack proof. |
-| Upstream | `docs/runbooks/CORRECTION_AND_ROLLBACK.md` | Uses this backlog when withdrawal, supersession, or rollback exposes unresolved proof gaps. |
+| Upstream | `docs/runbooks/publication.md` | Uses this backlog to block release claims that still lack proof. |
+| Upstream | `docs/runbooks/correction.md` and `docs/runbooks/rollback.md` | Uses this backlog when withdrawal, supersession, or rollback exposes unresolved proof gaps. |
 | Downstream | `contracts/OBJECT_MAP.md` | Retires object-family ambiguity by defining semantic objects and lifecycle roles. |
 | Downstream | `schemas/README.md` | Retires executable shape and schema-home ambiguity. |
 | Downstream | `policy/README.md` | Retires fail-closed, rights, sensitivity, AI-runtime, and promotion-policy uncertainty. |
@@ -200,7 +200,7 @@ flowchart LR
 | `VFY-002` | CODEOWNERS, branch protection, rulesets, environments, and required checks | `NEEDS VERIFICATION` | `B0` ownership and enforcement claims | Inspect `.github/CODEOWNERS`, repository rulesets, branch protections, environments, and required check settings. | Governance evidence note; update authority/ownership docs. |
 | `VFY-003` | Workflow YAML inventory and merge-gate reality | `NEEDS VERIFICATION` | `B1` automation claims | Inventory `.github/workflows/*.yml` or `*.yaml`; distinguish active, drafted, historical, and README-only workflows. | Workflow inventory table plus CI run evidence where available. |
 | `VFY-004` | Package manager, language stack, and test runner | `UNKNOWN` | `B1` executable instructions | Inspect lockfiles, package files, CI configs, Makefile, test configs, and app/package boundaries. | Runtime/tooling summary in repo map or relevant README. |
-| `VFY-005` | Schema-home authority: `contracts/` vs `schemas/` vs `schemas/contracts/v1/` | `CONFLICTED` | `B1` contract/schema claims | Inspect current tree and docs; decide semantic vs executable authority. | ADR and updated `contracts/OBJECT_MAP.md` / schema README. |
+| `VFY-005` | Schema/policy authority closure: `contracts/` vs `schemas/` and `policy/` vs `policies/` | `CONFLICTED` | `B1` contract/schema/policy claims | Inspect current tree and docs; decide semantic vs executable authority and policy home. | Accepted ADR-0001 + ADR-0013, updated `contracts/OBJECT_MAP.md`/schema README, and documented policy-home compatibility map. |
 | `VFY-006` | Public clients cannot reach `RAW`, `WORK`, `QUARANTINE`, canonical stores, or direct model runtime | `NEEDS VERIFICATION` | `B0` trust membrane | Inspect routes, client code, deployment config, CORS/proxy rules, and tests. | No-forbidden-path test or security boundary note. |
 | `VFY-007` | Source of truth for promotion state | `NEEDS VERIFICATION` | `B0` publication claims | Inspect promotion gate docs, release manifests, policy inputs, review records, and emitted decision objects. | Promotion-state ADR or runbook update. |
 | `VFY-008` | Correction and rollback mechanics preserve history | `NEEDS VERIFICATION` | `B0` release/correction claims | Inspect correction tests, rollback references, release history, cache invalidation, and withdrawal flow. | Correction drill evidence or rollback runbook update. |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -38,6 +38,7 @@ Operator playbooks for trust-critical operational actions in Kansas Frontier Mat
 - [`foundation-strategy.md`](./foundation-strategy.md): strategic sequencing guidance.
 - [`markdown-remediation-plan.md`](./markdown-remediation-plan.md): docs cleanup process.
 - [`markdown-debt-backlog.md`](./markdown-debt-backlog.md): debt tracking and triage backlog.
+- [`validation-entrypoints.md`](./validation-entrypoints.md): quick validation command/index reference.
 
 ## Operating expectations
 
@@ -45,6 +46,14 @@ Operator playbooks for trust-critical operational actions in Kansas Frontier Mat
 2. Keep every runbook reversible and validation-backed.
 3. Preserve auditability: correction/supersession history must remain visible.
 4. Do not treat projections, summaries, or generated text as canonical truth.
+
+## Validation entrypoints (confirmed paths)
+
+- Python test discovery: [`../../pytest.ini`](../../pytest.ini)
+- Pytest suites: [`../../tests/`](../../tests/)
+- Web app tests (vitest script): [`../../apps/web/package.json`](../../apps/web/package.json)
+- Governance/policy tests: [`../../tests/policy/`](../../tests/policy/) and [`../../policy/tests/`](../../policy/tests/)
+- Consolidated validation quick reference: [`validation-entrypoints.md`](./validation-entrypoints.md)
 
 ## Minimum runbook shape
 

--- a/docs/runbooks/reliability/README.md
+++ b/docs/runbooks/reliability/README.md
@@ -8,7 +8,7 @@ owners: NEEDS-VERIFICATION
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 policy_label: NEEDS-VERIFICATION
-related: [docs/runbooks/PROMOTION_GATE.md, docs/runbooks/CORRECTION_AND_ROLLBACK.md, docs/registers/VERIFICATION_BACKLOG.md, data/receipts/, data/proofs/, policy/]
+related: [docs/runbooks/publication.md, docs/runbooks/correction.md, docs/runbooks/rollback.md, docs/registers/VERIFICATION_BACKLOG.md, data/receipts/, data/proofs/, policy/]
 tags: [kfm, runbook, reliability, operations, observability, rollback]
 notes: [Repo-ready draft generated from attached KFM doctrine. Actual doc_id, owners, dates, policy label, adjacent paths, workflows, dashboards, emitted artifacts, and runtime maturity remain NEEDS VERIFICATION.]
 [/KFM_META_BLOCK_V2] -->
@@ -65,8 +65,8 @@ This README is a **directory landing page**, not a release record and not a repl
 | Local path | `docs/runbooks/reliability/README.md` | `PROPOSED` | Target file requested for this run. |
 | Docs landing | [`../../README.md`](../../README.md) | `NEEDS VERIFICATION` | Should orient readers to canonical docs, registers, and runbooks. |
 | Runbooks landing | [`../README.md`](../README.md) | `NEEDS VERIFICATION` | Should list operational runbooks as a family. |
-| Promotion gate | [`../PROMOTION_GATE.md`](../PROMOTION_GATE.md) | `PROPOSED / NEEDS VERIFICATION` | Release reliability depends on promotion evidence, not deployment success alone. |
-| Correction and rollback | [`../CORRECTION_AND_ROLLBACK.md`](../CORRECTION_AND_ROLLBACK.md) | `PROPOSED / NEEDS VERIFICATION` | Reliability recovery must preserve visible lineage. |
+| Promotion gate | [`../publication.md`](../publication.md) | `CONFIRMED path / content status may vary` | Release reliability depends on promotion evidence, not deployment success alone. |
+| Correction and rollback | [`../correction.md`](../correction.md) + [`../rollback.md`](../rollback.md) | `CONFIRMED path / content status may vary` | Reliability recovery must preserve visible lineage. |
 | Verification backlog | [`../../registers/VERIFICATION_BACKLOG.md`](../../registers/VERIFICATION_BACKLOG.md) | `NEEDS VERIFICATION` | Unverified reliability surfaces should become concrete checks. |
 | Policy | [`../../../policy/README.md`](../../../policy/README.md) | `NEEDS VERIFICATION` | Deny, abstain, release, sensitivity, and rights decisions should stay executable. |
 | Receipts | [`../../../data/receipts/README.md`](../../../data/receipts/README.md) | `NEEDS VERIFICATION` | Process memory belongs with emitted receipt surfaces, not in prose only. |
@@ -74,7 +74,7 @@ This README is a **directory landing page**, not a release record and not a repl
 | CI workflows | `../../../.github/workflows/` | `NEEDS VERIFICATION` | Workflow maturity must be confirmed from actual files and runs. |
 
 > [!WARNING]
-> Link targets above are doctrine-aligned and repo-plausible, but this draft does not prove they exist in the current branch. Verify targets before merging or replace missing links with tracked TODOs.
+> Link targets above should be revalidated whenever files are moved or renamed. Keep this table synchronized with current repository paths.
 
 [Back to top](#top)
 
@@ -174,7 +174,7 @@ find .github docs contracts schemas policy data tools tests apps packages infra 
   -maxdepth 3 -type f 2>/dev/null | sort | sed -n '1,250p'
 
 # Look for reliability-relevant object families.
-grep -RInE \
+rg -n \
   'run_receipt|ReleaseManifest|EvidenceBundle|DecisionEnvelope|CorrectionNotice|ValidationReport|audit_ref|request_id|rollback|stale|ABSTAIN|DENY|ERROR' \
   docs contracts schemas policy data tools tests apps packages 2>/dev/null | sed -n '1,200p'
 ```

--- a/docs/runbooks/validation-entrypoints.md
+++ b/docs/runbooks/validation-entrypoints.md
@@ -1,0 +1,22 @@
+# Validation Entrypoints
+
+Quick-reference for running repository validation checks without searching across multiple docs.
+
+## Core entrypoints (CONFIRMED in this repo)
+
+- Python test configuration: `pytest.ini`
+- Python tests root: `tests/`
+- Web test script: `apps/web/package.json` (`npm run test`)
+- Policy-focused tests: `tests/policy/` and `policy/tests/`
+
+## Recommended quick checks
+
+```bash
+pytest --collect-only -q
+npm --prefix apps/web run test -- --run
+```
+
+## Notes
+
+- These commands are discoverability entrypoints, not full release qualification.
+- Promotion remains governed by policy/review/release gates and evidence artifacts.


### PR DESCRIPTION
### Motivation

- Reduce ambiguity and accidental dual-authority between `contracts/` vs `schemas/` and `policy/` vs `policies/` during repo reorganization. 
- Declare a clear interim compatibility posture and prohibit dangerous duplication of machine or policy truth. 
- Establish `policy/` as the canonical runtime policy home and provide an explicit ADR to capture that decision. 
- Improve discoverability of validation commands and nearby control-plane registers for maintainers and reviewers.

### Description

- Updated `docs/adr/ADR-0012-authority-boundary-compatibility-map.md` to add truth labels, explicit prohibited actions, and a clarified compatibility map for schema and policy boundaries. 
- Added new ADR `docs/adr/ADR-0013-policy-home-authority.md` to designate `policy/` as canonical and `policies/` as compatibility/documentation-only with guardrails and a next-decision path. 
- Updated `docs/adr/README.md`, `docs/registers/README.md`, and related register files to include the new ADRs and a confirmed register inventory and to adjust related link targets. 
- Added `docs/runbooks/validation-entrypoints.md` and small runbook/readme edits to surface quick validation commands and to switch a few shell snippets to `rg` for discovery convenience.

### Testing

- No automated tests or CI jobs were modified or executed as part of this documentation-only change. 
- This PR did not run repository test suites, but the new `validation-entrypoints.md` recommends running `pytest --collect-only -q` and `npm --prefix apps/web run test -- --run` as quick checks. 
- Documentation build/lint steps were not run in this change and should be validated in CI after merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b8af2228832a85eb54ef1dbaae64)