### PR TITLE
Add workflow dependency register and CI validation guard

### DIFF
--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Validate repository structure
         run: python tools/validate_repo.py
 
+      - name: Validate workflow dependency register
+        run: python tools/ci/validate_workflow_dependency_register.py
+
       - name: Validate fixtures
         run: python tools/validate_fixtures.py
 

--- a/docs/registers/workflow_dependency_register.yaml
+++ b/docs/registers/workflow_dependency_register.yaml
@@ -1,0 +1,310 @@
+version: 1
+last_updated: '2026-05-06'
+owning_responsibility_root: .github/workflows
+workflows:
+- workflow_file: .github/workflows/baseline.yml
+  workflow_name: baseline
+  trigger:
+  - push
+  - pull_request
+  jobs:
+  - test
+  required_actions:
+  - actions/checkout@v4
+  - actions/setup-python@v5
+  required_scripts:
+  - scripts/validate_all.sh
+  required_package_managers:
+  - bash
+  - python
+  required_repo_paths:
+  - tools
+  - tests
+  - scripts
+  required_secrets_or_github_context:
+  - github.ref
+  - github.workflow
+  - github.workspace
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: Does not evaluate branch protection, required-check
+    policy, or Actions permission enforcement.
+  status: PASS
+- workflow_file: .github/workflows/incremental-stac-watcher.yml
+  workflow_name: incremental-stac-watcher
+  trigger:
+  - schedule
+  - workflow_dispatch
+  jobs:
+  - watcher
+  required_actions:
+  - actions/checkout@v4
+  required_scripts: []
+  required_package_managers:
+  - bash
+  - python
+  required_repo_paths:
+  - data/catalog/stac
+  - tools
+  required_secrets_or_github_context:
+  - github.event
+  - github.event_name
+  - github.ref
+  - github.token
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: Scheduled trigger timing and token scopes require
+    execution in GitHub-hosted Actions.
+  status: NEEDS VERIFICATION
+- workflow_file: .github/workflows/promote-and-reconcile.yml
+  workflow_name: promote-and-reconcile
+  trigger:
+  - pull_request
+  - push
+  - workflow_dispatch
+  jobs:
+  - promote-and-reconcile
+  required_actions:
+  - actions/checkout@v4
+  - actions/setup-python@v5
+  required_scripts: []
+  required_package_managers:
+  - bash
+  - python
+  required_repo_paths:
+  - contracts
+  - schemas
+  - fixtures
+  - release
+  - tools
+  - tests
+  required_secrets_or_github_context:
+  - github.ref
+  - github.workflow
+  - github.workspace
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: Artifact retention, PR annotations, and branch policy
+    checks require GitHub runtime.
+  status: PASS
+- workflow_file: .github/workflows/rehearse-rollback-and-correction.yml
+  workflow_name: Rehearse rollback and correction
+  trigger:
+  - pull_request
+  - push
+  - workflow_dispatch
+  jobs:
+  - dry-run-rehearsal
+  required_actions:
+  - actions/checkout@v4
+  - actions/setup-python@v5
+  required_scripts: []
+  required_package_managers:
+  - bash
+  required_repo_paths:
+  - release
+  - data/receipts
+  - tools
+  required_secrets_or_github_context:
+  - github.event
+  - github.ref
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: Commenting/status APIs and hosted runner environment
+    are GitHub-only.
+  status: FAIL
+- workflow_file: .github/workflows/release-evidence.yml
+  workflow_name: release-evidence
+  trigger:
+  - workflow_dispatch
+  - pull_request
+  - push
+  - release
+  jobs:
+  - assemble-release-evidence
+  required_actions:
+  - actions/checkout@v4
+  required_scripts: []
+  required_package_managers:
+  - bash
+  - python
+  required_repo_paths:
+  - release
+  - data/proofs
+  - data/catalog
+  - data/receipts
+  required_secrets_or_github_context:
+  - github.event_name
+  - github.ref
+  - github.run_id
+  - github.workflow
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: Release event semantics and tag protection cannot
+    be validated locally.
+  status: FAIL
+- workflow_file: .github/workflows/runtime-proof-soil-moisture.yml
+  workflow_name: Runtime Proof - Soil Moisture
+  trigger:
+  - pull_request
+  - push
+  - workflow_dispatch
+  jobs:
+  - runtime-proof-soil-moisture
+  required_actions:
+  - actions/checkout@v4
+  - actions/setup-python@v5
+  required_scripts: []
+  required_package_managers:
+  - bash
+  - python
+  required_repo_paths:
+  - tools
+  - contracts
+  - schemas
+  - data
+  required_secrets_or_github_context:
+  - github.event
+  - github.ref
+  - github.run_attempt
+  - github.run_id
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: OIDC/provenance and workflow summary rendering behavior
+    require GitHub execution.
+  status: NEEDS VERIFICATION
+- workflow_file: .github/workflows/synthetic-release-dry-run.yml
+  workflow_name: synthetic-release-dry-run
+  trigger:
+  - pull_request
+  - push
+  - workflow_dispatch
+  jobs:
+  - dry-run
+  required_actions:
+  - actions/checkout@v4
+  - actions/setup-python@v5
+  required_scripts: []
+  required_package_managers:
+  - bash
+  - python
+  required_repo_paths:
+  - release
+  - tools
+  - tests
+  required_secrets_or_github_context:
+  - github.ref
+  - github.workflow
+  - github.workspace
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: Actions summary annotations and artifacts are not
+    reproducible in local shell.
+  status: PASS
+- workflow_file: .github/workflows/verify-contracts-and-policy.yml
+  workflow_name: verify-contracts-and-policy
+  trigger:
+  - pull_request
+  - push
+  - workflow_dispatch
+  jobs:
+  - verify-contracts-and-policy
+  required_actions:
+  - actions/checkout@v4
+  - actions/setup-python@v5
+  required_scripts: []
+  required_package_managers:
+  - bash
+  - python
+  required_repo_paths:
+  - contracts
+  - schemas
+  - policy
+  - tools
+  - tests
+  required_secrets_or_github_context:
+  - github.ref
+  - github.workflow
+  - github.workspace
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: Repository security policy checks depend on GitHub
+    environment and branch configuration.
+  status: PASS
+- workflow_file: .github/workflows/verify-docs.yml
+  workflow_name: verify-docs
+  trigger:
+  - pull_request
+  - push
+  - workflow_dispatch
+  jobs:
+  - verify-docs
+  required_actions:
+  - actions/checkout@v4
+  - actions/setup-python@v5
+  required_scripts:
+  - tools/ci/check_readme_paths.sh
+  required_package_managers:
+  - bash
+  required_repo_paths:
+  - docs
+  - tools/ci
+  required_secrets_or_github_context:
+  - github.ref
+  - github.workflow
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: PR annotation rendering and required-check gating
+    are platform-level.
+  status: PASS
+- workflow_file: .github/workflows/verify-runtime.yml
+  workflow_name: verify-runtime
+  trigger:
+  - pull_request
+  - push
+  - workflow_dispatch
+  jobs:
+  - verify-runtime
+  required_actions:
+  - actions/checkout@v4
+  - actions/setup-python@v5
+  required_scripts: []
+  required_package_managers:
+  - bash
+  - python
+  required_repo_paths:
+  - apps/api
+  - contracts/runtime
+  - schemas/contracts/v1/runtime
+  - tools/ci
+  - tests
+  required_secrets_or_github_context:
+  - github.event
+  - github.event_name
+  - github.ref
+  - github.sha
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: End-to-end runner parity and merge-gate enforcement
+    require GitHub Actions context.
+  status: FAIL
+- workflow_file: .github/workflows/verify-tests-and-reproducibility.yml
+  workflow_name: Verify tests and reproducibility
+  trigger:
+  - pull_request
+  - push
+  - workflow_dispatch
+  jobs:
+  - verify
+  required_actions:
+  - actions/checkout@v4
+  - actions/setup-python@v5
+  required_scripts: []
+  required_package_managers:
+  - bash
+  - npm
+  - pnpm
+  - python
+  - yarn
+  required_repo_paths:
+  - tests
+  - tools
+  - scripts
+  required_secrets_or_github_context:
+  - github.ref
+  - github.run_id
+  - github.workflow
+  local_validation_command: python tools/ci/validate_workflow_dependency_register.py
+  github_only_validation_limits: Reproducibility attestation uploads and job-summary
+    links are GitHub-only.
+  status: PASS

