### PR TITLE
Rename ADR documents to ADR-0014..ADR-0018 and update cross-references

### DIFF
--- a/docs/adr/ADR-0014-truth-path.md
+++ b/docs/adr/ADR-0014-truth-path.md
@@ -10,14 +10,14 @@ updated: 2026-05-06
 policy_label: NEEDS_VERIFICATION
 related: [docs/adr/README.md, docs/adr/ADR-TEMPLATE.md, docs/adr/ADR-0001-schema-home.md, docs/adr/ADR-0004-evidencebundle-contract.md, docs/adr/ADR-0005-promotion-gate.md, docs/adr/ADR-0007-governed-ai-runtime-envelope.md, docs/adr/ADR-0009-sensitive-location-policy.md, docs/adr/ADR-0011-catalog-proof-release-separation.md, docs/adr/ADR-0012-authority-boundary-compatibility-map.md, docs/adr/ADR-0013-policy-home-authority.md]
 tags: [kfm, adr, truth-path, trust-membrane, evidence, publication, governance, public-safety, governed-ai]
-notes: [Rebuilt from existing docs/adr/0001-truth-path.md draft, ADR number remains NEEDS VERIFICATION because docs/adr/README.md assigns ADR-0001 to schema-home, No repository files were modified by this rebuild artifact]
+notes: [Rebuilt from existing docs/adr/ADR-0014-truth-path.md draft, ADR number remains NEEDS VERIFICATION because docs/adr/README.md assigns ADR-0001 to schema-home, No repository files were modified by this rebuild artifact]
 [/KFM_META_BLOCK_V2] -->
 
 # ADR: KFM Truth Path and Public Trust Membrane
 
 > [!IMPORTANT]
 > **Status:** `proposed` / `draft`  
-> **Current repo file:** `docs/adr/0001-truth-path.md` — `CONFIRMED` existing file in the GitHub connector.  
+> **Current repo file:** `docs/adr/ADR-0014-truth-path.md` — `CONFIRMED` existing file in the GitHub connector.  
 > **ADR number:** `NEEDS VERIFICATION` — the ADR index names `ADR-0001-schema-home.md` as the foundational `ADR-0001`, so this truth-path decision must not be treated as accepted `ADR-0001` until the index is reconciled.  
 > **Owning root:** `docs/` — human-facing architecture decision and governance explanation.  
 > **Decision confidence:** `CONFIRMED` KFM doctrine / `PROPOSED` governing decision / `UNKNOWN` enforcement maturity until tests, policies, schemas, release manifests, runtime routes, and UI behavior are verified.
@@ -91,7 +91,7 @@ This ADR makes those failure modes visible and gives reviewers a testable decisi
 
 | Evidence item | Source / path / artifact | What it supports | Truth label |
 |---|---|---|---|
-| Current draft | `docs/adr/0001-truth-path.md` | Existing draft contains the core truth-path substance and should be preserved rather than replaced by generic prose. | `CONFIRMED` file via GitHub connector |
+| Current draft | `docs/adr/ADR-0014-truth-path.md` | Existing draft contains the core truth-path substance and should be preserved rather than replaced by generic prose. | `CONFIRMED` file via GitHub connector |
 | ADR directory index | `docs/adr/README.md` | `docs/adr/` is the ADR home; the index lists `ADR-0001-schema-home.md` as foundational `ADR-0001`. | `CONFIRMED` file via GitHub connector |
 | ADR template | `docs/adr/ADR-TEMPLATE.md` | ADRs must separate evidence, scope, policy impact, validation, rollback, and supersession; ADRs are not implementation proof. | `CONFIRMED` file via GitHub connector |
 | Directory discipline | `Directory Rules.pdf` | `docs/` is the human-facing control plane; root folders are responsibility boundaries; domain work should live under responsibility roots rather than new root-level domain folders. | `CONFIRMED` supplied doctrine |
