### PR TITLE
Add ADR backlog placeholder files under docs/adr

### DIFF
--- a/docs/adr/ADR-0002-source-ledger-authority.md
+++ b/docs/adr/ADR-0002-source-ledger-authority.md
@@ -1,0 +1,19 @@
+# ADR-0002-source-ledger-authority
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+What counts as a source ledger, source IDs, supersession, and authority ranking among Drive/repo/generated reports.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-0003-evidencebundle-contract.md
+++ b/docs/adr/ADR-0003-evidencebundle-contract.md
@@ -1,0 +1,19 @@
+# ADR-0003-evidencebundle-contract
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+EvidenceRef→EvidenceBundle closure requirements, minimum evidence fields, and claim-support failure behavior.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-0004-promotion-gate.md
+++ b/docs/adr/ADR-0004-promotion-gate.md
@@ -1,0 +1,19 @@
+# ADR-0004-promotion-gate
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Promotion as governed state transition with outcomes, reviews, proof requirements, and rollback target.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-0005-maplibre-layer-manifest.md
+++ b/docs/adr/ADR-0005-maplibre-layer-manifest.md
@@ -1,0 +1,19 @@
+# ADR-0005-maplibre-layer-manifest
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Public-safe LayerManifest rules, source refs, stale/restricted/generalized states, and Evidence Drawer coupling.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-0006-governed-ai-runtime-envelope.md
+++ b/docs/adr/ADR-0006-governed-ai-runtime-envelope.md
@@ -1,0 +1,19 @@
+# ADR-0006-governed-ai-runtime-envelope
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Finite governed AI runtime envelope and cite-or-abstain behavior.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-0007-domain-lane-template.md
+++ b/docs/adr/ADR-0007-domain-lane-template.md
@@ -1,0 +1,19 @@
+# ADR-0007-domain-lane-template
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Standard domain-lane file family across docs/schemas/policy/registry/validators/fixtures/lifecycle/releases.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-0008-sensitive-location-policy.md
+++ b/docs/adr/ADR-0008-sensitive-location-policy.md
@@ -1,0 +1,19 @@
+# ADR-0008-sensitive-location-policy
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Fail-closed handling for exact-location sensitive classes and public suppression rules.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-0009-local-exposure-security.md
+++ b/docs/adr/ADR-0009-local-exposure-security.md
@@ -1,0 +1,19 @@
+# ADR-0009-local-exposure-security
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Local/home-hosted security posture: VPN, proxy, firewall, auth, audit, and no direct model exposure.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-0010-catalog-proof-release-separation.md
+++ b/docs/adr/ADR-0010-catalog-proof-release-separation.md
@@ -1,0 +1,19 @@
+# ADR-0010-catalog-proof-release-separation
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Separation of receipts, proofs, catalogs, releases, reviews, corrections, and rollback objects.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-0011-query-save-recompile-loop.md
+++ b/docs/adr/ADR-0011-query-save-recompile-loop.md
@@ -1,0 +1,19 @@
+# ADR-0011-query-save-recompile-loop
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Governed incremental loop: query→save→validate→compile→review→promote→recompile; no autonomous publishing.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-adr-index-numbering-and-supersession.md
+++ b/docs/adr/ADR-adr-index-numbering-and-supersession.md
@@ -1,0 +1,19 @@
+# ADR-adr-index-numbering-and-supersession
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+ADR numbering, status, successor links, supersession, immutability, and deprecation rules.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-agriculture-domain-boundary.md
+++ b/docs/adr/ADR-agriculture-domain-boundary.md
@@ -1,0 +1,19 @@
+# ADR-agriculture-domain-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **agriculture domain boundary**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-agriculture-lifecycle-boundary.md
+++ b/docs/adr/ADR-agriculture-lifecycle-boundary.md
@@ -1,0 +1,19 @@
+# ADR-agriculture-lifecycle-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **agriculture lifecycle boundary**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-agriculture-schema-home.md
+++ b/docs/adr/ADR-agriculture-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-agriculture-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **agriculture schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-agriculture-source-role-boundary.md
+++ b/docs/adr/ADR-agriculture-source-role-boundary.md
@@ -1,0 +1,19 @@
+# ADR-agriculture-source-role-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **agriculture source role boundary**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-ai-continuity-model.md
+++ b/docs/adr/ADR-ai-continuity-model.md
@@ -1,0 +1,19 @@
+# ADR-ai-continuity-model
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **ai continuity model**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-ai-no-chain-of-thought-storage.md
+++ b/docs/adr/ADR-ai-no-chain-of-thought-storage.md
@@ -1,0 +1,19 @@
+# ADR-ai-no-chain-of-thought-storage
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **ai no chain of thought storage**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-ai-provider-adapter.md
+++ b/docs/adr/ADR-ai-provider-adapter.md
@@ -1,0 +1,19 @@
+# ADR-ai-provider-adapter
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **ai provider adapter**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-archaeology-location-sensitivity.md
+++ b/docs/adr/ADR-archaeology-location-sensitivity.md
@@ -1,0 +1,19 @@
+# ADR-archaeology-location-sensitivity
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **archaeology location sensitivity**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-archaeology-public-vs-restricted-geometry.md
+++ b/docs/adr/ADR-archaeology-public-vs-restricted-geometry.md
@@ -1,0 +1,19 @@
+# ADR-archaeology-public-vs-restricted-geometry
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **archaeology public vs restricted geometry**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-archaeology-schema-home.md
+++ b/docs/adr/ADR-archaeology-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-archaeology-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **archaeology schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-archaeology-source-role-separation.md
+++ b/docs/adr/ADR-archaeology-source-role-separation.md
@@ -1,0 +1,19 @@
+# ADR-archaeology-source-role-separation
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **archaeology source role separation**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-atmosphere-lane.md
+++ b/docs/adr/ADR-atmosphere-lane.md
@@ -1,0 +1,19 @@
+# ADR-atmosphere-lane
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **atmosphere lane**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-atmosphere-schema-compatibility.md
+++ b/docs/adr/ADR-atmosphere-schema-compatibility.md
@@ -1,0 +1,19 @@
+# ADR-atmosphere-schema-compatibility
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **atmosphere schema compatibility**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-atmosphere-source-role-boundaries.md
+++ b/docs/adr/ADR-atmosphere-source-role-boundaries.md
@@ -1,0 +1,19 @@
+# ADR-atmosphere-source-role-boundaries
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **atmosphere source role boundaries**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-canonical-ui-root.md
+++ b/docs/adr/ADR-canonical-ui-root.md
@@ -1,0 +1,19 @@
+# ADR-canonical-ui-root
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Canonical UI app root and transitional compatibility among legacy UI roots.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-evidence-drawer-contract.md
+++ b/docs/adr/ADR-evidence-drawer-contract.md
@@ -1,0 +1,19 @@
+# ADR-evidence-drawer-contract
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **evidence drawer contract**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-fauna-domain-model.md
+++ b/docs/adr/ADR-fauna-domain-model.md
@@ -1,0 +1,19 @@
+# ADR-fauna-domain-model
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **fauna domain model**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-fauna-schema-home.md
+++ b/docs/adr/ADR-fauna-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-fauna-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **fauna schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-fauna-sensitive-location-policy.md
+++ b/docs/adr/ADR-fauna-sensitive-location-policy.md
@@ -1,0 +1,19 @@
+# ADR-fauna-sensitive-location-policy
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **fauna sensitive location policy**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-fauna-source-authority-ranking.md
+++ b/docs/adr/ADR-fauna-source-authority-ranking.md
@@ -1,0 +1,19 @@
+# ADR-fauna-source-authority-ranking
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **fauna source authority ranking**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-fixture-home-authority.md
+++ b/docs/adr/ADR-fixture-home-authority.md
@@ -1,0 +1,19 @@
+# ADR-fixture-home-authority
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Fixture placement authority between schema fixtures and repo-level tests/contracts fixtures.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-flood-source-role-separation.md
+++ b/docs/adr/ADR-flood-source-role-separation.md
@@ -1,0 +1,19 @@
+# ADR-flood-source-role-separation
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **flood source role separation**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-flora-public-layer-strategy.md
+++ b/docs/adr/ADR-flora-public-layer-strategy.md
@@ -1,0 +1,19 @@
+# ADR-flora-public-layer-strategy
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **flora public layer strategy**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-flora-schema-home.md
+++ b/docs/adr/ADR-flora-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-flora-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **flora schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-flora-sensitive-location-policy.md
+++ b/docs/adr/ADR-flora-sensitive-location-policy.md
@@ -1,0 +1,19 @@
+# ADR-flora-sensitive-location-policy
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **flora sensitive location policy**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-flora-source-roles.md
+++ b/docs/adr/ADR-flora-source-roles.md
@@ -1,0 +1,19 @@
+# ADR-flora-source-roles
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **flora source roles**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-focus-mode-adapter-boundary.md
+++ b/docs/adr/ADR-focus-mode-adapter-boundary.md
@@ -1,0 +1,19 @@
+# ADR-focus-mode-adapter-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **focus mode adapter boundary**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-frontier-bitemporal-release-model.md
+++ b/docs/adr/ADR-frontier-bitemporal-release-model.md
@@ -1,0 +1,19 @@
+# ADR-frontier-bitemporal-release-model
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **frontier bitemporal release model**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-frontier-definition-and-thresholds.md
+++ b/docs/adr/ADR-frontier-definition-and-thresholds.md
@@ -1,0 +1,19 @@
+# ADR-frontier-definition-and-thresholds
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **frontier definition and thresholds**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-frontier-panel-observation-model.md
+++ b/docs/adr/ADR-frontier-panel-observation-model.md
@@ -1,0 +1,19 @@
+# ADR-frontier-panel-observation-model
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **frontier panel observation model**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-frontier-publication-and-uncertainty.md
+++ b/docs/adr/ADR-frontier-publication-and-uncertainty.md
@@ -1,0 +1,19 @@
+# ADR-frontier-publication-and-uncertainty
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **frontier publication and uncertainty**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-geography-version-and-crosswalk-authority.md
+++ b/docs/adr/ADR-geography-version-and-crosswalk-authority.md
@@ -1,0 +1,19 @@
+# ADR-geography-version-and-crosswalk-authority
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **geography version and crosswalk authority**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-geology-doc-lineage-and-supersession.md
+++ b/docs/adr/ADR-geology-doc-lineage-and-supersession.md
@@ -1,0 +1,19 @@
+# ADR-geology-doc-lineage-and-supersession
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **geology doc lineage and supersession**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-geology-public-safe-geometry.md
+++ b/docs/adr/ADR-geology-public-safe-geometry.md
@@ -1,0 +1,19 @@
+# ADR-geology-public-safe-geometry
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **geology public safe geometry**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-geology-schema-home.md
+++ b/docs/adr/ADR-geology-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-geology-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **geology schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-geology-source-role-model.md
+++ b/docs/adr/ADR-geology-source-role-model.md
@@ -1,0 +1,19 @@
+# ADR-geology-source-role-model
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **geology source role model**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-governed-api-boundary.md
+++ b/docs/adr/ADR-governed-api-boundary.md
@@ -1,0 +1,19 @@
+# ADR-governed-api-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Canonical governed API home, route inventory, DTO ownership, and public trust membrane.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-habitat-document-evolution-model.md
+++ b/docs/adr/ADR-habitat-document-evolution-model.md
@@ -1,0 +1,19 @@
+# ADR-habitat-document-evolution-model
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **habitat document evolution model**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-habitat-expansion-boundaries.md
+++ b/docs/adr/ADR-habitat-expansion-boundaries.md
@@ -1,0 +1,19 @@
+# ADR-habitat-expansion-boundaries
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **habitat expansion boundaries**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-habitat-fauna-publication-boundary.md
+++ b/docs/adr/ADR-habitat-fauna-publication-boundary.md
@@ -1,0 +1,19 @@
+# ADR-habitat-fauna-publication-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **habitat fauna publication boundary**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-habitat-fauna-schema-home.md
+++ b/docs/adr/ADR-habitat-fauna-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-habitat-fauna-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **habitat fauna schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-habitat-fauna-source-role-split.md
+++ b/docs/adr/ADR-habitat-fauna-source-role-split.md
@@ -1,0 +1,19 @@
+# ADR-habitat-fauna-source-role-split
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **habitat fauna source role split**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-habitat-schema-home.md
+++ b/docs/adr/ADR-habitat-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-habitat-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **habitat schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-hazards-canonical-file-placement.md
+++ b/docs/adr/ADR-hazards-canonical-file-placement.md
@@ -1,0 +1,19 @@
+# ADR-hazards-canonical-file-placement
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **hazards canonical file placement**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-hazards-documentation-control-plane.md
+++ b/docs/adr/ADR-hazards-documentation-control-plane.md
@@ -1,0 +1,19 @@
+# ADR-hazards-documentation-control-plane
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **hazards documentation control plane**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-hydrologic-identity-and-abstain.md
+++ b/docs/adr/ADR-hydrologic-identity-and-abstain.md
@@ -1,0 +1,19 @@
+# ADR-hydrologic-identity-and-abstain
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **hydrologic identity and abstain**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-hydrology-public-surface-boundary.md
+++ b/docs/adr/ADR-hydrology-public-surface-boundary.md
@@ -1,0 +1,19 @@
+# ADR-hydrology-public-surface-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **hydrology public surface boundary**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-hydrology-schema-home.md
+++ b/docs/adr/ADR-hydrology-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-hydrology-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **hydrology schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-infrastructure-restricted-geometry-policy.md
+++ b/docs/adr/ADR-infrastructure-restricted-geometry-policy.md
@@ -1,0 +1,19 @@
+# ADR-infrastructure-restricted-geometry-policy
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **infrastructure restricted geometry policy**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-land-ownership-title-vs-assessor-vs-parcel.md
+++ b/docs/adr/ADR-land-ownership-title-vs-assessor-vs-parcel.md
@@ -1,0 +1,19 @@
+# ADR-land-ownership-title-vs-assessor-vs-parcel
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **land ownership title vs assessor vs parcel**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-maplibre-adapter-boundary.md
+++ b/docs/adr/ADR-maplibre-adapter-boundary.md
@@ -1,0 +1,19 @@
+# ADR-maplibre-adapter-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **maplibre adapter boundary**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-maplibre-mvt-mlt-posture.md
+++ b/docs/adr/ADR-maplibre-mvt-mlt-posture.md
@@ -1,0 +1,19 @@
+# ADR-maplibre-mvt-mlt-posture
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **maplibre mvt mlt posture**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-maplibre-renderer-default.md
+++ b/docs/adr/ADR-maplibre-renderer-default.md
@@ -1,0 +1,19 @@
+# ADR-maplibre-renderer-default
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **maplibre renderer default**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-maplibre-schema-home.md
+++ b/docs/adr/ADR-maplibre-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-maplibre-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **maplibre schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-outcome-grammar-by-surface-class.md
+++ b/docs/adr/ADR-outcome-grammar-by-surface-class.md
@@ -1,0 +1,19 @@
+# ADR-outcome-grammar-by-surface-class
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Normalize runtime/gate/release outcome grammars and allowed states.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-people-dna-land-consent-revocation.md
+++ b/docs/adr/ADR-people-dna-land-consent-revocation.md
@@ -1,0 +1,19 @@
+# ADR-people-dna-land-consent-revocation
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **people dna land consent revocation**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-people-dna-land-schema-placement.md
+++ b/docs/adr/ADR-people-dna-land-schema-placement.md
@@ -1,0 +1,19 @@
+# ADR-people-dna-land-schema-placement
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **people dna land schema placement**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-people-dna-land-sensitive-data-policy.md
+++ b/docs/adr/ADR-people-dna-land-sensitive-data-policy.md
@@ -1,0 +1,19 @@
+# ADR-people-dna-land-sensitive-data-policy
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **people dna land sensitive data policy**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-people-identity-resolution-and-hypothesis-status.md
+++ b/docs/adr/ADR-people-identity-resolution-and-hypothesis-status.md
@@ -1,0 +1,19 @@
+# ADR-people-identity-resolution-and-hypothesis-status
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **people identity resolution and hypothesis status**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-policy-engine-commitment.md
+++ b/docs/adr/ADR-policy-engine-commitment.md
@@ -1,0 +1,19 @@
+# ADR-policy-engine-commitment
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Whether OPA/Rego is normative, minimum policy bundles, and CI/runtime parity.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-project-source-ledger.md
+++ b/docs/adr/ADR-project-source-ledger.md
@@ -1,0 +1,19 @@
+# ADR-project-source-ledger
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **project source ledger**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-proof-pack-publishing-and-storage.md
+++ b/docs/adr/ADR-proof-pack-publishing-and-storage.md
@@ -1,0 +1,19 @@
+# ADR-proof-pack-publishing-and-storage
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** architecture/governance
+- **Supersedes:** none
+
+## Context
+This ADR was created from the April–May 2026 backlog normalization request to ensure a canonical decision record exists in `docs/adr/`.
+
+## Decision
+Proof-pack publishing/storage strategy, immutable bundles, and artifact inventory.
+
+## Consequences
+- Governs future implementation and validation work for this decision area.
+- Requires follow-up updates to schemas/contracts/policy/tests as applicable.
+
+## Verification
+- Add concrete file/path evidence and tests before marking this ADR as accepted.

