### PR TITLE
Add ADRs for repo layout, shared schemas, hydrology fixtures, and validator scripts

### DIFF
--- a/docs/adr/ADR-0001-schema-home.md
+++ b/docs/adr/ADR-0001-schema-home.md
@@ -1,2 +1,20 @@
-# ADR-0001
-Schemas live in `schemas/contracts/v1`.
+# ADR-0001: Schema Home
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+All canonical contract schemas are rooted under:
+
+`schemas/contracts/v1/`
+
+Versioned subdirectories beneath this path are the only valid homes for contract schema sources.
+
+## Rationale
+- Keeps schema ownership discoverable from one stable root.
+- Supports versioned evolution without changing repository topology.
+- Separates schema definitions from runtime code, fixtures, and generated artifacts.
+
+## Consequences
+- New contract schema work must be placed under `schemas/contracts/v1/` (or a future versioned sibling approved by ADR).
+- Tools and docs should reference this path as the source of truth.

--- a/docs/adr/ADR-0002-responsibility-root-monorepo.md
+++ b/docs/adr/ADR-0002-responsibility-root-monorepo.md
@@ -1,2 +1,17 @@
-# ADR-0002
-Responsibility-root monorepo, no root domain folders.
+# ADR-0002: Responsibility-Root Monorepo Layout
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+Repository layout is responsibility-rooted (e.g., `apps/`, `schemas/`, `contracts/`, `tools/`, `tests/`) and forbids greenfield domain roots at repository top level.
+
+## Rationale
+- Enforces clear separation of concerns by function.
+- Avoids domain sprawl at root and keeps governance/tooling predictable.
+- Preserves consistent paths for automation and policy checks.
+
+## Consequences
+- Domain-specific content belongs under approved responsibility roots.
+- New top-level folders must align to responsibility, not domain naming.
+- Directory-rule checks remain the enforcement point for root hygiene.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,7 @@
-# adr
+# Architecture Decision Records (ADR)
 
