### PR TITLE
Add paint_floor.sh to generate backdated GitHub contribution commits

### DIFF
--- a/README.paint_floor.md
+++ b/README.paint_floor.md
@@ -1,0 +1,17 @@
+# paint_floor.sh
+
+`paint_floor.sh` generates backdated empty commits to fill your GitHub contribution graph for the last 365 days (from 365 days ago through today).
+
+It requires these environment variables:
+
+- `GIT_USER_NAME`
+- `GIT_USER_EMAIL`
+
+> Important: `GIT_USER_EMAIL` must be a verified email on your GitHub account. If it is not verified on GitHub, contributions may not appear on your graph.
+
+Optional environment variables:
+
+- `MIN_COMMITS` (default: `1`)
+- `MAX_COMMITS` (default: `4`)
+
+The script is idempotent for the computed date window. After a successful run, it writes a `.painted` marker file with the exact start/end range and exits early on repeat runs for the same range.

--- a/paint_floor.sh
+++ b/paint_floor.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+START_DATE="$(date -d '365 days ago' +%F)"
+END_DATE="$(date +%F)"
+MARKER_FILE=".painted"
+
+if [[ -f "$MARKER_FILE" ]]; then
+  recorded_range="$(<"$MARKER_FILE")"
+  if [[ "$recorded_range" == "$START_DATE,$END_DATE" ]]; then
+    echo "Already painted for date range $START_DATE through $END_DATE. Nothing to do."
+    exit 0
+  fi
+fi
+
+if [[ -z "${GIT_USER_NAME:-}" ]]; then
+  echo "Error: GIT_USER_NAME is unset. Export it before running this script."
+  exit 1
+fi
+
+if [[ -z "${GIT_USER_EMAIL:-}" ]]; then
+  echo "Error: GIT_USER_EMAIL is unset. Export it before running this script."
+  echo "This email must match a verified email on your GitHub account or commits will not count."
+  exit 1
+fi
+
+MIN_COMMITS="${MIN_COMMITS:-1}"
+MAX_COMMITS="${MAX_COMMITS:-4}"
+
+if ! [[ "$MIN_COMMITS" =~ ^[0-9]+$ && "$MAX_COMMITS" =~ ^[0-9]+$ ]]; then
+  echo "Error: MIN_COMMITS and MAX_COMMITS must be non-negative integers."
+  exit 1
+fi
+
+if (( MIN_COMMITS < 0 || MAX_COMMITS < 0 )); then
+  echo "Error: MIN_COMMITS and MAX_COMMITS must be non-negative integers."
+  exit 1
+fi
+
+if (( MIN_COMMITS > MAX_COMMITS )); then
+  echo "Error: MIN_COMMITS cannot be greater than MAX_COMMITS."
+  exit 1
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git init
+fi
+
+git config user.name "$GIT_USER_NAME"
+git config user.email "$GIT_USER_EMAIL"
+
+current_date="$START_DATE"
+total_commits=0
+
+while [[ "$current_date" < "$END_DATE" || "$current_date" == "$END_DATE" ]]; do
+  range_size=$((MAX_COMMITS - MIN_COMMITS + 1))
+  commits_today=$((MIN_COMMITS + RANDOM % range_size))
+
+  for ((n = 1; n <= commits_today; n++)); do
+    hour=$((9 + RANDOM % 13))
+    minute=$((RANDOM % 60))
+    second=$((RANDOM % 60))
+
+    commit_ts="$(date -d "$current_date $hour:$minute:$second" '+%Y-%m-%dT%H:%M:%S%z')"
+
+    GIT_AUTHOR_DATE="$commit_ts" \
+    GIT_COMMITTER_DATE="$commit_ts" \
+      git commit --allow-empty -m "daily: $current_date #$n" >/dev/null
+
+    total_commits=$((total_commits + 1))
+  done
+
+  current_date="$(date -d "$current_date + 1 day" +%F)"
+done
+
+echo "$START_DATE,$END_DATE" > "$MARKER_FILE"
+
+repo_name="contrib-paint-$(date +%Y%m%d)"
+
+echo "Created $total_commits commits for $START_DATE through $END_DATE."
+echo ""
+echo "Next commands (not executed):"
+echo "  gh repo create \"$repo_name\" --public --source=. --remote=origin"
+echo "  git remote add origin \"git@github.com:<YOUR_GITHUB_USERNAME>/$repo_name.git\""
+echo "  git branch -M main"
+echo "  git push -u origin main"


### PR DESCRIPTION
### Motivation

- Provide a simple, dependency-free script to populate the GitHub contribution graph for the past 365 days with backdated empty commits. 
- Ensure commits are generated with a validated author identity and an idempotent marker so repeated runs for the same date window do nothing. 
- Avoid automatic pushes so the user can review, create a remote, and push manually using the provided commands.

### Description

- Add `paint_floor.sh`, an executable Bash script that initializes a repository if needed, validates `GIT_USER_NAME` and `GIT_USER_EMAIL`, supports `MIN_COMMITS`/`MAX_COMMITS` overrides, and creates randomized `--allow-empty` commits for each day from 365 days ago through today with `GIT_AUTHOR_DATE` and `GIT_COMMITTER_DATE` set to randomized local times between 09:00 and 21:00. 
- Implement idempotency by writing a `.painted` marker file containing the exact `START_DATE,END_DATE` range and exiting early when the marker matches the current range. 
- Print the total created commit count and the exact manual commands to create a public GitHub repo via `gh repo create`, add an `origin` remote, set the branch to `main`, and push, without executing those commands. 
- Add `README.paint_floor.md` documenting required environment variables, optional overrides, and the caveat that `GIT_USER_EMAIL` must be a verified email on the user’s GitHub account.

### Testing

- Ran a syntax check with `bash -n paint_floor.sh`, which succeeded. 
- Ran `git status --short` to confirm the new files are present, which listed the added files. 
- Executed a repository workflow to place the new files in the repository, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039c2d7498832a80b566c1ee13a00f)