### PR TITLE
Add promotion_decision contract, fixtures, validator, hydrology promote stub, and CI wiring

### DIFF
--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: 'echo TODO promotion-prerequisites'
+      - run: python tools/validators/release/validate_promotion_decision.py --fixtures
   review-records-present:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: 'echo TODO review-records-present'
+      - run: python pipelines/domains/hydrology/promote.py

--- a/contracts/release/promotion_decision.md
+++ b/contracts/release/promotion_decision.md
@@ -2,26 +2,28 @@
 
 **Family:** `release`
 **Schema:** `schemas/contracts/v1/release/promotion_decision.schema.json`
-**Status:** PROPOSED (greenfield scaffold)
+**Status:** PROPOSED
 
 ## Meaning
-What this object means in the KFM trust model. Define the semantic role:
-what claim does it support, what audience consumes it, what does it
-*not* assert.
+A `promotion_decision` records a governed transition decision for a specific domain run.
+The decision must cite evidence, the policy bundle used, and an explicit rollback target.
 
 ## Fields
-Field-by-field semantics live here. Schema enforces shape; this
-document enforces meaning.
+- `id`: deterministic decision id.
+- `domain`: lane being promoted (e.g., `hydrology`).
+- `run_id`: pipeline execution id being evaluated.
+- `decision`: one of `APPROVE`, `DENY`, `ABSTAIN`.
+- `evidence_ref` and `evidence_bundle_uri`: citation closure.
+- `rollback_card_uri`: rollback target for the promoted unit.
+- `review`: reviewer and ticket binding for auditable oversight.
 
 ## Invariants
-Cross-field rules, lifecycle rules, references that must resolve.
+- Promotion is a state transition decision, not a file move.
+- `decision=APPROVE` requires non-empty evidence and rollback references.
+- Review metadata is mandatory.
 
 ## Lifecycle
-Where this object is created, transformed, validated, released,
-superseded, and rolled back.
+Created by promotion gate evaluation, validated by schema+policy tests, and stored under `release/promotion_decisions/<domain>/`.
 
 ## Related contracts
-Upstream dependencies and downstream consumers.
-
-## Open questions
-Anything still UNKNOWN or NEEDS VERIFICATION.
+`release_manifest`, `rollback_card`, domain evidence bundle contracts.

--- a/fixtures/release/promotion_decision/invalid/hydrology_missing_evidence_ref.json
+++ b/fixtures/release/promotion_decision/invalid/hydrology_missing_evidence_ref.json
@@ -1,0 +1,15 @@
+{
+  "id": "promo:hydrology:run-2026-05-12T00-00-00Z",
+  "version": "v1",
+  "domain": "hydrology",
+  "run_id": "run-2026-05-12T00-00-00Z",
+  "decision": "APPROVE",
+  "evidence_bundle_uri": "data/proofs/hydrology/run-2026-05-12T00-00-00Z.promotion_proof.json",
+  "rollback_card_uri": "release/rollback_cards/hydrology/run-2026-05-12T00-00-00Z.md",
+  "policy_bundle": "policy/promotion/hydrology@v1",
+  "decided_at": "2026-05-12T00:00:00Z",
+  "review": {
+    "reviewer": "release-steward",
+    "ticket": "REL-123"
+  }
+}

--- a/fixtures/release/promotion_decision/valid/hydrology_valid_1.json
+++ b/fixtures/release/promotion_decision/valid/hydrology_valid_1.json
@@ -1,0 +1,16 @@
+{
+  "id": "promo:hydrology:run-2026-05-12T00-00-00Z",
+  "version": "v1",
+  "domain": "hydrology",
+  "run_id": "run-2026-05-12T00-00-00Z",
+  "decision": "APPROVE",
+  "evidence_ref": "evidence:hydrology:bundle:2026-05-12",
+  "evidence_bundle_uri": "data/proofs/hydrology/run-2026-05-12T00-00-00Z.promotion_proof.json",
+  "rollback_card_uri": "release/rollback_cards/hydrology/run-2026-05-12T00-00-00Z.md",
+  "policy_bundle": "policy/promotion/hydrology@v1",
+  "decided_at": "2026-05-12T00:00:00Z",
+  "review": {
+    "reviewer": "release-steward",
+    "ticket": "REL-123"
+  }
+}

