### PR TITLE
PR-002: Core Object Semantics (six contract families)

### DIFF
--- a/contracts/evidence/evidence_bundle.md
+++ b/contracts/evidence/evidence_bundle.md
@@ -1,26 +1,48 @@
 # evidence_bundle
 
-Schema: `https://schemas.kfm.local/contracts/v1/evidence/evidence_bundle.schema.json`
+> Status: PROPOSED
+> Schema: https://schemas.kfm.local/contracts/v1/evidence/evidence_bundle.schema.json
+> Schema file: schemas/contracts/v1/evidence/evidence_bundle.schema.json
+> Validator: tools/validators/validate_evidence_bundle.py (CONFIRMED — wired in tools/validators/_common/run_all.py)
+> Authority: contracts/ owns meaning; schemas/contracts/v1/ owns shape (ADR-0001, ADR-0002).
 
-## Meaning
-Defines the governed semantics for `evidence_bundle` in KFM.
+## 1. Purpose
+`evidence_bundle` is the closure artifact that packages all material needed to support a governed claim scope. It answers whether evidence is sufficiently assembled (refs, source records, citations, rights, sensitivity, transforms, checksums, and spec linkage) to support downstream decisions. It is not a release manifest and not a policy decision object.
 
-## Fields
-- See schema properties; each field carries provenance-safe, policy-evaluable meaning.
+## 2. Lifecycle role
+This object is formed in PROCESSED as the closure result of WORK evidence collection, where referenced materials are normalized and linked. It is validated before CATALOG / TRIPLET publication indexing and then referenced by runtime/release surfaces in PUBLISHED. Supersession happens via a new bundle with updated claim scope or evidence lineage; prior bundles remain auditable.
 
-## Invariants
-- Required fields must exist.
-- Enumerated values remain finite where specified.
-- No undeclared fields unless explicitly allowed.
+## 3. Fields
+| field | type | required | meaning | examples or enum | policy/sensitivity notes |
+|---|---|---|---|---|---|
+| `bundle_id` | string | yes | Stable identifier for the closure package. | `bundle:hydrology:2026-05-08:001` | Anchor id used in audit and publish gating. |
+| `claim_scope` | string | yes | Human/machine scope statement describing what claims this bundle supports. | `flood-risk-baseline:ks:county:shawnee` | Scope guides whether evidence is fit for intended exposure. |
+| `evidence_refs` | array | yes | Set of constituent `evidence_ref` members included in closure. | array of `evidence_ref` objects | `minItems: 1` ensures non-empty proof linkage. |
+| `source_records` | array | yes | Source-level record handles used to reconstruct provenance. | `raw/hydrology/usgs/2026-05-08/run-001.json` | Supports rights/sensitivity traceback during review. |
+| `citations` | array | yes | Publication-ready citation strings backing the claim scope. | `USGS Water Data, retrieved 2026-05-08` | Missing citations can block publish release. |
+| `rights` | object | yes | Effective rights summary after bundle assembly. | object with `license` | Must remain compatible with exposure channel obligations. |
+| `sensitivity` | object (via `$ref`) | yes | Sensitivity labeling for bundle exposure constraints. | sensitivity label object | Drives deny/redact behavior in policy evaluation. |
+| `transforms` | array | yes | Ordered transformations applied from source evidence to derived artifacts. | `reproject:EPSG:4326`, `aggregate:county` | Enables review of derivation risk and reproducibility. |
+| `checksums` | object | yes | Hash map covering critical inputs/outputs in closure. | `{"source.csv":"sha256:..."}` | Detects tampering/drift before promotion and publish. |
+| `spec_hash` | string (via `$ref`) | yes | Deterministic spec identity tying the bundle to contract/schema baseline. | `sha256:<64 hex>` | Allows policy/runtime to detect schema/spec drift. |
 
-## Lifecycle
-- Created in RAW/WORK processing.
-- Validated before promotion decisions.
-- Released through governed interfaces.
-- Superseded by newer versioned records.
+## 4. Invariants
+- All required fields must be present (enforced by schema `required` — CONFIRMED).
+- `evidence_refs`, `source_records`, and `citations` must be arrays, with `evidence_refs`/`source_records`/`citations` non-empty where schema `minItems: 1` is set (enforced by schema — CONFIRMED).
+- `rights` must include `license` and no undeclared fields (enforced by nested schema object — CONFIRMED).
+- `checksums` must contain at least one property and each checksum must match `^sha256:[a-f0-9]{64}$` (enforced by schema — CONFIRMED).
+- PROPOSED: every runtime `outcome == ANSWER` should reference at least one bundle-closed evidence chain.
+  - NEEDS VERIFICATION: enforce via `packages/evidence-resolver/` integration and/or runtime policy in `policy/runtime/`.
 
