### PR TITLE
Add synthetic no-network dry-run flow: mocks, validators, fixtures, schemas, and tests

### DIFF
--- a/.github/workflows/synthetic-release-dry-run.yml
+++ b/.github/workflows/synthetic-release-dry-run.yml
@@ -1,0 +1,16 @@
+name: synthetic-release-dry-run
+
+on:
+  pull_request:
+  push:
+    branches: ["**"]
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: bash scripts/check_synthetic_release_local.sh

--- a/apps/api/kfm_mock_api.py
+++ b/apps/api/kfm_mock_api.py
@@ -50,6 +50,25 @@ def get_drawer(drawer_id: str) -> tuple[dict, int]:
     return drawer, 200
 
 
+
+
+def get_mock_policy() -> tuple[dict, int]:
+    return {
+        "id": "mock-policy-001",
+        "mode": "SYNTHETIC_NO_NETWORK",
+        "decision": "ABSTAIN",
+        "reason": "PAYLOAD_ONLY",
+    }, 200
+
+
+def get_mock_focus() -> tuple[dict, int]:
+    return {
+        "id": "mock-focus-001",
+        "outcome": "ABSTAIN",
+        "reason": "MISSING_EVIDENCE",
+        "citations": [],
+    }, 200
+
 def focus_decision(request: dict) -> tuple[dict, int]:
     question = str(request.get("question", "")).strip().lower()
     if not question:
@@ -93,6 +112,12 @@ class Handler(BaseHTTPRequestHandler):
         if self.path.startswith("/v1/drawer/"):
             drawer_id = self.path.rsplit("/", 1)[-1]
             payload, code = get_drawer(drawer_id)
+            return self._json(payload, code)
+        if self.path == "/v1/mock/policy":
+            payload, code = get_mock_policy()
+            return self._json(payload, code)
+        if self.path == "/v1/mock/focus":
+            payload, code = get_mock_focus()
             return self._json(payload, code)
         return self._json({"outcome": "ERROR", "reason": "NOT_FOUND"}, 404)
 

--- a/apps/api/no_model_no_network_policy.py
+++ b/apps/api/no_model_no_network_policy.py
@@ -1,0 +1,36 @@
+"""No-model, no-network policy evaluator and Focus mock.
+
+This module is payload-only decision logic (no live model calls, no network I/O).
+"""
+
+FINITE_OUTCOMES = {"ANSWER", "ABSTAIN", "DENY", "ERROR"}
+
+
+def evaluate_policy(request: dict) -> dict:
+    """Evaluate request under no-model, no-network policy gates."""
+    if not isinstance(request, dict):
+        return {"outcome": "ERROR", "reason": "INVALID_REQUEST"}
+
+    question = str(request.get("question", "")).strip()
+    if not question:
+        return {"outcome": "ABSTAIN", "reason": "EMPTY_QUERY"}
+
+    if request.get("network_required") is True:
+        return {"outcome": "DENY", "reason": "NO_NETWORK_POLICY"}
+
+    if request.get("model_required") is True:
+        return {"outcome": "DENY", "reason": "NO_MODEL_POLICY"}
+
+    if request.get("evidence_resolved") is not True:
+        return {"outcome": "ABSTAIN", "reason": "MISSING_EVIDENCE"}
+
+    return {"outcome": "ANSWER", "reason": "POLICY_ALLOW"}
+
+
+def focus_mock(request: dict) -> dict:
+    """Return one of ANSWER/ABSTAIN/DENY/ERROR only."""
+    result = evaluate_policy(request)
+    outcome = result.get("outcome", "ERROR")
+    if outcome not in FINITE_OUTCOMES:
+        return {"outcome": "ERROR", "reason": "NON_FINITE_OUTCOME"}
+    return {"outcome": outcome, "reason": result.get("reason", "UNSPECIFIED")}

