### PR TITLE
ci: skip scheduled STAC watcher when source URL is not configured

### DIFF
--- a/.github/workflows/incremental-stac-watcher.yml
+++ b/.github/workflows/incremental-stac-watcher.yml
@@ -63,6 +63,7 @@ env:
 
 jobs:
   watcher:
+    if: ${{ github.event_name != 'schedule' || vars.KFM_STAC_SOURCE_URL != '' }}
     name: Run receipts-first incremental STAC watcher
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
### Motivation
- Prevent scheduled `incremental-stac-watcher` runs from failing immediately when the repository variable `KFM_STAC_SOURCE_URL` is not set by skipping the job for schedule events unless the variable is configured.

### Description
- Add a job-level conditional `if: ${{ github.event_name != 'schedule' || vars.KFM_STAC_SOURCE_URL != '' }}` to `.github/workflows/incremental-stac-watcher.yml` so schedule-triggered runs are skipped when `KFM_STAC_SOURCE_URL` is empty while preserving manual `workflow_dispatch` behavior.

### Testing
- Locally parsed the modified workflow YAML and ran `python tools/ci/validate_workflow_dependency_register.py`, `python tools/validate_repo.py`, and `bash scripts/validate_all.sh`, which reported workflow YAML OK, dependency validation PASSED, repository validation PASSED and unit tests "Ran 85 tests ... OK", and no GitHub Actions rerun was performed from this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb94f80db4832aa3d173824391acb6)