### PR TITLE
Add Next Move Log ADR with entry contract and initial run note

### DIFF
--- a/docs/adr/_next_move_log.md
+++ b/docs/adr/_next_move_log.md
@@ -1,0 +1,23 @@
+# Next Move Log
+
+Purpose: durable sequence log for repeated "one next substantive move" runs.
+
+## Entry Contract
+Each run appends one block in this exact shape:
+
+### Run YYYY-MM-DD — <Move Title>
+- Status: proposed | landed | partially landed | abandoned
+- PR: <number-or-link-or-n/a>
+- Doctrine basis: <docs + locators>
+- Slice shape: <one sentence>
+- Deferred to future runs: <bullets or "none">
+
+## Entries
+
+### Run 2026-05-12 — Establish doctrine artifact descriptors and verifier checks
+- Status: proposed
+- PR: n/a
+- Doctrine basis: required doctrine artifacts were missing in mounted repo (`KFM_Pass_18_Idea_Index_Category_Atlas_and_Expansion_Dossier.pdf`, `Master_MapLibre_Components-Functions-Features.pdf`, `Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf`); corroborated by `docs/registers/DRIFT_REGISTER.md` (2026-05-12 entry)
+- Slice shape: define a canonical doctrine-artifact preflight gate (descriptors + validator checks) so future runs can verify prerequisites before doctrine extraction
+- Deferred to future runs:
+  - Full doctrine-vs-implementation gap extraction after primary doctrine artifacts are present


### PR DESCRIPTION
### Motivation
- Introduce a durable sequence log to record one-next-substantive-move runs and to establish a preflight doctrine-artifact gate after missing artifacts were detected.

### Description
- Add `docs/adr/_next_move_log.md` containing the entry contract template for runs and an initial `Run 2026-05-12` entry that proposes canonical doctrine-artifact descriptors and verifier checks.

### Testing
- No automated tests were added or executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038d8ff3f0832a89d4486622ed51bb)