@@ -350,7 +350,7 @@ When rights, source terms, cultural stewardship, sovereignty, living-person stat
 
 | Area | Required update if this ADR is accepted | Status |
 |---|---|---|
-| `docs/adr/` | Reconcile ADR number/name, update ADR index, and preserve or redirect current `docs/adr/0001-truth-path.md`. | `NEEDS VERIFICATION` |
+| `docs/adr/` | Reconcile ADR number/name, update ADR index, and preserve or redirect current `docs/adr/ADR-0014-truth-path.md`. | `NEEDS VERIFICATION` |
 | `docs/doctrine/` | Add or confirm lifecycle, truth-posture, trust-membrane, and AI-boundary docs. | `NEEDS VERIFICATION` |
 | `contracts/` | Confirm semantic contracts for evidence, source, runtime, release, correction, and rollback objects. | `NEEDS VERIFICATION` |
 | `schemas/` | Add or confirm machine-checkable schemas in the accepted schema home. | `NEEDS VERIFICATION` |
@@ -426,7 +426,7 @@ python -m pytest tests/
 
 ### Adoption path
 
-This rebuild is a drop-in content replacement for the existing draft at `docs/adr/0001-truth-path.md`. It deliberately does **not** claim acceptance as `ADR-0001`.
+This rebuild is a drop-in content replacement for the existing draft at `docs/adr/ADR-0014-truth-path.md`. It deliberately does **not** claim acceptance as `ADR-0001`.
 
 Before merge, maintainers should choose one of these paths:
 
@@ -439,7 +439,7 @@ Before merge, maintainers should choose one of these paths:
 ### Rollback of this document-only change
 
 ```bash
-git checkout -- docs/adr/0001-truth-path.md
+git checkout -- docs/adr/ADR-0014-truth-path.md
 ```
 
 If related docs, registers, schemas, policies, tests, or indexes are changed in the same PR, revert them in the same rollback PR unless maintainers explicitly split rollback scope.

