### PR TITLE
Add synthetic no-network dry-run tooling, shared schemas, validators, mocks, fixtures and tests

### DIFF
--- a/.github/workflows/synthetic-release-dry-run.yml
+++ b/.github/workflows/synthetic-release-dry-run.yml
@@ -1,0 +1,16 @@
+name: synthetic-release-dry-run
+
+on:
+  pull_request:
+  push:
+    branches: ["**"]
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: bash scripts/check_synthetic_release_local.sh

--- a/apps/api/kfm_mock_api.py
+++ b/apps/api/kfm_mock_api.py
@@ -50,6 +50,25 @@ def get_drawer(drawer_id: str) -> tuple[dict, int]:
     return drawer, 200
 
 
+
+
+def get_mock_policy() -> tuple[dict, int]:
+    return {
+        "id": "mock-policy-001",
+        "mode": "SYNTHETIC_NO_NETWORK",
+        "decision": "ABSTAIN",
+        "reason": "PAYLOAD_ONLY",
+    }, 200
+
+
+def get_mock_focus() -> tuple[dict, int]:
+    return {
+        "id": "mock-focus-001",
+        "outcome": "ABSTAIN",
+        "reason": "MISSING_EVIDENCE",
+        "citations": [],
+    }, 200
+
 def focus_decision(request: dict) -> tuple[dict, int]:
     question = str(request.get("question", "")).strip().lower()
     if not question:
@@ -93,6 +112,12 @@ class Handler(BaseHTTPRequestHandler):
         if self.path.startswith("/v1/drawer/"):
             drawer_id = self.path.rsplit("/", 1)[-1]
             payload, code = get_drawer(drawer_id)
+            return self._json(payload, code)
+        if self.path == "/v1/mock/policy":
+            payload, code = get_mock_policy()
+            return self._json(payload, code)
+        if self.path == "/v1/mock/focus":
+            payload, code = get_mock_focus()
             return self._json(payload, code)
         return self._json({"outcome": "ERROR", "reason": "NOT_FOUND"}, 404)
 

--- a/apps/api/no_model_no_network_policy.py
+++ b/apps/api/no_model_no_network_policy.py
@@ -1,0 +1,36 @@
+"""No-model, no-network policy evaluator and Focus mock.
+
+This module is payload-only decision logic (no live model calls, no network I/O).
+"""
+
+FINITE_OUTCOMES = {"ANSWER", "ABSTAIN", "DENY", "ERROR"}
+
+
+def evaluate_policy(request: dict) -> dict:
+    """Evaluate request under no-model, no-network policy gates."""
+    if not isinstance(request, dict):
+        return {"outcome": "ERROR", "reason": "INVALID_REQUEST"}
+
+    question = str(request.get("question", "")).strip()
+    if not question:
+        return {"outcome": "ABSTAIN", "reason": "EMPTY_QUERY"}
+
+    if request.get("network_required") is True:
+        return {"outcome": "DENY", "reason": "NO_NETWORK_POLICY"}
+
+    if request.get("model_required") is True:
+        return {"outcome": "DENY", "reason": "NO_MODEL_POLICY"}
+
+    if request.get("evidence_resolved") is not True:
+        return {"outcome": "ABSTAIN", "reason": "MISSING_EVIDENCE"}
+
+    return {"outcome": "ANSWER", "reason": "POLICY_ALLOW"}
+
+
+def focus_mock(request: dict) -> dict:
+    """Return one of ANSWER/ABSTAIN/DENY/ERROR only."""
+    result = evaluate_policy(request)
+    outcome = result.get("outcome", "ERROR")
+    if outcome not in FINITE_OUTCOMES:
+        return {"outcome": "ERROR", "reason": "NON_FINITE_OUTCOME"}
+    return {"outcome": outcome, "reason": result.get("reason", "UNSPECIFIED")}

--- a/apps/web/src/app.js
+++ b/apps/web/src/app.js
@@ -1,1 +1,26 @@
-document.getElementById("app").innerHTML=`<p>Timeline: 2026 synthetic scope</p><p>Selected hydrology fixture: hydro-feature-001</p><div>Trust chips: <span class="chip">EVIDENCE_RESOLVED</span><span class="chip">POLICY_ALLOW</span></div><h3>Evidence Drawer</h3><p>bundle: evb-hydro-001</p><h3>Focus Mode</h3><ul><li>ANSWER</li><li>ABSTAIN</li><li>DENY</li><li>ERROR</li></ul><p>Negative states: MISSING_EVIDENCE, SOURCE_STALE, DENIED_BY_POLICY, GENERALIZED_GEOMETRY, RESTRICTED_ACCESS, CITATION_FAILED, RELEASE_WITHDRAWN, RUNTIME_ERROR</p>`;
+const evidenceDrawer = {
+  id: "drawer-hydro-001",
+  ui_trust_state: "EVIDENCE_MISSING",
+  release_status: "ABSTAIN",
+  evidence_ref: "evr-hydro-synth-001",
+  evidence_bundle_id: "evb-hydro-synth-001",
+};
+
+document.getElementById("app").innerHTML = `
+  <p>Timeline: 2026 synthetic scope</p>
+  <p>Selected hydrology fixture: hydro-feature-001</p>
+  <div>Trust chips: <span class="chip">EVIDENCE_RESOLVED</span><span class="chip">POLICY_ALLOW</span></div>
+
+  <h3>Evidence Drawer</h3>
+  <div class="drawer">
+    <p><strong>id:</strong> ${evidenceDrawer.id}</p>
+    <p><strong>trust:</strong> ${evidenceDrawer.ui_trust_state}</p>
+    <p><strong>release:</strong> ${evidenceDrawer.release_status}</p>
+    <p><strong>evidence_ref:</strong> ${evidenceDrawer.evidence_ref}</p>
+    <p><strong>bundle:</strong> ${evidenceDrawer.evidence_bundle_id}</p>
+  </div>
+
+  <h3>Focus Mode</h3>
+  <ul><li>ANSWER</li><li>ABSTAIN</li><li>DENY</li><li>ERROR</li></ul>
+  <p>Negative states: MISSING_EVIDENCE, SOURCE_STALE, DENIED_BY_POLICY, GENERALIZED_GEOMETRY, RESTRICTED_ACCESS, CITATION_FAILED, RELEASE_WITHDRAWN, RUNTIME_ERROR</p>
+`;

--- a/contracts/runtime/governed_api_mock_payloads.md
+++ b/contracts/runtime/governed_api_mock_payloads.md
@@ -1,0 +1,16 @@
+# Governed API Mock Payloads (No Route Implementation)
+
+This contract file defines mock payload examples for governed API interactions only.
+
+## Scope
+- Payload modeling only.
+- No route implementation, runtime wiring, or handler guarantees are included in this artifact.
+
+## Mock payload source
+- `fixtures/api/governed_api_mock_payloads.json`
+
+## Included examples
+- `healthz_response`
+- `focus_mode_request`
+- `focus_mode_response`
+- `evidence_drawer_response`

