### PR TITLE
Add next-move log entry: admit required doctrine artifacts and close prerequisite gate

### DIFF
--- a/docs/adr/_next_move_log.md
+++ b/docs/adr/_next_move_log.md
@@ -21,3 +21,12 @@ Each run appends one block in this exact shape:
 - Slice shape: define a canonical doctrine-artifact preflight gate (descriptors + validator checks) so future runs can verify prerequisites before doctrine extraction
 - Deferred to future runs:
   - Full doctrine-vs-implementation gap extraction after primary doctrine artifacts are present
+
+
+### Run 2026-05-12 — Admit canonical doctrine artifacts and close prerequisite gate
+- Status: proposed
+- PR: n/a
+- Doctrine basis: prerequisite doctrine artifacts are still absent while registry+policy gate is already staged; blocker remains explicit in `docs/registers/DRIFT_REGISTER.md`.
+- Slice shape: land the three required doctrine PDFs under canonical doctrine artifacts home with descriptor records, registry status updates, and passing prerequisite checks to unblock doctrine-vs-implementation extraction.
+- Deferred to future runs:
+  - Full doctrine expectation extraction and anti-circling candidate selection after artifact admission is CONFIRMED


### PR DESCRIPTION
### Motivation
- Record a concrete next substantive move to admit three required doctrine PDFs and close the prerequisite doctrine-artifact gate because the drift register and policy scaffolding show the artifacts are currently missing and block evidence-first doctrine extraction.

### Description
- Append a proposed run entry to `docs/adr/_next_move_log.md` titled "Admit canonical doctrine artifacts and close prerequisite gate" describing the slice (land three PDFs under canonical doctrine artifacts home, add descriptor records, update registry statuses, run the prerequisite checker/OPA policy, emit receipts) and listing deferred follow-ups (full doctrine extraction and anti-circling pass).

### Testing
- No automated tests were modified or executed because this is a documentation-only change; verification consisted of repository inspections and file updates using `rg`, `sed`, and `git` to confirm `docs/registers/DRIFT_REGISTER.md`, `control_plane/document_registry_doctrine_required.yaml`, and `policy/source/doctrine_artifact_required.rego` show the expected blocker and the new log entry, and a commit was created to persist the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03941cec08832aa9e48c4756265b6d)