--- a/apps/web/src/app.js
+++ b/apps/web/src/app.js
@@ -1,1 +1,26 @@
-document.getElementById("app").innerHTML=`<p>Timeline: 2026 synthetic scope</p><p>Selected hydrology fixture: hydro-feature-001</p><div>Trust chips: <span class="chip">EVIDENCE_RESOLVED</span><span class="chip">POLICY_ALLOW</span></div><h3>Evidence Drawer</h3><p>bundle: evb-hydro-001</p><h3>Focus Mode</h3><ul><li>ANSWER</li><li>ABSTAIN</li><li>DENY</li><li>ERROR</li></ul><p>Negative states: MISSING_EVIDENCE, SOURCE_STALE, DENIED_BY_POLICY, GENERALIZED_GEOMETRY, RESTRICTED_ACCESS, CITATION_FAILED, RELEASE_WITHDRAWN, RUNTIME_ERROR</p>`;
+const evidenceDrawer = {
+  id: "drawer-hydro-001",
+  ui_trust_state: "EVIDENCE_MISSING",
+  release_status: "ABSTAIN",
+  evidence_ref: "evr-hydro-synth-001",
+  evidence_bundle_id: "evb-hydro-synth-001",
+};
+
+document.getElementById("app").innerHTML = `
+  <p>Timeline: 2026 synthetic scope</p>
+  <p>Selected hydrology fixture: hydro-feature-001</p>
+  <div>Trust chips: <span class="chip">EVIDENCE_RESOLVED</span><span class="chip">POLICY_ALLOW</span></div>
+
+  <h3>Evidence Drawer</h3>
+  <div class="drawer">
+    <p><strong>id:</strong> ${evidenceDrawer.id}</p>
+    <p><strong>trust:</strong> ${evidenceDrawer.ui_trust_state}</p>
+    <p><strong>release:</strong> ${evidenceDrawer.release_status}</p>
+    <p><strong>evidence_ref:</strong> ${evidenceDrawer.evidence_ref}</p>
+    <p><strong>bundle:</strong> ${evidenceDrawer.evidence_bundle_id}</p>
+  </div>
+
+  <h3>Focus Mode</h3>
+  <ul><li>ANSWER</li><li>ABSTAIN</li><li>DENY</li><li>ERROR</li></ul>
+  <p>Negative states: MISSING_EVIDENCE, SOURCE_STALE, DENIED_BY_POLICY, GENERALIZED_GEOMETRY, RESTRICTED_ACCESS, CITATION_FAILED, RELEASE_WITHDRAWN, RUNTIME_ERROR</p>
+`;

--- a/contracts/runtime/governed_api_mock_payloads.md
+++ b/contracts/runtime/governed_api_mock_payloads.md
@@ -1,0 +1,16 @@
+# Governed API Mock Payloads (No Route Implementation)
+
+This contract file defines mock payload examples for governed API interactions only.
+
+## Scope
+- Payload modeling only.
+- No route implementation, runtime wiring, or handler guarantees are included in this artifact.
+
+## Mock payload source
+- `fixtures/api/governed_api_mock_payloads.json`
+
+## Included examples
+- `healthz_response`
+- `focus_mode_request`
+- `focus_mode_response`
+- `evidence_drawer_response`

--- a/docs/adr/ADR-0001-schema-home.md
+++ b/docs/adr/ADR-0001-schema-home.md
@@ -1,2 +1,20 @@
-# ADR-0001
-Schemas live in `schemas/contracts/v1`.
+# ADR-0001: Schema Home
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+All canonical contract schemas are rooted under:
+
+`schemas/contracts/v1/`
+
+Versioned subdirectories beneath this path are the only valid homes for contract schema sources.
+
+## Rationale
+- Keeps schema ownership discoverable from one stable root.
+- Supports versioned evolution without changing repository topology.
+- Separates schema definitions from runtime code, fixtures, and generated artifacts.
+
+## Consequences
+- New contract schema work must be placed under `schemas/contracts/v1/` (or a future versioned sibling approved by ADR).
+- Tools and docs should reference this path as the source of truth.

