### PR TITLE
docs: refresh bootstrap inspection evidence for current run

### DIFF
--- a/docs/reports/bootstrap-repo-inspection.md
+++ b/docs/reports/bootstrap-repo-inspection.md
@@ -1,23 +1,40 @@
 # Bootstrap Repo Inspection
 
+## Truth posture
+- **CONFIRMED**: Command outputs captured in this Codex session.
+- **NEEDS VERIFICATION**: PDF corpus was not directly inspectable in mounted workspace.
+
 ## Commands run
-- pwd
-- git status --short || true
-- git branch --show-current || true
-- git rev-parse --show-toplevel || true
-- find ... (as requested)
+1. `pwd`
+2. `git status --short || true`
+3. `git branch --show-current || true`
+4. `git rev-parse --show-toplevel || true`
+5. `find . -maxdepth 2 -type f | sort | head -200`
+6. `find . -maxdepth 2 -type d | sort | head -200`
+7. `find . -maxdepth 3 \( -name package.json -o -name pyproject.toml -o -name go.mod -o -name Cargo.toml -o -name Makefile -o -name README.md \) -print`
+8. `find . -maxdepth 4 -type f \( -path "*/docs/*" -o -path "*/schemas/*" -o -path "*/contracts/*" -o -path "*/policy/*" -o -path "*/tests/*" -o -path "*/apps/*" -o -path "*/packages/*" \) | sort | head -300`
 
-## Results
-Existing repo detected (git present, existing apps/).
+## Results (abridged)
+- `pwd` => `/workspace/Kansas-Frontier-Matrix`.
+- Branch => `work`.
+- Git toplevel => `/workspace/Kansas-Frontier-Matrix`.
+- `git status --short` => clean working tree at inspection time.
+- Repository is **existing**, not empty: governance/control-plane/docs/schemas/contracts/tests/apps/tools already present.
 
-## Stack evidence
-Python baseline tooling and unittest.
+## Package manager / stack evidence
+- Python stdlib-based validation and unittest baseline is present (`tools/*.py`, `tests/*.py`).
+- `pyproject.toml` exists for lightweight project metadata.
+- No internet-required baseline dependency was needed for validation in this run.
 
 ## Source PDF availability
-No PDFs found in mounted workspace during this run (NEEDS VERIFICATION).
+- The requested KFM PDFs were **not directly inspected** in this mounted workspace during this session.
+- Source-ledger entries should remain **NEEDS VERIFICATION** for those IDs until files are mounted and checked.
 
 ## Unknowns
-Whether missing PDFs exist outside mounted path.
+- Whether the referenced PDFs exist outside currently mounted paths.
+- Whether external source terms/rights constraints are complete for live connector activation.
 
-## Adaptation
-Preserved existing files and added governance-first baseline structure and synthetic fixtures.
+## Adaptation taken
+- Preserved existing repository structure and conventions.
+- Verified baseline governance membrane and hydrology synthetic slice via local no-network validators/tests.
+- Kept implementation posture evidence-first, map-first, time-aware, fail-closed, and release-auditable.


### PR DESCRIPTION
### Motivation
- Capture a session-grounded bootstrap inspection with explicit truth-posture so future reviewers can distinguish `CONFIRMED` outputs from `NEEDS VERIFICATION` claims.
- Record the exact inspection commands and observed repo state and note that the requested KFM PDF corpus was not directly inspectable in this run (therefore `NEEDS VERIFICATION`).

### Description
- Update `docs/reports/bootstrap-repo-inspection.md` to add a `## Truth posture` section, a numbered command list of the inspection steps, concrete abridged results, stack/package evidence, unknowns, and adaptation notes.
- This change is documentation-only and preserves the existing responsibility-root monorepo baseline and the no-network governance-first posture.

### Testing
- Ran repository validation and test suite: `python tools/validate_repo.py`, `python tools/validate_fixtures.py`, `python tools/check_directory_rules.py`, `python tools/check_no_public_internal_paths.py`, `python -m unittest discover -s tests`, and `bash scripts/validate_all.sh`, all of which passed (`OK`).
- The update does not change executable code or fixtures and left existing tests and validation tooling passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f8cb7fac832a89ff1db96d17cada)