### PR TITLE
Add placeholder documentation files for flora architecture directory

### DIFF
--- a/docs/domains/flora/architecture/CHANGELOG.md
+++ b/docs/domains/flora/architecture/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Flora CHANGELOG
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for CHANGELOG.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.

--- a/docs/domains/flora/architecture/CURRENT_STATE.md
+++ b/docs/domains/flora/architecture/CURRENT_STATE.md
@@ -1,0 +1,17 @@
+# Flora CURRENT_STATE
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for CURRENT_STATE.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.

--- a/docs/domains/flora/architecture/FILE_MANIFEST.md
+++ b/docs/domains/flora/architecture/FILE_MANIFEST.md
@@ -1,0 +1,17 @@
+# Flora FILE_MANIFEST
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for FILE_MANIFEST.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.

--- a/docs/domains/flora/architecture/GLOSSARY.md
+++ b/docs/domains/flora/architecture/GLOSSARY.md
@@ -1,0 +1,17 @@
+# Flora GLOSSARY
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for GLOSSARY.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.

--- a/docs/domains/flora/architecture/IDEA_INTAKE.md
+++ b/docs/domains/flora/architecture/IDEA_INTAKE.md
@@ -1,0 +1,17 @@
+# Flora IDEA_INTAKE
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for IDEA_INTAKE.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.

--- a/docs/domains/flora/architecture/PIPELINES_AND_LIFECYCLE.md
+++ b/docs/domains/flora/architecture/PIPELINES_AND_LIFECYCLE.md
@@ -1,0 +1,17 @@
+# Flora PIPELINES_AND_LIFECYCLE
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for PIPELINES_AND_LIFECYCLE.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.

--- a/docs/domains/flora/architecture/PUBLICATION_AND_POLICY.md
+++ b/docs/domains/flora/architecture/PUBLICATION_AND_POLICY.md
@@ -1,0 +1,17 @@
+# Flora PUBLICATION_AND_POLICY
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for PUBLICATION_AND_POLICY.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.

--- a/docs/domains/flora/architecture/ROADMAP.md
+++ b/docs/domains/flora/architecture/ROADMAP.md
@@ -1,0 +1,17 @@
+# Flora ROADMAP
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for ROADMAP.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.

--- a/docs/domains/flora/architecture/SOURCE_REGISTRY.md
+++ b/docs/domains/flora/architecture/SOURCE_REGISTRY.md
@@ -1,0 +1,17 @@
+# Flora SOURCE_REGISTRY
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for SOURCE_REGISTRY.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.

--- a/docs/domains/flora/architecture/VERIFICATION_BACKLOG.md
+++ b/docs/domains/flora/architecture/VERIFICATION_BACKLOG.md
@@ -1,0 +1,17 @@
+# Flora VERIFICATION_BACKLOG
+
+> Placeholder document created to complete the architecture lane file set. Replace with verified repo-backed content.
+
+## Status
+- **State:** Draft placeholder
+- **Truth posture:** PROPOSED (unverified)
+- **Owner:** TODO-flora-steward
+
+## Scope
+This page is reserved for VERIFICATION_BACKLOG.md details within 
+docs/domains/flora/architecture.
+
+## Next actions
+- Add validated references to contracts, schemas, and policies.
+- Add concrete examples and evidence-backed definitions.
+- Keep sensitive flora location data generalized or withheld.


### PR DESCRIPTION
### Motivation
- The `docs/domains/flora/architecture/` folder was missing several expected architecture artefacts, so placeholders were added to make the lane's documentation set complete and discoverable.

### Description
- Added ten placeholder Markdown files: `CURRENT_STATE.md`, `SOURCE_REGISTRY.md`, `PIPELINES_AND_LIFECYCLE.md`, `PUBLICATION_AND_POLICY.md`, `VERIFICATION_BACKLOG.md`, `ROADMAP.md`, `FILE_MANIFEST.md`, `GLOSSARY.md`, `IDEA_INTAKE.md`, and `CHANGELOG.md` under `docs/domains/flora/architecture/`.
- Each file contains a consistent scaffold including a one-line purpose header, `Status` (draft), `Truth posture` (PROPOSED), `Owner` placeholder, a brief `Scope` note, and a short `Next actions` checklist to guide future completion.
- These are intentionally placeholders (drafts) and do not introduce executable code or schema changes; they serve as targets for later verification and content population.

### Testing
- Verified presence of the new files on disk using `find docs/domains/flora/architecture -maxdepth 1 -type f -printf '%f
' | sort`, which returned the expected filenames (success).
- Spot-checked file contents with `nl`/`sed` to confirm the placeholder scaffold and headers were written to each file (success).
- No unit or integration tests were applicable to documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde63f68e8832a85aa076603bf08c5)