### PR TITLE
Add no-model/no-network policy evaluator, fixtures, schemas, validators, and synthetic dry-run tooling

### DIFF
--- a/apps/api/no_model_no_network_policy.py
+++ b/apps/api/no_model_no_network_policy.py
@@ -1,0 +1,36 @@
+"""No-model, no-network policy evaluator and Focus mock.
+
+This module is payload-only decision logic (no live model calls, no network I/O).
+"""
+
+FINITE_OUTCOMES = {"ANSWER", "ABSTAIN", "DENY", "ERROR"}
+
+
+def evaluate_policy(request: dict) -> dict:
+    """Evaluate request under no-model, no-network policy gates."""
+    if not isinstance(request, dict):
+        return {"outcome": "ERROR", "reason": "INVALID_REQUEST"}
+
+    question = str(request.get("question", "")).strip()
+    if not question:
+        return {"outcome": "ABSTAIN", "reason": "EMPTY_QUERY"}
+
+    if request.get("network_required") is True:
+        return {"outcome": "DENY", "reason": "NO_NETWORK_POLICY"}
+
+    if request.get("model_required") is True:
+        return {"outcome": "DENY", "reason": "NO_MODEL_POLICY"}
+
+    if request.get("evidence_resolved") is not True:
+        return {"outcome": "ABSTAIN", "reason": "MISSING_EVIDENCE"}
+
+    return {"outcome": "ANSWER", "reason": "POLICY_ALLOW"}
+
+
+def focus_mock(request: dict) -> dict:
+    """Return one of ANSWER/ABSTAIN/DENY/ERROR only."""
+    result = evaluate_policy(request)
+    outcome = result.get("outcome", "ERROR")
+    if outcome not in FINITE_OUTCOMES:
+        return {"outcome": "ERROR", "reason": "NON_FINITE_OUTCOME"}
+    return {"outcome": outcome, "reason": result.get("reason", "UNSPECIFIED")}

--- a/contracts/runtime/governed_api_mock_payloads.md
+++ b/contracts/runtime/governed_api_mock_payloads.md
@@ -1,0 +1,16 @@
+# Governed API Mock Payloads (No Route Implementation)
+
+This contract file defines mock payload examples for governed API interactions only.
+
+## Scope
+- Payload modeling only.
+- No route implementation, runtime wiring, or handler guarantees are included in this artifact.
+
+## Mock payload source
+- `fixtures/api/governed_api_mock_payloads.json`
+
+## Included examples
+- `healthz_response`
+- `focus_mode_request`
+- `focus_mode_response`
+- `evidence_drawer_response`

--- a/docs/adr/ADR-0001-schema-home.md
+++ b/docs/adr/ADR-0001-schema-home.md
@@ -1,2 +1,20 @@
-# ADR-0001
-Schemas live in `schemas/contracts/v1`.
+# ADR-0001: Schema Home
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+All canonical contract schemas are rooted under:
+
+`schemas/contracts/v1/`
+
+Versioned subdirectories beneath this path are the only valid homes for contract schema sources.
+
+## Rationale
+- Keeps schema ownership discoverable from one stable root.
+- Supports versioned evolution without changing repository topology.
+- Separates schema definitions from runtime code, fixtures, and generated artifacts.
+
+## Consequences
+- New contract schema work must be placed under `schemas/contracts/v1/` (or a future versioned sibling approved by ADR).
+- Tools and docs should reference this path as the source of truth.

--- a/docs/adr/ADR-0002-responsibility-root-monorepo.md
+++ b/docs/adr/ADR-0002-responsibility-root-monorepo.md
@@ -1,2 +1,17 @@
-# ADR-0002
-Responsibility-root monorepo, no root domain folders.
+# ADR-0002: Responsibility-Root Monorepo Layout
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+Repository layout is responsibility-rooted (e.g., `apps/`, `schemas/`, `contracts/`, `tools/`, `tests/`) and forbids greenfield domain roots at repository top level.
+
+## Rationale
+- Enforces clear separation of concerns by function.
+- Avoids domain sprawl at root and keeps governance/tooling predictable.
+- Preserves consistent paths for automation and policy checks.
+
+## Consequences
+- Domain-specific content belongs under approved responsibility roots.
+- New top-level folders must align to responsibility, not domain naming.
+- Directory-rule checks remain the enforcement point for root hygiene.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,7 @@
-# adr
+# Architecture Decision Records (ADR)
 
-CONFIRMED: baseline scaffold created in this Codex session.
+This directory stores accepted architecture decisions for repository structure and governance.
+
+## Foundational layout decisions
+- `ADR-0001-schema-home.md` — canonical schema home.
+- `ADR-0002-responsibility-root-monorepo.md` — responsibility-root top-level layout.

