### PR TITLE
Add doctrine artifact validation, fixtures, tests, and CI gate jobs

### DIFF
--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -8,12 +8,27 @@ on:
     branches: [main]
 
 jobs:
+  doctrine-artifact-prereq:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: python scripts/maintenance/check_required_doctrine_artifacts.py
+
+  doctrine-artifact-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: python tools/validators/source/validate_doctrine_artifact_descriptor.py --fixtures
+
   promotion-prerequisites:
+    needs: [doctrine-artifact-prereq, doctrine-artifact-schema]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - run: python tools/validators/release/validate_promotion_decision.py --fixtures
+
   review-records-present:
+    needs: [promotion-prerequisites]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/data/receipts/validation/doctrine_artifact_check/README.md
+++ b/data/receipts/validation/doctrine_artifact_check/README.md
@@ -1,3 +1,6 @@
-# doctrine artifact check receipts
+# doctrine_artifact_check receipts
 
-Holds machine-readable outputs from `scripts/maintenance/check_required_doctrine_artifacts.py`.
+This folder stores local and CI smoke receipts for the doctrine artifact admission prerequisite gate.
+
+- `run-local-smoke.json` captures the expected fail-closed result while required doctrine PDFs are still missing.
+- Downstream CI runs can emit additional receipts keyed by workflow run id.

--- a/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_2.expected_error.txt
+++ b/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_2.expected_error.txt
@@ -1,0 +1,2 @@
+- 'sha256' must match ^[a-fA-F0-9]{64}$
+- required property 'steward_signoff_ref' missing

--- a/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_2.json
+++ b/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_2.json
@@ -1,0 +1,8 @@
+{
+  "doc_id": "kfm://doc/doctrine/definitive-greenfield-building-plan-v1-1",
+  "filename": "Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf",
+  "sha256": "1234",
+  "provenance": "manual-curation",
+  "authority_status": "CONFIRMED",
+  "admitted_at": "2026-05-12T00:00:00Z"
+}

--- a/fixtures/contracts/v1/source/doctrine_artifact_descriptor/valid/valid_2.json
+++ b/fixtures/contracts/v1/source/doctrine_artifact_descriptor/valid/valid_2.json
@@ -1,0 +1,9 @@
+{
+  "doc_id": "kfm://doc/doctrine/master-maplibre-components-functions-features",
+  "filename": "Master_MapLibre_Components-Functions-Features.pdf",
+  "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "provenance": "manual-curation",
+  "authority_status": "NEEDS_VERIFICATION",
+  "admitted_at": "2026-05-12T00:00:00Z",
+  "steward_signoff_ref": "review://steward/2026-05-12/maplibre"
+}

--- a/scripts/maintenance/check_required_doctrine_artifacts.py
+++ b/scripts/maintenance/check_required_doctrine_artifacts.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
 root = Path(__file__).resolve().parents[2]
 reg_text = (root / "control_plane" / "document_registry_doctrine_required.yaml").read_text(encoding="utf-8")
-required = [line.split(":",1)[1].strip() for line in reg_text.splitlines() if "filename:" in line]
+required = [line.split(":", 1)[1].strip() for line in reg_text.splitlines() if "filename:" in line]
 artifacts_dir = root / "docs" / "doctrine" / "artifacts"
 missing = [f for f in required if not (artifacts_dir / f).exists()]
 
+result = {
+    "check": "required_doctrine_artifacts",
+    "artifacts_dir": str(artifacts_dir.relative_to(root)),
+    "required_count": len(required),
+    "missing_count": len(missing),
+    "missing": missing,
+}
+
+print(json.dumps(result, indent=2, sort_keys=True))
 if missing:
-    print("MISSING")
-    for m in missing:
-        print(m)
     raise SystemExit(1)
-print("OK")

--- a/tests/policy/test_doctrine_artifact_required.py
+++ b/tests/policy/test_doctrine_artifact_required.py
@@ -1,17 +1,19 @@
+import subprocess
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-REQUIRED = {
-    "KFM_Pass_18_Idea_Index_Category_Atlas_and_Expansion_Dossier.pdf",
-    "Master_MapLibre_Components-Functions-Features.pdf",
-    "Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf",
-}
 
