### PR TITLE
Stand up governed-api ABSTAIN-only stub with smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # KFM Makefile — greenfield scaffold.
 # Commands should be repo-native; replace placeholders as packages land.
 
-.PHONY: help validate test schemas policy fixtures release-dry-run             proof-slice catalog publish-check deny-test ui-build api-run
+.PHONY: help validate test schemas policy fixtures release-dry-run             proof-slice catalog publish-check deny-test ui-build api-run governed-api-dev governed-api-smoke
 
 help:
 	@echo "KFM make targets (greenfield):"
@@ -49,3 +49,10 @@ ui-build:
 
 api-run:
 	@echo "TODO: uvicorn apps.governed_api.main:app"
+
+
+governed-api-dev:
+	uvicorn governed_api.main:app --app-dir apps/governed-api/src --reload
+
+governed-api-smoke:
+	python -m pytest apps/governed-api/tests -q

--- a/apps/governed-api/README.md
+++ b/apps/governed-api/README.md
@@ -1,0 +1,26 @@
+# governed-api
+
+ABSTAIN-only trust membrane stub for KFM.
+
+## Run locally
+
+```bash
+uvicorn governed_api.main:app --app-dir apps/governed-api/src --reload
+```
+
+Or with make:
+
+```bash
+make governed-api-dev
+```
+
+## What ABSTAIN-only means
+
+Every scaffolded route returns a deterministic `DecisionEnvelope` with:
+- `decision = "ABSTAIN"`
+- `reason_code = "NOT_IMPLEMENTED"`
+- `evidence_refs = []`
+
+No data retrieval, policy evaluation, or external connector/model calls are performed.
+
+Real handlers come later per ADR-0004.

--- a/apps/governed-api/pyproject.toml
+++ b/apps/governed-api/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "governed-api"
+version = "0.1.0"
+description = "KFM trust membrane ABSTAIN-only stub"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.115,<1.0",
+  "uvicorn>=0.30,<1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "jsonschema>=4.0",
+]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/apps/governed-api/src/governed_api/__init__.py
+++ b/apps/governed-api/src/governed_api/__init__.py
@@ -1,0 +1,1 @@
+"""Governed API package."""

--- a/apps/governed-api/src/governed_api/main.py
+++ b/apps/governed-api/src/governed_api/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+from governed_api.routes import bootstrap, evidence, layers
+
+app = FastAPI(title="KFM Governed API", version="0.1.0")
+app.include_router(bootstrap.router)
+app.include_router(layers.router)
+app.include_router(evidence.router)

--- a/apps/governed-api/src/governed_api/routes/__init__.py
+++ b/apps/governed-api/src/governed_api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Route modules for governed API."""

--- a/apps/governed-api/src/governed_api/routes/bootstrap.py
+++ b/apps/governed-api/src/governed_api/routes/bootstrap.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from governed_api.stub import make_abstain_envelope
+
+router = APIRouter()
+
+
+@router.get("/bootstrap")
+def bootstrap() -> dict:
+    return make_abstain_envelope("bootstrap")

--- a/apps/governed-api/src/governed_api/routes/evidence.py
+++ b/apps/governed-api/src/governed_api/routes/evidence.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from governed_api.stub import make_abstain_envelope
+
+router = APIRouter()
+
+
+@router.get("/evidence")
+def evidence() -> dict:
+    return make_abstain_envelope("evidence")

--- a/apps/governed-api/src/governed_api/routes/layers.py
+++ b/apps/governed-api/src/governed_api/routes/layers.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from governed_api.stub import make_abstain_envelope
+
+router = APIRouter()
+
+
+@router.get("/layers")
+def layers() -> dict:
+    return make_abstain_envelope("layers")

--- a/apps/governed-api/src/governed_api/stub.py
+++ b/apps/governed-api/src/governed_api/stub.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timezone
+
+
+def make_abstain_envelope(route: str) -> dict:
+    issued_at = datetime.now(timezone.utc).isoformat()
+    return {
+        "id": f"stub:{route}",
+        "spec_hash": "stub:abstain",
+        "version": "v1-stub",
+        "issued_at": issued_at,
+        "decision": "ABSTAIN",
+        "reason_code": "NOT_IMPLEMENTED",
+        "evidence_refs": [],
+    }

--- a/apps/governed-api/tests/test_abstain_routes.py
+++ b/apps/governed-api/tests/test_abstain_routes.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from jsonschema import Draft202012Validator
+
+from governed_api.main import app
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "schemas"
+    / "contracts"
+    / "v1"
+    / "runtime"
+    / "decision_envelope.schema.json"
+)
+ROUTES = ["/bootstrap", "/layers", "/evidence"]
+
+
+def test_all_scaffolded_routes_abstain_and_validate() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema)
+    client = TestClient(app)
+
+    for route in ROUTES:
+        response = client.get(route)
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["decision"] == "ABSTAIN"
+        assert payload["reason_code"] == "NOT_IMPLEMENTED"
+        assert payload["evidence_refs"] == []
+        validator.validate(payload)


### PR DESCRIPTION
### Motivation
- Provide a minimal, network-free trust-membrane stub so the public API surface exists while real handlers and backends are added later per ADR-0004. 
- Ensure every existing scaffolded route returns a deterministic `DecisionEnvelope` with `decision="ABSTAIN"`, `reason_code="NOT_IMPLEMENTED"`, and `evidence_refs=[]` to enforce a deny-by-default posture at the public boundary.

### Description
- Added a new `apps/governed-api` Python package with `pyproject.toml`, `src/governed_api/` code, and route modules for the scaffolded routes `bootstrap`, `layers`, and `evidence` wired into `main.py`.
- Implemented `make_abstain_envelope(route: str)` in `governed_api.stub` that emits deterministic placeholders (`spec_hash="stub:abstain"`, `version="v1-stub"`, `id="stub:<route>"`, and `issued_at` set to request time) and the mandated `decision`, `reason_code`, and `evidence_refs` fields.
- Added a pytest `apps/governed-api/tests/test_abstain_routes.py` which exercises every scaffolded route with `fastapi.testclient.TestClient` and validates the response against `schemas/contracts/v1/runtime/decision_envelope.schema.json` using `jsonschema.Draft202012Validator`.
- Updated repository Makefile with `governed-api-dev` (local uvicorn run) and `governed-api-smoke` (headless pytest) targets, and added `apps/governed-api/README.md` documenting how to run and what ABSTAIN-only means.

### Testing
- Ran a search for banned imports and confirmed `git grep -E "^(import|from) (maplibre|cesium|ollama)" apps/governed-api/` produced no matches (success).
- Invoking `make governed-api-smoke` in this environment failed during test collection with `ModuleNotFoundError: No module named 'fastapi'` because required dependencies are not installed (test run failed).
- Attempting to install dependencies with `pip` failed due to network/package-index restrictions (`Tunnel connection failed: 403 Forbidden`), so the pytest suite could not be executed here (installation failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe65096780832a85b1369656389a93)