### PR TITLE
Add doctrine_artifact_descriptor schema, registry entry, policy and checks for required doctrine artifacts

### DIFF
--- a/contracts/source/doctrine_artifact_descriptor.md
+++ b/contracts/source/doctrine_artifact_descriptor.md
@@ -1,0 +1,6 @@
+# doctrine_artifact_descriptor
+
+Status: PROPOSED
+Schema: https://schemas.kfm.local/contracts/v1/source/doctrine_artifact_descriptor.schema.json
+
+Defines admission metadata for required KFM doctrine artifacts (filename, integrity hash, provenance, authority, and review sign-off).

--- a/control_plane/document_registry.yaml
+++ b/control_plane/document_registry.yaml
@@ -1,3 +1,8 @@
 # Document registry
 # Lists every authoritative doc, its authority level, owner, status.
-entries: []
+entries:
+  - doc_id: kfm://doc/doctrine/required-artifact-index
+    kind: doctrine_required_artifact_index
+    path: control_plane/document_registry_doctrine_required.yaml
+    authority: CONFIRMED
+    status: active

--- a/control_plane/document_registry_doctrine_required.yaml
+++ b/control_plane/document_registry_doctrine_required.yaml
@@ -1,0 +1,10 @@
+required_doctrine_artifacts:
+  - filename: KFM_Pass_18_Idea_Index_Category_Atlas_and_Expansion_Dossier.pdf
+    doc_id: kfm://doc/doctrine/pass-18-idea-index-category-atlas-expansion-dossier
+    status: missing
+  - filename: Master_MapLibre_Components-Functions-Features.pdf
+    doc_id: kfm://doc/doctrine/master-maplibre-components-functions-features
+    status: missing
+  - filename: Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf
+    doc_id: kfm://doc/doctrine/definitive-greenfield-building-plan-v1-1
+    status: missing

--- a/data/receipts/validation/doctrine_artifact_check/README.md
+++ b/data/receipts/validation/doctrine_artifact_check/README.md
@@ -1,0 +1,3 @@
+# doctrine artifact check receipts
+
+Holds machine-readable outputs from `scripts/maintenance/check_required_doctrine_artifacts.py`.

--- a/docs/registers/DRIFT_REGISTER.md
+++ b/docs/registers/DRIFT_REGISTER.md
@@ -3,3 +3,5 @@
 - 2026-05-09: NEEDS VERIFICATION PR-001 `$id` URL-to-file-path inspection found zero mismatches under `schemas/contracts/v1/**/*.schema.json`.
 
 - 2026-05-12: CONFIRMED blocking drift: required doctrine artifacts for evidence-first comparison are not present in mounted repo snapshot (`KFM_Pass_18_Idea_Index_Category_Atlas_and_Expansion_Dossier.pdf`, `Master_MapLibre_Components-Functions-Features.pdf`, `Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf`); impact: doctrine-vs-implementation gap analysis cannot be completed from primary sources; resolution path: add canonical artifacts (or approved canonical links with provenance) and re-run extraction.
+
+- 2026-05-12: CONFIRMED remediation staged: added governance gate scaffolding for required doctrine artifacts (`control_plane/document_registry_doctrine_required.yaml`, `policy/source/doctrine_artifact_required.rego`, schema+fixtures+tests+validator script). Blocking status remains until artifacts themselves are admitted.

--- a/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_1.expected_error.txt
+++ b/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_1.expected_error.txt
@@ -1,0 +1,1 @@
+64 hex chars

--- a/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_1.json
+++ b/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_1.json
@@ -1,0 +1,9 @@
+{
+  "doc_id": "kfm://doc/doctrine/missing-hash",
+  "filename": "Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf",
+  "sha256": "123",
+  "provenance": "repo://docs/doctrine/artifacts/Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf",
+  "authority_status": "CONFIRMED",
+  "admitted_at": "not-a-date",
+  "steward_signoff_ref": "review://docs-steward/2026-05-12/002"
+}

--- a/fixtures/contracts/v1/source/doctrine_artifact_descriptor/valid/valid_1.json
+++ b/fixtures/contracts/v1/source/doctrine_artifact_descriptor/valid/valid_1.json
@@ -1,0 +1,9 @@
+{
+  "doc_id": "kfm://doc/doctrine/master-maplibre-components-functions-features",
+  "filename": "Master_MapLibre_Components-Functions-Features.pdf",
+  "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "provenance": "repo://docs/doctrine/artifacts/Master_MapLibre_Components-Functions-Features.pdf",
+  "authority_status": "NEEDS_VERIFICATION",
+  "admitted_at": "2026-05-12T00:00:00Z",
+  "steward_signoff_ref": "review://docs-steward/2026-05-12/001"
+}

