### PR TITLE
Add missing Flora governance scaffolding docs

### DIFF
--- a/docs/domains/flora/governance/REVIEW_AND_PROMOTION.md
+++ b/docs/domains/flora/governance/REVIEW_AND_PROMOTION.md
@@ -1,0 +1,14 @@
+# Flora Review and Promotion
+
+This document is a governance companion for Flora lane review and promotion.
+
+## Purpose
+- Define required review checkpoints before promotion.
+- Define promotion authorization expectations.
+- Link to canonical lane lifecycle and policy documents.
+
+## Canonical references
+- [`../PIPELINES_AND_LIFECYCLE.md`](../PIPELINES_AND_LIFECYCLE.md)
+- [`PUBLICATION_AND_POLICY.md`](./PUBLICATION_AND_POLICY.md)
+- [`../tracking/REVIEW_AND_ROLLBACK.md`](../tracking/REVIEW_AND_ROLLBACK.md)
+

--- a/docs/domains/flora/governance/ROLLBACK_AND_CORRECTION.md
+++ b/docs/domains/flora/governance/ROLLBACK_AND_CORRECTION.md
@@ -1,0 +1,14 @@
+# Flora Rollback and Correction
+
+This document is a governance companion for Flora lane rollback and correction handling.
+
+## Purpose
+- Define rollback triggers and decision points.
+- Define correction publication expectations.
+- Link rollback behavior to review and promotion governance.
+
+## Canonical references
+- [`../tracking/REVIEW_AND_ROLLBACK.md`](../tracking/REVIEW_AND_ROLLBACK.md)
+- [`PUBLICATION_AND_POLICY.md`](./PUBLICATION_AND_POLICY.md)
+- [`../CHANGELOG.md`](../CHANGELOG.md)
+

--- a/docs/domains/flora/governance/adr/ADR-flora-public-layer-strategy.md
+++ b/docs/domains/flora/governance/adr/ADR-flora-public-layer-strategy.md
@@ -1,0 +1,6 @@
+# ADR: Flora Public Layer Strategy (Governance Mirror)
+
+Mirror entry in `governance/adr/`.
+
+Canonical source is currently tracked at:
+- [`../../adr/ADR-flora-public-layer-strategy.md`](../../adr/ADR-flora-public-layer-strategy.md)

--- a/docs/domains/flora/governance/adr/ADR-flora-schema-home.md
+++ b/docs/domains/flora/governance/adr/ADR-flora-schema-home.md
@@ -1,0 +1,6 @@
+# ADR: Flora Schema Home (Governance Mirror)
+
+Mirror entry in `governance/adr/`.
+
+Canonical source is currently tracked at:
+- [`../../adr/ADR-flora-schema-home.md`](../../adr/ADR-flora-schema-home.md)

--- a/docs/domains/flora/governance/adr/ADR-flora-sensitive-location-policy.md
+++ b/docs/domains/flora/governance/adr/ADR-flora-sensitive-location-policy.md
@@ -1,0 +1,6 @@
+# ADR: Flora Sensitive Location Policy (Governance Mirror)
+
+Mirror entry in `governance/adr/`.
+
+Canonical source is currently tracked at:
+- [`../../adr/ADR-flora-sensitive-location-policy.md`](../../adr/ADR-flora-sensitive-location-policy.md)

--- a/docs/domains/flora/governance/adr/ADR-flora-source-roles.md
+++ b/docs/domains/flora/governance/adr/ADR-flora-source-roles.md
@@ -1,0 +1,6 @@
+# ADR: Flora Source Roles (Governance Mirror)
+
+Mirror entry in `governance/adr/`.
+
+Canonical source is currently tracked at:
+- [`../../adr/ADR-flora-source-roles.md`](../../adr/ADR-flora-source-roles.md)

--- a/docs/domains/flora/governance/runbooks/flora-ingest.md
+++ b/docs/domains/flora/governance/runbooks/flora-ingest.md
@@ -1,0 +1,6 @@
+# Runbook: Flora Ingest (Governance Mirror)
+
+Mirror entry in `governance/runbooks/`.
+
+Canonical source is currently tracked at:
+- [`../../runbooks/flora-ingest.md`](../../runbooks/flora-ingest.md)

--- a/docs/domains/flora/governance/runbooks/flora-promotion.md
+++ b/docs/domains/flora/governance/runbooks/flora-promotion.md
@@ -1,0 +1,6 @@
+# Runbook: Flora Promotion (Governance Mirror)
+
+Mirror entry in `governance/runbooks/`.
+
+Canonical source is currently tracked at:
+- [`../../runbooks/flora-promotion.md`](../../runbooks/flora-promotion.md)

--- a/docs/domains/flora/governance/runbooks/flora-rollback.md
+++ b/docs/domains/flora/governance/runbooks/flora-rollback.md
@@ -1,0 +1,6 @@
+# Runbook: Flora Rollback (Governance Mirror)
+
+Mirror entry in `governance/runbooks/`.
+
+Canonical source is currently tracked at:
+- [`../../runbooks/flora-rollback.md`](../../runbooks/flora-rollback.md)


### PR DESCRIPTION
### Motivation
- Populate the Flora governance subtree which previously only contained an index and a publication policy, filling gaps required by the README's proposed grouped layout.
- Provide minimal governance companions and ADR/runbook mirrors so inbound links and the grouped structure can be validated without duplicating canonical content.

### Description
- Added two governance companion documents: `docs/domains/flora/governance/REVIEW_AND_PROMOTION.md` and `docs/domains/flora/governance/ROLLBACK_AND_CORRECTION.md` containing purpose statements and canonical cross-links.
- Created an `adr/` directory with mirror ADR stubs: `ADR-flora-schema-home.md`, `ADR-flora-source-roles.md`, `ADR-flora-sensitive-location-policy.md`, and `ADR-flora-public-layer-strategy.md` that point to the canonical ADRs under `docs/domains/flora/adr/`.
- Created a `runbooks/` directory with mirror runbook stubs: `flora-ingest.md`, `flora-promotion.md`, and `flora-rollback.md` that reference the canonical runbooks under `docs/domains/flora/runbooks/`.
- The new files are intentionally lightweight mirrors to avoid content drift while making the grouped `governance/` tree usable for indexing and link resolution.

### Testing
- Verified repository-wide file discovery with `find .. -name AGENTS.md -print` which ran successfully.
- Enumerated Flora docs with `rg --files docs/domains/flora` and inspected the governance README and publication policy using `sed -n '1,220p' docs/domains/flora/governance/README.md && sed -n '1,220p' docs/domains/flora/governance/PUBLICATION_AND_POLICY.md`, all of which succeeded.
- Confirmed governance subtree files with `rg "governance/" docs/domains/flora -n` and `find docs/domains/flora/governance -type f | sort`, both of which returned the expected new files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde6eecfa8832ab27e07558cb83bbc)