### PR TITLE
Add verify-contracts-and-policy GitHub Actions workflow

### DIFF
--- a/.github/workflows/verify-contracts-and-policy.yml
+++ b/.github/workflows/verify-contracts-and-policy.yml
@@ -1,1 +1,70 @@
+name: verify-contracts-and-policy
 
+"on":
+  pull_request:
+    paths:
+      - ".github/workflows/verify-contracts-and-policy.yml"
+      - "contracts/**"
+      - "schemas/**"
+      - "policy/**"
+      - "tools/**"
+      - "tests/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/verify-contracts-and-policy.yml"
+      - "contracts/**"
+      - "schemas/**"
+      - "policy/**"
+      - "tools/**"
+      - "tests/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  verify-contracts-and-policy:
+    name: Verify contracts, schemas, and policy gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate contract and schema surfaces
+        run: |
+          set -euo pipefail
+          python tools/validate_repo.py
+          python tools/validate_api_contracts.py
+          python tools/validate_schema_conformance.py
+          python tools/validate_fixture_schema_mapping.py
+
+      - name: Validate policy and governance boundaries
+        run: |
+          set -euo pipefail
+          python tools/check_directory_rules.py
+          python tools/check_no_public_internal_paths.py
+          python tools/check_publication_eligibility.py
+
+      - name: Run policy-focused unit tests
+        run: |
+          set -euo pipefail
+          python -m unittest discover -s tests -p "*policy*.py"


### PR DESCRIPTION
### Motivation
- Restore the missing contracts/policy verification lane so changes to `contracts/`, `schemas/`, or `policy/` surfaces are validated in CI.
- Keep the change minimal and reversible while relying on existing repo-native validators to preserve KFM governance boundaries.

### Description
- Added `.github/workflows/verify-contracts-and-policy.yml` implementing a runnable workflow with `pull_request`, `push` on `main`, and `workflow_dispatch` triggers scoped to contract/schema/policy/tool/test surfaces.
- Enforced least-privilege `permissions: contents: read`, concurrency controls, and deterministic bash defaults, and used `actions/checkout@v4` and `actions/setup-python@v5` with Python `3.11`.
- Orchestrated validation steps to call existing repo scripts and validators: `python tools/validate_repo.py`, `python tools/validate_api_contracts.py`, `python tools/validate_schema_conformance.py`, `python tools/validate_fixture_schema_mapping.py`, governance checks (`tools/check_directory_rules.py`, `tools/check_no_public_internal_paths.py`, `tools/check_publication_eligibility.py`), and policy-focused unit tests via `python -m unittest discover -s tests -p "*policy*.py"`.

### Testing
- Parsed the new workflow YAML with `yaml.safe_load` and the parse succeeded.
- Ran `python tools/validate_repo.py` locally and it completed with `PASS directory rules satisfied` and `PASS required repository skeleton present`.
- No other automated tests were executed as part of this change; CI will run the new workflow on relevant PRs or pushes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb78067508832a818da8aa4d4332b7)