--- a/docs/adr/ADR-0002-responsibility-root-monorepo.md
+++ b/docs/adr/ADR-0002-responsibility-root-monorepo.md
@@ -1,2 +1,17 @@
-# ADR-0002
-Responsibility-root monorepo, no root domain folders.
+# ADR-0002: Responsibility-Root Monorepo Layout
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+Repository layout is responsibility-rooted (e.g., `apps/`, `schemas/`, `contracts/`, `tools/`, `tests/`) and forbids greenfield domain roots at repository top level.
+
+## Rationale
+- Enforces clear separation of concerns by function.
+- Avoids domain sprawl at root and keeps governance/tooling predictable.
+- Preserves consistent paths for automation and policy checks.
+
+## Consequences
+- Domain-specific content belongs under approved responsibility roots.
+- New top-level folders must align to responsibility, not domain naming.
+- Directory-rule checks remain the enforcement point for root hygiene.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,7 @@
-# adr
+# Architecture Decision Records (ADR)
 
-CONFIRMED: baseline scaffold created in this Codex session.
+This directory stores accepted architecture decisions for repository structure and governance.
+
+## Foundational layout decisions
+- `ADR-0001-schema-home.md` — canonical schema home.
+- `ADR-0002-responsibility-root-monorepo.md` — responsibility-root top-level layout.

--- a/docs/reports/next-repo-scan.md
+++ b/docs/reports/next-repo-scan.md
@@ -1,0 +1,69 @@
+# next-repo-scan
+
+## Scan metadata
+- **CONFIRMED** Branch: `work`.
+- **CONFIRMED** Dirty state from `git status --short`: clean (no output).
+- **CONFIRMED** Latest commit: `3ef70f46f42a6e02500e4675af73c836700d6e6d`.
+
+## Top-level directories (active checkout)
+- **CONFIRMED** `.github`, `apps`, `artifacts`, `configs`, `connectors`, `contracts`, `control_plane`, `data`, `docs`, `examples`, `fixtures`, `infra`, `migrations`, `packages`, `pipeline_specs`, `pipelines`, `policy`, `release`, `runtime`, `schemas`, `scripts`, `tests`, `tools`.
+
+## Package markers and repo README markers
+- **CONFIRMED** `README.md` files discovered at root and key subtrees, including package and module markers:
+  - `README.md`
+  - `packages/README.md`
+  - `packages/kfm_core/README.md`
+  - `apps/api/README.md`
+  - `apps/web/README.md`
+  - `schemas/README.md`
+  - `tests/README.md`
+  - `tools/README.md`
+- **NEEDS VERIFICATION** Python packaging/build-system depth beyond visible `pyproject.toml` conventions was not re-audited in this scan.
+
+## Workflow files
+- **CONFIRMED** `.github/workflows/baseline.yml`.
+- **CONFIRMED** `.github/workflows/synthetic-release-dry-run.yml`.
+- **PROPOSED** Keep synthetic dry-run workflow optional for branch policy while baseline remains required.
+
+## Schema homes
+- **CONFIRMED** Primary schema root exists at `schemas/contracts` with versioned subtree `schemas/contracts/v1`.
+- **CONFIRMED** Shared schema subtree exists at `schemas/contracts/v1/shared`.
+- **NEEDS VERIFICATION** Enforcement breadth for shared schemas vs domain schemas across all validators should be periodically reviewed.
+
+## Tests
+- **CONFIRMED** Test roots include `tests/`, `tests/public_surface/`, and `tests/domains/`.
+- **CONFIRMED** `scripts/validate_all.sh` executed and completed with passing checks plus expected dry-run ABSTAIN outputs for network-disabled probes.
+
+## Validators
+- **CONFIRMED** Validator scripts present under `tools/validators/` including:
+  - `validate_activation_decisions.py`
+  - `validate_evidence_closure.py`
+  - `validate_fixture_validation.py`
+  - `validate_public_path_guards.py`
+  - `validate_source_terms.py`
+- **CONFIRMED** Gate-style validation tools under `tools/` executed via `scripts/validate_all.sh` and passed.
+
+## Transitional roots
+- **CONFIRMED** Lifecycle/transitional directories present under `data/`:
+  - `data/raw`
+  - `data/work`
+  - `data/quarantine`
+  - `data/processed`
+- **CONFIRMED** Publication/serving-adjacent roots present:
+  - `data/catalog`
+  - `data/triplets`
+  - `data/published`
+  - `release/dry_runs`
+
+## Open UNKNOWNs
+- **UNKNOWN** Whether any downstream consumers require stricter JSON schema constraints for newly added shared schemas beyond minimal `id`-based structure.
+- **UNKNOWN** Whether synthetic mock payloads should be formally linked into contract-schema validation mapping (outside current checks).
+- **UNKNOWN** Whether CI branch protection currently treats `synthetic-release-dry-run.yml` as required or informational.
+
+## Commands run (as requested)
+- **CONFIRMED** `git status --short`
+- **CONFIRMED** `git branch --show-current`
+- **CONFIRMED** `git rev-parse HEAD`
+- **CONFIRMED** `find . -maxdepth 2 -type d | sort`
+- **CONFIRMED** `find . -maxdepth 3 -name README.md | sort`
+- **CONFIRMED** `bash scripts/validate_all.sh` (available and executed)