-## Related contracts
-- Neighbor contracts in the same family and runtime policy decisions.
+## 5. Cross-references
+- Sibling contracts: `contracts/evidence/evidence_ref.md`, `contracts/evidence/kfm_geo_manifest.md`.
+- Schema file: `schemas/contracts/v1/evidence/evidence_bundle.schema.json`.
+- Governing ADRs: `docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md`, `docs/adr/ADR-0002-contracts-vs-schemas-split.md`, `docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md`.
+- Policy paths: `policy/evidence/` (PROPOSED — scaffold-level).
+- Validator: `tools/validators/validate_evidence_bundle.py` (CONFIRMED — wired in `tools/validators/_common/run_all.py`).
+- Resolver package: `packages/evidence-resolver/` (PROPOSED — stub status).
 
-## Open questions
-- NEEDS VERIFICATION: additional domain-specific constraints may be added in follow-up PRs.
+## 6. Status
+- Doc status: PROPOSED until reviewed and merged.
+- Schema status: PROPOSED (from schema `x-kfm.status` — CONFIRMED).
+- NEEDS VERIFICATION: define explicit resolver failure mode when an `evidence_ref` cannot be closed into a bundle.

--- a/contracts/evidence/evidence_ref.md
+++ b/contracts/evidence/evidence_ref.md
@@ -1,26 +1,39 @@
 # evidence_ref
 
-Schema: `https://schemas.kfm.local/contracts/v1/evidence/evidence_ref.schema.json`
+> Status: PROPOSED
+> Schema: https://schemas.kfm.local/contracts/v1/evidence/evidence_ref.schema.json
+> Schema file: schemas/contracts/v1/evidence/evidence_ref.schema.json
+> Validator: PROPOSED — not yet wired
+> Authority: contracts/ owns meaning; schemas/contracts/v1/ owns shape (ADR-0001, ADR-0002).
 
-## Meaning
-Defines the governed semantics for `evidence_ref` in KFM.
+## 1. Purpose
+`evidence_ref` is the smallest governed pointer to supporting material used in claim assembly and runtime explanation. It answers what item is being referenced and what kind of evidence it is. It is not the closure artifact and does not by itself guarantee citation completeness or policy clearance.
 
-## Fields
-- See schema properties; each field carries provenance-safe, policy-evaluable meaning.
+## 2. Lifecycle role
+`evidence_ref` appears during WORK evidence collection and normalization, then is validated as part of bundle assembly before PROCESSED closure. In CATALOG / TRIPLET and PUBLISHED-facing envelopes it is carried as traceable linkage back to bundle-closed proof material. Pre-closure refs may exist without a bundle assignment; closure binds them.
 
-## Invariants
-- Required fields must exist.
-- Enumerated values remain finite where specified.
-- No undeclared fields unless explicitly allowed.
+## 3. Fields
+| field | type | required | meaning | examples or enum | policy/sensitivity notes |
+|---|---|---|---|---|---|
+| `ref` | string | yes | Canonical pointer/id for the evidence item. | `ev:usgs:station:06892350:2026-05-01` | Must resolve through governed resolver paths before publish-grade use. |
+| `kind` | string | yes | Declares evidence category for downstream policy and rendering behavior. | enum: `measurement`, `record`, `dataset`, `artifact` | Certain kinds may require additional checks before exposure. |
+| `bundle_ref` | string | no | Identifier of the `evidence_bundle` that closed this reference. Unset when still pre-closure. | `bundle:hydrology:2026-05-08:001` | When absent, treat as pre-closure pointer and avoid claim-final ANSWER release. |
 
-## Lifecycle
-- Created in RAW/WORK processing.
-- Validated before promotion decisions.
-- Released through governed interfaces.
-- Superseded by newer versioned records.
+## 4. Invariants
+- Required fields `ref` and `kind` must be present (enforced by schema `required` — CONFIRMED).
+- `kind` must be one of `measurement | record | dataset | artifact` (enforced by schema `enum` — CONFIRMED).
+- No undeclared top-level fields are permitted (enforced by `additionalProperties: false` — CONFIRMED).
+- PROPOSED: if `bundle_ref` is set, it SHOULD resolve to an existing `evidence_bundle` identifier.
+  - NEEDS VERIFICATION: enforce in `packages/evidence-resolver/` or a dedicated validator for `evidence_ref`.
 
