### PR TITLE
Add doctrine artifact presence checks, renderer, and registry sync with tests

### DIFF
--- a/docs/adr/_next_move_log.md
+++ b/docs/adr/_next_move_log.md
@@ -21,3 +21,12 @@ Each run appends one block in this exact shape:
 - Slice shape: define a canonical doctrine-artifact preflight gate (descriptors + validator checks) so future runs can verify prerequisites before doctrine extraction
 - Deferred to future runs:
   - Full doctrine-vs-implementation gap extraction after primary doctrine artifacts are present
+
+
+### Run 2026-05-12 — Admit canonical doctrine artifacts and close prerequisite gate
+- Status: proposed
+- PR: n/a
+- Doctrine basis: prerequisite doctrine artifacts are still absent while registry+policy gate is already staged; blocker remains explicit in `docs/registers/DRIFT_REGISTER.md`.
+- Slice shape: land the three required doctrine PDFs under canonical doctrine artifacts home with descriptor records, registry status updates, and passing prerequisite checks to unblock doctrine-vs-implementation extraction.
+- Deferred to future runs:
+  - Full doctrine expectation extraction and anti-circling candidate selection after artifact admission is CONFIRMED

--- a/scripts/maintenance/check_required_doctrine_artifacts.py
+++ b/scripts/maintenance/check_required_doctrine_artifacts.py
@@ -6,18 +6,34 @@ import json
 from pathlib import Path
 
 
