### PR TITLE
Fix root surface register to include enforcement directory

### DIFF
--- a/control_plane/root_surface_register.yaml
+++ b/control_plane/root_surface_register.yaml
@@ -38,6 +38,9 @@ roots:
   docs:
     class: canonical
     notes: Human documentation, ADRs, runbooks, reports.
+  enforcement:
+    class: policy
+    notes: Enforcement logic and policy execution surfaces.
   examples:
     class: compatibility
     notes: Example walkthroughs and reference slices.

--- a/docs/registers/root-surface-register.md
+++ b/docs/registers/root-surface-register.md
@@ -3,7 +3,7 @@
 Source of truth: `control_plane/root_surface_register.yaml`.
 
 ## Purpose
-Classify each repository root surface for governance and compatibility handling.
+Classify each repository root surface for governance and compatibility handling, including enforcement roots.
 
 ## Allowed classes
 - canonical


### PR DESCRIPTION
### Motivation
- Local CI validation (`bash scripts/validate_all.sh`) failed because `tools/check_root_surface_register.py` reported a missing root entry for the existing `enforcement/` directory, so the register and docs need to be updated.

### Description
- Add the `enforcement` root to `control_plane/root_surface_register.yaml` with `class: policy` and update the `docs/registers/root-surface-register.md` purpose line to explicitly mention enforcement roots.

### Testing
- Ran `python3 tools/validate_repo.py` and `python3 tools/check_root_surface_register.py` which passed after the change, and re-ran `bash scripts/validate_all.sh` which still fails due to pre-existing `schema outside canonical home` violations unrelated to this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb90a4c1c4832aaa0562cb2c577bfb)