-## Related contracts
-- Neighbor contracts in the same family and runtime policy decisions.
+## 5. Cross-references
+- Sibling contracts: `contracts/evidence/evidence_bundle.md`, `contracts/evidence/kfm_geo_manifest.md`.
+- Schema file: `schemas/contracts/v1/evidence/evidence_ref.schema.json`.
+- Governing ADRs: `docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md`, `docs/adr/ADR-0002-contracts-vs-schemas-split.md`, `docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md`.
+- Policy paths: `policy/evidence/` (PROPOSED — scaffold-level).
+- Validator: `tools/validators/validate_evidence_ref.py` (PROPOSED — schema points here, but not wired in `tools/validators/_common/run_all.py`).
 
-## Open questions
-- NEEDS VERIFICATION: additional domain-specific constraints may be added in follow-up PRs.
+## 6. Status
+- Doc status: PROPOSED until reviewed and merged.
+- Schema status: PROPOSED (from schema `x-kfm.status` — CONFIRMED).
+- NEEDS VERIFICATION: confirm resolver contract for `bundle_ref` referential integrity.

--- a/contracts/policy/policy_decision.md
+++ b/contracts/policy/policy_decision.md
@@ -1,26 +1,46 @@
 # policy_decision
 
-Schema: `https://schemas.kfm.local/contracts/v1/policy/policy_decision.schema.json`
+> Status: PROPOSED
+> Schema: https://schemas.kfm.local/contracts/v1/policy/policy_decision.schema.json
+> Schema file: schemas/contracts/v1/policy/policy_decision.schema.json
+> Validator: PROPOSED — not yet wired
+> Authority: contracts/ owns meaning; schemas/contracts/v1/ owns shape (ADR-0001, ADR-0002).
 
-## Meaning
-Defines the governed semantics for `policy_decision` in KFM.
+## 1. Purpose
+`policy_decision` records the canonical policy outcome for a single policy evaluation event. It answers what family decided, what outcome was reached, and what reasons/obligations apply at that decision point. It is not the runtime transport wrapper (`decision_envelope`) used to carry decision context through API responses.
 
-## Fields
-- See schema properties; each field carries provenance-safe, policy-evaluable meaning.
+## 2. Lifecycle role
+Policy decisions are produced during promotion and runtime checks spanning WORK / QUARANTINE to PROCESSED and release gating into PUBLISHED. They are validated as contract objects before being relied on by governed API responses and release workflows. Supersession occurs by issuing a new decision record at a later `evaluated_at` point, not by mutating prior decisions.
 
-## Invariants
-- Required fields must exist.
-- Enumerated values remain finite where specified.
-- No undeclared fields unless explicitly allowed.
+## 3. Fields
+| field | type | required | meaning | examples or enum | policy/sensitivity notes |
+|---|---|---|---|---|---|
+| `decision_id` | string | yes | Unique identifier for this decision event. | `poldec:2026-05-08:run-001:access` | Audit key for policy traceability. |
+| `outcome` | string | yes | Finite decision outcome used by callers and envelopes. | enum: `ANSWER`, `ABSTAIN`, `DENY`, `ERROR` | Governs allow/deny/abstain behavior; ABSTAIN is first-class (ADR-0020). |
+| `policy_family` | string | yes | Policy lane that produced the decision. | enum: `promotion`, `access`, `render`, `capability`, `consent`, `sensitivity` | Determines applicable obligation interpreter and reviewers. |
+| `reasons` | array | yes | Machine/human-readable reason codes or explanations. | `['missing_citation']` | Drives transparency and challenge workflows. |
+| `obligations` | array | yes | Conditions required if/when outcome permits further action. | `['redact_coordinates','attach_notice']` | Obligations can force restricted rendering rather than full deny. |
+| `evaluated_at` | string | yes | Decision evaluation timestamp (`date-time`). | `2026-05-08T21:14:00Z` | Used for freshness/re-evaluation logic. |
 
-## Lifecycle
-- Created in RAW/WORK processing.
-- Validated before promotion decisions.
-- Released through governed interfaces.
-- Superseded by newer versioned records.
+## 4. Invariants
+- All required fields must be present (enforced by schema `required` — CONFIRMED).
+- `outcome` must be one of `ANSWER | ABSTAIN | DENY | ERROR` (enforced by schema `enum` — CONFIRMED).
+- `policy_family` must be one of `promotion | access | render | capability | consent | sensitivity` (enforced by schema `enum` — CONFIRMED).
+- `evaluated_at` must parse as `date-time` (enforced by schema `format` — CONFIRMED).
+- PROPOSED: `reasons` SHOULD be non-empty for `DENY`, `ABSTAIN`, and `ERROR` outcomes.
+  - NEEDS VERIFICATION: enforce in `policy/` decision logic or dedicated `validate_policy_decision.py` follow-up.
+- PROPOSED: `policy_decision` remains canonical decision content, while `contracts/runtime/decision_envelope.md` wraps runtime transport metadata.
+  - NEEDS VERIFICATION: verify full field mapping in `apps/governed-api/` adapter layer.
 
