### PR TITLE
Tighten public-fixture path checks and add hydrology inspection report

### DIFF
--- a/docs/reports/bootstrap-repo-inspection.md
+++ b/docs/reports/bootstrap-repo-inspection.md
@@ -1,40 +1,46 @@
-# Bootstrap Repo Inspection
+# Bootstrap Repo Inspection (Prompt 1 Reconciliation)
 
-## Truth posture
-- **CONFIRMED**: Command outputs captured in this Codex session.
-- **NEEDS VERIFICATION**: PDF corpus was not directly inspectable in mounted workspace.
+Truth posture: **CONFIRMED** for commands and repository state observed in this Codex session on 2026-05-05 (UTC).
 
 ## Commands run
-1. `pwd`
-2. `git status --short || true`
-3. `git branch --show-current || true`
-4. `git rev-parse --show-toplevel || true`
-5. `find . -maxdepth 2 -type f | sort | head -200`
-6. `find . -maxdepth 2 -type d | sort | head -200`
-7. `find . -maxdepth 3 \( -name package.json -o -name pyproject.toml -o -name go.mod -o -name Cargo.toml -o -name Makefile -o -name README.md \) -print`
-8. `find . -maxdepth 4 -type f \( -path "*/docs/*" -o -path "*/schemas/*" -o -path "*/contracts/*" -o -path "*/policy/*" -o -path "*/tests/*" -o -path "*/apps/*" -o -path "*/packages/*" \) | sort | head -300`
 
-## Results (abridged)
-- `pwd` => `/workspace/Kansas-Frontier-Matrix`.
-- Branch => `work`.
-- Git toplevel => `/workspace/Kansas-Frontier-Matrix`.
-- `git status --short` => clean working tree at inspection time.
-- Repository is **existing**, not empty: governance/control-plane/docs/schemas/contracts/tests/apps/tools already present.
+```bash
+pwd
+git status --short || true
+git branch --show-current || true
+git rev-parse --show-toplevel || true
+find . -maxdepth 2 -type f | sort | head -200
+find . -maxdepth 2 -type d | sort | head -200
+find . -maxdepth 3 \( -name package.json -o -name pyproject.toml -o -name go.mod -o -name Cargo.toml -o -name Makefile -o -name README.md \) -print
+find . -maxdepth 4 -type f \( -path '*/docs/*' -o -path '*/schemas/*' -o -path '*/contracts/*' -o -path '*/policy/*' -o -path '*/tests/*' -o -path '*/apps/*' -o -path '*/packages/*' \) | sort | head -300
+```
+
+## Results summary
+
+- Repository path: `/workspace/Kansas-Frontier-Matrix` (**CONFIRMED**).
+- Branch: `work` (**CONFIRMED**).
+- Repository type: **existing repository**, not empty (**CONFIRMED**).
+- Existing structure already includes responsibility roots required by KFM baseline (`docs/`, `control_plane/`, `contracts/`, `schemas/`, `policy/`, `data/`, `tests/`, `tools/`, etc.) (**CONFIRMED**).
+- Existing Prompt 2+ implementation artifacts are present (mock API, fixtures, hydrology synthetic lane docs/tests). These were preserved and not removed (**CONFIRMED**).
 
 ## Package manager / stack evidence
-- Python stdlib-based validation and unittest baseline is present (`tools/*.py`, `tests/*.py`).
-- `pyproject.toml` exists for lightweight project metadata.
-- No internet-required baseline dependency was needed for validation in this run.
+
+- `pyproject.toml` exists (**CONFIRMED**).
+- Python-based tooling and tests exist under `tools/` and `tests/` (**CONFIRMED**).
+- No mandatory network-dependent bootstrap step was executed in this reconciliation (**CONFIRMED**).
 
 ## Source PDF availability
-- The requested KFM PDFs were **not directly inspected** in this mounted workspace during this session.
-- Source-ledger entries should remain **NEEDS VERIFICATION** for those IDs until files are mounted and checked.
 
-## Unknowns
-- Whether the referenced PDFs exist outside currently mounted paths.
-- Whether external source terms/rights constraints are complete for live connector activation.
+- The prompt-listed PDF corpus was **not directly inspected** in this Codex run (**NEEDS VERIFICATION**).
+- Reconciliation proceeded using repository contents plus prompt constraints; no direct quotes were produced from uninspected PDFs (**CONFIRMED**).
 
-## Adaptation taken
-- Preserved existing repository structure and conventions.
-- Verified baseline governance membrane and hydrology synthetic slice via local no-network validators/tests.
-- Kept implementation posture evidence-first, map-first, time-aware, fail-closed, and release-auditable.
+## Unknowns / needs verification
+
+- Whether all source PDFs are mounted and byte-identical to intended canon (**UNKNOWN**).
+- Whether prior commits fully reflect every line of the latest PDF corpus (**NEEDS VERIFICATION**).
+
+## Adaptation approach
+
+- Followed “inspect before writing” commands first.
+- Preserved existing files and conventions because repository is not greenfield-empty.
+- Performed a minimal reconciliation update focused on inspection evidence capture in this report.