--- a/policy/source/doctrine_artifact_required.rego
+++ b/policy/source/doctrine_artifact_required.rego
@@ -1,0 +1,15 @@
+package kfm.doctrine_artifact_required
+
+default deny := []
+
+required := {
+  "KFM_Pass_18_Idea_Index_Category_Atlas_and_Expansion_Dossier.pdf",
+  "Master_MapLibre_Components-Functions-Features.pdf",
+  "Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf"
+}
+
+deny contains reason if {
+  some f in required
+  not input.present[f]
+  reason := sprintf("missing_required_doctrine_artifact:%s", [f])
+}

--- a/schemas/contracts/v1/source/doctrine_artifact_descriptor.schema.json
+++ b/schemas/contracts/v1/source/doctrine_artifact_descriptor.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.kfm.local/contracts/v1/source/doctrine_artifact_descriptor.schema.json",
+  "title": "doctrine_artifact_descriptor",
+  "type": "object",
+  "x-kfm": {
+    "contract_doc": "contracts/source/doctrine_artifact_descriptor.md",
+    "status": "PROPOSED"
+  },
+  "properties": {
+    "doc_id": {"type": "string"},
+    "filename": {"type": "string"},
+    "sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+    "provenance": {"type": "string"},
+    "authority_status": {"type": "string", "enum": ["CONFIRMED", "NEEDS_VERIFICATION", "PROPOSED"]},
+    "admitted_at": {"type": "string", "format": "date-time"},
+    "steward_signoff_ref": {"type": "string"}
+  },
+  "required": ["doc_id", "filename", "sha256", "provenance", "authority_status", "admitted_at", "steward_signoff_ref"],
+  "additionalProperties": false
+}

--- a/scripts/maintenance/check_required_doctrine_artifacts.py
+++ b/scripts/maintenance/check_required_doctrine_artifacts.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[2]
+reg_text = (root / "control_plane" / "document_registry_doctrine_required.yaml").read_text(encoding="utf-8")
+required = [line.split(":",1)[1].strip() for line in reg_text.splitlines() if "filename:" in line]
+artifacts_dir = root / "docs" / "doctrine" / "artifacts"
+missing = [f for f in required if not (artifacts_dir / f).exists()]
+
+if missing:
+    print("MISSING")
+    for m in missing:
+        print(m)
+    raise SystemExit(1)
+print("OK")

--- a/tests/policy/test_doctrine_artifact_required.py
+++ b/tests/policy/test_doctrine_artifact_required.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REQUIRED = {
+    "KFM_Pass_18_Idea_Index_Category_Atlas_and_Expansion_Dossier.pdf",
+    "Master_MapLibre_Components-Functions-Features.pdf",
+    "Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf",
+}
+
+def test_required_doctrine_filenames_declared_in_registry():
+    text = (ROOT / "control_plane" / "document_registry_doctrine_required.yaml").read_text(encoding="utf-8")
+    files = {
+        line.split(":", 1)[1].strip()
+        for line in text.splitlines()
+        if "filename:" in line
+    }
+    assert REQUIRED.issubset(files)


### PR DESCRIPTION
### Motivation

- Introduce a typed contract to describe required doctrine artifact admission metadata so artifacts can be validated and referenced programmatically.
- Surface a blocking drift where canonical doctrine PDFs are not present in the mounted repo snapshot so evidence-first comparisons can be completed.
- Provide governance tooling to detect and gate admission of those artifacts until canonical files or approved provenance links are added.

### Description

- Add the `doctrine_artifact_descriptor` contract and JSON Schema at `contracts/source/doctrine_artifact_descriptor.md` and `schemas/contracts/v1/source/doctrine_artifact_descriptor.schema.json` describing filename, `sha256`, provenance, authority and sign-off fields.
- Register a required-documents entry in `control_plane/document_registry.yaml` and add `control_plane/document_registry_doctrine_required.yaml` listing the three required doctrine filenames and their `doc_id`/status.
- Add a Rego policy `policy/source/doctrine_artifact_required.rego` that denies when any required filename is not present in the input, plus fixtures under `fixtures/contracts/v1/source/doctrine_artifact_descriptor/` for valid and invalid examples.
- Add operational checks and test support including `scripts/maintenance/check_required_doctrine_artifacts.py`, a unit test `tests/policy/test_doctrine_artifact_required.py`, a receipts README at `data/receipts/validation/doctrine_artifact_check/README.md`, and update `docs/registers/DRIFT_REGISTER.md` to record the drift and remediation status.

### Testing

- Ran `pytest tests/policy/test_doctrine_artifact_required.py` and the unit test passed.
- Ran `scripts/maintenance/check_required_doctrine_artifacts.py`, which printed the missing artifact filenames and exited non-zero as expected for the current repository snapshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037ee5c1f4832abcdb300780a35d56)