-## Related contracts
-- Neighbor contracts in the same family and runtime policy decisions.
+## 5. Cross-references
+- Sibling contracts: `contracts/policy/policy_input_bundle.md`, `contracts/policy/sensitivity_label.md`.
+- Runtime distinction: `contracts/runtime/decision_envelope.md`.
+- Schema file: `schemas/contracts/v1/policy/policy_decision.schema.json`.
+- Governing ADRs: `docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md`, `docs/adr/ADR-0002-contracts-vs-schemas-split.md`, `docs/adr/ADR-0019-ai-adapter-contract-and-finite-envelopes.md`, `docs/adr/ADR-0020-abstain-is-a-first-class-decision.md`.
+- Policy paths: `policy/` family lanes (PROPOSED — current repo policy files are scaffold-level).
+- Validator: `tools/validators/validate_policy_decision.py` (PROPOSED — not wired in `tools/validators/_common/run_all.py`).
 
-## Open questions
-- NEEDS VERIFICATION: additional domain-specific constraints may be added in follow-up PRs.
+## 6. Status
+- Doc status: PROPOSED until reviewed and merged.
+- Schema status: PROPOSED (from schema `x-kfm.status` — CONFIRMED).
+- NEEDS VERIFICATION: lock canonical mapping boundaries between `policy_decision` and runtime `decision_envelope` in validator/policy checks.

--- a/contracts/release/README.md
+++ b/contracts/release/README.md
@@ -1,3 +1,43 @@
 # Contracts: release
 
-Semantic meaning for the release family.
+## Purpose
+Defines semantic meaning for release governance object families. Shape enforcement remains in `schemas/contracts/v1/release/`.
+
+## Scope
+This folder contains contract prose for release decisions, release manifests, rollback, corrections, and withdrawals.
+
+## Authority
+- `contracts/` owns object meaning.
+- `schemas/contracts/v1/` owns machine-checkable shape.
+- `policy/` owns allow/deny/restrict/abstain behavior.
+
+## Naming
+- One Markdown file per object family, using snake_case names aligned with schema titles.
+
+## Lifecycle alignment
+These contracts cover objects used at promotion/release boundaries from PROCESSED and CATALOG/TRIPLET into PUBLISHED, including rollback and correction flows.
+
+## Review burden
+Changes must preserve contract/schema split and cite governing ADRs when semantics shift.
+
+## Files in this folder
+- `README.md`
+- `release_manifest.md`
+- `promotion_decision.md`
+- `rollback_card.md`
+- `correction_notice.md`
+- `withdrawal_notice.md`
+
+## Related folders
+- `schemas/contracts/v1/release/`
+- `policy/release/`
+- `release/`
+- `contracts/runtime/`
+
+## Governing ADRs
+- `docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md`
+- `docs/adr/ADR-0002-contracts-vs-schemas-split.md`
+- `docs/adr/ADR-0023-geo-manifest-signs-every-pmtiles-cog-release.md`
+
+## Last reviewed
+2026-05-09 (UTC)

--- a/contracts/release/release_manifest.md
+++ b/contracts/release/release_manifest.md
@@ -1,27 +1,41 @@
-# Contract: release_manifest
+# release_manifest
 
-**Family:** `release`
-**Schema:** `schemas/contracts/v1/release/release_manifest.schema.json`
-**Status:** PROPOSED (greenfield scaffold)
+> Status: PROPOSED
+> Schema: https://schemas.kfm.local/contracts/v1/release/release_manifest.schema.json
+> Schema file: schemas/contracts/v1/release/release_manifest.schema.json
+> Validator: PROPOSED — not yet wired
+> Authority: contracts/ owns meaning; schemas/contracts/v1/ owns shape (ADR-0001, ADR-0002).
 
-## Meaning
-What this object means in the KFM trust model. Define the semantic role:
-what claim does it support, what audience consumes it, what does it
-*not* assert.
+## 1. Purpose
+`release_manifest` identifies a governed release artifact set at publication time and links it to a specific spec lineage. It answers which release id/version/spec hash a published package claims. It is not yet a full signed release attestation object in the current thin schema.
 
-## Fields
-Field-by-field semantics live here. Schema enforces shape; this
-document enforces meaning.
+## 2. Lifecycle role
+This object is expected at release/publish handoff from CATALOG / TRIPLET outputs into PUBLISHED artifacts. It should be validated before publication and superseded when a newer release manifest is issued. Current schema thinness means some release-governance semantics remain deferred.
 