--- a/control_plane/root_surface_register.yaml
+++ b/control_plane/root_surface_register.yaml
@@ -1,0 +1,146 @@
+version: 1
+allowed_classes:
+  - canonical
+  - compatibility
+  - transitional
+  - generated
+  - data-lifecycle
+  - release/proof
+  - runtime
+  - policy
+  - UNKNOWN
+
+roots:
+  .github:
+    class: canonical
+    notes: CI/workflow definitions.
+  apps:
+    class: canonical
+    notes: Application surfaces (API + web).
+  artifacts:
+    class: generated
+    notes: Generated build/publication artifacts.
+  configs:
+    class: canonical
+    notes: Runtime/configuration inputs.
+  connectors:
+    class: compatibility
+    notes: Connector interfaces and offline adapters.
+  contracts:
+    class: canonical
+    notes: Human-readable contract specs.
+  control_plane:
+    class: policy
+    notes: Governance registers and controls.
+  data:
+    class: data-lifecycle
+    notes: Raw/work/quarantine/processed/catalog/triplets/published lifecycle roots.
+  docs:
+    class: canonical
+    notes: Human documentation, ADRs, runbooks, reports.
+  examples:
+    class: compatibility
+    notes: Example walkthroughs and reference slices.
+  fixtures:
+    class: compatibility
+    notes: Test and mock payload fixtures.
+  infra:
+    class: compatibility
+    notes: Infrastructure support files.
+  migrations:
+    class: transitional
+    notes: Migration-specific transition assets.
+  packages:
+    class: canonical
+    notes: Package/library roots.
+  pipeline_specs:
+    class: canonical
+    notes: Pipeline specification definitions.
+  pipelines:
+    class: canonical
+    notes: Pipeline implementations and domain flows.
+  policy:
+    class: policy
+    notes: Policy definitions and tests.
+  policies:
+    class: transitional
+    notes: Compatibility/transitional policy mirror surface.
+  release:
+    class: release/proof
+    notes: Dry-run and release proof artifacts.
+  runtime:
+    class: runtime
+    notes: Runtime envelopes/receipts and interfaces.
+  schemas:
+    class: canonical
+    notes: Canonical schema home.
+  scripts:
+    class: canonical
+    notes: Local orchestration and check scripts.
+  tests:
+    class: canonical
+    notes: Automated test suite.
+  tools:
+    class: canonical
+    notes: Validation, probing, and governance tools.
+  .git:
+    class: generated
+    notes: Git metadata directory.
+
+cross_links:
+  .github:
+    related:
+      - docs
+      - control_plane
+  docs:
+    related:
+      - control_plane
+      - contracts
+      - schemas
+      - policy
+  control_plane:
+    related:
+      - docs
+      - policy
+  contracts:
+    related:
+      - schemas
+      - docs
+  schemas:
+    related:
+      - contracts
+      - docs
+  policy:
+    related:
+      - control_plane
+      - docs
+  policies:
+    related:
+      - policy
+      - docs
+    class: compatibility
+  ui:
+    related:
+      - apps
+      - docs
+    class: transitional
+  web:
+    related:
+      - apps
+      - docs
+    class: compatibility
+  jsonschema:
+    related:
+      - schemas
+      - contracts
+    class: compatibility
+  styles:
+    related:
+      - apps
+      - docs
+    class: compatibility
+  viewer_templates:
+    related:
+      - apps
+      - docs
+    class: compatibility

--- a/docs/adr/ADR-0001-schema-home.md
+++ b/docs/adr/ADR-0001-schema-home.md
@@ -1,2 +1,20 @@
-# ADR-0001
-Schemas live in `schemas/contracts/v1`.
+# ADR-0001: Schema Home
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+All canonical contract schemas are rooted under:
+
+`schemas/contracts/v1/`
+
+Versioned subdirectories beneath this path are the only valid homes for contract schema sources.
+
+## Rationale
+- Keeps schema ownership discoverable from one stable root.
+- Supports versioned evolution without changing repository topology.
+- Separates schema definitions from runtime code, fixtures, and generated artifacts.
+
+## Consequences
+- New contract schema work must be placed under `schemas/contracts/v1/` (or a future versioned sibling approved by ADR).
+- Tools and docs should reference this path as the source of truth.

--- a/docs/adr/ADR-0002-policy-home.md
+++ b/docs/adr/ADR-0002-policy-home.md
@@ -1,0 +1,18 @@
+# ADR-0002: Policy Home
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+`policy/` is the canonical home for policy semantics.
+
+If `policies/` is present, it is treated as compatibility/transitional (or mirrored) only.
+
+## Rationale
+- Aligns policy governance to a single canonical root.
+- Prevents semantic drift from split canonical policy surfaces.
+- Allows migration/compatibility bridges without weakening canonical ownership.
+
+## Consequences
+- New canonical policy content must be added under `policy/`.
+- `policies/` may contain only README/migration-oriented compatibility notes unless explicitly governed otherwise.

--- a/docs/adr/ADR-0002-responsibility-root-monorepo.md
+++ b/docs/adr/ADR-0002-responsibility-root-monorepo.md
@@ -1,2 +1,17 @@
-# ADR-0002
-Responsibility-root monorepo, no root domain folders.
+# ADR-0002: Responsibility-Root Monorepo Layout
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+
+## Decision
+Repository layout is responsibility-rooted (e.g., `apps/`, `schemas/`, `contracts/`, `tools/`, `tests/`) and forbids greenfield domain roots at repository top level.
+
+## Rationale
+- Enforces clear separation of concerns by function.
+- Avoids domain sprawl at root and keeps governance/tooling predictable.
+- Preserves consistent paths for automation and policy checks.
+
+## Consequences
+- Domain-specific content belongs under approved responsibility roots.
+- New top-level folders must align to responsibility, not domain naming.
+- Directory-rule checks remain the enforcement point for root hygiene.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,7 @@
-# adr
+# Architecture Decision Records (ADR)
 
-CONFIRMED: baseline scaffold created in this Codex session.
+This directory stores accepted architecture decisions for repository structure and governance.
+
+## Foundational layout decisions
+- `ADR-0001-schema-home.md` — canonical schema home.
+- `ADR-0002-responsibility-root-monorepo.md` — responsibility-root top-level layout.

--- a/docs/registers/root-surface-register.md
+++ b/docs/registers/root-surface-register.md
@@ -1,0 +1,25 @@
+# Root Surface Compatibility Register
+
+Source of truth: `control_plane/root_surface_register.yaml`.
+
+## Purpose
+Classify each repository root surface for governance and compatibility handling.
+
+## Allowed classes
+- canonical
+- compatibility
+- transitional
+- generated
+- data-lifecycle
+- release/proof
+- runtime
+- policy
+- UNKNOWN
+
+## Cross-links (required)
+The register explicitly cross-links these surfaces:
+- `.github`, `docs`, `control_plane`, `contracts`, `schemas`, `policy`, `policies`, `ui`, `web`, `jsonschema`, `styles`, `viewer_templates`.
+
+## Notes
+- Some cross-linked compatibility/transitional roots may be absent in current checkout.
+- Absent roots are tracked for compatibility governance, not as active canonical roots.

--- a/docs/reports/hydrology-proof-slice-current-state.md
+++ b/docs/reports/hydrology-proof-slice-current-state.md
@@ -1,0 +1,27 @@
+# Hydrology Proof Slice — Current State
+
+Date: 2026-05-05
+
+## CONFIRMED (by files)
+- Source descriptor exists for synthetic/no-network posture in `fixtures/source/source_descriptor.valid.json`.
+- Evidence closure primitives exist in `fixtures/evidence/evidence_ref.valid.json` and `fixtures/evidence/evidence_bundle.valid.json`.
+- Evidence Drawer payload exists in `fixtures/ui/evidence_drawer_payload.valid.json`.
+- Focus-mode outcomes and hydrology focus fixtures exist in `fixtures/ai/` and `fixtures/domains/hydrology/focus/`.
+- Release manifest and rollback artifacts exist in `fixtures/release/release_manifest.valid.json` and `fixtures/release/rollback_card.valid.json`.
+- Mock API read-only surfaces exist in `apps/api/kfm_mock_api.py`.
+
+## CONFIRMED (by tests/checks)
+- `tools/validators/validate_evidence_closure.py` confirms ref-to-bundle closure logic for baseline fixtures.
+- `tools/validators/validate_hydrology_proof_slice.py` confirms hardening checks for source/evidence/drawer/release consistency.
+- `tests/test_mock_api_read_only_routes.py` confirms stable read-only mock surfaces.
+- `tests/test_hydrology_proof_slice_current_state.py` confirms new negative proofs:
+  - Focus ABSTAINS when EvidenceBundle closure is missing.
+  - Promotion DENIES before release manifest + rollback reference.
+
+## Added negative proofs
+- `fixtures/domains/hydrology/focus/hydrology_synthetic_streamflow.public_abstain_missing_bundle_closure.json`
+- `fixtures/domains/hydrology/release_dry_runs/hydrology_synthetic_streamflow.publish_denied.missing_manifest_and_rollback_ref.json`
+
+## Remaining UNKNOWN/NEEDS VERIFICATION
+- Whether additional domain-specific closure reasons should be enumerated beyond `MISSING_EVIDENCE`.
+- Whether promotion denial reason taxonomy should be expanded for finer rollback/manifest sub-states.