--- a/docs/adr/ADR-0015-promotion-contract.md
+++ b/docs/adr/ADR-0015-promotion-contract.md
@@ -1,6 +1,6 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: TODO(assign kfm://doc UUID)
-title: ADR 0002: Promotion Contract
+title: ADR 0015: Promotion Contract
 type: standard
 version: v1
 status: published
@@ -13,7 +13,7 @@ tags: [kfm, adr, promotion, release-governance, policy-gates]
 notes: [ADR status is Accepted; metadata placeholders require maintainer verification before merge.]
 [/KFM_META_BLOCK_V2] -->
 
-# ADR 0002: Promotion Contract
+# ADR 0015: Promotion Contract
 
 Promotion is a governed release transition, not a file move.
 
@@ -326,7 +326,7 @@ Do not roll back one surface at a time.
 A safe rollback must revert or supersede these surfaces together:
 
 ```text
-docs/adr/0002-promotion-contract.md
+docs/adr/ADR-0015-promotion-contract.md
 docs/governance/gates/PROMOTION_CONTRACT.md
 docs/runbooks/promotion-gates.md
 control_plane/promotion_contract.json

--- a/docs/adr/ADR-0016-spec-hash.md
+++ b/docs/adr/ADR-0016-spec-hash.md
@@ -1,6 +1,6 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://doc/NEEDS-VERIFICATION
-title: ADR 0003: Canonical spec_hash
+title: ADR 0016: Canonical spec_hash
 type: standard
 version: v1
 status: review
@@ -8,20 +8,20 @@ owners: OWNER_TBD_NEEDS_VERIFICATION
 created: NEEDS_VERIFICATION-YYYY-MM-DD
 updated: 2026-05-06
 policy_label: POLICY_LABEL_TBD_NEEDS_VERIFICATION
-related: [docs/adr/0002-promotion-contract.md, docs/governance/gates/PROMOTION_CONTRACT.md, docs/runbooks/promotion-gates.md, tools/validators/check_spec_hash.py, tools/validators/run_gate.sh, tools/validators/build_gate_input.py, tools/compute_spec_hash.py]
+related: [docs/adr/ADR-0015-promotion-contract.md, docs/governance/gates/PROMOTION_CONTRACT.md, docs/runbooks/promotion-gates.md, tools/validators/check_spec_hash.py, tools/validators/run_gate.sh, tools/validators/build_gate_input.py, tools/compute_spec_hash.py]
 tags: [kfm, adr, spec_hash, evidencebundle, promotion, gate-a, canonical-json, evidence-integrity]
-notes: [ADR decision status remains Accepted. Meta status is review because this revised Markdown still needs doc_id, owners, created date, policy_label, document-registry linkage, and workflow/contract-path verification before publication. Target path confirmed as docs/adr/0003-spec-hash.md from current GitHub evidence.]
+notes: [ADR decision status remains Accepted. Meta status is review because this revised Markdown still needs doc_id, owners, created date, policy_label, document-registry linkage, and workflow/contract-path verification before publication. Target path confirmed as docs/adr/ADR-0016-spec-hash.md from current GitHub evidence.]
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-# ADR 0003: Canonical `spec_hash`
+# ADR 0016: Canonical `spec_hash`
 
 Defines the reproducible KFM `EvidenceBundle` digest used by promotion Gate `A` to verify release-candidate evidence integrity.
 
 > [!IMPORTANT]
 > **Decision status:** `Accepted`  
-> **Target path:** `docs/adr/0003-spec-hash.md`  
+> **Target path:** `docs/adr/ADR-0016-spec-hash.md`  
 > **Decision area:** evidence integrity, release-candidate hashing, Gate `A`, and downstream receipt alignment  
 > **Truth posture:** `CONFIRMED` algorithm and validator path where current repository evidence supports them; `NEEDS VERIFICATION` for owners, document registry metadata, CI workflow enforcement, and promotion-contract path alignment.
 
@@ -57,7 +57,7 @@ This ADR is governing for the `canonical-json-v1` `spec_hash` algorithm unless a
 
 | Field | Value |
 | --- | --- |
-| ADR ID | `0003` |
+| ADR ID | `0016` |
 | Title | Canonical `spec_hash` |
 | Status | `Accepted` |
 | Decision confidence | `CONFIRMED` for the algorithm as written in this ADR and implemented by `tools/validators/check_spec_hash.py`; `NEEDS VERIFICATION` for CI enforcement and promotion-contract path alignment |
@@ -67,7 +67,7 @@ This ADR is governing for the `canonical-json-v1` `spec_hash` algorithm unless a
 | Scope | Release-candidate evidence integrity; Gate `A`; `EvidenceBundle` content hashing |
 | Primary validator | [`../../tools/validators/check_spec_hash.py`](../../tools/validators/check_spec_hash.py) |
 | Generated receipt | `.promotion/spec_hash_check.json` |
-| Related ADR | [`./0002-promotion-contract.md`](./0002-promotion-contract.md) |
+| Related ADR | [`./ADR-0015-promotion-contract.md`](./ADR-0015-promotion-contract.md) |
 | Rollback target | Prior accepted state of this ADR plus aligned validator, runbook, fixtures, and promotion-gate behavior |
 
 > [!NOTE]
@@ -83,12 +83,12 @@ This revision preserves the existing ADR substance and adds reviewable evidence 
 
 | Evidence item | What it supports | Status | Limit |
 | --- | --- | --- | --- |
-| `docs/adr/0003-spec-hash.md` | Existing ADR path and current accepted decision text | `CONFIRMED` | Does not by itself prove CI enforcement. |
+| `docs/adr/ADR-0016-spec-hash.md` | Existing ADR path and current accepted decision text | `CONFIRMED` | Does not by itself prove CI enforcement. |
 | `tools/validators/check_spec_hash.py` | Normative implementation of `canonical-json-v1`, root-only exclusions, SHA-256 digest, and receipt fields | `CONFIRMED` | Does not prove all callers use it. |
 | `tools/validators/run_gate.sh` | Gate `A` invokes `check_spec_hash.py` and writes `.promotion/spec_hash_check.json` | `CONFIRMED / NEEDS ALIGNMENT` | Current default contract path requires alignment with ADR 0002 unless an override is used. |
 | `tools/validators/build_gate_input.py` | Gate inputs are normalized before Conftest policy evaluation | `CONFIRMED` | Does not prove the machine promotion contract file is present. |
 | `tools/compute_spec_hash.py` | Generic JSON hash helper exists | `CONFIRMED` | It does not implement this ADR’s root-key exclusions or Gate `A` receipt behavior. |
-| `docs/adr/0002-promotion-contract.md` | Gate `A` is the evidence-integrity gate and uses canonical `spec_hash` verification | `CONFIRMED` | Some implementation surfaces still need alignment. |
+| `docs/adr/ADR-0015-promotion-contract.md` | Gate `A` is the evidence-integrity gate and uses canonical `spec_hash` verification | `CONFIRMED` | Some implementation surfaces still need alignment. |
 | `docs/runbooks/promotion-gates.md` | Operational instructions say Gate `A` runs canonical `spec_hash` validation | `CONFIRMED` | Runbook expectations must be checked against actual workflow and contract files. |
 | `docs/governance/gates/PROMOTION_CONTRACT.md` | Human promotion contract maps Gate `A` to canonical `spec_hash` | `CONFIRMED / CONFLICTED` | Machine-contract path wording needs alignment with ADR 0002. |
 | `.github/workflows/promotion.yml` | CI promotion enforcement | `NEEDS VERIFICATION` | Not verified by this revision. |
@@ -98,7 +98,7 @@ This revision preserves the existing ADR substance and adds reviewable evidence 
 
 | Surface | Finding | Status |
 | --- | --- | --- |
-| Target ADR path | `docs/adr/0003-spec-hash.md` is the current target ADR path. | `CONFIRMED` |
+| Target ADR path | `docs/adr/ADR-0016-spec-hash.md` is the current target ADR path. | `CONFIRMED` |
 | ADR template / metadata convention | KFM ADR template uses `KFM_META_BLOCK_V2` and truth-label guidance. | `CONFIRMED` |
 | Markdown protocol | KFM standard docs require evidence-grounded metadata and visible uncertainty. | `CONFIRMED` |
 | Directory rule basis | ADRs belong under the human-facing governance/control-plane responsibility root `docs/adr/`. | `CONFIRMED` |
@@ -289,7 +289,7 @@ This ADR does not make generated text, map tiles, search indexes, graph projecti
 
 | Surface | Expected relationship to this ADR | Current alignment status |
 | --- | --- | --- |
-| [`./0002-promotion-contract.md`](./0002-promotion-contract.md) | Gate `A` uses canonical `spec_hash` verification as its evidence-integrity check. | `CONFIRMED` |
+| [`./ADR-0015-promotion-contract.md`](./ADR-0015-promotion-contract.md) | Gate `A` uses canonical `spec_hash` verification as its evidence-integrity check. | `CONFIRMED` |
 | [`../governance/gates/PROMOTION_CONTRACT.md`](../governance/gates/PROMOTION_CONTRACT.md) | Human contract should identify Gate `A` as canonical `spec_hash` validation and should align machine-contract path wording with ADR 0002. | `CONFIRMED / CONFLICTED` on machine-contract path wording |
 | [`../runbooks/promotion-gates.md`](../runbooks/promotion-gates.md) | Operational instructions must tell maintainers that Gate `A` runs canonical `spec_hash` validation. | `CONFIRMED` |
 | [`../../tools/validators/check_spec_hash.py`](../../tools/validators/check_spec_hash.py) | Normative implementation of `canonical-json-v1`. | `CONFIRMED` |
@@ -476,7 +476,7 @@ Rollback of this ADR's file content is allowed only if `tools/validators/check_s
 - [ ] Confirm any `EvidenceBundle` schema documents the optional embedded `spec_hash` field and the `canonical-json-v1` algorithm id.
 - [ ] Confirm release manifests or proof packs record enough information to replay the hash calculation.
 - [ ] Confirm KFM meta block values: `doc_id`, owners, created date, policy label, related links, and document-registry entry.
-- [ ] Add or update ADR index entries so `0003-spec-hash.md` is discoverable from `docs/adr/README.md`.
+- [ ] Add or update ADR index entries so `ADR-0016-spec-hash.md` is discoverable from `docs/adr/README.md`.
 
 [Back to top](#top)
 
@@ -486,7 +486,7 @@ Rollback of this ADR's file content is allowed only if `tools/validators/check_s
 
 | Path | Relationship | Status |
 | --- | --- | --- |
-| [`./0002-promotion-contract.md`](./0002-promotion-contract.md) | Defines Gate `A` as evidence integrity and binds promotion gates `A` through `G`. | `CONFIRMED` |
+| [`./ADR-0015-promotion-contract.md`](./ADR-0015-promotion-contract.md) | Defines Gate `A` as evidence integrity and binds promotion gates `A` through `G`. | `CONFIRMED` |
 | [`../governance/gates/PROMOTION_CONTRACT.md`](../governance/gates/PROMOTION_CONTRACT.md) | Human promotion contract; should remain aligned with ADR 0002 and this ADR. | `CONFIRMED / NEEDS ALIGNMENT` |
 | [`../runbooks/promotion-gates.md`](../runbooks/promotion-gates.md) | Operational runbook for local and CI gate execution. | `CONFIRMED` |
 | [`../../tools/validators/check_spec_hash.py`](../../tools/validators/check_spec_hash.py) | Normative `canonical-json-v1` validator. | `CONFIRMED` |

--- a/docs/adr/ADR-0017-meta-block-v2.md
+++ b/docs/adr/ADR-0017-meta-block-v2.md
@@ -1,7 +1,7 @@
 <!-- [KFM_META_BLOCK_V2]
 meta:
   schema: meta-block-v2
-  standard_id: ADR-0004-META-BLOCK-V2
+  standard_id: ADR-0017-META-BLOCK-V2
   title: Meta Block V2
   version: 1.0.0
   status: accepted
@@ -27,10 +27,10 @@ meta:
       summary: Initial version
 [/KFM_META_BLOCK_V2] -->
 
-# ADR 0004: Meta Block V2
+# ADR 0017: Meta Block V2
 
 > **Status:** Accepted  
-> **Repo path:** `docs/adr/0004-meta-block-v2.md`  
+> **Repo path:** `docs/adr/ADR-0017-meta-block-v2.md`  
 > **Owner/steward:** `NEEDS VERIFICATION`  
 > **Implementation posture:** Metadata standard accepted; full repository enforcement remains staged.
 
@@ -307,7 +307,7 @@ If Meta Block V2 enforcement blocks necessary work because the linter is wrong o
 | `evidence_bundle_ref` physical path | NEEDS VERIFICATION | `artifacts/EvidenceBundle.json` follows the supplied ADR example but may need alignment with the repo artifact/release layout. |
 | `decision_log_ref` physical path | NEEDS VERIFICATION | `artifacts/decision_log.json` must resolve before strict release gating. |
 | `spec_hash` canonicalization rule | NEEDS VERIFICATION | This draft uses a documented normative-profile hash; repo-wide reproducibility rules should be standardized. |
-| ADR numbering namespace | NEEDS VERIFICATION | The repo contains both `docs/adr/0004-meta-block-v2.md` and `docs/adr/ADR-0004-evidencebundle-contract.md`; keep both discoverable until the ADR index resolves the naming convention. |
+| ADR numbering namespace | NEEDS VERIFICATION | The repo contains both `docs/adr/ADR-0017-meta-block-v2.md` and `docs/adr/ADR-0004-evidencebundle-contract.md`; keep both discoverable until the ADR index resolves the naming convention. |
 | Full linter implementation | PROPOSED | Existing token checks are useful but insufficient for complete Meta Block V2 enforcement. |
 
 ---

--- a/docs/adr/ADR-0018-prov-stac-dcat-catalog-mapping.md
+++ b/docs/adr/ADR-0018-prov-stac-dcat-catalog-mapping.md
@@ -71,7 +71,7 @@ notes: [
 | Field | Value |
 | --- | --- |
 | **Status** | `draft` |
-| **Target path** | `docs/adr/ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md` |
+| **Target path** | `docs/adr/ADR-0018-prov-stac-dcat-catalog-mapping.md` |
 | **Decision type** | Catalog / provenance / release-closure ADR |
 | **Evidence mode** | `NO_MOUNTED_CHECKOUT / ATTACHED_REPO_REPORT_LINEAGE` |
 | **Owners** | `OWNER_TBD` |
@@ -222,7 +222,7 @@ Public clients, map popups, Evidence Drawer payloads, Focus Mode answers, story 
 
 | Surface | Proposed path | Upstream / downstream role |
 | --- | --- | --- |
-| ADR | `docs/adr/ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md` | Governs profile, schema, validator, policy, and workflow alignment. |
+| ADR | `docs/adr/ADR-0018-prov-stac-dcat-catalog-mapping.md` | Governs profile, schema, validator, policy, and workflow alignment. |
 | Schema-home ADR | `docs/adr/ADR-0001-schema-home.md` | Confirms whether `contracts/`, `schemas/`, `jsonschema/`, or another path is authoritative. |
 | PROV schema | `contracts/v1/provenance/kfm_prov_sidecar.schema.json` | Shapes provenance sidecars consumed by validators and policy gates. |
 | STAC schema | `contracts/v1/catalog/stac/kfm_stac_item.schema.json` | Shapes public-safe STAC item exports. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,3 +5,11 @@ This directory stores accepted architecture decisions for repository structure a
 ## Foundational layout decisions
 - `ADR-0001-schema-home.md` — canonical schema home.
 - `ADR-0002-responsibility-root-monorepo.md` — responsibility-root top-level layout.
+
+## Renumbered records for numeric ADR ordering
+- `ADR-0014-truth-path.md` (renamed from `0001-truth-path.md`).
+- `ADR-0015-promotion-contract.md` (renamed from `0002-promotion-contract.md`).
+- `ADR-0016-spec-hash.md` (renamed from `0003-spec-hash.md`).
+- `ADR-0017-meta-block-v2.md` (renamed from `0004-meta-block-v2.md`).
+
+- `ADR-0018-prov-stac-dcat-catalog-mapping.md` (renamed from `ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md`).

--- a/docs/registers/reorg/path_inventory.tsv
+++ b/docs/registers/reorg/path_inventory.tsv
@@ -354,7 +354,7 @@ docs/adr/ADR-0012-authority-boundary-compatibility-map.md	doc_adr
 docs/adr/ADR-0013-policy-home-authority.md	doc_adr
 docs/adr/ADR-0241-policy-obligation-engine-and-release-gate.md	doc_adr
 docs/adr/ADR-0427-consent-vc-and-revocation-delta.md	doc_adr
-docs/adr/ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md	doc_adr
+docs/adr/ADR-0018-prov-stac-dcat-catalog-mapping.md	doc_adr
 docs/adr/ADR-TEMPLATE.md	doc_adr
 docs/adr/README.md	doc_adr
 docs/architecture/CLIENT_VERIFICATION.md	doc_architecture

--- a/docs/sources/catalog_profiles/KFM_DCAT_EXPORT_PROFILE.md
+++ b/docs/sources/catalog_profiles/KFM_DCAT_EXPORT_PROFILE.md
@@ -10,7 +10,7 @@ updated: 2026-05-03
 policy_label: public
 related: [
   docs/adr/ADR-0001-schema-home.md,
-  docs/adr/ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md,
+  docs/adr/ADR-0018-prov-stac-dcat-catalog-mapping.md,
   docs/sources/catalog_profiles/KFM_STAC_EXTENSION_PROFILE.md,
   contracts/v1/catalog/dcat/kfm_dcat_dataset.schema.json,
   contracts/v1/provenance/kfm_prov_sidecar.schema.json,

--- a/docs/sources/catalog_profiles/KFM_STAC_EXTENSION_PROFILE.md
+++ b/docs/sources/catalog_profiles/KFM_STAC_EXTENSION_PROFILE.md
@@ -9,7 +9,7 @@ created: NEEDS VERIFICATION
 updated: 2026-05-03
 policy_label: public
 related: [
-  docs/adr/ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md,
+  docs/adr/ADR-0018-prov-stac-dcat-catalog-mapping.md,
   docs/adr/ADR-schema-home.md,
   docs/sources/catalog_profiles/KFM_DCAT_EXPORT_PROFILE.md,
   SCHEMA_HOME_TBD_AFTER_REPO_INSPECTION/catalog/stac/kfm_stac_item.schema.json,
@@ -134,7 +134,7 @@ A STAC record may make an artifact discoverable. It must never become the proof 
 | --- | --- | --- | --- |
 | STAC profile doc | PROPOSED | `docs/sources/catalog_profiles/KFM_STAC_EXTENSION_PROFILE.md` | Human-readable profile for KFM public-safe STAC publication. |
 | Schema-home ADR | PROPOSED | `docs/adr/ADR-schema-home.md` | Resolves whether machine contracts live under `contracts/`, `schemas/contracts/v1/`, or another repo-native home. |
-| STAC/DCAT/PROV mapping ADR | PROPOSED | `docs/adr/ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md` | Defines catalog closure, identity mapping, and link relation conventions. |
+| STAC/DCAT/PROV mapping ADR | PROPOSED | `docs/adr/ADR-0018-prov-stac-dcat-catalog-mapping.md` | Defines catalog closure, identity mapping, and link relation conventions. |
 | STAC schema | PROPOSED | `SCHEMA_HOME_TBD_AFTER_REPO_INSPECTION/catalog/stac/kfm_stac_item.schema.json` | Machine-readable KFM STAC Item profile. |
 | STAC validator | PROPOSED | `tools/validators/catalog/validate_stac_item.py` | Enforces schema, KFM governance rules, and public-safe publication gates. |
 | STAC policy gate | PROPOSED | `policy/catalog/stac/stac_item_gate.rego` | Denies unsafe public catalog records. |


### PR DESCRIPTION
### Motivation
- Normalize ADR filenames and internal targets to a consistent `ADR-00NN-*` numeric namespace for discoverability and ordering.
- Avoid conflicts with the ADR index and preserve existing ADR content while clarifying target paths in metadata and cross-document links.

### Description
- Renamed ADR documents and updated their metadata and target-path references: `docs/adr/0001-truth-path.md` -> `docs/adr/ADR-0014-truth-path.md`, `docs/adr/0002-promotion-contract.md` -> `docs/adr/ADR-0015-promotion-contract.md`, `docs/adr/0003-spec-hash.md` -> `docs/adr/ADR-0016-spec-hash.md`, `docs/adr/0004-meta-block-v2.md` -> `docs/adr/ADR-0017-meta-block-v2.md`, and `docs/adr/ADR-PROV-STAC-DCAT-CATALOG-MAPPING.md` -> `docs/adr/ADR-0018-prov-stac-dcat-catalog-mapping.md`.
- Updated cross-document links and inline references inside the renamed ADRs to point to the new `ADR-00NN` paths and adjusted meta-block notes to reflect the new targets.
- Updated repository index and inventory entries by editing `docs/adr/README.md` and `docs/registers/reorg/path_inventory.tsv` and fixed references in catalog profile docs to the new ADR paths.

### Testing
- No automated tests were executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faaff54ff4832a9eb4f8307bdb7d22)