-CONFIRMED: baseline scaffold created in this Codex session.
+This directory stores accepted architecture decisions for repository structure and governance.
+
+## Foundational layout decisions
+- `ADR-0001-schema-home.md` — canonical schema home.
+- `ADR-0002-responsibility-root-monorepo.md` — responsibility-root top-level layout.

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_bad_activation_enum.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_bad_activation_enum.json
@@ -1,0 +1,12 @@
+{
+  "id": "HYDRO-NONET-INVALID-ACTIVATION-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "MAYBE",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_invented_http_facts.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_invented_http_facts.json
@@ -1,0 +1,20 @@
+{
+  "id": "HYDRO-NONET-INVALID-HTTP-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "http_facts": [
+    {
+      "kind": "LIVE_HTTP_RESPONSE",
+      "status": 200,
+      "url": "https://example.invalid/usgs",
+      "detail": "Invented live API response in no-network mode"
+    }
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_missing_citations.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_missing_citations.json
@@ -1,0 +1,10 @@
+{
+  "id": "HYDRO-NONET-INVALID-CITATIONS-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_unresolved_evidence.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_unresolved_evidence.json
@@ -1,0 +1,12 @@
+{
+  "id": "HYDRO-NONET-INVALID-UNRESOLVED-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ANSWER",
+  "reason": "RESOLVED",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json
@@ -1,0 +1,19 @@
+{
+  "id": "HYDRO-NONET-VALID-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "http_facts": [
+    {
+      "kind": "NO_NETWORK_ASSERTION",
+      "observed": true,
+      "detail": "No external HTTP request executed in synthetic baseline mode"
+    }
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/schemas/contracts/v1/shared/correction_notice.schema.json
+++ b/schemas/contracts/v1/shared/correction_notice.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CorrectionNotice",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_bundle.schema.json
+++ b/schemas/contracts/v1/shared/evidence_bundle.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceBundle",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_ref.schema.json
+++ b/schemas/contracts/v1/shared/evidence_ref.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceRef",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/policy_decision.schema.json
+++ b/schemas/contracts/v1/shared/policy_decision.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PolicyDecision",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "decision": {
+      "enum": ["ALLOW", "ABSTAIN", "DENY", "ERROR"]
+    }
+  },
+  "required": ["id", "decision"]
+}

--- a/schemas/contracts/v1/shared/rollback_reference.schema.json
+++ b/schemas/contracts/v1/shared/rollback_reference.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RollbackReference",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
+++ b/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RuntimeResponseEnvelope",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/source_descriptor.schema.json
+++ b/schemas/contracts/v1/shared/source_descriptor.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SourceDescriptor",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/tools/validators/validate_activation_decisions.py
+++ b/tools/validators/validate_activation_decisions.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    allowed = {"ALLOW", "ABSTAIN", "DENY", "ERROR"}
+
+    for path in sorted((ROOT / "fixtures/source/hydrology").glob("source_activation_decision*.valid.json")):
+        data = json.loads(path.read_text())
+        decision = data.get("decision")
+        if decision not in allowed:
+            errors.append(f"{path.name} invalid decision: {decision}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS source activation decisions validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_evidence_closure.py
+++ b/tools/validators/validate_evidence_closure.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    evidence_ref = json.loads((ROOT / "fixtures/evidence/evidence_ref.valid.json").read_text())
+    bundle = json.loads((ROOT / "fixtures/evidence/evidence_bundle.valid.json").read_text())
+
+    if evidence_ref.get("bundle_id") != bundle.get("id"):
+        errors.append("evidence_ref.bundle_id must match evidence_bundle.id")
+    if evidence_ref.get("id") not in bundle.get("evidence_refs", []):
+        errors.append("evidence_ref.id must be listed in evidence_bundle.evidence_refs")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS evidence closure validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_fixture_validation.py
+++ b/tools/validators/validate_fixture_validation.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    cmd = [sys.executable, str(ROOT / "tools/validate_fixtures.py")]
+    result = subprocess.run(cmd, cwd=ROOT)
+    if result.returncode != 0:
+        print("FAIL fixture validation")
+        return result.returncode
+    print("PASS fixture validation")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_public_path_guards.py
+++ b/tools/validators/validate_public_path_guards.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FORBIDDEN = ["data/raw/", "data/work/", "data/quarantine/", "data/processed/"]
+TARGETS = [
+    "fixtures/ui/evidence_drawer_payload.valid.json",
+    "fixtures/ai/focus_mode_response.answer.valid.json",
+    "fixtures/release/release_manifest.valid.json",
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    for rel in TARGETS:
+        text = json.dumps(json.loads((ROOT / rel).read_text())).lower()
+        for bad in FORBIDDEN:
+            if bad in text:
+                errors.append(f"{rel} contains forbidden path fragment: {bad}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS public-path guards validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_source_terms.py
+++ b/tools/validators/validate_source_terms.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    review = json.loads((ROOT / "fixtures/source/hydrology/source_terms_review.valid.json").read_text())
+    receipt = json.loads((ROOT / "fixtures/source/hydrology/source_terms_check_receipt.wbd.no_network.valid.json").read_text())
+
+    if review.get("rights_status") not in {"NEEDS_LEGAL_REVIEW", "CLEARED", "DENIED"}:
+        errors.append("source_terms_review has invalid rights_status")
+    if receipt.get("check_kind") != "TERMS_RIGHTS_ONLY":
+        errors.append("source_terms_check_receipt must be TERMS_RIGHTS_ONLY")
+    if receipt.get("network_mode") != "DISABLED":
+        errors.append("source_terms_check_receipt network_mode must be DISABLED")
+    if receipt.get("validation_result") not in {"ALLOW", "ABSTAIN", "DENY", "ERROR"}:
+        errors.append("source_terms_check_receipt has invalid validation_result")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS source terms fixtures validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Establish canonical repository layout and governance decisions for schema and root directory organization. 
- Provide minimal shared JSON Schemas for common contract fragments to enable consistent validation and references. 
- Add hydrology fixture cases (valid and several invalid variants) to exercise offline/no-network behavior and evidence/citation rules. 
- Introduce small validator tools to enforce fixture and cross-file consistency, public-path guards, source-term expectations, and activation decision enums.

### Description
- Add two ADRs: `ADR-0001: Schema Home` and `ADR-0002: Responsibility-Root Monorepo Layout` and update ADR README to reference them. 
- Create multiple tiny shared schemas under `schemas/contracts/v1/shared/` (`correction_notice`, `evidence_bundle`, `evidence_ref`, `policy_decision`, `rollback_reference`, `runtime_response_envelope`, `source_descriptor`). 
- Add hydrology fixtures under `fixtures/domains/hydrology/no_network/` including one valid case and several invalid cases that cover bad activation enum, invented HTTP facts in no-network mode, missing citations, and unresolved evidence. 
- Add validator scripts under `tools/validators/` to check activation decision enums (`validate_activation_decisions.py`), evidence closure (`validate_evidence_closure.py`), fixture validation wrapper (`validate_fixture_validation.py`), public path guards (`validate_public_path_guards.py`), and source-term expectations (`validate_source_terms.py`).

### Testing
- No automated tests were executed as part of this rollout; the change introduces validator scripts intended to be run independently. 
- The added validator scripts are designed to return exit code `0` on success and non-zero with printed errors on failure and can be invoked with the repository Python interpreter. 
- Future CI should wire the new `tools/validators/*` scripts into repository checks to validate fixtures, schemas, and path hygiene automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e5911f34832ab7ac3084becb5e04)