--- a/docs/adr/ADR-review-console-readonly-boundary.md
+++ b/docs/adr/ADR-review-console-readonly-boundary.md
@@ -1,0 +1,19 @@
+# ADR-review-console-readonly-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **review console readonly boundary**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-schema-authority.md
+++ b/docs/adr/ADR-schema-authority.md
@@ -1,0 +1,19 @@
+# ADR-schema-authority
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **schema authority**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-settlements-infrastructure-domain.md
+++ b/docs/adr/ADR-settlements-infrastructure-domain.md
@@ -1,0 +1,19 @@
+# ADR-settlements-infrastructure-domain
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **settlements infrastructure domain**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-settlements-infrastructure-schema-home.md
+++ b/docs/adr/ADR-settlements-infrastructure-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-settlements-infrastructure-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **settlements infrastructure schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-settlements-legal-status-evidence.md
+++ b/docs/adr/ADR-settlements-legal-status-evidence.md
@@ -1,0 +1,19 @@
+# ADR-settlements-legal-status-evidence
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **settlements legal status evidence**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-soil-domain-completeness-boundaries.md
+++ b/docs/adr/ADR-soil-domain-completeness-boundaries.md
@@ -1,0 +1,19 @@
+# ADR-soil-domain-completeness-boundaries
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **soil domain completeness boundaries**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-soil-non-regression-and-migration.md
+++ b/docs/adr/ADR-soil-non-regression-and-migration.md
@@ -1,0 +1,19 @@
+# ADR-soil-non-regression-and-migration
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **soil non regression and migration**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-soil-spec-hash-and-receipt-split.md
+++ b/docs/adr/ADR-soil-spec-hash-and-receipt-split.md
@@ -1,0 +1,19 @@
+# ADR-soil-spec-hash-and-receipt-split
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **soil spec hash and receipt split**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-soil-static-vs-moisture-support.md
+++ b/docs/adr/ADR-soil-static-vs-moisture-support.md
@@ -1,0 +1,19 @@
+# ADR-soil-static-vs-moisture-support
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **soil static vs moisture support**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-soil-truth-path.md
+++ b/docs/adr/ADR-soil-truth-path.md
@@ -1,0 +1,19 @@
+# ADR-soil-truth-path
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **soil truth path**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-story-node-3d-boundary.md
+++ b/docs/adr/ADR-story-node-3d-boundary.md
@@ -1,0 +1,19 @@
+# ADR-story-node-3d-boundary
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **story node 3d boundary**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-transport-graph-derived-status.md
+++ b/docs/adr/ADR-transport-graph-derived-status.md
@@ -1,0 +1,19 @@
+# ADR-transport-graph-derived-status
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **transport graph derived status**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-transport-historic-corridor-uncertainty.md
+++ b/docs/adr/ADR-transport-historic-corridor-uncertainty.md
@@ -1,0 +1,19 @@
+# ADR-transport-historic-corridor-uncertainty
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **transport historic corridor uncertainty**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-transport-public-generalization.md
+++ b/docs/adr/ADR-transport-public-generalization.md
@@ -1,0 +1,19 @@
+# ADR-transport-public-generalization
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **transport public generalization**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-transport-schema-home.md
+++ b/docs/adr/ADR-transport-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-transport-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **transport schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.

