### PR TITLE
docs: add root-level organization recommendations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ tests/                            # NEEDS VERIFICATION
 
 ---
 
+
+## Root organization opportunities
+
+Based on the current root layout, the following changes would improve maintainability:
+
+1. **Create a `docs/` home and move narrative policy/process docs there** (keep machine-enforced policy in `policy/` and machine contracts in `schemas/`).
+2. **Consolidate overlapping output/state directories** such as `runtime_outcome/`, `policy_distribution/`, and `data_use_response/` under a single `artifacts/` or `out/` convention.
+3. **Split `tools/` into clearer sub-domains** (for example `tools/policy/`, `tools/data/`, `tools/release/`, `tools/ops/`) to reduce discoverability friction across dozens of tool namespaces.
+4. **Add root-level ownership and contribution entrypoints** (`CODEOWNERS`, `CONTRIBUTING.md`, and `docs/ARCHITECTURE.md`) so new contributors can locate decision authority quickly.
+5. **Introduce a root index for major directory intent** (a small table in this README) mapping each top-level directory to purpose, primary maintainer group, and stability level.
+
 ## Accepted inputs
 
 KFM input classes should be admitted only through source-aware, policy-aware intake.


### PR DESCRIPTION
### Motivation
- The repository root contains many top-level directories and overlapping output/tool namespaces which reduce discoverability and maintainability. 
- A compact, actionable guidance section in the root `README.md` helps maintainers prioritize structural cleanup before larger refactors.

### Description
- Added a new `## Root organization opportunities` section to the root `README.md` with five concise recommendations for organizing the repository root. 
- Recommendations include creating a `docs/` narrative home, consolidating overlapping output/state directories under an `artifacts/` or `out/` convention, and splitting `tools/` into clearer sub-domains. 
- The section also suggests adding root-level contributor entrypoints (`CODEOWNERS`, `CONTRIBUTING.md`, `docs/ARCHITECTURE.md`) and a root index mapping top-level directories to intent and ownership.

### Testing
- Inspected repository layout with `find . -maxdepth 2 -mindepth 1 -type d` to enumerate top-level directories and confirm the need for consolidation, which completed successfully. 
- Verified the edited `README.md` content with `sed -n '1,220p' README.md` and `nl -ba README.md | sed -n '148,160p'`, both of which returned the updated section as expected. 
- Executed the in-place update script via `python - <<'PY'` to insert the new recommendations into `README.md` and validated the change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f761238cf4832a880a45cbc885f9d7)