### PR TITLE
Add missing fauna source subdirectory READMEs

### DIFF
--- a/docs/domains/fauna/sources/eddmaps/README.md
+++ b/docs/domains/fauna/sources/eddmaps/README.md
@@ -1,0 +1,20 @@
+# Eddmaps Source Notes
+
+## Purpose
+This folder documents the `eddmaps` source family for the fauna domain and tracks readiness, rights, sensitivity, and validation expectations before any public-safe release.
+
+## Current Status
+- State: `PROPOSED / NEEDS VERIFICATION`
+- Connector: Disabled
+- Public exact sensitive geometry: Denied by default
+
+## Required Before Activation
+1. Source descriptor in `data/registry/fauna/` with authority scope and cadence.
+2. Rights and redistribution review completed.
+3. Geoprivacy controls verified against `docs/domains/fauna/GEOPRIVACY.md`.
+4. Fixture-based validation added and passing.
+5. Release review and rollback path documented.
+
+## Notes
+- This README is documentation only; it does not activate ingestion.
+- Treat source claims as scoped inputs, not canonical legal truth.

--- a/docs/domains/fauna/sources/inaturalist/README.md
+++ b/docs/domains/fauna/sources/inaturalist/README.md
@@ -1,0 +1,20 @@
+# Inaturalist Source Notes
+
+## Purpose
+This folder documents the `inaturalist` source family for the fauna domain and tracks readiness, rights, sensitivity, and validation expectations before any public-safe release.
+
+## Current Status
+- State: `PROPOSED / NEEDS VERIFICATION`
+- Connector: Disabled
+- Public exact sensitive geometry: Denied by default
+
+## Required Before Activation
+1. Source descriptor in `data/registry/fauna/` with authority scope and cadence.
+2. Rights and redistribution review completed.
+3. Geoprivacy controls verified against `docs/domains/fauna/GEOPRIVACY.md`.
+4. Fixture-based validation added and passing.
+5. Release review and rollback path documented.
+
+## Notes
+- This README is documentation only; it does not activate ingestion.
+- Treat source claims as scoped inputs, not canonical legal truth.

--- a/docs/domains/fauna/sources/kdwp/README.md
+++ b/docs/domains/fauna/sources/kdwp/README.md
@@ -1,0 +1,20 @@
+# Kdwp Source Notes
+
+## Purpose
+This folder documents the `kdwp` source family for the fauna domain and tracks readiness, rights, sensitivity, and validation expectations before any public-safe release.
+
+## Current Status
+- State: `PROPOSED / NEEDS VERIFICATION`
+- Connector: Disabled
+- Public exact sensitive geometry: Denied by default
+
+## Required Before Activation
+1. Source descriptor in `data/registry/fauna/` with authority scope and cadence.
+2. Rights and redistribution review completed.
+3. Geoprivacy controls verified against `docs/domains/fauna/GEOPRIVACY.md`.
+4. Fixture-based validation added and passing.
+5. Release review and rollback path documented.
+
+## Notes
+- This README is documentation only; it does not activate ingestion.
+- Treat source claims as scoped inputs, not canonical legal truth.

--- a/docs/domains/fauna/sources/monitoring/README.md
+++ b/docs/domains/fauna/sources/monitoring/README.md
@@ -1,0 +1,20 @@
+# Monitoring Source Notes
+
+## Purpose
+This folder documents the `monitoring` source family for the fauna domain and tracks readiness, rights, sensitivity, and validation expectations before any public-safe release.
+
+## Current Status
+- State: `PROPOSED / NEEDS VERIFICATION`
+- Connector: Disabled
+- Public exact sensitive geometry: Denied by default
+
+## Required Before Activation
+1. Source descriptor in `data/registry/fauna/` with authority scope and cadence.
+2. Rights and redistribution review completed.
+3. Geoprivacy controls verified against `docs/domains/fauna/GEOPRIVACY.md`.
+4. Fixture-based validation added and passing.
+5. Release review and rollback path documented.
+
+## Notes
+- This README is documentation only; it does not activate ingestion.
+- Treat source claims as scoped inputs, not canonical legal truth.

--- a/docs/domains/fauna/sources/museum-specimens/README.md
+++ b/docs/domains/fauna/sources/museum-specimens/README.md
@@ -1,0 +1,20 @@
+# Museum Specimens Source Notes
+
+## Purpose
+This folder documents the `museum-specimens` source family for the fauna domain and tracks readiness, rights, sensitivity, and validation expectations before any public-safe release.
+
+## Current Status
+- State: `PROPOSED / NEEDS VERIFICATION`
+- Connector: Disabled
+- Public exact sensitive geometry: Denied by default
+
+## Required Before Activation
+1. Source descriptor in `data/registry/fauna/` with authority scope and cadence.
+2. Rights and redistribution review completed.
+3. Geoprivacy controls verified against `docs/domains/fauna/GEOPRIVACY.md`.
+4. Fixture-based validation added and passing.
+5. Release review and rollback path documented.
+
+## Notes
+- This README is documentation only; it does not activate ingestion.
+- Treat source claims as scoped inputs, not canonical legal truth.

