### PR TITLE
Add missing docs/domains compatibility files and directories

### DIFF
--- a/docs/domains/flora/ARCHITECTURE.md
+++ b/docs/domains/flora/ARCHITECTURE.md
@@ -1,0 +1,3 @@
+# Architecture
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`architecture/ARCHITECTURE.md`](architecture/ARCHITECTURE.md).

--- a/docs/domains/flora/PIPELINES_AND_LIFECYCLE.md
+++ b/docs/domains/flora/PIPELINES_AND_LIFECYCLE.md
@@ -1,0 +1,3 @@
+# Pipelines And Lifecycle
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`operations/PIPELINES_AND_LIFECYCLE.md`](operations/PIPELINES_AND_LIFECYCLE.md).

--- a/docs/domains/flora/PUBLICATION_AND_POLICY.md
+++ b/docs/domains/flora/PUBLICATION_AND_POLICY.md
@@ -1,0 +1,3 @@
+# Publication And Policy
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`governance/PUBLICATION_AND_POLICY.md`](governance/PUBLICATION_AND_POLICY.md).

--- a/docs/domains/flora/SOURCE_REGISTRY.md
+++ b/docs/domains/flora/SOURCE_REGISTRY.md
@@ -1,0 +1,3 @@
+# Source Registry
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/SOURCE_REGISTRY.md`](registers/SOURCE_REGISTRY.md).

--- a/docs/domains/flora/UI_AND_EVIDENCE_DRAWER.md
+++ b/docs/domains/flora/UI_AND_EVIDENCE_DRAWER.md
@@ -1,0 +1,3 @@
+# Ui And Evidence Drawer
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`architecture/UI_AND_EVIDENCE_DRAWER.md`](architecture/UI_AND_EVIDENCE_DRAWER.md).

--- a/docs/domains/geology-natural-resources/README.md
+++ b/docs/domains/geology-natural-resources/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`../geology/README.md`](../geology/README.md).

--- a/docs/domains/geology/CROSS_LANE_RELATIONS.md
+++ b/docs/domains/geology/CROSS_LANE_RELATIONS.md
@@ -1,0 +1,3 @@
+# Cross Lane Relations
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`architecture/CROSS_LANE_RELATIONS.md`](architecture/CROSS_LANE_RELATIONS.md).

--- a/docs/domains/geology/DATASET_OR_LAYER_INDEX.md
+++ b/docs/domains/geology/DATASET_OR_LAYER_INDEX.md
@@ -1,0 +1,3 @@
+# Dataset Or Layer Index
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/DATASET_OR_LAYER_INDEX.md`](registers/DATASET_OR_LAYER_INDEX.md).

--- a/docs/domains/geology/DOMAIN_INDEX.md
+++ b/docs/domains/geology/DOMAIN_INDEX.md
@@ -1,0 +1,3 @@
+# Domain Index
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/DOMAIN_INDEX.md`](registers/DOMAIN_INDEX.md).

--- a/docs/domains/geology/SCHEMA_INDEX.md
+++ b/docs/domains/geology/SCHEMA_INDEX.md
@@ -1,0 +1,3 @@
+# Schema Index
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/SCHEMA_INDEX.md`](registers/SCHEMA_INDEX.md).