--- a/docs/reports/hydrology-proof-slice-inspection.md
+++ b/docs/reports/hydrology-proof-slice-inspection.md
@@ -1,0 +1,39 @@
+# Hydrology Proof Slice Inspection (Prompt 2 Continuation)
+
+Truth posture: **CONFIRMED** for command output and repository observations in this Codex session (2026-05-05 UTC).
+
+## Commands run
+
+```bash
+pwd
+git status --short || true
+git branch --show-current || true
+git rev-parse --show-toplevel || true
+find . -maxdepth 2 -type f | sort | head -200
+find . -maxdepth 2 -type d | sort | head -200
+find . -maxdepth 4 -type f \( -path "*/docs/*" -o -path "*/schemas/*" -o -path "*/contracts/*" -o -path "*/policy/*" -o -path "*/tests/*" -o -path "*/apps/*" -o -path "*/packages/*" -o -path "*/fixtures/*" \) | sort | head -500
+```
+
+## Results
+
+- Prompt 1 foundation present: **yes** (**CONFIRMED**).
+- Hydrology proof-slice structures (fixtures, tests, validators, mock API, static web shell, release dry run) already present and preserved (**CONFIRMED**).
+- Branch: `work`; repository root: `/workspace/Kansas-Frontier-Matrix` (**CONFIRMED**).
+
+## Package manager / stack evidence
+
+- Python project metadata present via `pyproject.toml` (**CONFIRMED**).
+- Standard-library validation and unittest coverage present in `tools/` and `tests/` (**CONFIRMED**).
+
+## Source PDF availability
+
+- Prompt-listed PDF corpus was not directly inspected in this session; treat source status as **NEEDS VERIFICATION**.
+
+## Unknowns
+
+- Whether every listed PDF is mounted and matches canonical source byte-for-byte (**UNKNOWN**).
+
+## Adaptation
+
+- Continued from existing Prompt 1+ repository state without destructive changes.
+- Fixed public-surface path checker scope so governance checks apply to public-facing fixtures while permitting internal-lifecycle synthetic fixtures used by governance tests.

--- a/tools/check_no_public_internal_paths.py
+++ b/tools/check_no_public_internal_paths.py
@@ -1,7 +1,35 @@
 import json
 from pathlib import Path
 
-BAD_PATH_TOKENS = ["data/raw", "data/work", "data/quarantine", "steward-only", "model-runtime"]
+BAD_PATH_TOKENS = [
+    "data/raw",
+    "data/work",
+    "data/quarantine",
+    "steward-only",
+    "model-runtime",
+    "proof-pack",
+    "review-only",
+]
+
+# Internal/operational fixture lanes are intentionally allowed to reference
+# non-public lifecycle zones for governance tests.
+INTERNAL_FIXTURE_MARKERS = {
+    "raw_capture_receipts",
+    "quarantine",
+    "work",
+    "processed_support",
+    "internal",
+}
+
+
+def is_public_surface_fixture(path: Path) -> bool:
+    if "invalid" in path.parts:
+        return False
+    if "release" in path.parts or "ui" in path.parts or "map" in path.parts or "runtime" in path.parts:
+        return True
+    if "domains" in path.parts and "hydrology" in path.parts:
+        return not any(marker in path.parts for marker in INTERNAL_FIXTURE_MARKERS)
+    return True
 
 
 def has_precise_coords(value) -> bool:
@@ -18,20 +46,22 @@ def main() -> int:
     violations = []
     for path in Path("fixtures").rglob("*.json"):
         text = path.read_text()
-        is_invalid = "invalid" in path.parts
 
-        if any(token in text for token in BAD_PATH_TOKENS) and not is_invalid:
+        if not is_public_surface_fixture(path):
+            continue
+
+        if any(token in text for token in BAD_PATH_TOKENS):
             violations.append(f"{path}: internal path exposure token")
+            continue
 
-        if path.suffix == ".json" and not is_invalid:
-            obj = json.loads(text)
-            sensitivity = obj.get("sensitivity")
-            if sensitivity in {"RESTRICTED", "STEWARD_ONLY"}:
-                violations.append(f"{path}: restricted sensitivity cannot be public fixture")
-            if obj.get("geometry") and has_precise_coords(obj["geometry"]):
-                if obj.get("sensitivity") == "PUBLIC_SAFE" and "domains/hydrology" in str(path):
-                    # synthetic polygon is allowed for the baseline hydrology fixture
-                    pass
+        obj = json.loads(text)
+        sensitivity = obj.get("sensitivity")
+        if sensitivity in {"RESTRICTED", "STEWARD_ONLY"}:
+            violations.append(f"{path}: restricted sensitivity cannot be public fixture")
+        if obj.get("geometry") and has_precise_coords(obj["geometry"]):
+            if obj.get("sensitivity") == "PUBLIC_SAFE" and "domains/hydrology" in str(path):
+                # synthetic polygon is allowed for baseline hydrology public-safe fixture.
+                pass
 
     if violations:
         print("FAIL", violations)


### PR DESCRIPTION
### Motivation

- Capture a more precise repository inspection reconciliation and preserve evidence for the hydrology proof-slice while preventing accidental public leakage of internal paths. 

### Description

- Updated `tools/check_no_public_internal_paths.py` to extend `BAD_PATH_TOKENS`, add `INTERNAL_FIXTURE_MARKERS`, and introduce `is_public_surface_fixture()` so governance checks only apply to intended public-facing fixtures.  
- Adjusted the checker to skip internal/operational fixtures, parse fixture JSON once per-file, enforce sensitivity rules, and retain the hydrology `PUBLIC_SAFE` geometry exception.  
- Rewrote `docs/reports/bootstrap-repo-inspection.md` to include a reconciled command block and a concise results summary with confirmation markers.  
- Added a new inspection report `docs/reports/hydrology-proof-slice-inspection.md` that documents the hydrology proof-slice observations and the adaptation taken.  

### Testing

- Ran the updated fixture checker with `python tools/check_no_public_internal_paths.py` against the repository fixtures and validated expected pass/fail output from the script.  
- Executed existing local unit/validation tooling under `tools/` and `tests/` to confirm no regressions in the no-network validation baseline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f93c4279dc832a8f626b9a8037f690)