-## Invariants
-Cross-field rules, lifecycle rules, references that must resolve.
+## 3. Fields
+| field | type | required | meaning | examples or enum | policy/sensitivity notes |
+|---|---|---|---|---|---|
+| `spec_hash` | string | no | Deterministic hash claiming spec lineage for the release. | `sha256:<64 hex>` | Useful for compatibility checks; currently optional in shape. |
+| `id` | string | yes | Canonical release manifest identifier. | `release:hydrology:2026-05-08` | Primary governance anchor for release tracking. |
+| `version` | string | no | Release version string. | `2026.05.08-1` | Supports rollback/comparison workflows when present. |
 
-## Lifecycle
-Where this object is created, transformed, validated, released,
-superseded, and rolled back.
+Schema asymmetry note (CONFIRMED): this schema currently uses `additionalProperties: true`, unlike the other five core family schemas that close undeclared fields. This permissive posture is intentionally thin in PR-001 and needs follow-up governance hardening.
 
-## Related contracts
-Upstream dependencies and downstream consumers.
+## 4. Invariants
+- Required field `id` must be present (enforced by schema `required` — CONFIRMED).
+- Additional undeclared fields are currently permitted (enforced by `additionalProperties: true` — CONFIRMED).
+- PROPOSED: production release manifests SHOULD include `spec_hash` and `version` even though optional today.
+  - NEEDS VERIFICATION: enforce via release validator/policy in a follow-up aligned with ADR-0023.
 
-## Open questions
-Anything still UNKNOWN or NEEDS VERIFICATION.
+## 5. Cross-references
+- Sibling contracts: `contracts/release/promotion_decision.md`, `contracts/release/rollback_card.md`, `contracts/release/correction_notice.md`, `contracts/release/withdrawal_notice.md`.
+- Schema file: `schemas/contracts/v1/release/release_manifest.schema.json`.
+- Governing ADRs: `docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md`, `docs/adr/ADR-0002-contracts-vs-schemas-split.md`, `docs/adr/ADR-0023-geo-manifest-signs-every-pmtiles-cog-release.md`.
+- Policy paths: `policy/release/` (PROPOSED — scaffold-level).
+- Validator: `tools/validators/release/validate_release_manifest.py` (PROPOSED — not wired in `tools/validators/_common/run_all.py`).
+
+## 6. Status
+- Doc status: PROPOSED until reviewed and merged.
+- Schema status: PROPOSED (from schema `x-kfm.status` — CONFIRMED).
+- OPEN: Release manifest schema is intentionally permissive in PR-001; fields for signed manifests, layer manifests, and rollback linkage are PROPOSED for ADR-0023 follow-up.
+- NEEDS VERIFICATION: decide when to move `additionalProperties` from `true` to `false` after explicit field expansion.

--- a/contracts/runtime/runtime_response_envelope.md
+++ b/contracts/runtime/runtime_response_envelope.md
@@ -1,26 +1,49 @@
 # runtime_response_envelope
 
-Schema: `https://schemas.kfm.local/contracts/v1/runtime/runtime_response_envelope.schema.json`
+> Status: PROPOSED
+> Schema: https://schemas.kfm.local/contracts/v1/runtime/runtime_response_envelope.schema.json
+> Schema file: schemas/contracts/v1/runtime/runtime_response_envelope.schema.json
+> Validator: tools/validators/validate_runtime_response_envelope.py (CONFIRMED — wired in tools/validators/_common/run_all.py)
+> Authority: contracts/ owns meaning; schemas/contracts/v1/ owns shape (ADR-0001, ADR-0002).
 
-## Meaning
-Defines the governed semantics for `runtime_response_envelope` in KFM.
+## 1. Purpose
+`runtime_response_envelope` is the governed API-facing response contract that carries outcome, provenance pointers, and state indicators needed for safe client rendering. It answers what the caller may treat as answer/abstain/deny/error and what governance conditions apply to display. It is not raw evidence storage and not a substitute for canonical internal lifecycle stores.
 
-## Fields
-- See schema properties; each field carries provenance-safe, policy-evaluable meaning.
+## 2. Lifecycle role
+This object is emitted at the trust membrane when serving PUBLISHED-safe outputs derived from upstream PROCESSED/CATALOG evidence and policy state. It is validated before API exposure and may be superseded by later envelopes when freshness or correction posture changes. It must not imply direct RAW/WORK/QUARANTINE reads by public clients.
 