--- a/docs/domains/geology/SOURCE_INDEX.md
+++ b/docs/domains/geology/SOURCE_INDEX.md
@@ -1,0 +1,3 @@
+# Source Index
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/SOURCE_INDEX.md`](registers/SOURCE_INDEX.md).

--- a/docs/domains/habitat/API_AND_UI_SURFACES.md
+++ b/docs/domains/habitat/API_AND_UI_SURFACES.md
@@ -1,0 +1,3 @@
+# Api And Ui Surfaces
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`architecture/API_AND_UI_SURFACES.md`](architecture/API_AND_UI_SURFACES.md).

--- a/docs/domains/habitat/ARCHITECTURE.md
+++ b/docs/domains/habitat/ARCHITECTURE.md
@@ -1,0 +1,3 @@
+# Architecture
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`architecture/ARCHITECTURE.md`](architecture/ARCHITECTURE.md).

--- a/docs/domains/habitat/OPEN_QUESTIONS.md
+++ b/docs/domains/habitat/OPEN_QUESTIONS.md
@@ -1,0 +1,3 @@
+# Open Questions
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`operations/OPEN_QUESTIONS.md`](operations/OPEN_QUESTIONS.md).

--- a/docs/domains/habitat/PROMOTION_AND_ROLLBACK.md
+++ b/docs/domains/habitat/PROMOTION_AND_ROLLBACK.md
@@ -1,0 +1,3 @@
+# Promotion And Rollback
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`operations/PROMOTION_AND_ROLLBACK.md`](operations/PROMOTION_AND_ROLLBACK.md).

--- a/docs/domains/habitat/SOURCE_REGISTRY.md
+++ b/docs/domains/habitat/SOURCE_REGISTRY.md
@@ -1,0 +1,3 @@
+# Source Registry
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`governance/SOURCE_REGISTRY.md`](governance/SOURCE_REGISTRY.md).

--- a/docs/domains/habitat/VALIDATION_AND_POLICY.md
+++ b/docs/domains/habitat/VALIDATION_AND_POLICY.md
@@ -1,0 +1,3 @@
+# Validation And Policy
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`governance/VALIDATION_AND_POLICY.md`](governance/VALIDATION_AND_POLICY.md).

--- a/docs/domains/hazards/ARCHITECTURE.md
+++ b/docs/domains/hazards/ARCHITECTURE.md
@@ -1,0 +1,3 @@
+# Architecture
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`architecture/ARCHITECTURE.md`](architecture/ARCHITECTURE.md).

--- a/docs/domains/hazards/PROMOTION.md
+++ b/docs/domains/hazards/PROMOTION.md
@@ -1,0 +1,3 @@
+# Promotion
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`operations/PROMOTION.md`](operations/PROMOTION.md).

--- a/docs/domains/hazards/ROLLBACK_AND_CORRECTION.md
+++ b/docs/domains/hazards/ROLLBACK_AND_CORRECTION.md
@@ -1,0 +1,3 @@
+# Rollback And Correction
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`operations/ROLLBACK_AND_CORRECTION.md`](operations/ROLLBACK_AND_CORRECTION.md).

--- a/docs/domains/hazards/SOURCE_ROLES.md
+++ b/docs/domains/hazards/SOURCE_ROLES.md
@@ -1,0 +1,3 @@
+# Source Roles
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`governance/SOURCE_ROLES.md`](governance/SOURCE_ROLES.md).

--- a/docs/domains/hazards/TIME_SEMANTICS.md
+++ b/docs/domains/hazards/TIME_SEMANTICS.md
@@ -1,0 +1,3 @@
+# Time Semantics
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`architecture/TIME_SEMANTICS.md`](architecture/TIME_SEMANTICS.md).

--- a/docs/domains/hazards/UI_AND_EVIDENCE_DRAWER.md
+++ b/docs/domains/hazards/UI_AND_EVIDENCE_DRAWER.md
@@ -1,0 +1,3 @@
+# Ui And Evidence Drawer
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`architecture/UI_AND_EVIDENCE_DRAWER.md`](architecture/UI_AND_EVIDENCE_DRAWER.md).

--- a/docs/domains/hazards/VERIFICATION_BACKLOG.md
+++ b/docs/domains/hazards/VERIFICATION_BACKLOG.md
@@ -1,0 +1,3 @@
+# Verification Backlog
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`tracking/VERIFICATION_BACKLOG.md`](tracking/VERIFICATION_BACKLOG.md).

--- a/docs/domains/roads_rail_trade_routes/api_surface.md
+++ b/docs/domains/roads_rail_trade_routes/api_surface.md
@@ -1,0 +1,3 @@
+# Api Surface
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/api_surface.md`](registers/api_surface.md).

--- a/docs/domains/roads_rail_trade_routes/architecture.md
+++ b/docs/domains/roads_rail_trade_routes/architecture.md
@@ -1,0 +1,3 @@
+# Architecture
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/architecture.md`](registers/architecture.md).

--- a/docs/domains/roads_rail_trade_routes/catalog_and_proof_objects.md
+++ b/docs/domains/roads_rail_trade_routes/catalog_and_proof_objects.md
@@ -1,0 +1,3 @@
+# Catalog And Proof Objects
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/catalog_and_proof_objects.md`](registers/catalog_and_proof_objects.md).

--- a/docs/domains/roads_rail_trade_routes/change_log.md
+++ b/docs/domains/roads_rail_trade_routes/change_log.md
@@ -1,0 +1,3 @@
+# Change Log
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/change_log.md`](registers/change_log.md).

--- a/docs/domains/roads_rail_trade_routes/ci_gate_matrix.md
+++ b/docs/domains/roads_rail_trade_routes/ci_gate_matrix.md
@@ -1,0 +1,3 @@
+# Ci Gate Matrix
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/ci_gate_matrix.md`](registers/ci_gate_matrix.md).

--- a/docs/domains/roads_rail_trade_routes/data_model.md
+++ b/docs/domains/roads_rail_trade_routes/data_model.md
@@ -1,0 +1,3 @@
+# Data Model
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/data_model.md`](registers/data_model.md).

--- a/docs/domains/roads_rail_trade_routes/evidence_drawer_payloads.md
+++ b/docs/domains/roads_rail_trade_routes/evidence_drawer_payloads.md
@@ -1,0 +1,3 @@
+# Evidence Drawer Payloads
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/evidence_drawer_payloads.md`](registers/evidence_drawer_payloads.md).