--- a/pipelines/domains/hydrology/README.md
+++ b/pipelines/domains/hydrology/README.md
@@ -29,3 +29,8 @@ See parallel domain folders under docs/, contracts/, schemas/, policy/, tests/, 
 
 ## Status
 PROPOSED (greenfield scaffold)
+
+
+## Promotion gate slice
+- `promote.py` emits a hydrology promotion decision stub to `release/promotion_decisions/hydrology/`.
+- Validate fixtures with `python tools/validators/release/validate_promotion_decision.py --fixtures`.

--- a/pipelines/domains/hydrology/promote.py
+++ b/pipelines/domains/hydrology/promote.py
@@ -1,0 +1,34 @@
+"""Hydrology promotion gate stub.
+
+Creates minimal governed artifacts for a promotion decision run.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def emit_stub(run_id: str) -> None:
+    root = Path(__file__).resolve().parents[3]
+    decided_at = datetime.now(timezone.utc).isoformat()
+    decision = {
+        "id": f"promo:hydrology:{run_id}",
+        "version": "v1",
+        "domain": "hydrology",
+        "run_id": run_id,
+        "decision": "APPROVE",
+        "evidence_ref": f"evidence:hydrology:bundle:{run_id}",
+        "evidence_bundle_uri": f"data/proofs/hydrology/{run_id}.promotion_proof.json",
+        "rollback_card_uri": f"release/rollback_cards/hydrology/{run_id}.md",
+        "policy_bundle": "policy/promotion/hydrology@v1",
+        "decided_at": decided_at,
+        "review": {"reviewer": "automation-smoke", "ticket": "REL-SMOKE"},
+    }
+    out = root / "release" / "promotion_decisions" / "hydrology" / f"{run_id}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(decision, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    emit_stub("run-local-smoke")

--- a/release/promotion_decisions/hydrology/run-local-smoke.json
+++ b/release/promotion_decisions/hydrology/run-local-smoke.json
@@ -1,0 +1,16 @@
+{
+  "id": "promo:hydrology:run-local-smoke",
+  "version": "v1",
+  "domain": "hydrology",
+  "run_id": "run-local-smoke",
+  "decision": "APPROVE",
+  "evidence_ref": "evidence:hydrology:bundle:run-local-smoke",
+  "evidence_bundle_uri": "data/proofs/hydrology/run-local-smoke.promotion_proof.json",
+  "rollback_card_uri": "release/rollback_cards/hydrology/run-local-smoke.md",
+  "policy_bundle": "policy/promotion/hydrology@v1",
+  "decided_at": "2026-05-12T19:43:24.530590+00:00",
+  "review": {
+    "reviewer": "automation-smoke",
+    "ticket": "REL-SMOKE"
+  }
+}

--- a/schemas/contracts/v1/release/promotion_decision.schema.json
+++ b/schemas/contracts/v1/release/promotion_decision.schema.json
@@ -3,30 +3,47 @@
   "$id": "https://schemas.kfm.local/contracts/v1/release/promotion_decision.schema.json",
   "title": "promotion_decision",
   "type": "object",
-  "description": "KFM v1 contract schema stub for promotion_decision. Greenfield placeholder; fields to be defined per the contract document and ADR.",
+  "description": "Governed promotion decision for moving a domain run from candidate to published readiness.",
   "x-kfm": {
     "contract_doc": "contracts/release/promotion_decision.md",
     "fixtures_root": "fixtures/release/promotion_decision/",
     "validator": "tools/validators/release/validate_promotion_decision.py",
-    "policy": "policy/release/",
+    "policy": "policy/promotion/",
     "status": "PROPOSED"
   },
   "properties": {
-    "spec_hash": {
-      "type": "string",
-      "description": "Deterministic content hash."
-    },
-    "id": {
-      "type": "string",
-      "description": "Canonical identifier."
-    },
-    "version": {
-      "type": "string",
-      "description": "Contract or object version."
+    "id": {"type": "string", "minLength": 1},
+    "version": {"type": "string", "const": "v1"},
+    "domain": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "decision": {"type": "string", "enum": ["APPROVE", "DENY", "ABSTAIN"]},
+    "evidence_ref": {"type": "string", "minLength": 1},
+    "evidence_bundle_uri": {"type": "string", "minLength": 1},
+    "rollback_card_uri": {"type": "string", "minLength": 1},
+    "policy_bundle": {"type": "string", "minLength": 1},
+    "decided_at": {"type": "string", "format": "date-time"},
+    "review": {
+      "type": "object",
+      "properties": {
+        "reviewer": {"type": "string", "minLength": 1},
+        "ticket": {"type": "string", "minLength": 1}
+      },
+      "required": ["reviewer", "ticket"],
+      "additionalProperties": false
     }
   },
   "required": [
-    "id"
+    "id", "version", "domain", "run_id", "decision", "evidence_ref", "evidence_bundle_uri", "rollback_card_uri", "policy_bundle", "decided_at", "review"
   ],
-  "additionalProperties": true
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {"properties": {"domain": {"const": "hydrology"}}},
+      "then": {
+        "properties": {
+          "id": {"pattern": "^promo:hydrology:[A-Za-z0-9._:-]+$"}
+        }
+      }
+    }
+  ]
 }

--- a/tests/release/test_promotion_decision_schema.py
+++ b/tests/release/test_promotion_decision_schema.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_promotion_decision_fixtures_validate():
+    cmd = [sys.executable, str(ROOT / "tools/validators/release/validate_promotion_decision.py"), "--fixtures"]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0, res.stdout + res.stderr

--- a/tools/validators/release/validate_promotion_decision.py
+++ b/tools/validators/release/validate_promotion_decision.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.validators._common.jsonschema_runner import run
+
+SCHEMA = ROOT / "schemas/contracts/v1/release/promotion_decision.schema.json"
+FIXTURES = ROOT / "fixtures/release/promotion_decision"
+
+if __name__ == "__main__":
+    raise SystemExit(run(SCHEMA, FIXTURES, sys.argv[1:]))


### PR DESCRIPTION
### Motivation
- Define and enforce a governed `promotion_decision` contract for promoting domain runs and provide tooling to validate real and fixture decisions.
- Provide a minimal hydrology promotion gate workflow and artifacts to allow automated smoke runs and CI validation.

### Description
- Introduce a JSON Schema `schemas/contracts/v1/release/promotion_decision.schema.json` with required fields, strict properties, and a domain-specific `id` pattern for `hydrology`.
- Add the contract doc `contracts/release/promotion_decision.md` with semantics, invariants, lifecycle, and related contracts documentation.
- Add fixtures: a valid example `fixtures/release/promotion_decision/valid/hydrology_valid_1.json` and an invalid example `fixtures/release/promotion_decision/invalid/hydrology_missing_evidence_ref.json` to exercise the validator.
- Add a validator script `tools/validators/release/validate_promotion_decision.py` and a test `tests/release/test_promotion_decision_schema.py` that runs the validator against fixtures.
- Add a hydrology promotion stub `pipelines/domains/hydrology/promote.py`, update the hydrology README with promotion gate notes, emit a smoke artifact `release/promotion_decisions/hydrology/run-local-smoke.json`, and wire the validator and promote steps into the GitHub Actions workflow `.github/workflows/promotion-gate.yml`.

### Testing
- Ran the validator directly with `python tools/validators/release/validate_promotion_decision.py --fixtures`, which returned success against the provided fixtures.
- Executed the new test with `python -m pytest tests/release/test_promotion_decision_schema.py`, and it passed (validator exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03814c4514832aaa4c67a9d23685e2)