-## Invariants
-- Required fields must exist.
-- Enumerated values remain finite where specified.
-- No undeclared fields unless explicitly allowed.
+## 3. Fields
+| field | type | required | meaning | examples or enum | policy/sensitivity notes |
+|---|---|---|---|---|---|
+| `id` | string | yes | Envelope identifier for traceability and client reconciliation. | `resp:focus:2026-05-08:abc123` | Used for correction/supersession tracking. |
+| `spec_hash` | string | yes | Contract/spec hash binding envelope to governed schema/spec lineage. | `sha256:<64 hex>` | Guards against serving responses from mismatched contract baselines. |
+| `version` | string | yes | Envelope version token. | `v1` | Used for compatibility and migration handling. |
+| `issued_at` | string | yes | Emission timestamp (`date-time`). | `2026-05-08T21:20:00Z` | Supports freshness and replay controls. |
+| `outcome` | string | yes | Finite runtime outcome. | enum: `ANSWER`, `ABSTAIN`, `DENY`, `ERROR` | Directly gates client behavior and messaging. |
+| `reason_code` | string | yes | Primary reason classification for the outcome. | `insufficient_evidence` | Helps UI show denied/abstained rationale safely. |
+| `evidence_refs` | array | yes | Evidence pointers supporting the envelope outcome. | array of `evidence_ref` objects | Enables cite-or-abstain rendering and traceability. |
+| `policy_state` | string | yes | Governance state summary from policy evaluation. | `allow_with_obligations` | Governance-bearing state used by UI to show constrained results. |
+| `freshness` | string | yes | Freshness/staleness status for the response payload. | `fresh`, `stale` | Governance-bearing state; stale signals caution or re-query expectations. |
+| `correction_state` | string | yes | Correction/withdrawal posture for this response lineage. | `none`, `corrected`, `withdrawn` | Governance-bearing state; UI must reflect corrections/withdrawals. |
 
-## Lifecycle
-- Created in RAW/WORK processing.
-- Validated before promotion decisions.
-- Released through governed interfaces.
-- Superseded by newer versioned records.
+## 4. Invariants
+- All required fields must be present (enforced by schema `required` — CONFIRMED).
+- `spec_hash` must match `^sha256:[a-f0-9]{64}$` (enforced by schema pattern — CONFIRMED).
+- `issued_at` must be `date-time` format (enforced by schema format — CONFIRMED).
+- `outcome` must be one of `ANSWER | ABSTAIN | DENY | ERROR` (enforced by schema enum — CONFIRMED).
+- PROPOSED: `evidence_refs` SHOULD be non-empty whenever `outcome == ANSWER`.
+  - NEEDS VERIFICATION: enforce in `tools/validators/validate_runtime_response_envelope.py` or `policy/runtime/` follow-up.
+- PROPOSED: `policy_state`, `freshness`, and `correction_state` values should be constrained to a controlled vocabulary.
+  - NEEDS VERIFICATION: add enum constraints in future schema/ADR-aligned change if adopted.
 
-## Related contracts
-- Neighbor contracts in the same family and runtime policy decisions.
+## 5. Cross-references
+- Sibling contracts: `contracts/runtime/decision_envelope.md`, `contracts/runtime/run_receipt.md`, `contracts/runtime/ai_receipt.md`.
+- Schema file: `schemas/contracts/v1/runtime/runtime_response_envelope.schema.json`.
+- Governing ADRs: `docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md`, `docs/adr/ADR-0002-contracts-vs-schemas-split.md`, `docs/adr/ADR-0019-ai-adapter-contract-and-finite-envelopes.md`, `docs/adr/ADR-0020-abstain-is-a-first-class-decision.md`, `docs/adr/ADR-0025-public-client-never-reads-canonical-internal-stores.md`.
+- Policy paths: `policy/runtime/` (PROPOSED — scaffold-level).
+- Validator: `tools/validators/validate_runtime_response_envelope.py` (CONFIRMED — wired in `tools/validators/_common/run_all.py`).
 
-## Open questions
-- NEEDS VERIFICATION: additional domain-specific constraints may be added in follow-up PRs.
+## 6. Status
+- Doc status: PROPOSED until reviewed and merged.
+- Schema status: PROPOSED (from schema `x-kfm.status` — CONFIRMED).
+- NEEDS VERIFICATION: confirm canonical vocabulary for `policy_state`, `freshness`, and `correction_state` before tightening shape.

--- a/contracts/source/source_descriptor.md
+++ b/contracts/source/source_descriptor.md
@@ -1,26 +1,48 @@
 # source_descriptor
 
