### PR TITLE
Add missing flora tracking documentation stubs

### DIFF
--- a/docs/domains/flora/tracking/INVASIVE_SPREAD.md
+++ b/docs/domains/flora/tracking/INVASIVE_SPREAD.md
@@ -1,0 +1,7 @@
+# PLACEHOLDER
+
+This document is planned by `docs/domains/flora/tracking/README.md` and should define scope, contracts, and verification gates for this tracking slice.
+
+## Status
+
+Draft placeholder created to satisfy expected tracking file layout.

--- a/docs/domains/flora/tracking/PHENOLOGY_AND_CONDITION.md
+++ b/docs/domains/flora/tracking/PHENOLOGY_AND_CONDITION.md
@@ -1,0 +1,7 @@
+# PLACEHOLDER
+
+This document is planned by `docs/domains/flora/tracking/README.md` and should define scope, contracts, and verification gates for this tracking slice.
+
+## Status
+
+Draft placeholder created to satisfy expected tracking file layout.

--- a/docs/domains/flora/tracking/RANGE_AND_DISTRIBUTION.md
+++ b/docs/domains/flora/tracking/RANGE_AND_DISTRIBUTION.md
@@ -1,0 +1,7 @@
+# PLACEHOLDER
+
+This document is planned by `docs/domains/flora/tracking/README.md` and should define scope, contracts, and verification gates for this tracking slice.
+
+## Status
+
+Draft placeholder created to satisfy expected tracking file layout.

--- a/docs/domains/flora/tracking/REPEAT_OCCURRENCES.md
+++ b/docs/domains/flora/tracking/REPEAT_OCCURRENCES.md
@@ -1,0 +1,7 @@
+# PLACEHOLDER
+
+This document is planned by `docs/domains/flora/tracking/README.md` and should define scope, contracts, and verification gates for this tracking slice.
+
+## Status
+
+Draft placeholder created to satisfy expected tracking file layout.

--- a/docs/domains/flora/tracking/REVIEW_AND_ROLLBACK.md
+++ b/docs/domains/flora/tracking/REVIEW_AND_ROLLBACK.md
@@ -1,0 +1,7 @@
+# PLACEHOLDER
+
+This document is planned by `docs/domains/flora/tracking/README.md` and should define scope, contracts, and verification gates for this tracking slice.
+
+## Status
+
+Draft placeholder created to satisfy expected tracking file layout.

--- a/docs/domains/flora/tracking/STATUS_AND_LISTING.md
+++ b/docs/domains/flora/tracking/STATUS_AND_LISTING.md
@@ -1,0 +1,7 @@
+# PLACEHOLDER
+
+This document is planned by `docs/domains/flora/tracking/README.md` and should define scope, contracts, and verification gates for this tracking slice.
+
+## Status
+
+Draft placeholder created to satisfy expected tracking file layout.


### PR DESCRIPTION
### Motivation
- The `docs/domains/flora/tracking/README.md` declares several tracking sub-documents that were absent, so create placeholder files to complete the proposed directory layout and make the folder consistent with the README.

### Description
- Add six draft placeholder markdown files under `docs/domains/flora/tracking/`: `PHENOLOGY_AND_CONDITION.md`, `REPEAT_OCCURRENCES.md`, `RANGE_AND_DISTRIBUTION.md`, `INVASIVE_SPREAD.md`, `STATUS_AND_LISTING.md`, and `REVIEW_AND_ROLLBACK.md`, each containing a short note that the file is planned by the tracking README and a `Status` placeholder.

### Testing
- Verified file creation and staged/committed changes with `git status --short` and `git add ... && git commit -m "Add missing flora tracking documentation stubs"`, and inspected file contents with `nl`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5765cae8832ab6fa9fe23c72b8c9)