--- a/docs/domains/fauna/sources/natureserve/README.md
+++ b/docs/domains/fauna/sources/natureserve/README.md
@@ -1,0 +1,20 @@
+# Natureserve Source Notes
+
+## Purpose
+This folder documents the `natureserve` source family for the fauna domain and tracks readiness, rights, sensitivity, and validation expectations before any public-safe release.
+
+## Current Status
+- State: `PROPOSED / NEEDS VERIFICATION`
+- Connector: Disabled
+- Public exact sensitive geometry: Denied by default
+
+## Required Before Activation
+1. Source descriptor in `data/registry/fauna/` with authority scope and cadence.
+2. Rights and redistribution review completed.
+3. Geoprivacy controls verified against `docs/domains/fauna/GEOPRIVACY.md`.
+4. Fixture-based validation added and passing.
+5. Release review and rollback path documented.
+
+## Notes
+- This README is documentation only; it does not activate ingestion.
+- Treat source claims as scoped inputs, not canonical legal truth.

--- a/docs/domains/fauna/sources/steward-restricted/README.md
+++ b/docs/domains/fauna/sources/steward-restricted/README.md
@@ -1,0 +1,20 @@
+# Steward Restricted Source Notes
+
+## Purpose
+This folder documents the `steward-restricted` source family for the fauna domain and tracks readiness, rights, sensitivity, and validation expectations before any public-safe release.
+
+## Current Status
+- State: `PROPOSED / NEEDS VERIFICATION`
+- Connector: Disabled
+- Public exact sensitive geometry: Denied by default
+
+## Required Before Activation
+1. Source descriptor in `data/registry/fauna/` with authority scope and cadence.
+2. Rights and redistribution review completed.
+3. Geoprivacy controls verified against `docs/domains/fauna/GEOPRIVACY.md`.
+4. Fixture-based validation added and passing.
+5. Release review and rollback path documented.
+
+## Notes
+- This README is documentation only; it does not activate ingestion.
+- Treat source claims as scoped inputs, not canonical legal truth.

--- a/docs/domains/fauna/sources/usfws/README.md
+++ b/docs/domains/fauna/sources/usfws/README.md
@@ -1,0 +1,20 @@
+# Usfws Source Notes
+
+## Purpose
+This folder documents the `usfws` source family for the fauna domain and tracks readiness, rights, sensitivity, and validation expectations before any public-safe release.
+
+## Current Status
+- State: `PROPOSED / NEEDS VERIFICATION`
+- Connector: Disabled
+- Public exact sensitive geometry: Denied by default
+
+## Required Before Activation
+1. Source descriptor in `data/registry/fauna/` with authority scope and cadence.
+2. Rights and redistribution review completed.
+3. Geoprivacy controls verified against `docs/domains/fauna/GEOPRIVACY.md`.
+4. Fixture-based validation added and passing.
+5. Release review and rollback path documented.
+
+## Notes
+- This README is documentation only; it does not activate ingestion.
+- Treat source claims as scoped inputs, not canonical legal truth.


### PR DESCRIPTION
### Motivation
- Provide human-facing landing READMEs for proposed fauna source families so reviewers and stewards have a consistent place to record readiness, rights, geoprivacy, and activation prerequisites. 
- Prevent the source-directory from appearing incomplete and ensure each listed source-family has a governance-only README that does not enable connectors or runtime behavior.

### Description
- Added README files under `docs/domains/fauna/sources/` for the following source families: `inaturalist`, `kdwp`, `usfws`, `natureserve`, `eddmaps`, `museum-specimens`, `monitoring`, and `steward-restricted`.
- Each README contains purpose, a `PROPOSED / NEEDS VERIFICATION` current status, required activation prerequisites (descriptor, rights review, geoprivacy verification, fixture validation, and release/rollback docs), and explicit non-activation notes.
- Changes are documentation-only and do not alter code, connectors, schemas, or runtime configuration.

### Testing
- Verified presence of newly added READMEs with `find docs/domains/fauna/sources -maxdepth 2 -name README.md | sort` which succeeded. 
- Confirmed working tree status via `git status --short` and staged/committed the new files using `git add docs/domains/fauna/sources/*/README.md && git commit -m "Add missing fauna source subdirectory READMEs"`, which produced a successful commit. 
- No automated unit or integration tests were required because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf2cf9434832a9c51026bba82273a)