--- a/docs/runbooks/synthetic-release-dry-run-proof-boundary.md
+++ b/docs/runbooks/synthetic-release-dry-run-proof-boundary.md
@@ -1,0 +1,21 @@
+# Synthetic Release Dry-Run: What Is Proven vs Not Proven
+
+## What this runbook proves
+Running `bash scripts/check_synthetic_release_local.sh` proves that:
+- Required synthetic/no-network validation gates execute successfully.
+- A synthetic dry-run receipt is produced.
+- Publish is refused by policy (`publish_decision=REFUSE`) even when gates pass.
+
+## What this runbook does **not** prove
+This runbook does not prove:
+- Real external connectivity behavior (network is intentionally not used).
+- Live-source freshness, uptime, or third-party API correctness.
+- Production deployment readiness or operational SLO compliance.
+- That publication occurred (it must not occur in this dry-run path).
+
+## Commands
+- Local: `bash scripts/check_synthetic_release_local.sh`
+- Direct dry-run only: `python tools/synthetic_release_dry_run.py`
+
+## Artifacts
+- Dry-run receipt: `release/dry_runs/synthetic_release_dry_run_receipt.json`

--- a/fixtures/api/governed_api_mock_payloads.json
+++ b/fixtures/api/governed_api_mock_payloads.json
@@ -1,0 +1,28 @@
+{
+  "governed_api": {
+    "healthz_response": {
+      "status": "ok",
+      "service": "kfm-mock-api",
+      "mode": "synthetic_no_network"
+    },
+    "focus_mode_request": {
+      "question": "What is the flood risk status for synthetic parcel A?",
+      "scope": "public",
+      "trace_id": "trace-focus-001"
+    },
+    "focus_mode_response": {
+      "outcome": "ABSTAIN",
+      "reason": "MISSING_EVIDENCE",
+      "citations": [],
+      "trace_id": "trace-focus-001"
+    },
+    "evidence_drawer_response": {
+      "id": "drawer-hydro-001",
+      "ui_trust_state": "EVIDENCE_MISSING",
+      "release_status": "ABSTAIN",
+      "evidence_ref": "evr-hydro-synth-001",
+      "evidence_bundle_id": "evb-hydro-synth-001",
+      "sources": []
+    }
+  }
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_bad_activation_enum.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_bad_activation_enum.json
@@ -1,0 +1,12 @@
+{
+  "id": "HYDRO-NONET-INVALID-ACTIVATION-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "MAYBE",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_invented_http_facts.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_invented_http_facts.json
@@ -1,0 +1,20 @@
+{
+  "id": "HYDRO-NONET-INVALID-HTTP-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "http_facts": [
+    {
+      "kind": "LIVE_HTTP_RESPONSE",
+      "status": 200,
+      "url": "https://example.invalid/usgs",
+      "detail": "Invented live API response in no-network mode"
+    }
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_missing_citations.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_missing_citations.json
@@ -1,0 +1,10 @@
+{
+  "id": "HYDRO-NONET-INVALID-CITATIONS-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_unresolved_evidence.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_unresolved_evidence.json
@@ -1,0 +1,12 @@
+{
+  "id": "HYDRO-NONET-INVALID-UNRESOLVED-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ANSWER",
+  "reason": "RESOLVED",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json
@@ -1,0 +1,19 @@
+{
+  "id": "HYDRO-NONET-VALID-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "http_facts": [
+    {
+      "kind": "NO_NETWORK_ASSERTION",
+      "observed": true,
+      "detail": "No external HTTP request executed in synthetic baseline mode"
+    }
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/release/dry_runs/synthetic_release_dry_run_receipt.json
+++ b/release/dry_runs/synthetic_release_dry_run_receipt.json
@@ -1,0 +1,65 @@
+{
+  "id": "synthetic-release-dry-run-001",
+  "mode": "SYNTHETIC_NO_NETWORK",
+  "publish_decision": "REFUSE",
+  "result": "PASS",
+  "gates": [
+    {
+      "gate": "tools/validate_fixtures.py",
+      "returncode": 0,
+      "stdout": "PASS valid fixtures pass and invalid fixtures remain intentionally invalid",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validate_schema_conformance.py",
+      "returncode": 0,
+      "stdout": "PASS validated schema-conformance checks for 7 fixture contracts",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validate_api_contracts.py",
+      "returncode": 0,
+      "stdout": "PASS api contract checks",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/check_directory_rules.py",
+      "returncode": 0,
+      "stdout": "PASS directory rules satisfied",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/check_no_public_internal_paths.py",
+      "returncode": 0,
+      "stdout": "PASS no prohibited internal/public-surface path or sensitivity leakage",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validators/validate_evidence_closure.py",
+      "returncode": 0,
+      "stdout": "PASS evidence closure validated",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validators/validate_activation_decisions.py",
+      "returncode": 0,
+      "stdout": "PASS source activation decisions validated",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validators/validate_source_terms.py",
+      "returncode": 0,
+      "stdout": "PASS source terms fixtures validated",
+      "stderr": "",
+      "status": "PASS"
+    }
+  ],
+  "reason": "DRY_RUN_ONLY_REFUSES_PUBLISH"
+}

--- a/schemas/contracts/v1/shared/correction_notice.schema.json
+++ b/schemas/contracts/v1/shared/correction_notice.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CorrectionNotice",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_bundle.schema.json
+++ b/schemas/contracts/v1/shared/evidence_bundle.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceBundle",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_ref.schema.json
+++ b/schemas/contracts/v1/shared/evidence_ref.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceRef",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/policy_decision.schema.json
+++ b/schemas/contracts/v1/shared/policy_decision.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PolicyDecision",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "decision": {
+      "enum": ["ALLOW", "ABSTAIN", "DENY", "ERROR"]
+    }
+  },
+  "required": ["id", "decision"]
+}

--- a/schemas/contracts/v1/shared/rollback_reference.schema.json
+++ b/schemas/contracts/v1/shared/rollback_reference.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RollbackReference",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
+++ b/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RuntimeResponseEnvelope",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/source_descriptor.schema.json
+++ b/schemas/contracts/v1/shared/source_descriptor.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SourceDescriptor",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/scripts/check_synthetic_release_local.sh
+++ b/scripts/check_synthetic_release_local.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python tools/validate_fixtures.py
+python tools/validators/validate_source_terms.py
+python tools/validators/validate_activation_decisions.py
+python tools/validators/validate_evidence_closure.py
+python tools/validators/validate_public_path_guards.py
+python tools/synthetic_release_dry_run.py
+
+echo "PASS local synthetic release checks completed (publish remains refused by dry-run policy)"

--- a/tests/test_mock_api_read_only_routes.py
+++ b/tests/test_mock_api_read_only_routes.py
@@ -1,0 +1,20 @@
+import unittest
+
+from apps.api.kfm_mock_api import get_mock_focus, get_mock_policy
+
+
+class MockApiReadOnlyRouteTests(unittest.TestCase):
+    def test_get_mock_policy(self):
+        payload, code = get_mock_policy()
+        self.assertEqual(code, 200)
+        self.assertEqual(payload.get("mode"), "SYNTHETIC_NO_NETWORK")
+        self.assertEqual(payload.get("decision"), "ABSTAIN")
+
+    def test_get_mock_focus(self):
+        payload, code = get_mock_focus()
+        self.assertEqual(code, 200)
+        self.assertIn(payload.get("outcome"), {"ANSWER", "ABSTAIN", "DENY", "ERROR"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_model_no_network_policy.py
+++ b/tests/test_no_model_no_network_policy.py
@@ -1,0 +1,27 @@
+import unittest
+
+from apps.api.no_model_no_network_policy import FINITE_OUTCOMES, focus_mock
+
+
+class NoModelNoNetworkPolicyTests(unittest.TestCase):
+    def test_focus_mock_finite_outcomes_only(self):
+        cases = [
+            {"question": "", "expected": "ABSTAIN"},
+            {"question": "q", "network_required": True, "expected": "DENY"},
+            {"question": "q", "model_required": True, "expected": "DENY"},
+            {"question": "q", "evidence_resolved": False, "expected": "ABSTAIN"},
+            {"question": "q", "evidence_resolved": True, "expected": "ANSWER"},
+        ]
+        for case in cases:
+            expected = case.pop("expected")
+            out = focus_mock(case)
+            self.assertEqual(out["outcome"], expected)
+            self.assertIn(out["outcome"], FINITE_OUTCOMES)
+
+    def test_non_dict_request_errors(self):
+        out = focus_mock("not-a-dict")
+        self.assertEqual(out["outcome"], "ERROR")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_synthetic_release_dry_run.py
+++ b/tests/test_synthetic_release_dry_run.py
@@ -1,0 +1,20 @@
+import json
+import unittest
+from pathlib import Path
+
+from tests.subprocess_utils import assert_python_ok
+
+
+class SyntheticReleaseDryRunTests(unittest.TestCase):
+    def test_synthetic_release_dry_run_tool(self):
+        assert_python_ok(self, ["tools/synthetic_release_dry_run.py"])
+
+        receipt = json.loads(Path("release/dry_runs/synthetic_release_dry_run_receipt.json").read_text())
+        self.assertEqual(receipt.get("publish_decision"), "REFUSE")
+        self.assertEqual(receipt.get("reason"), "DRY_RUN_ONLY_REFUSES_PUBLISH")
+        self.assertIn(receipt.get("result"), {"PASS", "FAIL"})
+        self.assertTrue(receipt.get("gates"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validator_extensions.py
+++ b/tests/test_validator_extensions.py
@@ -1,0 +1,68 @@
+import json
+import unittest
+from pathlib import Path
+
+from tests.subprocess_utils import assert_python_ok
+
+
+class ValidatorScriptTests(unittest.TestCase):
+    def test_validator_scripts(self):
+        for script in [
+            "tools/validators/validate_source_terms.py",
+            "tools/validators/validate_activation_decisions.py",
+            "tools/validators/validate_evidence_closure.py",
+            "tools/validators/validate_public_path_guards.py",
+            "tools/validators/validate_fixture_validation.py",
+        ]:
+            with self.subTest(script=script):
+                assert_python_ok(self, [script])
+
+
+class HashingTests(unittest.TestCase):
+    def test_compute_spec_hash_shared_schema(self):
+        assert_python_ok(self, ["tools/compute_spec_hash.py", "schemas/contracts/v1/shared/policy_decision.schema.json"])
+
+
+class EvidenceClosureFixtureTests(unittest.TestCase):
+    def test_evidence_ref_closes_to_bundle(self):
+        evidence_ref = json.loads(Path("fixtures/evidence/evidence_ref.valid.json").read_text())
+        bundle = json.loads(Path("fixtures/evidence/evidence_bundle.valid.json").read_text())
+        self.assertEqual(evidence_ref.get("bundle_id"), bundle.get("id"))
+        self.assertIn(evidence_ref.get("id"), bundle.get("evidence_refs", []))
+
+
+class InvalidFixtureSemanticsTests(unittest.TestCase):
+    def test_intentional_invalid_no_network_fixtures(self):
+        base = Path("fixtures/domains/hydrology/no_network")
+
+        unresolved = json.loads((base / "hydrology_no_network.invalid_unresolved_evidence.json").read_text())
+        self.assertEqual(unresolved["focus_outcome"], "ANSWER")
+        self.assertFalse(unresolved["evidence_resolved"])
+
+        bad_enum = json.loads((base / "hydrology_no_network.invalid_bad_activation_enum.json").read_text())
+        self.assertNotIn(bad_enum["source_activation_decision"], {"ALLOW", "ABSTAIN", "DENY", "ERROR"})
+
+        missing_citations = json.loads((base / "hydrology_no_network.invalid_missing_citations.json").read_text())
+        self.assertEqual(missing_citations.get("citations"), [])
+
+        invented_http = json.loads((base / "hydrology_no_network.invalid_invented_http_facts.json").read_text())
+        self.assertEqual(invented_http["network_mode"], "DISABLED")
+        self.assertEqual(invented_http["http_facts"][0]["kind"], "LIVE_HTTP_RESPONSE")
+
+
+class NoNetworkBehaviorTests(unittest.TestCase):
+    def test_valid_no_network_fixture(self):
+        valid = json.loads(Path("fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json").read_text())
+        self.assertEqual(valid["network_mode"], "DISABLED")
+        self.assertEqual(valid["source_activation_decision"], "ABSTAIN")
+        self.assertEqual(valid["focus_outcome"], "ABSTAIN")
+        self.assertGreater(len(valid.get("citations", [])), 0)
+
+
+class HydrologySyntheticProofTests(unittest.TestCase):
+    def test_hydrology_proof_validator(self):
+        assert_python_ok(self, ["tools/validators/validate_hydrology_proof_slice.py"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/synthetic_release_dry_run.py
+++ b/tools/synthetic_release_dry_run.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT = ROOT / "release/dry_runs/synthetic_release_dry_run_receipt.json"
+
+GATES = [
+    ["tools/validate_fixtures.py"],
+    ["tools/validate_schema_conformance.py"],
+    ["tools/validate_api_contracts.py"],
+    ["tools/check_directory_rules.py"],
+    ["tools/check_no_public_internal_paths.py"],
+    ["tools/validators/validate_evidence_closure.py"],
+    ["tools/validators/validate_activation_decisions.py"],
+    ["tools/validators/validate_source_terms.py"],
+]
+
+
+def run_gate(args: list[str]) -> dict:
+    proc = subprocess.run([sys.executable, str(ROOT / args[0]), *args[1:]], capture_output=True, text=True)
+    return {
+        "gate": args[0],
+        "returncode": proc.returncode,
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+        "status": "PASS" if proc.returncode == 0 else "FAIL",
+    }
+
+
+def main() -> int:
+    gate_results = [run_gate(g) for g in GATES]
+    failed = [g for g in gate_results if g["status"] == "FAIL"]
+
+    receipt = {
+        "id": "synthetic-release-dry-run-001",
+        "mode": "SYNTHETIC_NO_NETWORK",
+        "publish_decision": "REFUSE",
+        "result": "PASS" if not failed else "FAIL",
+        "gates": gate_results,
+        "reason": "DRY_RUN_ONLY_REFUSES_PUBLISH",
+    }
+
+    RECEIPT.parent.mkdir(parents=True, exist_ok=True)
+    RECEIPT.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+
+    if failed:
+        print("FAIL", f"{len(failed)} gates failed; publish refused; receipt={RECEIPT}")
+        return 1
+
+    print("PASS", f"all gates passed; publish refused by policy; receipt={RECEIPT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_activation_decisions.py
+++ b/tools/validators/validate_activation_decisions.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    allowed = {"ALLOW", "ABSTAIN", "DENY", "ERROR"}
+
+    for path in sorted((ROOT / "fixtures/source/hydrology").glob("source_activation_decision*.valid.json")):
+        data = json.loads(path.read_text())
+        decision = data.get("decision")
+        if decision not in allowed:
+            errors.append(f"{path.name} invalid decision: {decision}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS source activation decisions validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_evidence_closure.py
+++ b/tools/validators/validate_evidence_closure.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    evidence_ref = json.loads((ROOT / "fixtures/evidence/evidence_ref.valid.json").read_text())
+    bundle = json.loads((ROOT / "fixtures/evidence/evidence_bundle.valid.json").read_text())
+
+    if evidence_ref.get("bundle_id") != bundle.get("id"):
+        errors.append("evidence_ref.bundle_id must match evidence_bundle.id")
+    if evidence_ref.get("id") not in bundle.get("evidence_refs", []):
+        errors.append("evidence_ref.id must be listed in evidence_bundle.evidence_refs")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS evidence closure validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_fixture_validation.py
+++ b/tools/validators/validate_fixture_validation.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    cmd = [sys.executable, str(ROOT / "tools/validate_fixtures.py")]
+    result = subprocess.run(cmd, cwd=ROOT)
+    if result.returncode != 0:
+        print("FAIL fixture validation")
+        return result.returncode
+    print("PASS fixture validation")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_public_path_guards.py
+++ b/tools/validators/validate_public_path_guards.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FORBIDDEN = ["data/raw/", "data/work/", "data/quarantine/", "data/processed/"]
+TARGETS = [
+    "fixtures/ui/evidence_drawer_payload.valid.json",
+    "fixtures/ai/focus_mode_response.answer.valid.json",
+    "fixtures/release/release_manifest.valid.json",
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    for rel in TARGETS:
+        text = json.dumps(json.loads((ROOT / rel).read_text())).lower()
+        for bad in FORBIDDEN:
+            if bad in text:
+                errors.append(f"{rel} contains forbidden path fragment: {bad}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS public-path guards validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_source_terms.py
+++ b/tools/validators/validate_source_terms.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    review = json.loads((ROOT / "fixtures/source/hydrology/source_terms_review.valid.json").read_text())
+    receipt = json.loads((ROOT / "fixtures/source/hydrology/source_terms_check_receipt.wbd.no_network.valid.json").read_text())
+
+    if review.get("rights_status") not in {"NEEDS_LEGAL_REVIEW", "CLEARED", "DENIED"}:
+        errors.append("source_terms_review has invalid rights_status")
+    if receipt.get("check_kind") != "TERMS_RIGHTS_ONLY":
+        errors.append("source_terms_check_receipt must be TERMS_RIGHTS_ONLY")
+    if receipt.get("network_mode") != "DISABLED":
+        errors.append("source_terms_check_receipt network_mode must be DISABLED")
+    if receipt.get("validation_result") not in {"ALLOW", "ABSTAIN", "DENY", "ERROR"}:
+        errors.append("source_terms_check_receipt has invalid validation_result")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS source terms fixtures validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a reproducible synthetic/no-network dry-run path that validates fixtures, contracts, and policy gates without performing any external network I/O or publishing.
- Supply small, canonical shared schemas and mock payloads to support no-network proofing and runtime contract checks.
- Add lightweight runtime mocks and a no-model/no-network policy evaluator to exercise Focus and Policy behaviors in payload-only mode.
- Surface repository-level ADRs and runbook guidance for schema layout and the synthetic dry-run proof boundary.

### Description
- Add `tools/synthetic_release_dry_run.py` and `scripts/check_synthetic_release_local.sh` to run a sequence of validator gates and emit a dry-run receipt at `release/dry_runs/synthetic_release_dry_run_receipt.json` with `publish_decision: REFUSE`.
- Introduce multiple validator scripts under `tools/validators/` (`validate_evidence_closure.py`, `validate_activation_decisions.py`, `validate_source_terms.py`, `validate_public_path_guards.py`, `validate_fixture_validation.py`) and wire them into the dry-run gate list.
- Add mock runtime pieces: `apps/api/no_model_no_network_policy.py` (policy evaluator and Focus mock) and new read-only routes in `apps/api/kfm_mock_api.py` with `get_mock_policy` and `get_mock_focus` and corresponding unit tests.
- Add fixtures and example payloads under `fixtures/` including governed API mock payloads and no-network hydrology fixtures (valid and intentionally invalid cases) and small shared schemas under `schemas/contracts/v1/shared/`.
- Update web UI example `apps/web/src/app.js` to render an evidence drawer example, and add ADRs and documentation (`docs/adr/*`, `docs/runbooks/*`, `docs/reports/*`) describing the schema home, repo layout, and synthetic dry-run proof boundary.
- Add unit tests for the new validators, policy logic, mock API routes, and the synthetic dry-run tool under `tests/` and a GitHub Actions workflow `/.github/workflows/synthetic-release-dry-run.yml` to run the local dry-run in CI.

### Testing
- Executed `bash scripts/check_synthetic_release_local.sh`, which ran the validator gates and `tools/synthetic_release_dry_run.py`, and produced `release/dry_runs/synthetic_release_dry_run_receipt.json` with `"publish_decision": "REFUSE"` and `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e5911f34832ab7ac3084becb5e04)