--- a/docs/domains/roads_rail_trade_routes/extension_points.md
+++ b/docs/domains/roads_rail_trade_routes/extension_points.md
@@ -1,0 +1,3 @@
+# Extension Points
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/extension_points.md`](registers/extension_points.md).

--- a/docs/domains/roads_rail_trade_routes/file_inventory.md
+++ b/docs/domains/roads_rail_trade_routes/file_inventory.md
@@ -1,0 +1,3 @@
+# File Inventory
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/file_inventory.md`](registers/file_inventory.md).

--- a/docs/domains/roads_rail_trade_routes/fixture_inventory.md
+++ b/docs/domains/roads_rail_trade_routes/fixture_inventory.md
@@ -1,0 +1,3 @@
+# Fixture Inventory
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/fixture_inventory.md`](registers/fixture_inventory.md).

--- a/docs/domains/roads_rail_trade_routes/focus_mode_behavior.md
+++ b/docs/domains/roads_rail_trade_routes/focus_mode_behavior.md
@@ -1,0 +1,3 @@
+# Focus Mode Behavior
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/focus_mode_behavior.md`](registers/focus_mode_behavior.md).

--- a/docs/domains/roads_rail_trade_routes/lifecycle_and_promotion.md
+++ b/docs/domains/roads_rail_trade_routes/lifecycle_and_promotion.md
@@ -1,0 +1,3 @@
+# Lifecycle And Promotion
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/lifecycle_and_promotion.md`](registers/lifecycle_and_promotion.md).

--- a/docs/domains/roads_rail_trade_routes/pipeline_inventory.md
+++ b/docs/domains/roads_rail_trade_routes/pipeline_inventory.md
@@ -1,0 +1,3 @@
+# Pipeline Inventory
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/pipeline_inventory.md`](registers/pipeline_inventory.md).

--- a/docs/domains/roads_rail_trade_routes/rollback_and_corrections.md
+++ b/docs/domains/roads_rail_trade_routes/rollback_and_corrections.md
@@ -1,0 +1,3 @@
+# Rollback And Corrections
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/rollback_and_corrections.md`](registers/rollback_and_corrections.md).

--- a/docs/domains/roads_rail_trade_routes/schema_index.md
+++ b/docs/domains/roads_rail_trade_routes/schema_index.md
@@ -1,0 +1,3 @@
+# Schema Index
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/schema_index.md`](registers/schema_index.md).

--- a/docs/domains/roads_rail_trade_routes/source_registry.md
+++ b/docs/domains/roads_rail_trade_routes/source_registry.md
@@ -1,0 +1,3 @@
+# Source Registry
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/source_registry.md`](registers/source_registry.md).

--- a/docs/domains/roads_rail_trade_routes/test_matrix.md
+++ b/docs/domains/roads_rail_trade_routes/test_matrix.md
@@ -1,0 +1,3 @@
+# Test Matrix
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/test_matrix.md`](registers/test_matrix.md).

--- a/docs/domains/roads_rail_trade_routes/ui_layer_inventory.md
+++ b/docs/domains/roads_rail_trade_routes/ui_layer_inventory.md
@@ -1,0 +1,3 @@
+# Ui Layer Inventory
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/ui_layer_inventory.md`](registers/ui_layer_inventory.md).

--- a/docs/domains/roads_rail_trade_routes/verification_backlog.md
+++ b/docs/domains/roads_rail_trade_routes/verification_backlog.md
@@ -1,0 +1,3 @@
+# Verification Backlog
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`registers/verification_backlog.md`](registers/verification_backlog.md).

--- a/docs/domains/tiles/delta_apply.md
+++ b/docs/domains/tiles/delta_apply.md
@@ -1,0 +1,3 @@
+# Delta Apply
+
+This file exists as a compatibility entrypoint. Canonical content lives at [`../../architecture/tiles/delta_apply.md`](../../architecture/tiles/delta_apply.md).


### PR DESCRIPTION
### Motivation
- Several Markdown files under `docs/domains` referenced local relative paths that did not exist, causing broken links and missing compatibility entrypoints. 
- The change restores those expected top-level paths so existing relative links and external tooling that expect those files keep working without moving canonical content.

### Description
- Added 44 lightweight compatibility entrypoint Markdown files under `docs/domains` that forward to the canonical documents in their respective subfolders. 
- Created the directories `docs/domains/geology-natural-resources/` and `docs/domains/tiles/` to satisfy referenced paths. 
- Key affected domain lanes include `flora`, `geology`, `habitat`, `hazards`, and `roads_rail_trade_routes`, with each new file pointing to the canonical file (for example `architecture/`, `operations/`, `governance/`, and `registers/` locations). 
- Files contain a short header and a pointer to the canonical path to preserve link contracts while leaving authoritative content in place.

### Testing
- Ran a link-resolution scan with the embedded Python script (`python - <<'PY' ...`) to enumerate unresolved relative links under `docs/domains` and confirmed there are no remaining missing `docs/domains` targets after the changes. 
- Verified the working tree with `git status --short` and recorded a commit via `git commit` to capture the created files. 
- No automated test failures were produced by the scan and commit steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd586907b4832a9070f638efa0cf35)