--- a/docs/reports/next-repo-scan.md
+++ b/docs/reports/next-repo-scan.md
@@ -1,0 +1,69 @@
+# next-repo-scan
+
+## Scan metadata
+- **CONFIRMED** Branch: `work`.
+- **CONFIRMED** Dirty state from `git status --short`: clean (no output).
+- **CONFIRMED** Latest commit: `3ef70f46f42a6e02500e4675af73c836700d6e6d`.
+
+## Top-level directories (active checkout)
+- **CONFIRMED** `.github`, `apps`, `artifacts`, `configs`, `connectors`, `contracts`, `control_plane`, `data`, `docs`, `examples`, `fixtures`, `infra`, `migrations`, `packages`, `pipeline_specs`, `pipelines`, `policy`, `release`, `runtime`, `schemas`, `scripts`, `tests`, `tools`.
+
+## Package markers and repo README markers
+- **CONFIRMED** `README.md` files discovered at root and key subtrees, including package and module markers:
+  - `README.md`
+  - `packages/README.md`
+  - `packages/kfm_core/README.md`
+  - `apps/api/README.md`
+  - `apps/web/README.md`
+  - `schemas/README.md`
+  - `tests/README.md`
+  - `tools/README.md`
+- **NEEDS VERIFICATION** Python packaging/build-system depth beyond visible `pyproject.toml` conventions was not re-audited in this scan.
+
+## Workflow files
+- **CONFIRMED** `.github/workflows/baseline.yml`.
+- **CONFIRMED** `.github/workflows/synthetic-release-dry-run.yml`.
+- **PROPOSED** Keep synthetic dry-run workflow optional for branch policy while baseline remains required.
+
+## Schema homes
+- **CONFIRMED** Primary schema root exists at `schemas/contracts` with versioned subtree `schemas/contracts/v1`.
+- **CONFIRMED** Shared schema subtree exists at `schemas/contracts/v1/shared`.
+- **NEEDS VERIFICATION** Enforcement breadth for shared schemas vs domain schemas across all validators should be periodically reviewed.
+
+## Tests
+- **CONFIRMED** Test roots include `tests/`, `tests/public_surface/`, and `tests/domains/`.
+- **CONFIRMED** `scripts/validate_all.sh` executed and completed with passing checks plus expected dry-run ABSTAIN outputs for network-disabled probes.
+
+## Validators
+- **CONFIRMED** Validator scripts present under `tools/validators/` including:
+  - `validate_activation_decisions.py`
+  - `validate_evidence_closure.py`
+  - `validate_fixture_validation.py`
+  - `validate_public_path_guards.py`
+  - `validate_source_terms.py`
+- **CONFIRMED** Gate-style validation tools under `tools/` executed via `scripts/validate_all.sh` and passed.
+
+## Transitional roots
+- **CONFIRMED** Lifecycle/transitional directories present under `data/`:
+  - `data/raw`
+  - `data/work`
+  - `data/quarantine`
+  - `data/processed`
+- **CONFIRMED** Publication/serving-adjacent roots present:
+  - `data/catalog`
+  - `data/triplets`
+  - `data/published`
+  - `release/dry_runs`
+
+## Open UNKNOWNs
+- **UNKNOWN** Whether any downstream consumers require stricter JSON schema constraints for newly added shared schemas beyond minimal `id`-based structure.
+- **UNKNOWN** Whether synthetic mock payloads should be formally linked into contract-schema validation mapping (outside current checks).
+- **UNKNOWN** Whether CI branch protection currently treats `synthetic-release-dry-run.yml` as required or informational.
+
+## Commands run (as requested)
+- **CONFIRMED** `git status --short`
+- **CONFIRMED** `git branch --show-current`
+- **CONFIRMED** `git rev-parse HEAD`
+- **CONFIRMED** `find . -maxdepth 2 -type d | sort`
+- **CONFIRMED** `find . -maxdepth 3 -name README.md | sort`
+- **CONFIRMED** `bash scripts/validate_all.sh` (available and executed)

--- a/docs/reports/schema-home-audit.md
+++ b/docs/reports/schema-home-audit.md
@@ -1,0 +1,22 @@
+# Schema Home Audit
+
+Date: 2026-05-05
+
+## Scope
+Audit of machine-schema placement for ADR-0001 enforcement.
+
+## Rule
+Machine schemas (`*.schema.json`) must live under `schemas/contracts/v1/`.
+
+Non-canonical surfaces (`contracts/`, `jsonschema/`) are only allowed when documented with exemption phrases:
+- human contract docs
+- compatibility examples
+- generated mirrors
+
+## Audit result
+- Command: `python tools/check_schema_home.py`
+- Outcome: **PASS**
+- Violations found: **0**
+
+## Notes
+- Test fixtures for PASS/FAIL scenarios are stored under `fixtures/policy/schema_home/` and intentionally excluded from repository-wide enforcement scanning.

--- a/docs/runbooks/synthetic-release-dry-run-proof-boundary.md
+++ b/docs/runbooks/synthetic-release-dry-run-proof-boundary.md
@@ -1,0 +1,21 @@
+# Synthetic Release Dry-Run: What Is Proven vs Not Proven
+
+## What this runbook proves
+Running `bash scripts/check_synthetic_release_local.sh` proves that:
+- Required synthetic/no-network validation gates execute successfully.
+- A synthetic dry-run receipt is produced.
+- Publish is refused by policy (`publish_decision=REFUSE`) even when gates pass.
+
+## What this runbook does **not** prove
+This runbook does not prove:
+- Real external connectivity behavior (network is intentionally not used).
+- Live-source freshness, uptime, or third-party API correctness.
+- Production deployment readiness or operational SLO compliance.
+- That publication occurred (it must not occur in this dry-run path).
+
+## Commands
+- Local: `bash scripts/check_synthetic_release_local.sh`
+- Direct dry-run only: `python tools/synthetic_release_dry_run.py`
+
+## Artifacts
+- Dry-run receipt: `release/dry_runs/synthetic_release_dry_run_receipt.json`

--- a/docs/standards/finite-outcomes.md
+++ b/docs/standards/finite-outcomes.md
@@ -1,0 +1,15 @@
+# Finite Outcomes Standard
+
+Shared finite outcome wave lives under `schemas/contracts/v1/shared/`:
+- `runtime_response_envelope.schema.json`
+- `policy_decision.schema.json`
+- `promotion_decision.schema.json`
+- `validation_report.schema.json`
+- `rollback_reference.schema.json`
+
+`evidence_bundle.schema.json` is reused as-is (no duplicate shared definition).
+
+Allowed finite decision/outcome values:
+- `ANSWER`, `ABSTAIN`, `DENY`, `ERROR` for runtime outcomes.
+- `ALLOW`, `ABSTAIN`, `DENY`, `ERROR` for policy/promotion/rollback decisions.
+- `PASS`, `FAIL`, `ABSTAIN`, `ERROR` for validation report status.

