### PR TITLE
Add top-level Flora documentation shims

### DIFF
--- a/docs/domains/flora/CHANGELOG.md
+++ b/docs/domains/flora/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Flora Changelog
+
+This document has moved to the tracking subfolder.
+
+- Canonical location: [`docs/domains/flora/tracking/CHANGELOG.md`](./tracking/CHANGELOG.md)
+
+Keep this shim so top-level Flora links remain stable.

--- a/docs/domains/flora/DATA_MODEL.md
+++ b/docs/domains/flora/DATA_MODEL.md
@@ -1,0 +1,7 @@
+# Flora Data Model
+
+This document has moved to the architecture subfolder.
+
+- Canonical location: [`docs/domains/flora/architecture/DATA_MODEL.md`](./architecture/DATA_MODEL.md)
+
+Keep this shim so top-level Flora links remain stable.

--- a/docs/domains/flora/FILE_MANIFEST.md
+++ b/docs/domains/flora/FILE_MANIFEST.md
@@ -1,0 +1,7 @@
+# Flora File Manifest
+
+This document has moved to the registers subfolder.
+
+- Canonical location: [`docs/domains/flora/registers/FILE_MANIFEST.md`](./registers/FILE_MANIFEST.md)
+
+Keep this shim so top-level Flora links remain stable.

--- a/docs/domains/flora/ROADMAP.md
+++ b/docs/domains/flora/ROADMAP.md
@@ -1,0 +1,7 @@
+# Flora Roadmap
+
+This document has moved to the tracking subfolder.
+
+- Canonical location: [`docs/domains/flora/tracking/ROADMAP.md`](./tracking/ROADMAP.md)
+
+Keep this shim so top-level Flora links remain stable.

--- a/docs/domains/flora/VERIFICATION_BACKLOG.md
+++ b/docs/domains/flora/VERIFICATION_BACKLOG.md
@@ -1,0 +1,7 @@
+# Flora Verification Backlog
+
+This document has moved to the tracking subfolder.
+
+- Canonical location: [`docs/domains/flora/tracking/VERIFICATION_BACKLOG.md`](./tracking/VERIFICATION_BACKLOG.md)
+
+Keep this shim so top-level Flora links remain stable.


### PR DESCRIPTION
### Motivation
- The Flora README and other references expect several top-level docs under `docs/domains/flora/`, but canonical content was moved into subfolders, so stable top-level paths must be preserved. 

### Description
- Added five lightweight shim files at `docs/domains/flora/`: `DATA_MODEL.md`, `VERIFICATION_BACKLOG.md`, `CHANGELOG.md`, `ROADMAP.md`, and `FILE_MANIFEST.md`. 
- Each shim contains a short note and a link to the canonical document in the current subfolder (`architecture/`, `tracking/`, or `registers/`) so existing top-level links remain stable. 
- This change is documentation-only and does not modify code or runtime behavior. 

### Testing
- Verified the shim contents and presence using `nl -ba docs/domains/flora/{DATA_MODEL.md,VERIFICATION_BACKLOG.md,CHANGELOG.md,ROADMAP.md,FILE_MANIFEST.md}`, which showed the expected pointer text and links. 
- Confirmed file creation via repository status checks and generated a PR record using `make_pr`; the PR body and title were produced. 
- No unit tests apply to these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde507b89c832aa8299eb0887e5664)