### PR TITLE
docs: repair stale test path in air receipts quickstart

### DIFF
--- a/data/receipts/air/README.md
+++ b/data/receipts/air/README.md
@@ -213,7 +213,7 @@ find data/receipts/atmosphere -maxdepth 3 -type f | sort 2>/dev/null || true
 # PROPOSED validation shape only.
 # Replace with repo-native validator once schema and tool locations are confirmed.
 python tools/validators/atmosphere/validate_receipts.py data/receipts/air
-pytest -q tests/atmosphere
+pytest -q tests/air
 ```
 
 ```bash


### PR DESCRIPTION
### Motivation
- Correct a confirmed stale quickstart command in the air receipts README so the example test invocation matches the repository's test path.

### Description
- Update `data/receipts/air/README.md` by replacing `pytest -q tests/atmosphere` with `pytest -q tests/air` to align the quickstart with the repo layout.

### Testing
- Ran `pytest -q tests/repo_inventory tests/test_directory_rules.py tests/test_fixture_schema_mapping.py` which passed (`9 passed`), and ran `pytest -q tests/air` which still reports pre-existing failures (9 failed) due to missing files/schemas and a missing `jsonschema` dependency unrelated to this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9b4c7418832a9846d1f7d02ae5ec)