### PR TITLE
Add compatibility shims for legacy governed_api and soilgrids imports

### DIFF
--- a/apps/governed_api/__init__.py
+++ b/apps/governed_api/__init__.py
@@ -1,0 +1,1 @@
+"""Backward-compatible governed_api package."""

--- a/apps/governed_api/server.py
+++ b/apps/governed_api/server.py
@@ -1,0 +1,5 @@
+"""Compatibility shim for tests importing apps.governed_api.server."""
+
+from apps.api.server import app
+
+__all__ = ["app"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ include = ["tools*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+addopts = "--import-mode=importlib"
 
 [tool.ruff]
 line-length = 100

--- a/soilgrids_disclosure_packet.py
+++ b/soilgrids_disclosure_packet.py
@@ -1,0 +1,12 @@
+"""Compatibility shim exposing soilgrids_disclosure_packet at repository root."""
+
+from tools.soilgrids import soilgrids_disclosure_packet as _impl
+from tools.soilgrids.soilgrids_disclosure_packet import *  # noqa: F401,F403
+
+
+def main(argv=None):
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/soilgrids_registry_runtime.py
+++ b/soilgrids_registry_runtime.py
@@ -1,0 +1,12 @@
+"""Compatibility shim exposing soilgrids_registry_runtime at repository root."""
+
+from tools.soilgrids import soilgrids_registry_runtime as _impl
+from tools.soilgrids.soilgrids_registry_runtime import *  # noqa: F401,F403
+
+
+def main(argv=None):
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/soilgrids_release_publish.py
+++ b/soilgrids_release_publish.py
@@ -1,0 +1,12 @@
+"""Compatibility shim exposing soilgrids_release_publish at repository root."""
+
+from tools.soilgrids import soilgrids_release_publish as _impl
+from tools.soilgrids.soilgrids_release_publish import *  # noqa: F401,F403
+
+
+def main(argv=None):
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/soilgrids_serve_validate.py
+++ b/soilgrids_serve_validate.py
@@ -1,0 +1,12 @@
+"""Compatibility shim exposing soilgrids_serve_validate at repository root."""
+
+from tools.soilgrids import soilgrids_serve_validate as _impl
+from tools.soilgrids.soilgrids_serve_validate import *  # noqa: F401,F403
+
+
+def main(argv=None):
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/soilgrids_viewer_bundle.py
+++ b/soilgrids_viewer_bundle.py
@@ -1,0 +1,12 @@
+"""Compatibility shim exposing soilgrids_viewer_bundle at repository root."""
+
+from tools.soilgrids import soilgrids_viewer_bundle as _impl
+from tools.soilgrids.soilgrids_viewer_bundle import *  # noqa: F401,F403
+
+
+def main(argv=None):
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Tests were failing during collection and import with `ModuleNotFoundError` for `apps.governed_api` and with duplicate test-module basename collisions, indicating legacy import paths and pytest import-mode issues. 
- Some tests invoke repository-root CLI modules (e.g. `soilgrids_disclosure_packet.py`) so wrappers are needed to preserve expected entrypoints for subprocess-based tests. 

### Description
- Add a backward-compatible `apps.governed_api` package that re-exports `app` from `apps.api.server` via `apps/governed_api/__init__.py` and `apps/governed_api/server.py`. 
- Add root-level compatibility shims `soilgrids_disclosure_packet.py`, `soilgrids_registry_runtime.py`, `soilgrids_release_publish.py`, `soilgrids_serve_validate.py`, and `soilgrids_viewer_bundle.py` that re-export the implementations from `tools.soilgrids.*` and expose a `main()` entrypoint so CLI-based tests invoke real behavior. 
- Configure pytest import behaviour by adding `addopts = "--import-mode=importlib"` to `pyproject.toml` to avoid duplicate-basename collection collisions. 
- Files changed: `pyproject.toml`, `apps/governed_api/__init__.py`, `apps/governed_api/server.py`, `soilgrids_disclosure_packet.py`, `soilgrids_registry_runtime.py`, `soilgrids_release_publish.py`, `soilgrids_serve_validate.py`, and `soilgrids_viewer_bundle.py`. 

### Testing
- Running the full test suite with `python3 -m pytest -q` before fixes produced collection/import errors (11 errors during collection). 
- Running a focused subset before the fix (`tests/fixtures/crosswalk/test_crosswalk_fixture.py`, `tests/governed_api/test_governed_api_app_registration.py`, `tests/test_soilgrids_disclosure_packet.py`) showed `2 failed, 4 passed`. 
- After applying the compatibility shims and pytest configuration, the same focused test command `python3 -m pytest -q tests/fixtures/crosswalk/test_crosswalk_fixture.py tests/governed_api/test_governed_api_app_registration.py tests/test_soilgrids_disclosure_packet.py` succeeded with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb800814b8832aab07b84030fa4134)