--- a/fixtures/api/governed_api_mock_payloads.json
+++ b/fixtures/api/governed_api_mock_payloads.json
@@ -1,0 +1,28 @@
+{
+  "governed_api": {
+    "healthz_response": {
+      "status": "ok",
+      "service": "kfm-mock-api",
+      "mode": "synthetic_no_network"
+    },
+    "focus_mode_request": {
+      "question": "What is the flood risk status for synthetic parcel A?",
+      "scope": "public",
+      "trace_id": "trace-focus-001"
+    },
+    "focus_mode_response": {
+      "outcome": "ABSTAIN",
+      "reason": "MISSING_EVIDENCE",
+      "citations": [],
+      "trace_id": "trace-focus-001"
+    },
+    "evidence_drawer_response": {
+      "id": "drawer-hydro-001",
+      "ui_trust_state": "EVIDENCE_MISSING",
+      "release_status": "ABSTAIN",
+      "evidence_ref": "evr-hydro-synth-001",
+      "evidence_bundle_id": "evb-hydro-synth-001",
+      "sources": []
+    }
+  }
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_bad_activation_enum.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_bad_activation_enum.json
@@ -1,0 +1,12 @@
+{
+  "id": "HYDRO-NONET-INVALID-ACTIVATION-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "MAYBE",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_invented_http_facts.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_invented_http_facts.json
@@ -1,0 +1,20 @@
+{
+  "id": "HYDRO-NONET-INVALID-HTTP-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "http_facts": [
+    {
+      "kind": "LIVE_HTTP_RESPONSE",
+      "status": 200,
+      "url": "https://example.invalid/usgs",
+      "detail": "Invented live API response in no-network mode"
+    }
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_missing_citations.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_missing_citations.json
@@ -1,0 +1,10 @@
+{
+  "id": "HYDRO-NONET-INVALID-CITATIONS-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_unresolved_evidence.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_unresolved_evidence.json
@@ -1,0 +1,12 @@
+{
+  "id": "HYDRO-NONET-INVALID-UNRESOLVED-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ANSWER",
+  "reason": "RESOLVED",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json
@@ -1,0 +1,19 @@
+{
+  "id": "HYDRO-NONET-VALID-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "http_facts": [
+    {
+      "kind": "NO_NETWORK_ASSERTION",
+      "observed": true,
+      "detail": "No external HTTP request executed in synthetic baseline mode"
+    }
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/release/dry_runs/synthetic_release_dry_run_receipt.json
+++ b/release/dry_runs/synthetic_release_dry_run_receipt.json
@@ -1,0 +1,65 @@
+{
+  "id": "synthetic-release-dry-run-001",
+  "mode": "SYNTHETIC_NO_NETWORK",
+  "publish_decision": "REFUSE",
+  "result": "PASS",
+  "gates": [
+    {
+      "gate": "tools/validate_fixtures.py",
+      "returncode": 0,
+      "stdout": "PASS valid fixtures pass and invalid fixtures remain intentionally invalid",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validate_schema_conformance.py",
+      "returncode": 0,
+      "stdout": "PASS validated schema-conformance checks for 7 fixture contracts",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validate_api_contracts.py",
+      "returncode": 0,
+      "stdout": "PASS api contract checks",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/check_directory_rules.py",
+      "returncode": 0,
+      "stdout": "PASS directory rules satisfied",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/check_no_public_internal_paths.py",
+      "returncode": 0,
+      "stdout": "PASS no prohibited internal/public-surface path or sensitivity leakage",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validators/validate_evidence_closure.py",
+      "returncode": 0,
+      "stdout": "PASS evidence closure validated",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validators/validate_activation_decisions.py",
+      "returncode": 0,
+      "stdout": "PASS source activation decisions validated",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validators/validate_source_terms.py",
+      "returncode": 0,
+      "stdout": "PASS source terms fixtures validated",
+      "stderr": "",
+      "status": "PASS"
+    }
+  ],
+  "reason": "DRY_RUN_ONLY_REFUSES_PUBLISH"
+}

--- a/schemas/contracts/v1/shared/correction_notice.schema.json
+++ b/schemas/contracts/v1/shared/correction_notice.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CorrectionNotice",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_bundle.schema.json
+++ b/schemas/contracts/v1/shared/evidence_bundle.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceBundle",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_ref.schema.json
+++ b/schemas/contracts/v1/shared/evidence_ref.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceRef",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/policy_decision.schema.json
+++ b/schemas/contracts/v1/shared/policy_decision.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PolicyDecision",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "decision": {
+      "enum": ["ALLOW", "ABSTAIN", "DENY", "ERROR"]
+    }
+  },
+  "required": ["id", "decision"]
+}

--- a/schemas/contracts/v1/shared/rollback_reference.schema.json
+++ b/schemas/contracts/v1/shared/rollback_reference.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RollbackReference",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
+++ b/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RuntimeResponseEnvelope",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/source_descriptor.schema.json
+++ b/schemas/contracts/v1/shared/source_descriptor.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SourceDescriptor",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/tests/test_no_model_no_network_policy.py
+++ b/tests/test_no_model_no_network_policy.py
@@ -1,0 +1,27 @@
+import unittest
+
+from apps.api.no_model_no_network_policy import FINITE_OUTCOMES, focus_mock
+
+
+class NoModelNoNetworkPolicyTests(unittest.TestCase):
+    def test_focus_mock_finite_outcomes_only(self):
+        cases = [
+            {"question": "", "expected": "ABSTAIN"},
+            {"question": "q", "network_required": True, "expected": "DENY"},
+            {"question": "q", "model_required": True, "expected": "DENY"},
+            {"question": "q", "evidence_resolved": False, "expected": "ABSTAIN"},
+            {"question": "q", "evidence_resolved": True, "expected": "ANSWER"},
+        ]
+        for case in cases:
+            expected = case.pop("expected")
+            out = focus_mock(case)
+            self.assertEqual(out["outcome"], expected)
+            self.assertIn(out["outcome"], FINITE_OUTCOMES)
+
+    def test_non_dict_request_errors(self):
+        out = focus_mock("not-a-dict")
+        self.assertEqual(out["outcome"], "ERROR")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_synthetic_release_dry_run.py
+++ b/tests/test_synthetic_release_dry_run.py
@@ -1,0 +1,20 @@
+import json
+import unittest
+from pathlib import Path
+
+from tests.subprocess_utils import assert_python_ok
+
+
+class SyntheticReleaseDryRunTests(unittest.TestCase):
+    def test_synthetic_release_dry_run_tool(self):
+        assert_python_ok(self, ["tools/synthetic_release_dry_run.py"])
+
+        receipt = json.loads(Path("release/dry_runs/synthetic_release_dry_run_receipt.json").read_text())
+        self.assertEqual(receipt.get("publish_decision"), "REFUSE")
+        self.assertEqual(receipt.get("reason"), "DRY_RUN_ONLY_REFUSES_PUBLISH")
+        self.assertIn(receipt.get("result"), {"PASS", "FAIL"})
+        self.assertTrue(receipt.get("gates"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validator_extensions.py
+++ b/tests/test_validator_extensions.py
@@ -1,0 +1,68 @@
+import json
+import unittest
+from pathlib import Path
+
+from tests.subprocess_utils import assert_python_ok
+
+
+class ValidatorScriptTests(unittest.TestCase):
+    def test_validator_scripts(self):
+        for script in [
+            "tools/validators/validate_source_terms.py",
+            "tools/validators/validate_activation_decisions.py",
+            "tools/validators/validate_evidence_closure.py",
+            "tools/validators/validate_public_path_guards.py",
+            "tools/validators/validate_fixture_validation.py",
+        ]:
+            with self.subTest(script=script):
+                assert_python_ok(self, [script])
+
+
+class HashingTests(unittest.TestCase):
+    def test_compute_spec_hash_shared_schema(self):
+        assert_python_ok(self, ["tools/compute_spec_hash.py", "schemas/contracts/v1/shared/policy_decision.schema.json"])
+
+
+class EvidenceClosureFixtureTests(unittest.TestCase):
+    def test_evidence_ref_closes_to_bundle(self):
+        evidence_ref = json.loads(Path("fixtures/evidence/evidence_ref.valid.json").read_text())
+        bundle = json.loads(Path("fixtures/evidence/evidence_bundle.valid.json").read_text())
+        self.assertEqual(evidence_ref.get("bundle_id"), bundle.get("id"))
+        self.assertIn(evidence_ref.get("id"), bundle.get("evidence_refs", []))
+
+
+class InvalidFixtureSemanticsTests(unittest.TestCase):
+    def test_intentional_invalid_no_network_fixtures(self):
+        base = Path("fixtures/domains/hydrology/no_network")
+
+        unresolved = json.loads((base / "hydrology_no_network.invalid_unresolved_evidence.json").read_text())
+        self.assertEqual(unresolved["focus_outcome"], "ANSWER")
+        self.assertFalse(unresolved["evidence_resolved"])
+
+        bad_enum = json.loads((base / "hydrology_no_network.invalid_bad_activation_enum.json").read_text())
+        self.assertNotIn(bad_enum["source_activation_decision"], {"ALLOW", "ABSTAIN", "DENY", "ERROR"})
+
+        missing_citations = json.loads((base / "hydrology_no_network.invalid_missing_citations.json").read_text())
+        self.assertEqual(missing_citations.get("citations"), [])
+
+        invented_http = json.loads((base / "hydrology_no_network.invalid_invented_http_facts.json").read_text())
+        self.assertEqual(invented_http["network_mode"], "DISABLED")
+        self.assertEqual(invented_http["http_facts"][0]["kind"], "LIVE_HTTP_RESPONSE")
+
+
+class NoNetworkBehaviorTests(unittest.TestCase):
+    def test_valid_no_network_fixture(self):
+        valid = json.loads(Path("fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json").read_text())
+        self.assertEqual(valid["network_mode"], "DISABLED")
+        self.assertEqual(valid["source_activation_decision"], "ABSTAIN")
+        self.assertEqual(valid["focus_outcome"], "ABSTAIN")
+        self.assertGreater(len(valid.get("citations", [])), 0)
+
+
+class HydrologySyntheticProofTests(unittest.TestCase):
+    def test_hydrology_proof_validator(self):
+        assert_python_ok(self, ["tools/validators/validate_hydrology_proof_slice.py"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/synthetic_release_dry_run.py
+++ b/tools/synthetic_release_dry_run.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT = ROOT / "release/dry_runs/synthetic_release_dry_run_receipt.json"
+
+GATES = [
+    ["tools/validate_fixtures.py"],
+    ["tools/validate_schema_conformance.py"],
+    ["tools/validate_api_contracts.py"],
+    ["tools/check_directory_rules.py"],
+    ["tools/check_no_public_internal_paths.py"],
+    ["tools/validators/validate_evidence_closure.py"],
+    ["tools/validators/validate_activation_decisions.py"],
+    ["tools/validators/validate_source_terms.py"],
+]
+
+
+def run_gate(args: list[str]) -> dict:
+    proc = subprocess.run([sys.executable, str(ROOT / args[0]), *args[1:]], capture_output=True, text=True)
+    return {
+        "gate": args[0],
+        "returncode": proc.returncode,
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+        "status": "PASS" if proc.returncode == 0 else "FAIL",
+    }
+
+
+def main() -> int:
+    gate_results = [run_gate(g) for g in GATES]
+    failed = [g for g in gate_results if g["status"] == "FAIL"]
+
+    receipt = {
+        "id": "synthetic-release-dry-run-001",
+        "mode": "SYNTHETIC_NO_NETWORK",
+        "publish_decision": "REFUSE",
+        "result": "PASS" if not failed else "FAIL",
+        "gates": gate_results,
+        "reason": "DRY_RUN_ONLY_REFUSES_PUBLISH",
+    }
+
+    RECEIPT.parent.mkdir(parents=True, exist_ok=True)
+    RECEIPT.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+
+    if failed:
+        print("FAIL", f"{len(failed)} gates failed; publish refused; receipt={RECEIPT}")
+        return 1
+
+    print("PASS", f"all gates passed; publish refused by policy; receipt={RECEIPT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_activation_decisions.py
+++ b/tools/validators/validate_activation_decisions.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    allowed = {"ALLOW", "ABSTAIN", "DENY", "ERROR"}
+
+    for path in sorted((ROOT / "fixtures/source/hydrology").glob("source_activation_decision*.valid.json")):
+        data = json.loads(path.read_text())
+        decision = data.get("decision")
+        if decision not in allowed:
+            errors.append(f"{path.name} invalid decision: {decision}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS source activation decisions validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_evidence_closure.py
+++ b/tools/validators/validate_evidence_closure.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    evidence_ref = json.loads((ROOT / "fixtures/evidence/evidence_ref.valid.json").read_text())
+    bundle = json.loads((ROOT / "fixtures/evidence/evidence_bundle.valid.json").read_text())
+
+    if evidence_ref.get("bundle_id") != bundle.get("id"):
+        errors.append("evidence_ref.bundle_id must match evidence_bundle.id")
+    if evidence_ref.get("id") not in bundle.get("evidence_refs", []):
+        errors.append("evidence_ref.id must be listed in evidence_bundle.evidence_refs")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS evidence closure validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_fixture_validation.py
+++ b/tools/validators/validate_fixture_validation.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    cmd = [sys.executable, str(ROOT / "tools/validate_fixtures.py")]
+    result = subprocess.run(cmd, cwd=ROOT)
+    if result.returncode != 0:
+        print("FAIL fixture validation")
+        return result.returncode
+    print("PASS fixture validation")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_public_path_guards.py
+++ b/tools/validators/validate_public_path_guards.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FORBIDDEN = ["data/raw/", "data/work/", "data/quarantine/", "data/processed/"]
+TARGETS = [
+    "fixtures/ui/evidence_drawer_payload.valid.json",
+    "fixtures/ai/focus_mode_response.answer.valid.json",
+    "fixtures/release/release_manifest.valid.json",
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    for rel in TARGETS:
+        text = json.dumps(json.loads((ROOT / rel).read_text())).lower()
+        for bad in FORBIDDEN:
+            if bad in text:
+                errors.append(f"{rel} contains forbidden path fragment: {bad}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS public-path guards validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_source_terms.py
+++ b/tools/validators/validate_source_terms.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    review = json.loads((ROOT / "fixtures/source/hydrology/source_terms_review.valid.json").read_text())
+    receipt = json.loads((ROOT / "fixtures/source/hydrology/source_terms_check_receipt.wbd.no_network.valid.json").read_text())
+
+    if review.get("rights_status") not in {"NEEDS_LEGAL_REVIEW", "CLEARED", "DENIED"}:
+        errors.append("source_terms_review has invalid rights_status")
+    if receipt.get("check_kind") != "TERMS_RIGHTS_ONLY":
+        errors.append("source_terms_check_receipt must be TERMS_RIGHTS_ONLY")
+    if receipt.get("network_mode") != "DISABLED":
+        errors.append("source_terms_check_receipt network_mode must be DISABLED")
+    if receipt.get("validation_result") not in {"ALLOW", "ABSTAIN", "DENY", "ERROR"}:
+        errors.append("source_terms_check_receipt has invalid validation_result")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS source terms fixtures validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a payload-only policy evaluator and Focus mock for synthetic no-network scenarios without calling models or performing network I/O.
- Add canonical contract schemas and ADRs to document repository layout and schema home.
- Supply synthetic fixtures and validators to assert intentional invalid fixtures and enforce evidence/source/fixture invariants in no-network mode.
- Introduce a synthetic dry-run tool to exercise release gates and produce a machine-readable receipt for dry runs.

### Description
- Added a lightweight policy module `apps/api/no_model_no_network_policy.py` with `evaluate_policy` and `focus_mock` to return finite outcomes (`ANSWER`, `ABSTAIN`, `DENY`, `ERROR`).
- Introduced governed API mock payloads in `fixtures/api/governed_api_mock_payloads.json` and a contract note `contracts/runtime/governed_api_mock_payloads.md` describing scope.
- Added hydrology no-network fixtures (valid and intentionally invalid examples) under `fixtures/domains/hydrology/no_network/` to encode expected failure modes for tests.
- Added minimal shared contract schemas under `schemas/contracts/v1/shared/` and ADRs in `docs/adr/` documenting schema home and repository layout.
- Implemented validators and helper tooling under `tools/validators/` and `tools/` including `validate_evidence_closure.py`, `validate_activation_decisions.py`, `validate_source_terms.py`, `validate_public_path_guards.py`, `validate_fixture_validation.py`, and `synthetic_release_dry_run.py` which runs a list of gates and writes a receipt to `release/dry_runs/synthetic_release_dry_run_receipt.json`.
- Added unit tests: `tests/test_no_model_no_network_policy.py`, `tests/test_synthetic_release_dry_run.py`, and `tests/test_validator_extensions.py` to exercise the new policy, dry-run tool, and validators.

### Testing
- Executed the synthetic dry-run tool `tools/synthetic_release_dry_run.py`, which ran gates `tools/validate_fixtures.py`, `tools/validate_schema_conformance.py`, `tools/validate_api_contracts.py`, `tools/check_directory_rules.py`, `tools/check_no_public_internal_paths.py`, `tools/validators/validate_evidence_closure.py`, `tools/validators/validate_activation_decisions.py`, and `tools/validators/validate_source_terms.py`, and produced `release/dry_runs/synthetic_release_dry_run_receipt.json` with all gates reporting `PASS`.
- Ran the new unit tests `tests/test_no_model_no_network_policy.py`, `tests/test_synthetic_release_dry_run.py`, and `tests/test_validator_extensions.py`, and they completed successfully.
- Validator scripts under `tools/validators/` were executed as part of the dry-run and returned `PASS` for the checked fixture and schema expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e5911f34832ab7ac3084becb5e04)