-Schema: `https://schemas.kfm.local/contracts/v1/source/source_descriptor.schema.json`
+> Status: PROPOSED
+> Schema: https://schemas.kfm.local/contracts/v1/source/source_descriptor.schema.json
+> Schema file: schemas/contracts/v1/source/source_descriptor.schema.json
+> Validator: tools/validators/validate_source_descriptor.py (CONFIRMED — wired in tools/validators/_common/run_all.py)
+> Authority: contracts/ owns meaning; schemas/contracts/v1/ owns shape (ADR-0001, ADR-0002).
 
-## Meaning
-Defines the governed semantics for `source_descriptor` in KFM.
+## 1. Purpose
+`source_descriptor` captures the governed admission profile for a source before its records can influence downstream claims. It answers whether KFM may ingest and cite the source under stated rights, sensitivity, and access posture constraints. It is not a runtime answer object and it does not prove claim truth by itself.
 
-## Fields
-- See schema properties; each field carries provenance-safe, policy-evaluable meaning.
+## 2. Lifecycle role
+This object is authored at RAW intake planning and used during RAW → WORK / QUARANTINE admission checks. It is validated before promotion into PROCESSED evidence assembly, then referenced indirectly through source records in CATALOG / TRIPLET and PUBLISHED outputs. Superseding a source descriptor requires a newer descriptor that re-evaluates rights/sensitivity rather than skipping lifecycle stages.
 
-## Invariants
-- Required fields must exist.
-- Enumerated values remain finite where specified.
-- No undeclared fields unless explicitly allowed.
+## 3. Fields
+| field | type | required | meaning | examples or enum | policy/sensitivity notes |
+|---|---|---|---|---|---|
+| `id` | string | yes | Stable source descriptor identifier used by admission and audit paths. | `usgs_water_data` | Used as a join key for policy decisions and source registry lookups. |
+| `domain` | string | yes | Domain lane where this source is intended to operate. | `hydrology` | Domain-specific policy gates may differ by lane. |
+| `role` | string | yes | Declares evidentiary role expected from the source. | enum: `primary`, `corroborating`, `context`, `restricted` | Restrictive roles can trigger stricter promotion checks. |
+| `authority` | string | yes | Human-readable authority statement naming publisher or steward. | `USGS Water Data` | Used during review when weighing source trust posture. |
+| `rights` | object | yes | Rights bundle governing license and attribution obligations. | object with `license`, `attribution_required` | Rights obligations can force deny/restrict when incompatible with target publication surface. |
+| `sensitivity_floor` | string | yes | Minimum allowed sensitivity level for this source's admitted use. | enum: `public`, `generalized`, `restricted`, `quarantine` | Policy-evaluable floor; a source admitted at one floor MUST NOT be silently re-admitted at a lower floor (PROPOSED enforcement in policy/source). |
+| `update_cadence` | string | yes | Expected refresh rhythm used for stale and review timing. | `daily`, `monthly`, `irregular` | Impacts freshness policy expectations. |
+| `access_posture` | string | yes | Access mode required to retrieve the source. | enum: `open`, `credentialed`, `restricted`, `closed` | Policy-evaluable posture for capability/access gates; downgrades require explicit review (ADR-0017). |
+| `citation_template` | string | yes | Canonical citation pattern for downstream evidence/citation rendering. | `USGS Water Data ({retrieval_date})` | Missing/weak templates can block publishability when citation duties cannot be met. |
 
-## Lifecycle
-- Created in RAW/WORK processing.
-- Validated before promotion decisions.
-- Released through governed interfaces.
-- Superseded by newer versioned records.
+## 4. Invariants
+- Required fields `id`, `domain`, `role`, `authority`, `rights`, `sensitivity_floor`, `update_cadence`, `access_posture`, and `citation_template` must be present (enforced by schema `required` — CONFIRMED).
+- `role` must be one of `primary | corroborating | context | restricted` (enforced by schema `enum` — CONFIRMED).
+- `sensitivity_floor` must be one of `public | generalized | restricted | quarantine` (enforced by schema `enum` — CONFIRMED).
+- `access_posture` must be one of `open | credentialed | restricted | closed` (enforced by schema `enum` — CONFIRMED).
+- `rights` must contain `license` and `attribution_required` and disallow undeclared members (enforced by nested schema object — CONFIRMED).
+- PROPOSED: source re-admission MUST NOT lower `sensitivity_floor` without explicit policy review and receipt linkage.
+  - NEEDS VERIFICATION: enforce in `policy/source/` and/or a dedicated validator beyond `validate_source_descriptor.py`.
 
