### PR TITLE
fix: unblock fixture and docs truth-label validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kansas Frontier Matrix
 
-A governed, evidence-first, map-first, time-aware spatial knowledge and publication system for inspectable Kansas-centered claims.
+A governed, evidence-first, map-first, time-aware spatial knowledge and publication system for inspectable Kansas-first claims.
 
 > [!NOTE]
 > **Status:** `draft`  
@@ -43,7 +43,7 @@ A governed, evidence-first, map-first, time-aware spatial knowledge and publicat
 
 Kansas Frontier Matrix, or KFM, is a governed spatial evidence system. It is designed to help people inspect how evidence becomes a map feature, a story, a dashboard value, an API response, a release artifact, or a bounded AI answer.
 
-The durable unit of value is the **inspectable claim**: a public or semi-public statement whose evidence, source role, spatial scope, temporal scope, policy posture, review state, release state, and correction lineage can be inspected.
+The durable and auditable public unit of value is the **inspectable claim**: a public or semi-public statement whose evidence, source role, spatial scope, temporal scope, policy posture, review state, release state, and correction lineage can be inspected.
 
 KFM is **not** just a map viewer, database, AI assistant, graph, report generator, tile server, or GIS exercise. Maps, tiles, graphs, summaries, vector indexes, scenes, dashboards, exports, and AI answers are carriers of evidence. They are not sovereign truth.
 

--- a/docs/doctrine/trust-membrane.md
+++ b/docs/doctrine/trust-membrane.md
@@ -66,7 +66,7 @@ It applies to:
 
 The trust membrane is not a single middleware file, UI panel, backend package, data folder, or model adapter. It is the doctrine rule that public and semi-public outputs must remain downstream of the KFM truth path.
 
-> KFM public value is not “the map rendered” or “the model answered.” KFM public value is an inspectable claim whose support, policy posture, release state, and correction lineage can be examined.
+> KFM public value is not “the map rendered” or “the model answered.” KFM public value is an inspectable claim, the public unit of value whose support, policy posture, release state, and correction lineage can be examined.
 
 [Back to top](#top)
 

--- a/fixtures/runtime/evidence_bundle.valid.json
+++ b/fixtures/runtime/evidence_bundle.valid.json
@@ -1,1 +1,1 @@
-{"evidence_bundle_id":"evb-001","source_authority":"trusted"}
+{"evidence_bundle_id":"evb-001","source_authority":"trusted","knowledge_character":"SYNTHETIC_TEST"}

--- a/fixtures/runtime/release_manifest.valid.json
+++ b/fixtures/runtime/release_manifest.valid.json
@@ -1,1 +1,1 @@
-{"release_manifest_id":"rel-001","contains_sensitive_geometry":false,"sensitive_geometry_transformed":true}
+{"release_manifest_id":"rel-001","contains_sensitive_geometry":false,"sensitive_geometry_transformed":true,"knowledge_character":"SYNTHETIC_TEST"}

--- a/fixtures/runtime/signature.valid.json
+++ b/fixtures/runtime/signature.valid.json
@@ -1,1 +1,1 @@
-{"status": "valid", "manifest_hash": "f3ccd0c051a5c62babfaa9563d3bfe51f01f4614eb4ef3ecb576c83dbbc70677"}
+{"status":"valid","manifest_hash":"f3ccd0c051a5c62babfaa9563d3bfe51f01f4614eb4ef3ecb576c83dbbc70677","knowledge_character":"SYNTHETIC_TEST"}


### PR DESCRIPTION
### Motivation

- Unblock automated workflow-aligned validation that failed due to runtime fixture metadata and missing doctrine truth-label tokens.  
- Keep changes minimal and reversible so CI/validators can proceed to the next reconciliation steps.  
- Satisfy requirements of repository tools that mark synthetic fixtures and enforce documentation truth-label tokens.

### Description

- Added `knowledge_character: "SYNTHETIC_TEST"` to `fixtures/runtime/evidence_bundle.valid.json`, `fixtures/runtime/release_manifest.valid.json`, and `fixtures/runtime/signature.valid.json` to align fixtures with fixture validation expectations.  
- Modified `README.md` wording to include the required doctrine/truth-label phrasing and make the public unit intent explicit.  
- Tweaked `docs/doctrine/trust-membrane.md` to include the "public unit of value" phrasing required by docs truth-label checks.  
- Changes are intentionally small and focused only on unblocking the validation gates rather than addressing broader schema/home or policy reorganizations.

### Testing

- Ran docs truth-label validation with `python tools/validate_docs_truth_labels.py`, which passed after the documentation edits.  
- Ran the repository baseline/validation chain (multiple `python tools/...` checks and `bash scripts/validate_all.sh`), which initially failed on missing `knowledge_character` in runtime fixtures and passed those fixture checks after the fixture updates.  
- Ran unit tests with `python -m unittest discover -s tests` (and `PYTHONPATH=. python -m unittest discover -s tests`), which still fail due to unrelated pre-existing issues: import errors for missing `soilgrids_*` modules and failing `test_policy_home` / `test_schema_home` assertions; final run reported 2 failures and 5 errors.  
- Executed a workflow-reference heuristic that scanned `.github/workflows/*.yml` for referenced files and reported many conditional or environment-dependent references that need manual triage (these are labeled for follow-up rather than changed in this patch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7a1f655c832aab903a3cbe5fb825)