--- a/fixtures/ai/focus_citation_abstain.valid.json
+++ b/fixtures/ai/focus_citation_abstain.valid.json
@@ -1,0 +1,7 @@
+{
+  "id": "focus-cite-abstain-001",
+  "outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "citations": [],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/ai/focus_citation_answer.invalid_uncited.json
+++ b/fixtures/ai/focus_citation_answer.invalid_uncited.json
@@ -1,0 +1,7 @@
+{
+  "id": "focus-cite-answer-002",
+  "outcome": "ANSWER",
+  "reason": "RESOLVED",
+  "citations": [],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/ai/focus_citation_answer.valid.json
+++ b/fixtures/ai/focus_citation_answer.valid.json
@@ -1,0 +1,7 @@
+{
+  "id": "focus-cite-answer-001",
+  "outcome": "ANSWER",
+  "reason": "RESOLVED",
+  "citations": ["evr-hydro-synth-001", "evb-hydro-synth-001"],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/ai/focus_citation_deny.valid.json
+++ b/fixtures/ai/focus_citation_deny.valid.json
@@ -1,0 +1,7 @@
+{
+  "id": "focus-cite-deny-001",
+  "outcome": "DENY",
+  "reason": "DENIED_BY_POLICY",
+  "citations": [],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/ai/focus_citation_error.valid.json
+++ b/fixtures/ai/focus_citation_error.valid.json
@@ -1,0 +1,7 @@
+{
+  "id": "focus-cite-error-001",
+  "outcome": "ERROR",
+  "reason": "RUNTIME_ERROR",
+  "citations": [],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/api/governed_api_mock_payloads.json
+++ b/fixtures/api/governed_api_mock_payloads.json
@@ -1,0 +1,28 @@
+{
+  "governed_api": {
+    "healthz_response": {
+      "status": "ok",
+      "service": "kfm-mock-api",
+      "mode": "synthetic_no_network"
+    },
+    "focus_mode_request": {
+      "question": "What is the flood risk status for synthetic parcel A?",
+      "scope": "public",
+      "trace_id": "trace-focus-001"
+    },
+    "focus_mode_response": {
+      "outcome": "ABSTAIN",
+      "reason": "MISSING_EVIDENCE",
+      "citations": [],
+      "trace_id": "trace-focus-001"
+    },
+    "evidence_drawer_response": {
+      "id": "drawer-hydro-001",
+      "ui_trust_state": "EVIDENCE_MISSING",
+      "release_status": "ABSTAIN",
+      "evidence_ref": "evr-hydro-synth-001",
+      "evidence_bundle_id": "evb-hydro-synth-001",
+      "sources": []
+    }
+  }
+}

--- a/fixtures/domains/hydrology/focus/hydrology_synthetic_streamflow.public_abstain_missing_bundle_closure.json
+++ b/fixtures/domains/hydrology/focus/hydrology_synthetic_streamflow.public_abstain_missing_bundle_closure.json
@@ -1,0 +1,11 @@
+{
+  "id": "focus-hydro-closure-missing-001",
+  "knowledge_character": "SYNTHETIC_TEST",
+  "question": "What is the flood risk status for synthetic parcel A?",
+  "outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_ref": "evr-hydro-synth-001",
+  "evidence_bundle_id": "evb-hydro-synth-999",
+  "release_state": "RELEASE_CANDIDATE",
+  "citations": []
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_bad_activation_enum.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_bad_activation_enum.json
@@ -1,0 +1,12 @@
+{
+  "id": "HYDRO-NONET-INVALID-ACTIVATION-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "MAYBE",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_invented_http_facts.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_invented_http_facts.json
@@ -1,0 +1,20 @@
+{
+  "id": "HYDRO-NONET-INVALID-HTTP-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "http_facts": [
+    {
+      "kind": "LIVE_HTTP_RESPONSE",
+      "status": 200,
+      "url": "https://example.invalid/usgs",
+      "detail": "Invented live API response in no-network mode"
+    }
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_missing_citations.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_missing_citations.json
@@ -1,0 +1,10 @@
+{
+  "id": "HYDRO-NONET-INVALID-CITATIONS-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_unresolved_evidence.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.invalid_unresolved_evidence.json
@@ -1,0 +1,12 @@
+{
+  "id": "HYDRO-NONET-INVALID-UNRESOLVED-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ANSWER",
+  "reason": "RESOLVED",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json
+++ b/fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json
@@ -1,0 +1,19 @@
+{
+  "id": "HYDRO-NONET-VALID-001",
+  "network_mode": "DISABLED",
+  "source_activation_decision": "ABSTAIN",
+  "focus_outcome": "ABSTAIN",
+  "reason": "MISSING_EVIDENCE",
+  "evidence_resolved": false,
+  "citations": [
+    "evr-hydro-synth-001"
+  ],
+  "http_facts": [
+    {
+      "kind": "NO_NETWORK_ASSERTION",
+      "observed": true,
+      "detail": "No external HTTP request executed in synthetic baseline mode"
+    }
+  ],
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/fixtures/domains/hydrology/release_dry_runs/hydrology_synthetic_streamflow.publish_denied.missing_manifest_and_rollback_ref.json
+++ b/fixtures/domains/hydrology/release_dry_runs/hydrology_synthetic_streamflow.publish_denied.missing_manifest_and_rollback_ref.json
@@ -1,0 +1,9 @@
+{
+  "id": "rdr-hydro-deny-prepublish-001",
+  "knowledge_character": "SYNTHETIC_TEST",
+  "decision": "DENY",
+  "reason": "MISSING_RELEASE_MANIFEST_OR_ROLLBACK_REFERENCE",
+  "release_manifest_present": false,
+  "rollback_reference_present": false,
+  "publish_attempted": false
+}

--- a/fixtures/policy/schema_home/fail/contracts/bad/should_fail.schema.json
+++ b/fixtures/policy/schema_home/fail/contracts/bad/should_fail.schema.json
@@ -1,0 +1,1 @@
+{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}

--- a/fixtures/policy/schema_home/pass/contracts/README.md
+++ b/fixtures/policy/schema_home/pass/contracts/README.md
@@ -1,0 +1,1 @@
+This folder may include compatibility examples and generated mirrors and human contract docs.

--- a/fixtures/policy/schema_home/pass/contracts/examples/compat.schema.json
+++ b/fixtures/policy/schema_home/pass/contracts/examples/compat.schema.json
@@ -1,0 +1,1 @@
+{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}

--- a/fixtures/policy/schema_home/pass/schemas/contracts/v1/example/ok.schema.json
+++ b/fixtures/policy/schema_home/pass/schemas/contracts/v1/example/ok.schema.json
@@ -1,0 +1,1 @@
+{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}

--- a/fixtures/shared/finite_outcomes.invalid.json
+++ b/fixtures/shared/finite_outcomes.invalid.json
@@ -1,0 +1,8 @@
+{
+  "runtime_response_envelope": {"id": "rre-002", "outcome": "MAYBE", "reason": "INVALID"},
+  "policy_decision": {"id": "pd-002", "decision": "PERMIT", "reason": "INVALID"},
+  "promotion_decision": {"id": "prd-002", "decision": "GO", "reason": "INVALID"},
+  "validation_report": {"id": "vr-002", "status": "MYSTERY", "summary": "invalid"},
+  "rollback_reference": {"id": "rr-002", "rollback_target": "release-0002", "decision": "UNDO"},
+  "evidence_bundle_ref": "schemas/contracts/v1/shared/evidence_bundle.schema.json"
+}

--- a/fixtures/shared/finite_outcomes.valid.json
+++ b/fixtures/shared/finite_outcomes.valid.json
@@ -1,0 +1,29 @@
+{
+  "runtime_response_envelope": {
+    "id": "rre-001",
+    "outcome": "ABSTAIN",
+    "reason": "MISSING_EVIDENCE"
+  },
+  "policy_decision": {
+    "id": "pd-001",
+    "decision": "DENY",
+    "reason": "NO_NETWORK_POLICY"
+  },
+  "promotion_decision": {
+    "id": "prd-001",
+    "decision": "DENY",
+    "reason": "MISSING_RELEASE_MANIFEST"
+  },
+  "validation_report": {
+    "id": "vr-001",
+    "status": "PASS",
+    "summary": "synthetic checks passed"
+  },
+  "rollback_reference": {
+    "id": "rr-001",
+    "rollback_target": "release-0001",
+    "decision": "ALLOW"
+  },
+  "evidence_bundle_ref": "schemas/contracts/v1/shared/evidence_bundle.schema.json",
+  "knowledge_character": "SYNTHETIC_TEST"
+}

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,7 @@
+# policies (compatibility/transitional root)
+
+Status: transitional compatibility root.
+
+Canonical policy semantics home is `policy/`.
+This `policies/` surface exists only for compatibility/mirroring/migration references.
+No new canonical policy files should be authored here.

--- a/release/dry_runs/synthetic_release_dry_run_receipt.json
+++ b/release/dry_runs/synthetic_release_dry_run_receipt.json
@@ -1,0 +1,65 @@
+{
+  "id": "synthetic-release-dry-run-001",
+  "mode": "SYNTHETIC_NO_NETWORK",
+  "publish_decision": "REFUSE",
+  "result": "PASS",
+  "gates": [
+    {
+      "gate": "tools/validate_fixtures.py",
+      "returncode": 0,
+      "stdout": "PASS valid fixtures pass and invalid fixtures remain intentionally invalid",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validate_schema_conformance.py",
+      "returncode": 0,
+      "stdout": "PASS validated schema-conformance checks for 7 fixture contracts",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validate_api_contracts.py",
+      "returncode": 0,
+      "stdout": "PASS api contract checks",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/check_directory_rules.py",
+      "returncode": 0,
+      "stdout": "PASS directory rules satisfied",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/check_no_public_internal_paths.py",
+      "returncode": 0,
+      "stdout": "PASS no prohibited internal/public-surface path or sensitivity leakage",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validators/validate_evidence_closure.py",
+      "returncode": 0,
+      "stdout": "PASS evidence closure validated",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validators/validate_activation_decisions.py",
+      "returncode": 0,
+      "stdout": "PASS source activation decisions validated",
+      "stderr": "",
+      "status": "PASS"
+    },
+    {
+      "gate": "tools/validators/validate_source_terms.py",
+      "returncode": 0,
+      "stdout": "PASS source terms fixtures validated",
+      "stderr": "",
+      "status": "PASS"
+    }
+  ],
+  "reason": "DRY_RUN_ONLY_REFUSES_PUBLISH"
+}

--- a/schemas/contracts/v1/shared/correction_notice.schema.json
+++ b/schemas/contracts/v1/shared/correction_notice.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CorrectionNotice",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_bundle.schema.json
+++ b/schemas/contracts/v1/shared/evidence_bundle.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceBundle",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/evidence_ref.schema.json
+++ b/schemas/contracts/v1/shared/evidence_ref.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceRef",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/policy_decision.schema.json
+++ b/schemas/contracts/v1/shared/policy_decision.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PolicyDecision",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "decision": { "enum": ["ALLOW", "ABSTAIN", "DENY", "ERROR"] },
+    "reason": { "type": "string" }
+  },
+  "required": ["id", "decision", "reason"]
+}

--- a/schemas/contracts/v1/shared/promotion_decision.schema.json
+++ b/schemas/contracts/v1/shared/promotion_decision.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PromotionDecision",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "decision": { "enum": ["ALLOW", "ABSTAIN", "DENY", "ERROR"] },
+    "reason": { "type": "string" }
+  },
+  "required": ["id", "decision", "reason"]
+}

--- a/schemas/contracts/v1/shared/rollback_reference.schema.json
+++ b/schemas/contracts/v1/shared/rollback_reference.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RollbackReference",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "rollback_target": { "type": "string" },
+    "decision": { "enum": ["ALLOW", "ABSTAIN", "DENY", "ERROR"] }
+  },
+  "required": ["id", "rollback_target", "decision"]
+}

--- a/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
+++ b/schemas/contracts/v1/shared/runtime_response_envelope.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RuntimeResponseEnvelope",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "outcome": { "enum": ["ANSWER", "ABSTAIN", "DENY", "ERROR"] },
+    "reason": { "type": "string" }
+  },
+  "required": ["id", "outcome", "reason"]
+}

--- a/schemas/contracts/v1/shared/source_descriptor.schema.json
+++ b/schemas/contracts/v1/shared/source_descriptor.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SourceDescriptor",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/schemas/contracts/v1/shared/validation_report.schema.json
+++ b/schemas/contracts/v1/shared/validation_report.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ValidationReport",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "status": { "enum": ["PASS", "FAIL", "ABSTAIN", "ERROR"] },
+    "summary": { "type": "string" }
+  },
+  "required": ["id", "status", "summary"]
+}

--- a/scripts/check_synthetic_release_local.sh
+++ b/scripts/check_synthetic_release_local.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python tools/validate_fixtures.py
+python tools/validators/validate_source_terms.py
+python tools/validators/validate_activation_decisions.py
+python tools/validators/validate_evidence_closure.py
+python tools/validators/validate_public_path_guards.py
+python tools/synthetic_release_dry_run.py
+
+echo "PASS local synthetic release checks completed (publish remains refused by dry-run policy)"

--- a/scripts/validate_all.sh
+++ b/scripts/validate_all.sh
@@ -6,8 +6,11 @@ python tools/validate_schema_conformance.py
 python tools/validate_fixture_schema_mapping.py
 python tools/validate_docs_truth_labels.py
 python tools/check_directory_rules.py
+python tools/check_root_surface_register.py
+python tools/check_schema_home.py
 python tools/check_no_public_internal_paths.py
 python tools/validate_api_contracts.py
+python tools/validate_focus_citations.py
 python tools/check_source_ledger.py
 python tools/promotion_dry_run.py
 python tools/check_promotion_receipt_determinism.py

--- a/tests/test_directory_rules.py
+++ b/tests/test_directory_rules.py
@@ -1,8 +1,36 @@
+import tempfile
 import unittest
+from pathlib import Path
 
 from tests.subprocess_utils import assert_python_ok
+from tools.check_directory_rules import collect_violations
 
 
 class DirectoryRulesTests(unittest.TestCase):
     def test_check_directory_rules(self):
         assert_python_ok(self, ["tools/check_directory_rules.py"])
+
+    def test_documented_transitional_root_is_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "ui").mkdir()
+            (root / "ui" / "README.md").write_text("status: legacy transitional root")
+            self.assertEqual(collect_violations(root), [])
+
+    def test_undocumented_transitional_root_is_forbidden(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "web").mkdir()
+            violations = collect_violations(root)
+            self.assertTrue(any("transitional root missing documented status" in v for v in violations))
+
+    def test_domain_root_is_forbidden(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "hydrology").mkdir()
+            violations = collect_violations(root)
+            self.assertIn("forbidden domain root directory: hydrology/", violations)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_focus_citation_validation.py
+++ b/tests/test_focus_citation_validation.py
@@ -1,0 +1,12 @@
+import unittest
+
+from tests.subprocess_utils import assert_python_ok
+
+
+class FocusCitationValidationTests(unittest.TestCase):
+    def test_validate_focus_citations(self):
+        assert_python_ok(self, ["tools/validate_focus_citations.py"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hydrology_proof_slice_current_state.py
+++ b/tests/test_hydrology_proof_slice_current_state.py
@@ -1,0 +1,27 @@
+import json
+import unittest
+from pathlib import Path
+
+
+class HydrologyProofSliceCurrentStateTests(unittest.TestCase):
+    def test_focus_abstains_when_bundle_closure_missing(self):
+        p = Path("fixtures/domains/hydrology/focus/hydrology_synthetic_streamflow.public_abstain_missing_bundle_closure.json")
+        data = json.loads(p.read_text())
+        self.assertEqual(data.get("outcome"), "ABSTAIN")
+        self.assertEqual(data.get("reason"), "MISSING_EVIDENCE")
+        self.assertNotEqual(data.get("evidence_bundle_id"), "evb-hydro-synth-001")
+
+    def test_promotion_denies_before_manifest_and_rollback_reference(self):
+        p = Path(
+            "fixtures/domains/hydrology/release_dry_runs/"
+            "hydrology_synthetic_streamflow.publish_denied.missing_manifest_and_rollback_ref.json"
+        )
+        data = json.loads(p.read_text())
+        self.assertEqual(data.get("decision"), "DENY")
+        self.assertFalse(data.get("release_manifest_present"))
+        self.assertFalse(data.get("rollback_reference_present"))
+        self.assertFalse(data.get("publish_attempted"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mock_api_read_only_routes.py
+++ b/tests/test_mock_api_read_only_routes.py
@@ -1,0 +1,20 @@
+import unittest
+
+from apps.api.kfm_mock_api import get_mock_focus, get_mock_policy
+
+
+class MockApiReadOnlyRouteTests(unittest.TestCase):
+    def test_get_mock_policy(self):
+        payload, code = get_mock_policy()
+        self.assertEqual(code, 200)
+        self.assertEqual(payload.get("mode"), "SYNTHETIC_NO_NETWORK")
+        self.assertEqual(payload.get("decision"), "ABSTAIN")
+
+    def test_get_mock_focus(self):
+        payload, code = get_mock_focus()
+        self.assertEqual(code, 200)
+        self.assertIn(payload.get("outcome"), {"ANSWER", "ABSTAIN", "DENY", "ERROR"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_model_no_network_policy.py
+++ b/tests/test_no_model_no_network_policy.py
@@ -1,0 +1,27 @@
+import unittest
+
+from apps.api.no_model_no_network_policy import FINITE_OUTCOMES, focus_mock
+
+
+class NoModelNoNetworkPolicyTests(unittest.TestCase):
+    def test_focus_mock_finite_outcomes_only(self):
+        cases = [
+            {"question": "", "expected": "ABSTAIN"},
+            {"question": "q", "network_required": True, "expected": "DENY"},
+            {"question": "q", "model_required": True, "expected": "DENY"},
+            {"question": "q", "evidence_resolved": False, "expected": "ABSTAIN"},
+            {"question": "q", "evidence_resolved": True, "expected": "ANSWER"},
+        ]
+        for case in cases:
+            expected = case.pop("expected")
+            out = focus_mock(case)
+            self.assertEqual(out["outcome"], expected)
+            self.assertIn(out["outcome"], FINITE_OUTCOMES)
+
+    def test_non_dict_request_errors(self):
+        out = focus_mock("not-a-dict")
+        self.assertEqual(out["outcome"], "ERROR")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_policy_home.py
+++ b/tests/test_policy_home.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+
+
+class PolicyHomeTests(unittest.TestCase):
+    def test_policy_root_exists_as_canonical_home(self):
+        self.assertTrue(Path("policy").is_dir())
+
+    def test_policies_root_allows_only_readme_or_migration_notes(self):
+        root = Path("policies")
+        if not root.exists():
+            self.skipTest("policies/ root not present")
+
+        violations = []
+        for p in root.rglob("*"):
+            if p.is_dir():
+                continue
+            rel = p.relative_to(root).as_posix()
+            name = p.name.lower()
+            if name == "readme.md":
+                continue
+            if "migration" in name or "migrate" in name:
+                continue
+            violations.append(rel)
+
+        self.assertEqual(
+            violations,
+            [],
+            msg=f"non-compatible files under policies/: {violations}; canonical policy files must live under policy/",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema_home.py
+++ b/tests/test_schema_home.py
@@ -1,0 +1,23 @@
+import unittest
+from pathlib import Path
+
+from tests.subprocess_utils import assert_python_ok
+from tools.check_schema_home import collect_violations
+
+
+class SchemaHomeTests(unittest.TestCase):
+    def test_checker_passes_repository(self):
+        assert_python_ok(self, ["tools/check_schema_home.py"])
+
+    def test_pass_fixture_with_documented_exemption(self):
+        root = Path("fixtures/policy/schema_home/pass")
+        self.assertEqual(collect_violations(root), [])
+
+    def test_fail_fixture_without_documented_exemption(self):
+        root = Path("fixtures/policy/schema_home/fail")
+        violations = collect_violations(root)
+        self.assertTrue(any("schema outside canonical home" in v for v in violations))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shared_finite_outcomes.py
+++ b/tests/test_shared_finite_outcomes.py
@@ -1,0 +1,36 @@
+import json
+import unittest
+from pathlib import Path
+
+
+class SharedFiniteOutcomeTests(unittest.TestCase):
+    def test_required_shared_schemas_exist(self):
+        for name in [
+            "runtime_response_envelope.schema.json",
+            "policy_decision.schema.json",
+            "promotion_decision.schema.json",
+            "validation_report.schema.json",
+            "rollback_reference.schema.json",
+            "evidence_bundle.schema.json",
+        ]:
+            self.assertTrue(Path("schemas/contracts/v1/shared", name).exists(), msg=name)
+
+    def test_valid_fixture_uses_finite_values(self):
+        d = json.loads(Path("fixtures/shared/finite_outcomes.valid.json").read_text())
+        self.assertIn(d["runtime_response_envelope"]["outcome"], {"ANSWER", "ABSTAIN", "DENY", "ERROR"})
+        self.assertIn(d["policy_decision"]["decision"], {"ALLOW", "ABSTAIN", "DENY", "ERROR"})
+        self.assertIn(d["promotion_decision"]["decision"], {"ALLOW", "ABSTAIN", "DENY", "ERROR"})
+        self.assertIn(d["validation_report"]["status"], {"PASS", "FAIL", "ABSTAIN", "ERROR"})
+        self.assertIn(d["rollback_reference"]["decision"], {"ALLOW", "ABSTAIN", "DENY", "ERROR"})
+
+    def test_invalid_fixture_has_out_of_set_values(self):
+        d = json.loads(Path("fixtures/shared/finite_outcomes.invalid.json").read_text())
+        self.assertNotIn(d["runtime_response_envelope"]["outcome"], {"ANSWER", "ABSTAIN", "DENY", "ERROR"})
+        self.assertNotIn(d["policy_decision"]["decision"], {"ALLOW", "ABSTAIN", "DENY", "ERROR"})
+        self.assertNotIn(d["promotion_decision"]["decision"], {"ALLOW", "ABSTAIN", "DENY", "ERROR"})
+        self.assertNotIn(d["validation_report"]["status"], {"PASS", "FAIL", "ABSTAIN", "ERROR"})
+        self.assertNotIn(d["rollback_reference"]["decision"], {"ALLOW", "ABSTAIN", "DENY", "ERROR"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_synthetic_release_dry_run.py
+++ b/tests/test_synthetic_release_dry_run.py
@@ -1,0 +1,20 @@
+import json
+import unittest
+from pathlib import Path
+
+from tests.subprocess_utils import assert_python_ok
+
+
+class SyntheticReleaseDryRunTests(unittest.TestCase):
+    def test_synthetic_release_dry_run_tool(self):
+        assert_python_ok(self, ["tools/synthetic_release_dry_run.py"])
+
+        receipt = json.loads(Path("release/dry_runs/synthetic_release_dry_run_receipt.json").read_text())
+        self.assertEqual(receipt.get("publish_decision"), "REFUSE")
+        self.assertEqual(receipt.get("reason"), "DRY_RUN_ONLY_REFUSES_PUBLISH")
+        self.assertIn(receipt.get("result"), {"PASS", "FAIL"})
+        self.assertTrue(receipt.get("gates"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validator_extensions.py
+++ b/tests/test_validator_extensions.py
@@ -1,0 +1,68 @@
+import json
+import unittest
+from pathlib import Path
+
+from tests.subprocess_utils import assert_python_ok
+
+
+class ValidatorScriptTests(unittest.TestCase):
+    def test_validator_scripts(self):
+        for script in [
+            "tools/validators/validate_source_terms.py",
+            "tools/validators/validate_activation_decisions.py",
+            "tools/validators/validate_evidence_closure.py",
+            "tools/validators/validate_public_path_guards.py",
+            "tools/validators/validate_fixture_validation.py",
+        ]:
+            with self.subTest(script=script):
+                assert_python_ok(self, [script])
+
+
+class HashingTests(unittest.TestCase):
+    def test_compute_spec_hash_shared_schema(self):
+        assert_python_ok(self, ["tools/compute_spec_hash.py", "schemas/contracts/v1/shared/policy_decision.schema.json"])
+
+
+class EvidenceClosureFixtureTests(unittest.TestCase):
+    def test_evidence_ref_closes_to_bundle(self):
+        evidence_ref = json.loads(Path("fixtures/evidence/evidence_ref.valid.json").read_text())
+        bundle = json.loads(Path("fixtures/evidence/evidence_bundle.valid.json").read_text())
+        self.assertEqual(evidence_ref.get("bundle_id"), bundle.get("id"))
+        self.assertIn(evidence_ref.get("id"), bundle.get("evidence_refs", []))
+
+
+class InvalidFixtureSemanticsTests(unittest.TestCase):
+    def test_intentional_invalid_no_network_fixtures(self):
+        base = Path("fixtures/domains/hydrology/no_network")
+
+        unresolved = json.loads((base / "hydrology_no_network.invalid_unresolved_evidence.json").read_text())
+        self.assertEqual(unresolved["focus_outcome"], "ANSWER")
+        self.assertFalse(unresolved["evidence_resolved"])
+
+        bad_enum = json.loads((base / "hydrology_no_network.invalid_bad_activation_enum.json").read_text())
+        self.assertNotIn(bad_enum["source_activation_decision"], {"ALLOW", "ABSTAIN", "DENY", "ERROR"})
+
+        missing_citations = json.loads((base / "hydrology_no_network.invalid_missing_citations.json").read_text())
+        self.assertEqual(missing_citations.get("citations"), [])
+
+        invented_http = json.loads((base / "hydrology_no_network.invalid_invented_http_facts.json").read_text())
+        self.assertEqual(invented_http["network_mode"], "DISABLED")
+        self.assertEqual(invented_http["http_facts"][0]["kind"], "LIVE_HTTP_RESPONSE")
+
+
+class NoNetworkBehaviorTests(unittest.TestCase):
+    def test_valid_no_network_fixture(self):
+        valid = json.loads(Path("fixtures/domains/hydrology/no_network/hydrology_no_network.valid.json").read_text())
+        self.assertEqual(valid["network_mode"], "DISABLED")
+        self.assertEqual(valid["source_activation_decision"], "ABSTAIN")
+        self.assertEqual(valid["focus_outcome"], "ABSTAIN")
+        self.assertGreater(len(valid.get("citations", [])), 0)
+
+
+class HydrologySyntheticProofTests(unittest.TestCase):
+    def test_hydrology_proof_validator(self):
+        assert_python_ok(self, ["tools/validators/validate_hydrology_proof_slice.py"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_directory_rules.py
+++ b/tools/check_directory_rules.py
@@ -1,18 +1,44 @@
 from pathlib import Path
 
 FORBIDDEN_DOMAIN_ROOTS = {"hydrology", "soil", "fauna", "roads", "archaeology", "agriculture"}
-FORBIDDEN_MISC_ROOTS = {"ui", "web", "jsonschema", "policies", "styles", "viewer_templates"}
+TRANSITIONAL_ROOTS = {"ui", "web", "jsonschema", "policies", "styles", "viewer_templates"}
+TRANSITIONAL_STATUS_TERMS = {
+    "canonical",
+    "legacy",
+    "generated",
+    "mirrored",
+    "awaiting-migration",
+    "awaiting migration",
+}
+
+
+def _readme_declares_transitional_status(root: Path, dirname: str) -> bool:
+    readme = root / dirname / "README.md"
+    if not readme.exists():
+        return False
+    text = readme.read_text(encoding="utf-8").lower()
+    return any(term in text for term in TRANSITIONAL_STATUS_TERMS)
+
+
+def collect_violations(root: Path) -> list[str]:
+    root_dirs = {p.name for p in root.iterdir() if p.is_dir()}
+    violations: list[str] = []
+
+    for d in sorted(FORBIDDEN_DOMAIN_ROOTS & root_dirs):
+        violations.append(f"forbidden domain root directory: {d}/")
+
+    for d in sorted(TRANSITIONAL_ROOTS & root_dirs):
+        if not _readme_declares_transitional_status(root, d):
+            violations.append(
+                f"transitional root missing documented status README.md: {d}/ "
+                f"(must declare canonical/legacy/generated/mirrored/awaiting-migration)"
+            )
+
+    return violations
 
 
 def main() -> int:
-    root_dirs = {p.name for p in Path(".").iterdir() if p.is_dir()}
-
-    violations = []
-    for d in sorted(FORBIDDEN_DOMAIN_ROOTS & root_dirs):
-        violations.append(f"forbidden domain root directory: {d}/")
-    for d in sorted(FORBIDDEN_MISC_ROOTS & root_dirs):
-        violations.append(f"forbidden greenfield root directory: {d}/")
-
+    violations = collect_violations(Path("."))
     if violations:
         print("FAIL", violations)
         return 1

--- a/tools/check_root_surface_register.py
+++ b/tools/check_root_surface_register.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+ALLOWED_CLASSES = {
+    "canonical",
+    "compatibility",
+    "transitional",
+    "generated",
+    "data-lifecycle",
+    "release/proof",
+    "runtime",
+    "policy",
+    "UNKNOWN",
+}
+
+REQUIRED_CROSSLINKS = {
+    ".github",
+    "docs",
+    "control_plane",
+    "contracts",
+    "schemas",
+    "policy",
+    "policies",
+    "ui",
+    "web",
+    "jsonschema",
+    "styles",
+    "viewer_templates",
+}
+
+
+def parse_register(path: Path) -> tuple[dict[str, str], set[str]]:
+    roots: dict[str, str] = {}
+    cross_links: set[str] = set()
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    mode = None
+    current_root = None
+    current_cross = None
+
+    for raw in lines:
+        line = raw.rstrip()
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if stripped == "roots:":
+            mode = "roots"
+            current_root = None
+            continue
+        if stripped == "cross_links:":
+            mode = "cross"
+            current_cross = None
+            continue
+
+        if mode == "roots":
+            if line.startswith("  ") and not line.startswith("    ") and stripped.endswith(":"):
+                current_root = stripped[:-1]
+                continue
+            if current_root and stripped.startswith("class:"):
+                roots[current_root] = stripped.split(":", 1)[1].strip()
+                continue
+
+        if mode == "cross":
+            if line.startswith("  ") and not line.startswith("    ") and stripped.endswith(":"):
+                current_cross = stripped[:-1]
+                cross_links.add(current_cross)
+                continue
+
+    return roots, cross_links
+
+
+def main() -> int:
+    register_path = Path("control_plane/root_surface_register.yaml")
+    doc_path = Path("docs/registers/root-surface-register.md")
+    if not register_path.exists() or not doc_path.exists():
+        print("FAIL", "missing register source files")
+        return 1
+
+    roots, cross_links = parse_register(register_path)
+    errors = []
+
+    root_dirs = {p.name for p in Path(".").iterdir() if p.is_dir()}
+    for d in sorted(root_dirs):
+        if d not in roots:
+            errors.append(f"root missing from register: {d}")
+        elif roots[d] not in ALLOWED_CLASSES:
+            errors.append(f"invalid class for root {d}: {roots[d]}")
+
+    for d, c in sorted(roots.items()):
+        if c not in ALLOWED_CLASSES:
+            errors.append(f"invalid class in register for {d}: {c}")
+
+    for k in sorted(REQUIRED_CROSSLINKS):
+        if k not in cross_links:
+            errors.append(f"missing required cross-link: {k}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+
+    print("PASS", "root surface register is complete and valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_schema_home.py
+++ b/tools/check_schema_home.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+CANONICAL_PREFIX = Path("schemas/contracts/v1")
+EXEMPT_PHRASES = {
+    "human contract docs",
+    "compatibility examples",
+    "generated mirrors",
+}
+
+
+def is_machine_schema(path: Path) -> bool:
+    return path.name.endswith(".schema.json")
+
+
+def _readme_has_exemption(path: Path) -> bool:
+    for parent in [path.parent, *path.parents]:
+        readme = parent / "README.md"
+        if readme.exists():
+            text = readme.read_text(encoding="utf-8").lower()
+            if any(p in text for p in EXEMPT_PHRASES):
+                return True
+    return False
+
+
+IGNORED_PREFIXES = {"fixtures/policy/schema_home/"}
+
+
+def collect_violations(root: Path) -> list[str]:
+    violations: list[str] = []
+    for p in root.rglob("*.schema.json"):
+        rel = p.relative_to(root)
+        if str(rel).startswith(str(CANONICAL_PREFIX)):
+            continue
+
+        rel_str = rel.as_posix()
+        if any(rel_str.startswith(prefix) for prefix in IGNORED_PREFIXES):
+            continue
+        in_forbidden_surface = rel_str.startswith("contracts/") or rel_str.startswith("jsonschema/")
+        if in_forbidden_surface and _readme_has_exemption(p):
+            continue
+
+        violations.append(
+            f"schema outside canonical home: {rel_str} (expected under schemas/contracts/v1/ or documented exemption)"
+        )
+    return violations
+
+
+def main() -> int:
+    root = Path(".")
+    violations = collect_violations(root)
+    if violations:
+        print("FAIL", violations)
+        return 1
+    print("PASS", "schema-home enforcement satisfied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/synthetic_release_dry_run.py
+++ b/tools/synthetic_release_dry_run.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT = ROOT / "release/dry_runs/synthetic_release_dry_run_receipt.json"
+
+GATES = [
+    ["tools/validate_fixtures.py"],
+    ["tools/validate_schema_conformance.py"],
+    ["tools/validate_api_contracts.py"],
+    ["tools/check_directory_rules.py"],
+    ["tools/check_no_public_internal_paths.py"],
+    ["tools/validators/validate_evidence_closure.py"],
+    ["tools/validators/validate_activation_decisions.py"],
+    ["tools/validators/validate_source_terms.py"],
+]
+
+
+def run_gate(args: list[str]) -> dict:
+    proc = subprocess.run([sys.executable, str(ROOT / args[0]), *args[1:]], capture_output=True, text=True)
+    return {
+        "gate": args[0],
+        "returncode": proc.returncode,
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+        "status": "PASS" if proc.returncode == 0 else "FAIL",
+    }
+
+
+def main() -> int:
+    gate_results = [run_gate(g) for g in GATES]
+    failed = [g for g in gate_results if g["status"] == "FAIL"]
+
+    receipt = {
+        "id": "synthetic-release-dry-run-001",
+        "mode": "SYNTHETIC_NO_NETWORK",
+        "publish_decision": "REFUSE",
+        "result": "PASS" if not failed else "FAIL",
+        "gates": gate_results,
+        "reason": "DRY_RUN_ONLY_REFUSES_PUBLISH",
+    }
+
+    RECEIPT.parent.mkdir(parents=True, exist_ok=True)
+    RECEIPT.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+
+    if failed:
+        print("FAIL", f"{len(failed)} gates failed; publish refused; receipt={RECEIPT}")
+        return 1
+
+    print("PASS", f"all gates passed; publish refused by policy; receipt={RECEIPT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_focus_citations.py
+++ b/tools/validate_focus_citations.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = ROOT / "fixtures/ai"
+REASON_REQUIRED_OUTCOMES = {"ABSTAIN", "DENY", "ERROR"}
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _evaluate(obj: dict, valid_citations: set[str]) -> list[str]:
+    errors: list[str] = []
+    outcome = obj.get("outcome")
+    reason = obj.get("reason")
+    citations = obj.get("citations", [])
+
+    if outcome == "ANSWER":
+        if not citations:
+            errors.append("ANSWER must include citations")
+        unresolved = [c for c in citations if c not in valid_citations]
+        if unresolved:
+            errors.append(f"unresolved citations {unresolved}")
+
+    if outcome in REASON_REQUIRED_OUTCOMES:
+        if not isinstance(reason, str) or not reason.strip():
+            errors.append(f"{outcome} must include non-empty reason code")
+
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    bundle = _load(ROOT / "fixtures/evidence/evidence_bundle.valid.json")
+    valid_citations = set(bundle.get("evidence_refs", [])) | {bundle.get("id")}
+
+    for p in sorted(FIXTURE_DIR.glob("focus_citation_*.json")):
+        evaluation_errors = _evaluate(_load(p), valid_citations)
+        is_invalid_fixture = ".invalid" in p.name
+
+        if is_invalid_fixture and not evaluation_errors:
+            errors.append(f"{p}: expected invalid fixture but validation passed")
+        if not is_invalid_fixture and evaluation_errors:
+            errors.append(f"{p}: expected valid fixture but failed: {evaluation_errors}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+
+    print("PASS", "focus citation validation checks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_activation_decisions.py
+++ b/tools/validators/validate_activation_decisions.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    allowed = {"ALLOW", "ABSTAIN", "DENY", "ERROR"}
+
+    for path in sorted((ROOT / "fixtures/source/hydrology").glob("source_activation_decision*.valid.json")):
+        data = json.loads(path.read_text())
+        decision = data.get("decision")
+        if decision not in allowed:
+            errors.append(f"{path.name} invalid decision: {decision}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS source activation decisions validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_evidence_closure.py
+++ b/tools/validators/validate_evidence_closure.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    evidence_ref = json.loads((ROOT / "fixtures/evidence/evidence_ref.valid.json").read_text())
+    bundle = json.loads((ROOT / "fixtures/evidence/evidence_bundle.valid.json").read_text())
+
+    if evidence_ref.get("bundle_id") != bundle.get("id"):
+        errors.append("evidence_ref.bundle_id must match evidence_bundle.id")
+    if evidence_ref.get("id") not in bundle.get("evidence_refs", []):
+        errors.append("evidence_ref.id must be listed in evidence_bundle.evidence_refs")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS evidence closure validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_fixture_validation.py
+++ b/tools/validators/validate_fixture_validation.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    cmd = [sys.executable, str(ROOT / "tools/validate_fixtures.py")]
+    result = subprocess.run(cmd, cwd=ROOT)
+    if result.returncode != 0:
+        print("FAIL fixture validation")
+        return result.returncode
+    print("PASS fixture validation")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_public_path_guards.py
+++ b/tools/validators/validate_public_path_guards.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FORBIDDEN = ["data/raw/", "data/work/", "data/quarantine/", "data/processed/"]
+TARGETS = [
+    "fixtures/ui/evidence_drawer_payload.valid.json",
+    "fixtures/ai/focus_mode_response.answer.valid.json",
+    "fixtures/release/release_manifest.valid.json",
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    for rel in TARGETS:
+        text = json.dumps(json.loads((ROOT / rel).read_text())).lower()
+        for bad in FORBIDDEN:
+            if bad in text:
+                errors.append(f"{rel} contains forbidden path fragment: {bad}")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS public-path guards validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validators/validate_source_terms.py
+++ b/tools/validators/validate_source_terms.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    errors: list[str] = []
+    review = json.loads((ROOT / "fixtures/source/hydrology/source_terms_review.valid.json").read_text())
+    receipt = json.loads((ROOT / "fixtures/source/hydrology/source_terms_check_receipt.wbd.no_network.valid.json").read_text())
+
+    if review.get("rights_status") not in {"NEEDS_LEGAL_REVIEW", "CLEARED", "DENIED"}:
+        errors.append("source_terms_review has invalid rights_status")
+    if receipt.get("check_kind") != "TERMS_RIGHTS_ONLY":
+        errors.append("source_terms_check_receipt must be TERMS_RIGHTS_ONLY")
+    if receipt.get("network_mode") != "DISABLED":
+        errors.append("source_terms_check_receipt network_mode must be DISABLED")
+    if receipt.get("validation_result") not in {"ALLOW", "ABSTAIN", "DENY", "ERROR"}:
+        errors.append("source_terms_check_receipt has invalid validation_result")
+
+    if errors:
+        print("FAIL", errors)
+        return 1
+    print("PASS source terms fixtures validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Introduce a reproducible synthetic/no-network dry-run path to validate repository policy gates and fixtures without performing any publication or network I/O.
- Centralize shared finite outcome schemas and repository surface/register metadata so directory and schema-home rules can be enforced automatically.
- Provide payload-only mock policy/focus evaluators and read-only mock API routes for local validation and tests.

### Description
- Add synthetic dry-run tooling and orchestration including `tools/synthetic_release_dry_run.py`, `scripts/check_synthetic_release_local.sh`, and a GitHub workflow `.github/workflows/synthetic-release-dry-run.yml` that runs the dry-run checks. 
- Add a set of validator scripts under `tools/` and `tools/validators/` (`check_root_surface_register.py`, `check_schema_home.py`, `validate_focus_citations.py`, `validate_*` validators) and wire them into `scripts/validate_all.sh`.
- Introduce shared contract schemas under `schemas/contracts/v1/shared/` for finite outcomes and related types and add numerous fixtures to exercise valid/invalid cases in `fixtures/` (AI focus, governed API payloads, hydrology domain proofs, and shared finite outcome fixtures).
- Add mock API and policy modules: extend `apps/api/kfm_mock_api.py` with `get_mock_policy` and `get_mock_focus`, and add `apps/api/no_model_no_network_policy.py` implementing no-model/no-network payload-only logic and `focus_mock` helper.
- Add repository governance artifacts: ADRs (`docs/adr/*`), root surface register (`control_plane/root_surface_register.yaml`) and docs/reports/runbooks describing synthetic dry-run provenance and scope.
- Add unit and integration tests under `tests/` to validate directory rules, schema-home enforcement, shared finite outcomes, mock API routes, policy logic, validator scripts, and the synthetic dry-run receipt generation.
- Minor UI update in `apps/web/src/app.js` to display an evidence drawer sample object.

### Testing
- Ran the synthetic dry-run tool `tools/synthetic_release_dry_run.py` which executed the configured gate scripts and wrote `release/dry_runs/synthetic_release_dry_run_receipt.json` with `publish_decision: REFUSE` and `result: PASS` indicating gates passed in dry-run posture. 
- Executed the repository validator sweep via `scripts/validate_all.sh` which runs the added validators and checks, and completed with passing checks in the synthetic dry-run context. 
- Ran the unit test suite via `python -m unittest discover -s tests` which includes tests for `no_model_no_network_policy`, mock API routes, directory/schema-home rules, shared finite outcomes, validator extensions, and synthetic dry-run behavior, and these tests passed in the dry-run validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e5911f34832ab7ac3084becb5e04)