-def _extract_required_filenames(registry_text: str) -> list[str]:
-    return [
-        line.split(":", 1)[1].strip()
-        for line in registry_text.splitlines()
-        if line.strip().startswith("- filename:")
-    ]
+def _extract_required_entries(registry_text: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for raw in registry_text.splitlines():
+        line = raw.strip()
+        if line.startswith("- filename:"):
+            if current:
+                entries.append(current)
+            current = {"filename": line.split(":", 1)[1].strip()}
+        elif line.startswith("status:") and current is not None:
+            current["status"] = line.split(":", 1)[1].strip()
+    if current:
+        entries.append(current)
+    return entries
 
 
 def run(registry_path: Path, artifacts_dir: Path, output_path: Path | None = None) -> int:
     reg_text = registry_path.read_text(encoding="utf-8")
-    required = _extract_required_filenames(reg_text)
-    missing = [f for f in required if not (artifacts_dir / f).exists()]
+    entries = _extract_required_entries(reg_text)
+    required = [entry["filename"] for entry in entries]
+    expected_status = {entry["filename"]: entry.get("status", "unknown") for entry in entries}
+    present = {f: (artifacts_dir / f).exists() for f in required}
+    missing = [f for f, ok in present.items() if not ok]
+    status_mismatches = [
+        f
+        for f in required
+        if (expected_status[f] == "missing" and present[f]) or (expected_status[f] == "present" and not present[f])
+    ]
 
     result = {
         "check": "required_doctrine_artifacts",
@@ -26,7 +42,9 @@ def run(registry_path: Path, artifacts_dir: Path, output_path: Path | None = Non
         "required_count": len(required),
         "missing_count": len(missing),
         "missing": missing,
-        "result": "pass" if not missing else "fail",
+        "present": present,
+        "status_mismatches": status_mismatches,
+        "result": "pass" if not missing and not status_mismatches else "fail",
     }
 
     payload = json.dumps(result, indent=2, sort_keys=True)
@@ -36,7 +54,7 @@ def run(registry_path: Path, artifacts_dir: Path, output_path: Path | None = Non
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(payload + "\n", encoding="utf-8")
 
-    return 0 if not missing else 1
+    return 0 if not missing and not status_mismatches else 1
 
 
 def main() -> int:

--- a/scripts/maintenance/render_doctrine_presence_input.py
+++ b/scripts/maintenance/render_doctrine_presence_input.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("receipt", type=Path, help="JSON output from check_required_doctrine_artifacts.py")
+    args = parser.parse_args()
+
+    payload = json.loads(args.receipt.read_text(encoding="utf-8"))
+    present = payload.get("present")
+    if not isinstance(present, dict):
+        raise SystemExit("receipt missing 'present' map")
+
+    print(json.dumps({"present": present}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/sync_doctrine_artifact_registry_status.py
+++ b/scripts/maintenance/sync_doctrine_artifact_registry_status.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def sync(registry: Path, artifacts_dir: Path, output: Path | None = None) -> int:
+    lines = registry.read_text(encoding="utf-8").splitlines()
+    updated: list[str] = []
+    current_filename: str | None = None
+    changes: list[dict[str, str]] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("- filename:"):
+            current_filename = stripped.split(":", 1)[1].strip()
+            updated.append(line)
+            continue
+        if stripped.startswith("status:") and current_filename is not None:
+            indent = line[: len(line) - len(line.lstrip())]
+            desired = "present" if (artifacts_dir / current_filename).exists() else "missing"
+            old = stripped.split(":", 1)[1].strip()
+            if old != desired:
+                changes.append({"filename": current_filename, "from": old, "to": desired})
+            updated.append(f"{indent}status: {desired}")
+            continue
+        updated.append(line)
+
+    registry.write_text("\n".join(updated) + "\n", encoding="utf-8")
+
+    payload = {
+        "check": "sync_doctrine_artifact_registry_status",
+        "registry": str(registry),
+        "artifacts_dir": str(artifacts_dir),
+        "changes": changes,
+        "changed_count": len(changes),
+    }
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    print(rendered)
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered + "\n", encoding="utf-8")
+    return 0
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", type=Path, default=root / "control_plane" / "document_registry_doctrine_required.yaml")
+    parser.add_argument("--artifacts-dir", type=Path, default=root / "docs" / "doctrine" / "artifacts")
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+    return sync(args.registry, args.artifacts_dir, args.output)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/policy/test_doctrine_artifact_presence_input.py
+++ b/tests/policy/test_doctrine_artifact_presence_input.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_presence_input_renderer_emits_present_map(tmp_path: Path):
+    receipt = tmp_path / "receipt.json"
+    check_cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--output",
+        str(receipt),
+    ]
+    subprocess.run(check_cmd, cwd=ROOT, check=False, capture_output=True, text=True)
+
+    render_cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "render_doctrine_presence_input.py"),
+        str(receipt),
+    ]
+    res = subprocess.run(render_cmd, cwd=ROOT, check=True, capture_output=True, text=True)
+    payload = json.loads(res.stdout)
+    assert "present" in payload
+    assert isinstance(payload["present"], dict)
+    assert len(payload["present"]) == 3

--- a/tests/policy/test_doctrine_artifact_registry_status_alignment.py
+++ b/tests/policy/test_doctrine_artifact_registry_status_alignment.py
@@ -1,0 +1,30 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_registry_status_present_mismatch_fails(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: sample.pdf\n    doc_id: kfm://doc/example\n    status: present\n""",
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 1
+    payload = json.loads(res.stdout)
+    assert payload["status_mismatches"] == ["sample.pdf"]
+    assert payload["result"] == "fail"

--- a/tests/policy/test_doctrine_artifact_required.py
+++ b/tests/policy/test_doctrine_artifact_required.py
@@ -21,6 +21,8 @@ def test_required_doctrine_artifact_check_fails_until_artifacts_admitted():
     assert payload["check"] == "required_doctrine_artifacts"
     assert payload["missing_count"] >= 1
     assert payload["result"] == "fail"
+    assert isinstance(payload["present"], dict)
+    assert payload["status_mismatches"] == []
 
 
 def test_required_doctrine_artifact_check_writes_receipt(tmp_path: Path):
@@ -36,3 +38,5 @@ def test_required_doctrine_artifact_check_writes_receipt(tmp_path: Path):
     written = json.loads(out.read_text(encoding="utf-8"))
     assert written["check"] == "required_doctrine_artifacts"
     assert written["result"] == "fail"
+    assert isinstance(written["present"], dict)
+    assert isinstance(written["status_mismatches"], list)

--- a/tests/policy/test_sync_doctrine_artifact_registry_status.py
+++ b/tests/policy/test_sync_doctrine_artifact_registry_status.py
@@ -1,0 +1,38 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_sync_registry_marks_present_when_artifact_exists(tmp_path: Path):
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "a.pdf").write_text("x", encoding="utf-8")
+
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n  - filename: b.pdf\n    doc_id: kfm://doc/b\n    status: present\n""",
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "sync_receipt.json"
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "sync_doctrine_artifact_registry_status.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+        "--output",
+        str(output),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["changed_count"] == 2
+    edited = registry.read_text(encoding="utf-8")
+    assert "status: present" in edited
+    assert "status: missing" in edited


### PR DESCRIPTION
### Motivation
- Ensure the doctrine-required registry can express expected `status` for each artifact and that CI can check both file presence and registry alignment before doctrine extraction. 
- Provide tooling to render the presence map for downstream automation and to reconcile the registry `status` fields with actual artifact files.

### Description
- Extended `scripts/maintenance/check_required_doctrine_artifacts.py` to parse registry entries (filename + optional `status`), emit a `present` map and `status_mismatches`, and fail when either files are missing or statuses are out-of-sync. The script now returns a non-zero exit on either kind of failure. 
- Added `scripts/maintenance/render_doctrine_presence_input.py` which reads the JSON receipt from the checker and emits a compact `{"present": ...}` payload for downstream consumers. 
- Added `scripts/maintenance/sync_doctrine_artifact_registry_status.py` to update the registry `status:` lines to `present`/`missing` based on the artifacts directory and emit a JSON receipt with detected `changes`. 
- Updated ADR log `docs/adr/_next_move_log.md` with runs describing the new gate and admission move. 
- Added policy tests under `tests/policy/` exercising the checker output shape, presence renderer, sync behavior, and registry-status mismatch detection, and adjusted an existing test to assert the new `present` and `status_mismatches` fields.

### Testing
- Ran the new test suite with `pytest tests/policy` and all tests in that directory passed. 
- Executed `scripts/maintenance/check_required_doctrine_artifacts.py --output <file>` and verified the written JSON includes `present` map and `status_mismatches` as expected. 
- Executed `scripts/maintenance/sync_doctrine_artifact_registry_status.py` against a temporary registry and artifacts directory and verified `changed_count` and registry file updates matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03941cec08832aa9e48c4756265b6d)