--- a/docs/adr/ADR-ui-schema-home.md
+++ b/docs/adr/ADR-ui-schema-home.md
@@ -1,0 +1,19 @@
+# ADR-ui-schema-home
+
+- **Status:** proposed
+- **Decision Date:** 2026-05-08
+- **Scope:** domain architecture/governance
+- **Supersedes:** none
+
+## Context
+Backlog-defined ADR placeholder created to establish canonical decision coverage in `docs/adr/`.
+
+## Decision
+This ADR will settle: **ui schema home**.
+
+## Consequences
+- Prevents silent drift by tracking this unresolved decision explicitly.
+- Must be replaced with accepted decision language and concrete evidence links before enforcement.
+
+## Verification
+- Add references to implemented paths, schemas, policies, validators, and tests before acceptance.


### PR DESCRIPTION
### Motivation

- Normalize and surface the April–May 2026 ADR backlog by creating canonical ADR paths under `docs/adr/` so unresolved governance decisions are tracked in-repo. 
- Treat each backlog item as a `proposed` placeholder to prevent silent drift and to require explicit follow-up verification before enforcement. 
- Provide a consistent authoring shape (Context / Decision / Consequences / Verification) for downstream reviewers and automation to pick up missing decision records. 

### Description

- Added 89 new ADR markdown placeholders under `docs/adr/` covering foundation/repo-wide ADRs, Governed AI, UI/MapLibre/story-surface, hydrology/soil/habitat/fauna/flora, agriculture, geology, atmosphere, hazards, transport, settlements/infrastructure, archaeology, people/DNA/land, and frontier analytics decision areas. 
- Each new file is marked `proposed` and includes the sections `Context`, `Decision`, `Consequences`, and `Verification` to document the intended decision scope and remaining validation work. 
- These files are intentionally placeholders (no decisions were marked `accepted`) and are intended to be replaced or expanded with concrete evidence, schema/policy links, and validation plans in follow-up PRs. 

### Testing

- Ran `rg --files docs/adr` to enumerate the ADR directory and confirm the new files are present, which succeeded. 
- Executed the Python scripts used to generate the placeholders (the generation runs completed and reported files created), which succeeded. 
- Spot-checked content of several new ADRs with `nl -ba <file> | sed -n '1,40p'` to verify each file contains the expected header and the `Context/Decision/Consequences/Verification` sections, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5d850828832aa710d5ef964557e4)