### PR TITLE
Declare python package manager for rehearse-rollback-and-correction workflow

### DIFF
--- a/docs/registers/workflow_dependency_register.yaml
+++ b/docs/registers/workflow_dependency_register.yaml
@@ -98,6 +98,7 @@ workflows:
   required_scripts: []
   required_package_managers:
   - bash
+  - python
   required_repo_paths:
   - release
   - data/receipts


### PR DESCRIPTION
### Motivation
- The workflow dependency register omitted that `.github/workflows/rehearse-rollback-and-correction.yml` executes Python, causing a root-cause entry in the failure matrix. 

### Description
- Add `- python` under `required_package_managers` for the rehearse workflow in `docs/registers/workflow_dependency_register.yaml` so the register reflects the workflow's actual execution requirements. 

### Testing
- Ran `python tools/ci/validate_workflow_dependency_register.py` but execution was blocked by `ModuleNotFoundError: No module named 'yaml'` and `pip install pyyaml` could not complete due to network/proxy `403 Forbidden`, so local validator could not finish; as a result the `rehearse-rollback-and-correction` entry is expected to move from **FAIL** to **PASS** once the validator runs with PyYAML available, and no other workflows were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb98be7df8832aaa840d96851db6e4)