-def test_required_doctrine_filenames_declared_in_registry():
-    text = (ROOT / "control_plane" / "document_registry_doctrine_required.yaml").read_text(encoding="utf-8")
-    files = {
-        line.split(":", 1)[1].strip()
-        for line in text.splitlines()
-        if "filename:" in line
-    }
-    assert REQUIRED.issubset(files)
+
+def test_doctrine_artifact_policy_exists_and_is_non_empty():
+    policy_path = ROOT / "policy" / "source" / "doctrine_artifact_required.rego"
+    text = policy_path.read_text(encoding="utf-8")
+    assert "package" in text
+    assert "deny" in text
+
+
+def test_required_doctrine_artifact_check_fails_until_artifacts_admitted():
+    cmd = [sys.executable, str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py")]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 1
+    assert "missing_count" in res.stdout

--- a/tests/source/test_doctrine_artifact_descriptor_schema.py
+++ b/tests/source/test_doctrine_artifact_descriptor_schema.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_doctrine_artifact_descriptor_fixtures_validate():
+    cmd = [
+        sys.executable,
+        str(ROOT / "tools" / "validators" / "source" / "validate_doctrine_artifact_descriptor.py"),
+        "--fixtures",
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0, res.stdout + res.stderr

--- a/tools/validators/source/validate_doctrine_artifact_descriptor.py
+++ b/tools/validators/source/validate_doctrine_artifact_descriptor.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = ROOT / "schemas" / "contracts" / "v1" / "source" / "doctrine_artifact_descriptor.schema.json"
+FIXTURE_ROOT = ROOT / "fixtures" / "contracts" / "v1" / "source" / "doctrine_artifact_descriptor"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_fixtures() -> int:
+    schema = _load_json(SCHEMA_PATH)
+    validator = Draft202012Validator(schema)
+    failures: list[str] = []
+
+    for path in sorted((FIXTURE_ROOT / "valid").glob("*.json")):
+        errors = sorted(validator.iter_errors(_load_json(path)), key=lambda e: e.path)
+        if errors:
+            failures.append(f"valid fixture failed: {path}")
+
+    for path in sorted((FIXTURE_ROOT / "invalid").glob("*.json")):
+        if path.name.endswith(".expected_error.txt"):
+            continue
+        errors = sorted(validator.iter_errors(_load_json(path)), key=lambda e: e.path)
+        if not errors:
+            failures.append(f"invalid fixture unexpectedly passed: {path}")
+
+    if failures:
+        print("FAIL")
+        for failure in failures:
+            print(f" - {failure}")
+        return 1
+
+    print("OK doctrine_artifact_descriptor fixtures")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fixtures", action="store_true", help="Validate standard fixture set")
+    args = parser.parse_args()
+
+    if args.fixtures:
+        return run_fixtures()
+
+    print("No action selected. Use --fixtures.")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Ensure required doctrine artifact PDFs are present and admitted before promotion by adding an admission prerequisite and schema validation step.
- Provide machine-readable output for the artifact check so CI can emit receipts and make gating decisions.
- Add schema validation tooling and fixtures to catch format regressions in doctrine artifact descriptors.

### Description
- Added CI jobs to the promotion gate workflow in `/.github/workflows/promotion-gate.yml` including `doctrine-artifact-prereq` and `doctrine-artifact-schema`, and wired job dependencies so `promotion-prerequisites` waits for those checks.
- Enhanced `scripts/maintenance/check_required_doctrine_artifacts.py` to emit a JSON summary of the check and fail with a non-zero exit when artifacts are missing.
- Introduced a schema validator `tools/validators/source/validate_doctrine_artifact_descriptor.py` that validates fixtures under `fixtures/contracts/v1/source/doctrine_artifact_descriptor` and added corresponding valid/invalid fixture files and expected error text.
- Added and updated tests: `tests/policy/test_doctrine_artifact_required.py` now exercises the check script and policy file, and `tests/source/test_doctrine_artifact_descriptor_schema.py` runs the schema validator; also updated `data/receipts/validation/doctrine_artifact_check/README.md` to document receipts.

### Testing
- Executed the unit test suite with `pytest -q`, which ran the new tests including `tests/policy/test_doctrine_artifact_required.py` and `tests/source/test_doctrine_artifact_descriptor_schema.py`, and they passed.
- Ran the schema validator with `python tools/validators/source/validate_doctrine_artifact_descriptor.py --fixtures` and observed a successful validation run.
- Ran `python scripts/maintenance/check_required_doctrine_artifacts.py` to confirm it emits JSON output and returns non-zero when artifacts are missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038371bbc0832aae6d1b960aaf68f9)