-## Related contracts
-- Neighbor contracts in the same family and runtime policy decisions.
+## 5. Cross-references
+- Sibling contracts: `contracts/source/ingest_receipt.md`.
+- Schema file: `schemas/contracts/v1/source/source_descriptor.schema.json`.
+- Governing ADRs: `docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md`, `docs/adr/ADR-0002-contracts-vs-schemas-split.md`, `docs/adr/ADR-0017-source-descriptor-admission-process.md`.
+- Policy paths: `policy/source/` (PROPOSED — policy lane currently scaffold-level).
+- Validator: `tools/validators/validate_source_descriptor.py` (CONFIRMED — wired in `tools/validators/_common/run_all.py`).
 
-## Open questions
-- NEEDS VERIFICATION: additional domain-specific constraints may be added in follow-up PRs.
+## 6. Status
+- Doc status: PROPOSED until reviewed and merged.
+- Schema status: PROPOSED (from schema `x-kfm.status` — CONFIRMED).
+- NEEDS VERIFICATION: confirm which `policy/source/` rego package enforces sensitivity-floor downgrade blocking.
+- OPEN: whether `update_cadence` should be constrained to a controlled enum in a follow-up schema revision.

--- a/docs/registers/VERIFICATION_BACKLOG.md
+++ b/docs/registers/VERIFICATION_BACKLOG.md
@@ -4,3 +4,5 @@ Indexes the corresponding `control_plane/*.yaml` register.
 - 2026-05-09: NEEDS VERIFICATION: domain-specific evidence_bundle duplicates should be migrated to $ref in follow-up PR.
 - 2026-05-09: CONFIRMED PR-001 closes the local-resolver gap. Open: domain-specific schemas not yet on `$ref` form remain candidates for follow-up; runtime/UI/policy slices still UNKNOWN.
 
+
+- 2026-05-09 — OPEN: Release manifest schema is intentionally permissive in PR-001; fields for signed manifests, layer manifests, and rollback linkage are PROPOSED for ADR-0023 follow-up.


### PR DESCRIPTION
### Motivation
- CONFIRMED: Replace auto-generated placeholder prose for the six core contract families with substantive, schema-grounded semantic documentation so the machine-checkable schemas from PR-001 have corresponding human-checkable meaning.
- CONFIRMED: Keep scope strictly to `contracts/` plus the minimal `contracts/release/README.md` and a mirrored verification backlog entry; no schemas, validators, policies, fixtures, apps, pipelines, connectors, runtime, or release artifacts were edited.
- PROPOSED: Surface a small set of governance open questions (marked NEEDS VERIFICATION) rather than changing schema/validation behavior in this PR.

### Description
- CONFIRMED: Rewrote six contract docs to the required contract structure (`Purpose`, `Lifecycle role`, full `Fields` table matching schema `properties`, `Invariants`, `Cross-references`, `Status`) for `source_descriptor`, `evidence_ref`, `evidence_bundle`, `policy_decision`, `runtime_response_envelope`, and `release_manifest` and preserved exact schema field names and `required` designations.
- CONFIRMED: Annotated validator wiring where present (`validate_source_descriptor.py`, `validate_evidence_bundle.py`, `validate_runtime_response_envelope.py` noted as wired) and marked validators as PROPOSED where not wired; added family-specific semantics required by the project guidance (e.g., `sensitivity_floor`/`access_posture` policy-evaluable notes, `bundle_ref` pre/post-closure meaning, `evidence_bundle` as closure artifact, runtime state fields explanation, and release_manifest thin-schema note).
- CONFIRMED: Brought `contracts/release/README.md` to the §15 minimum (purpose, scope, authority, naming, lifecycle, review burden, related folders, ADRs, last reviewed) and appended an OPEN/VERIFICATION entry into `docs/registers/VERIFICATION_BACKLOG.md` about the permissive `release_manifest` schema.
- CONFIRMED: Added explicit PROPOSED / NEEDS VERIFICATION items per file for follow-up work (resolver integrity, policy enforcement points, controlled vocabularies, ADR sealing remains deferred).

### Testing
- Ran `make schemas` — FAIL: environment dependency missing (`ModuleNotFoundError: No module named 'jsonschema'`), so schema/validator-run verification is blocked in this environment (NEEDS VERIFICATION).
- Ran `make test` — FAIL: same dependency error during `pytest` collection (NEEDS VERIFICATION).
- Ran repository checks: `git diff --stat` shows changes only under allowed paths and the out-of-scope guard produced no output, confirming scope is clean (CONFIRMED).
- Manual review: every `Fields` table was checked against the corresponding schema `properties` and `required` arrays and enum values were cited verbatim (CONFIRMED).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff92a9d4b8832a9db1abd174a38dbd)