### PR TITLE
Add runtime and test dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,17 @@ name = "kfm-governed-ingestion-starter"
 version = "0.1.0"
 description = "KFM ecology/hydrology governed-ingestion starter kit with an evented source watcher and batched micro-runner for cosign-signed EvidenceBundles"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+  "fastapi>=0.115",
+  "jsonschema>=4.21",
+  "PyYAML>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [
   "pytest>=8",
+  "pytest-asyncio>=0.23",
+  "pytest-timeout>=2.3",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
### Motivation

- Ensure the project declares required runtime libraries for the FastAPI-based ingestion service and common data validation/parsing needs.
- Provide additional test tooling for async tests and timeout enforcement during test runs.

### Description

- Updated `pyproject.toml` to populate `dependencies` with `fastapi>=0.115`, `jsonschema>=4.21`, and `PyYAML>=6.0` instead of an empty list.
- Extended `[project.optional-dependencies]` `dev` extras with `pytest-asyncio>=0.23` and `pytest-timeout>=2.3` alongside the existing `pytest>=8` entry.
- Kept existing build and packaging settings intact and preserved test configuration under `[tool.pytest.ini_options]`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe43117014832a885aef076dc08b4d)