### PR TITLE
Add ADRs for repository layout and introduce shared contract schemas

### DIFF
--- a/docs/adr/ADR-0001-schema-home.md
+++ b/docs/adr/ADR-0001-schema-home.md
@@ -1,2 +1,20 @@
-# ADR-0001
-Schemas live in `schemas/contracts/v1`.
+# ADR-0001: Schema Home
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+All canonical contract schemas are rooted under:
+
+`schemas/contracts/v1/`
+
+Versioned subdirectories beneath this path are the only valid homes for contract schema sources.
+
+## Rationale
+- Keeps schema ownership discoverable from one stable root.
+- Supports versioned evolution without changing repository topology.
+- Separates schema definitions from runtime code, fixtures, and generated artifacts.
+
+## Consequences
+- New contract schema work must be placed under `schemas/contracts/v1/` (or a future versioned sibling approved by ADR).
+- Tools and docs should reference this path as the source of truth.

--- a/docs/adr/ADR-0002-responsibility-root-monorepo.md
+++ b/docs/adr/ADR-0002-responsibility-root-monorepo.md
@@ -1,2 +1,17 @@
-# ADR-0002
-Responsibility-root monorepo, no root domain folders.
+# ADR-0002: Responsibility-Root Monorepo Layout
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+Repository layout is responsibility-rooted (e.g., `apps/`, `schemas/`, `contracts/`, `tools/`, `tests/`) and forbids greenfield domain roots at repository top level.
+
+## Rationale
+- Enforces clear separation of concerns by function.
+- Avoids domain sprawl at root and keeps governance/tooling predictable.
+- Preserves consistent paths for automation and policy checks.
+
+## Consequences
+- Domain-specific content belongs under approved responsibility roots.
+- New top-level folders must align to responsibility, not domain naming.
+- Directory-rule checks remain the enforcement point for root hygiene.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,7 @@
-# adr
+# Architecture Decision Records (ADR)
 
-CONFIRMED: baseline scaffold created in this Codex session.
+This directory stores accepted architecture decisions for repository structure and governance.
+
+## Foundational layout decisions
+- `ADR-0001-schema-home.md` — canonical schema home.
+- `ADR-0002-responsibility-root-monorepo.md` — responsibility-root top-level layout.

--- a/schemas/contracts/v1/shared/correction_notice.schema.json
+++ b/schemas/contracts/v1/shared/correction_notice.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CorrectionNotice",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_bundle.schema.json
+++ b/schemas/contracts/v1/shared/evidence_bundle.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceBundle",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_ref.schema.json
+++ b/schemas/contracts/v1/shared/evidence_ref.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceRef",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/policy_decision.schema.json
+++ b/schemas/contracts/v1/shared/policy_decision.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PolicyDecision",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "decision": {
+      "enum": ["ALLOW", "ABSTAIN", "DENY", "ERROR"]
+    }
+  },
+  "required": ["id", "decision"]
+}

--- a/schemas/contracts/v1/shared/rollback_reference.schema.json
+++ b/schemas/contracts/v1/shared/rollback_reference.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RollbackReference",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
+++ b/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RuntimeResponseEnvelope",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/source_descriptor.schema.json
+++ b/schemas/contracts/v1/shared/source_descriptor.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SourceDescriptor",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}


### PR DESCRIPTION
### Motivation
- Define a stable canonical home for contract schemas and a responsibility-rooted repository layout to make ownership and tooling predictable.
- Provide a set of minimal shared JSON Schema types used by contract definitions to standardize common references.
- Separate schema sources from runtime and generated artifacts to support versioning and automation.

### Description
- Add `ADR-0001: Schema Home` as `docs/adr/ADR-0001-schema-home.md` to declare `schemas/contracts/v1/` as the canonical schema root and allow future versioned siblings.
- Add `ADR-0002: Responsibility-Root Monorepo Layout` as `docs/adr/ADR-0002-responsibility-root-monorepo.md` to mandate responsibility-rooted top-level folders such as `apps/`, `schemas/`, `contracts/`, `tools/`, and `tests/`.
- Update `docs/adr/README.md` to document the new ADRs and their roles.
- Add several minimal shared JSON Schema files under `schemas/contracts/v1/shared/`: `correction_notice.schema.json`, `evidence_bundle.schema.json`, `evidence_ref.schema.json`, `policy_decision.schema.json`, `rollback_reference.schema.json`, `runtime_response_envelope.schema.json`, and `source_descriptor.schema.json`; all use JSON Schema draft 2020-12, define an `id` property, and `policy_decision` includes a `decision` enum of `ALLOW`, `ABSTAIN`, `DENY`, and `ERROR`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e5911f34832ab7ac3084becb5e04)