--- a/tools/ci/validate_workflow_dependency_register.py
+++ b/tools/ci/validate_workflow_dependency_register.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTER = ROOT / "docs/registers/workflow_dependency_register.yaml"
+WORKFLOWS = ROOT / ".github/workflows"
+
+SCRIPT_RE = re.compile(r"(?:python\s+|bash\s+|sh\s+|\.\/)([\w./-]+\.(?:py|sh))")
+PATH_RE = re.compile(r"([A-Za-z0-9_./-]+\.(?:json|ya?ml|toml|ini|cfg))")
+SECRET_RE = re.compile(r"secrets\.([A-Z0-9_]+)")
+CTX_RE = re.compile(r"github\.([a-zA-Z_]+)")
+PM_RE = re.compile(r"\b(python|pip|pip3|npm|pnpm|yarn|go|cargo|uv|poetry|bash|sh)\b")
+
+
+def load_yaml(path: Path):
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+def collect_from_workflow(path: Path):
+    data = load_yaml(path)
+    txt = path.read_text()
+    scripts, cfgs, pms = set(), set(), set()
+    for m in SCRIPT_RE.finditer(txt):
+        scripts.add(m.group(1).lstrip("./"))
+    for m in PATH_RE.finditer(txt):
+        candidate = m.group(1).lstrip("./")
+        if candidate.startswith("github"):
+            continue
+        cfgs.add(candidate)
+    for m in PM_RE.finditer(txt):
+        t = m.group(1)
+        pms.add("python" if t in {"pip", "pip3"} else ("bash" if t == "sh" else t))
+    secrets = {"secrets." + s for s in SECRET_RE.findall(txt)}
+    context = {"github." + c for c in CTX_RE.findall(txt) if c != "com"}
+    return data, scripts, cfgs, pms, secrets | context
+
+
+def main() -> int:
+    reg = load_yaml(REGISTER)
+    entries = {e["workflow_file"]: e for e in reg["workflows"]}
+    failures = []
+
+    workflow_files = sorted(p.relative_to(ROOT).as_posix() for p in WORKFLOWS.glob("*.yml"))
+    missing_entries = [wf for wf in workflow_files if wf not in entries]
+    if missing_entries:
+        failures.append(f"Missing register entries: {missing_entries}")
+
+    for wf in workflow_files:
+        entry = entries.get(wf)
+        if not entry:
+            continue
+        _, scripts, cfgs, pms, ctx = collect_from_workflow(ROOT / wf)
+        documented_scripts = set(entry.get("required_scripts", []))
+        documented_paths = set(entry.get("required_repo_paths", []))
+        documented_pms = set(entry.get("required_package_managers", []))
+        documented_ctx = set(entry.get("required_secrets_or_github_context", []))
+
+        for s in documented_scripts:
+            if not (ROOT / s).exists():
+                failures.append(f"{wf}: documented script missing: {s}")
+        for p in documented_paths:
+            if not (ROOT / p).exists():
+                failures.append(f"{wf}: documented repo path missing: {p}")
+
+        repo_prefixes=("configs/","contracts/","schemas/","policy/","release/","data/","tests/","tools/","scripts/","apps/",".github/")
+        missing_cfg = sorted(c for c in cfgs if c and c.startswith(repo_prefixes) and not (ROOT / c).exists())
+        if missing_cfg:
+            failures.append(f"{wf}: missing referenced config/files: {missing_cfg[:10]}")
+
+        missing_pm_docs = sorted(pm for pm in pms if pm not in documented_pms)
+        if missing_pm_docs:
+            failures.append(f"{wf}: package commands undocumented: {missing_pm_docs}")
+
+        undocumented_ctx = sorted(c for c in ctx if c not in documented_ctx)
+        if undocumented_ctx:
+            failures.append(f"{wf}: undocumented secrets/context: {undocumented_ctx}")
+
+    if failures:
+        print("workflow dependency validation FAILED")
+        for f in failures:
+            print("-", f)
+        return 1
+    print("workflow dependency validation PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Make workflow-to-repo dependencies explicit and machine-checkable so CI can catch missing local scripts, config files, package commands, or undocumented GitHub context before a workflow change lands.
- Provide a single, repo-local inventory for `.github/workflows/` to support reviewer/auditor checks and reduce hidden runtime-only surprises.

### Description
- Added a workflow dependency register at `docs/registers/workflow_dependency_register.yaml` that inventories each workflow with name, triggers, jobs, required actions, scripts, package managers, repo paths, secrets/GitHub context, a local validation command, GitHub-only validation limits, owning root, and a status field.
- Added a lightweight validator `tools/ci/validate_workflow_dependency_register.py` that parses workflow YAML and fails when workflows reference missing repo-local scripts/configs, use package-manager commands that are not documented, or rely on undocumented secrets/GitHub context.
- Integrated the validator into the baseline CI by adding a baseline step that runs `python tools/ci/validate_workflow_dependency_register.py` so register consistency is enforced during the baseline check.
- Updated the register to mark workflows that require attention: workflows referencing missing local files are marked `FAIL` and workflows that require runtime-only verification are marked `NEEDS VERIFICATION`.

### Testing
- Ran `python tools/ci/validate_workflow_dependency_register.py` which initially failed and reported many undocumented scripts and references, then was iteratively adjusted and re-run; the final run failed as designed because workflows reference missing repo-local files (examples include `release/release_manifest_v1.json`, `release/release_manifest_v2.json`, `release/rollback_card_v2_to_v1.dry_run.json`, `data/catalog/catalog-matrix.json`, `data/proofs/release-proof-pack.json`, `release/manifests/release-manifest.json`, `release/promotion/promotion-decision.json`, `release/rollback/rollback-card.json`, and `schemas/contracts/v1/runtime/runtime_response.schema.json`).
- Ran the baseline verification script `bash tools/ci/test_verify_baseline.sh` which failed in this environment due to `Permission denied` when executing `tools/ci/verify_baseline.sh`, which is an environment/setup issue rather than a validator defect.
- The register file records the failing workflows (`.github/workflows/rehearse-rollback-and-correction.yml`, `.github/workflows/release-evidence.yml`, `.github/workflows/verify-runtime.yml`) as `FAIL` and marks `.github/workflows/incremental-stac-watcher.yml` and `.github/workflows/runtime-proof-soil-moisture.yml` as `NEEDS VERIFICATION` for GitHub-only checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7c5d32c8832ab7b45d8c99d10cf8)