### PR TITLE
Add initial next-move run log for governed sequencing

### DIFF
--- a/docs/adr/_next_move_log.md
+++ b/docs/adr/_next_move_log.md
@@ -1,0 +1,11 @@
+# Next Move Log
+
+Tracks consecutive runs of the governed “one next substantive move” prompt.
+
+### Run 2026-05-12 — Establish doctrine artifact descriptors and verifier checks
+- Status: proposed
+- PR: <to be filled on merge>
+- Doctrine basis: unavailable in mounted repo (`KFM_Pass_18_Idea_Index_Category_Atlas_and_Expansion_Dossier.pdf`, `Master_MapLibre_Components-Functions-Features.pdf`, `Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf`); fallback to drift signal in `docs/registers/DRIFT_REGISTER.md` row dated 2026-05-12
+- Slice shape: add canonical doctrine-artifact descriptor records and a validator test fixture so doctrine prerequisites are machine-checkable before future next-move runs
+- Deferred to future runs:
+  - Full doctrine-vs-implementation gap extraction after primary doctrine artifacts are present


### PR DESCRIPTION
### Motivation
- Provide a durable, inspectable run ledger for the governed "one next substantive move" workflow by recording the current run’s proposed move so future runs can reconcile landed/partial/abandoned work and avoid duplicate proposals.

### Description
- Add a new ADR-run ledger file at `docs/adr/_next_move_log.md` seeded with the 2026-05-12 run entry describing the doctrine-artifact-preflight proposal and the deferment of full doctrine extraction until the primary PDFs are available.

### Testing
- No automated tests were required or executed for this documentation-only change; a local repository scan confirmed the new file is present and the seeded entry references the existing drift register signal that motivated the entry. CI will exercise standard validators on merge as usual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038d8ff3f0832a89d4486622ed51bb)