### PR TITLE
Fix test import paths and add project/dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,20 @@ name = "kfm-governed-ingestion-starter"
 version = "0.1.0"
 description = "KFM ecology/hydrology governed-ingestion starter kit with an evented source watcher and batched micro-runner for cosign-signed EvidenceBundles"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+  "fastapi>=0.115",
+  "httpx>=0.27",
+  "jsonschema>=4.21",
+  "pydantic>=2.7",
+  "PyYAML>=6.0",
+  "requests>=2.32",
+]
 
 [project.optional-dependencies]
 dev = [
   "pytest>=8",
+  "pytest-asyncio>=0.23",
+  "pytest-timeout>=2.3",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/soil/test_soil_active_release_pointer_check.py
+++ b/tests/soil/test_soil_active_release_pointer_check.py
@@ -1,4 +1,4 @@
-from test_soil_active_release_pointer_builder import test_builder, run, ROOT
+from tests.soil.test_soil_active_release_pointer_builder import test_builder, run, ROOT
 import sys
 
 def test_check(tmp_path):

--- a/tests/soil/test_soil_active_release_pointer_gate.py
+++ b/tests/soil/test_soil_active_release_pointer_gate.py
@@ -1,4 +1,4 @@
-from test_soil_active_release_pointer_builder import test_builder, run, ROOT
+from tests.soil.test_soil_active_release_pointer_builder import test_builder, run, ROOT
 
 def test_gate(tmp_path):
  test_builder(tmp_path)

--- a/tests/soil/test_soil_discovery_api_integration.py
+++ b/tests/soil/test_soil_discovery_api_integration.py
@@ -1,4 +1,4 @@
-from test_soil_discovery_builder import prep,run,DISC
+from tests.soil.test_soil_discovery_builder import prep,run,DISC
 from pathlib import Path
 import json, subprocess, sys, time, urllib.request
 SVC=Path(__file__).resolve().parents[2]/'tools/serve/soil/public_api.py'

--- a/tests/soil/test_soil_discovery_check.py
+++ b/tests/soil/test_soil_discovery_check.py
@@ -1,4 +1,4 @@
-from test_soil_discovery_builder import prep,run,DISC
+from tests.soil.test_soil_discovery_builder import prep,run,DISC
 from pathlib import Path
 import json,sys
 CHK=Path(__file__).resolve().parents[2]/'tools/validators/soil/discovery_check.py'

--- a/tests/soil/test_soil_discovery_gate.py
+++ b/tests/soil/test_soil_discovery_gate.py
@@ -1,4 +1,4 @@
-from test_soil_discovery_builder import prep,run,DISC
+from tests.soil.test_soil_discovery_builder import prep,run,DISC
 from pathlib import Path
 G=Path(__file__).resolve().parents[2]/'tools/validators/soil/discovery_gate.py'
 

--- a/tests/soil/test_soil_federation_check.py
+++ b/tests/soil/test_soil_federation_check.py
@@ -1,4 +1,4 @@
-from test_soil_federation_builder import prep,run,FED,ROOT
+from tests.soil.test_soil_federation_builder import prep,run,FED,ROOT
 import json
 CHK=ROOT/'tools/validators/soil/federation_check.py'
 def test_check_ok(tmp_path):

--- a/tests/soil/test_soil_federation_gate.py
+++ b/tests/soil/test_soil_federation_gate.py
@@ -1,4 +1,4 @@
-from test_soil_federation_builder import prep,run,FED,ROOT
+from tests.soil.test_soil_federation_builder import prep,run,FED,ROOT
 G=ROOT/'tools/validators/soil/federation_gate.py'
 def test_gate_ok(tmp_path):
  p,o,d,f=prep(tmp_path); assert run([FED,'--discovery-root',d,'--published-root',p,'--ops-root',o,'--out-root',f,'--base-public-url','https://example.invalid/kfm/soil']).returncode==0

--- a/tests/soil/test_soil_federation_withdrawal.py
+++ b/tests/soil/test_soil_federation_withdrawal.py
@@ -1,4 +1,4 @@
-from test_soil_federation_builder import prep,run,FED,ROOT
+from tests.soil.test_soil_federation_builder import prep,run,FED,ROOT
 import json
 W=ROOT/'tools/federation/soil/build_withdrawal.py'
 def test_withdrawal(tmp_path):

--- a/tests/soil/test_soil_mock_submit.py
+++ b/tests/soil/test_soil_mock_submit.py
@@ -1,4 +1,4 @@
-from test_soil_federation_builder import prep,run,FED,ROOT
+from tests.soil.test_soil_federation_builder import prep,run,FED,ROOT
 M=ROOT/'tools/federation/soil/mock_submit.py'; ACC=ROOT/'tests/fixtures/soil/federation/registries/ckan_accept.json'; REJ=ROOT/'tests/fixtures/soil/federation/registries/ckan_reject.json'
 def test_submit_accept(tmp_path):
  p,o,d,f=prep(tmp_path); assert run([FED,'--discovery-root',d,'--published-root',p,'--ops-root',o,'--out-root',f,'--base-public-url','https://example.invalid/kfm/soil']).returncode==0

--- a/tests/soil/test_soil_public_stability_check.py
+++ b/tests/soil/test_soil_public_stability_check.py
@@ -1,4 +1,4 @@
-from test_soil_public_stability_builder import test_build,ROOT
+from tests.soil.test_soil_public_stability_builder import test_build,ROOT
 import subprocess,sys
 
 def test_check(tmp_path):

--- a/tests/soil/test_soil_public_stability_gate.py
+++ b/tests/soil/test_soil_public_stability_gate.py
@@ -1,4 +1,4 @@
-from test_soil_public_stability_builder import test_build,ROOT
+from tests.soil.test_soil_public_stability_builder import test_build,ROOT
 import subprocess,sys
 
 def test_gate(tmp_path):

--- a/tests/test_soilgrids_registry_runtime.py
+++ b/tests/test_soilgrids_registry_runtime.py
@@ -1,6 +1,6 @@
 import json, sqlite3
 from pathlib import Path
-from soilgrids_registry_runtime import enforce_readonly_sql, open_sqlite_readonly_immutable, build_dashboard_bundle
+from tools.soilgrids.soilgrids_registry_runtime import enforce_readonly_sql, open_sqlite_readonly_immutable, build_dashboard_bundle
 
 
 def _mk(tmp):

--- a/tests/test_soilgrids_release_publish.py
+++ b/tests/test_soilgrids_release_publish.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 import pytest
 
-from soilgrids_release_publish import load_publish_inputs, publish_approved_bundle, compute_release_id, compute_publish_spec_hash, PublishError
+from tools.soilgrids.soilgrids_release_publish import load_publish_inputs, publish_approved_bundle, compute_release_id, compute_publish_spec_hash, PublishError
 
 
 def _write(p: Path, obj):

--- a/tests/test_soilgrids_viewer_bundle.py
+++ b/tests/test_soilgrids_viewer_bundle.py
@@ -1,7 +1,7 @@
 import json, subprocess, sys
 from pathlib import Path
 import pytest
-from soilgrids_viewer_bundle import parse_args, build_viewer_bundle, ViewerError, compute_viewer_spec_hash
+from tools.soilgrids.soilgrids_viewer_bundle import parse_args, build_viewer_bundle, ViewerError, compute_viewer_spec_hash
 
 
 def wj(p,o): p.parent.mkdir(parents=True, exist_ok=True); p.write_text(json.dumps(o), encoding='utf-8')


### PR DESCRIPTION
### Motivation
- Ensure test modules import package-qualified paths so tests run under `--import-mode=importlib` and when project modules are installed as packages.
- Add missing runtime dependencies required by the tools (FastAPI stack, YAML, requests, jsonschema, pydantic) and useful pytest plugins for async and timeout support.

### Description
- Added project dependencies: `fastapi`, `httpx`, `jsonschema`, `pydantic`, `PyYAML`, and `requests` in `pyproject.toml`.
- Added dev dependencies: `pytest-asyncio` and `pytest-timeout` to the `dev` optional dependencies.
- Updated a large set of test files to use package-qualified imports by prefixing test module imports with `tests.` and tools modules with `tools.` (for example `soilgrids_release_publish` -> `tools.soilgrids.soilgrids_release_publish`).
- Kept `pytest` configuration and package discovery settings in `pyproject.toml` and adjusted nothing else in test runtime config.

### Testing
- Ran the test suite with `pytest` against the modified files; the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe43117014832a885aef076dc08b4d)