### PR TITLE
Add doctrine artifact preflight tooling: registry parser, checks, renderer, sync, and tests

### DIFF
--- a/docs/adr/_next_move_log.md
+++ b/docs/adr/_next_move_log.md
@@ -21,3 +21,12 @@ Each run appends one block in this exact shape:
 - Slice shape: define a canonical doctrine-artifact preflight gate (descriptors + validator checks) so future runs can verify prerequisites before doctrine extraction
 - Deferred to future runs:
   - Full doctrine-vs-implementation gap extraction after primary doctrine artifacts are present
+
+
+### Run 2026-05-12 — Admit canonical doctrine artifacts and close prerequisite gate
+- Status: proposed
+- PR: n/a
+- Doctrine basis: prerequisite doctrine artifacts are still absent while registry+policy gate is already staged; blocker remains explicit in `docs/registers/DRIFT_REGISTER.md`.
+- Slice shape: land the three required doctrine PDFs under canonical doctrine artifacts home with descriptor records, registry status updates, and passing prerequisite checks to unblock doctrine-vs-implementation extraction.
+- Deferred to future runs:
+  - Full doctrine expectation extraction and anti-circling candidate selection after artifact admission is CONFIRMED

--- a/scripts/maintenance/_doctrine_registry.py
+++ b/scripts/maintenance/_doctrine_registry.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ALLOWED_STATUSES = {"missing", "present"}
+
+
+def parse_required_entries(registry_path: Path) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+
+    for raw in registry_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line.startswith("- filename:"):
+            if current:
+                entries.append(current)
+            current = {"filename": line.split(":", 1)[1].strip()}
+        elif line.startswith("status:") and current is not None:
+            current["status"] = line.split(":", 1)[1].strip()
+        elif line.startswith("doc_id:") and current is not None:
+            current["doc_id"] = line.split(":", 1)[1].strip()
+
+    if current:
+        entries.append(current)
+
+    seen: set[str] = set()
+    for entry in entries:
+        name = entry["filename"]
+        if name in seen:
+            raise ValueError(f"duplicate filename in registry: {name}")
+        seen.add(name)
+
+        status = entry.get("status", "missing")
+        if status not in ALLOWED_STATUSES:
+            raise ValueError(f"invalid status for {name}: {status}")
+        entry["status"] = status
+
+        doc_id = entry.get("doc_id", "")
+        if not doc_id:
+            raise ValueError(f"missing doc_id for {name}")
+
+    return entries

--- a/scripts/maintenance/check_required_doctrine_artifacts.py
+++ b/scripts/maintenance/check_required_doctrine_artifacts.py
@@ -5,19 +5,19 @@ import argparse
 import json
 from pathlib import Path
 
-
-def _extract_required_filenames(registry_text: str) -> list[str]:
-    return [
-        line.split(":", 1)[1].strip()
-        for line in registry_text.splitlines()
-        if line.strip().startswith("- filename:")
-    ]
-
+from _doctrine_registry import parse_required_entries
 
 def run(registry_path: Path, artifacts_dir: Path, output_path: Path | None = None) -> int:
-    reg_text = registry_path.read_text(encoding="utf-8")
-    required = _extract_required_filenames(reg_text)
-    missing = [f for f in required if not (artifacts_dir / f).exists()]
+    entries = parse_required_entries(registry_path)
+    required = [entry["filename"] for entry in entries]
+    expected_status = {entry["filename"]: entry.get("status", "unknown") for entry in entries}
+    present = {f: (artifacts_dir / f).exists() for f in required}
+    missing = [f for f, ok in present.items() if not ok]
+    status_mismatches = [
+        f
+        for f in required
+        if (expected_status[f] == "missing" and present[f]) or (expected_status[f] == "present" and not present[f])
+    ]
 
     result = {
         "check": "required_doctrine_artifacts",
@@ -26,7 +26,9 @@ def run(registry_path: Path, artifacts_dir: Path, output_path: Path | None = Non
         "required_count": len(required),
         "missing_count": len(missing),
         "missing": missing,
-        "result": "pass" if not missing else "fail",
+        "present": present,
+        "status_mismatches": status_mismatches,
+        "result": "pass" if not missing and not status_mismatches else "fail",
     }
 
     payload = json.dumps(result, indent=2, sort_keys=True)
@@ -36,7 +38,7 @@ def run(registry_path: Path, artifacts_dir: Path, output_path: Path | None = Non
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(payload + "\n", encoding="utf-8")
 
-    return 0 if not missing else 1
+    return 0 if not missing and not status_mismatches else 1
 
 
 def main() -> int:
@@ -62,7 +64,11 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    return run(args.registry, args.artifacts_dir, args.output)
+    try:
+        return run(args.registry, args.artifacts_dir, args.output)
+    except ValueError as exc:
+        print(json.dumps({"check": "required_doctrine_artifacts", "result": "error", "error": str(exc)}))
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/maintenance/render_doctrine_presence_input.py
+++ b/scripts/maintenance/render_doctrine_presence_input.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("receipt", type=Path, help="JSON output from check_required_doctrine_artifacts.py")
+    args = parser.parse_args()
+
+    payload = json.loads(args.receipt.read_text(encoding="utf-8"))
+    present = payload.get("present")
+    if not isinstance(present, dict):
+        raise SystemExit("receipt missing 'present' map")
+
+    print(json.dumps({"present": present}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/run_doctrine_artifact_preflight.py
+++ b/scripts/maintenance/run_doctrine_artifact_preflight.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cmd(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", type=Path, default=root / "control_plane" / "document_registry_doctrine_required.yaml")
+    parser.add_argument("--artifacts-dir", type=Path, default=root / "docs" / "doctrine" / "artifacts")
+    parser.add_argument("--output-dir", type=Path, default=root / "receipts" / "doctrine_artifacts")
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    check_receipt = args.output_dir / "check_required_doctrine_artifacts.json"
+
+    check_cmd = [
+        sys.executable,
+        str(root / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(args.registry),
+        "--artifacts-dir",
+        str(args.artifacts_dir),
+        "--output",
+        str(check_receipt),
+    ]
+    check_res = run_cmd(check_cmd, root)
+
+    render_cmd = [
+        sys.executable,
+        str(root / "scripts" / "maintenance" / "render_doctrine_presence_input.py"),
+        str(check_receipt),
+    ]
+    render_res = run_cmd(render_cmd, root)
+
+    summary = {
+        "check_returncode": check_res.returncode,
+        "render_returncode": render_res.returncode,
+        "check_receipt": str(check_receipt),
+        "presence_input": json.loads(render_res.stdout) if render_res.returncode == 0 else None,
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    return 0 if check_res.returncode in (0, 1) and render_res.returncode == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/sync_doctrine_artifact_registry_status.py
+++ b/scripts/maintenance/sync_doctrine_artifact_registry_status.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _doctrine_registry import parse_required_entries
+
+
+def sync(registry: Path, artifacts_dir: Path, output: Path | None = None) -> int:
+    # Validate duplicate filenames / invalid status values before mutation.
+    parse_required_entries(registry)
+    lines = registry.read_text(encoding="utf-8").splitlines()
+    updated: list[str] = []
+    current_filename: str | None = None
+    changes: list[dict[str, str]] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("- filename:"):
+            current_filename = stripped.split(":", 1)[1].strip()
+            updated.append(line)
+            continue
+        if stripped.startswith("status:") and current_filename is not None:
+            indent = line[: len(line) - len(line.lstrip())]
+            desired = "present" if (artifacts_dir / current_filename).exists() else "missing"
+            old = stripped.split(":", 1)[1].strip()
+            if old != desired:
+                changes.append({"filename": current_filename, "from": old, "to": desired})
+            updated.append(f"{indent}status: {desired}")
+            continue
+        updated.append(line)
+
+    registry.write_text("\n".join(updated) + "\n", encoding="utf-8")
+
+    payload = {
+        "check": "sync_doctrine_artifact_registry_status",
+        "registry": str(registry),
+        "artifacts_dir": str(artifacts_dir),
+        "changes": changes,
+        "changed_count": len(changes),
+    }
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    print(rendered)
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered + "\n", encoding="utf-8")
+    return 0
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", type=Path, default=root / "control_plane" / "document_registry_doctrine_required.yaml")
+    parser.add_argument("--artifacts-dir", type=Path, default=root / "docs" / "doctrine" / "artifacts")
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+    try:
+        return sync(args.registry, args.artifacts_dir, args.output)
+    except ValueError as exc:
+        print(json.dumps({"check": "sync_doctrine_artifact_registry_status", "result": "error", "error": str(exc)}))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/policy/test_doctrine_artifact_presence_input.py
+++ b/tests/policy/test_doctrine_artifact_presence_input.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_presence_input_renderer_emits_present_map(tmp_path: Path):
+    receipt = tmp_path / "receipt.json"
+    check_cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--output",
+        str(receipt),
+    ]
+    subprocess.run(check_cmd, cwd=ROOT, check=False, capture_output=True, text=True)
+
+    render_cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "render_doctrine_presence_input.py"),
+        str(receipt),
+    ]
+    res = subprocess.run(render_cmd, cwd=ROOT, check=True, capture_output=True, text=True)
+    payload = json.loads(res.stdout)
+    assert "present" in payload
+    assert isinstance(payload["present"], dict)
+    assert len(payload["present"]) == 3

--- a/tests/policy/test_doctrine_artifact_registry_status_alignment.py
+++ b/tests/policy/test_doctrine_artifact_registry_status_alignment.py
@@ -1,0 +1,30 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_registry_status_present_mismatch_fails(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: sample.pdf\n    doc_id: kfm://doc/example\n    status: present\n""",
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 1
+    payload = json.loads(res.stdout)
+    assert payload["status_mismatches"] == ["sample.pdf"]
+    assert payload["result"] == "fail"

--- a/tests/policy/test_doctrine_artifact_registry_validation.py
+++ b/tests/policy/test_doctrine_artifact_registry_validation.py
@@ -1,0 +1,75 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_checker_fails_on_duplicate_filenames(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: dup.pdf\n    doc_id: kfm://doc/1\n    status: missing\n  - filename: dup.pdf\n    doc_id: kfm://doc/2\n    status: missing\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"
+    assert "duplicate filename" in payload["error"]
+
+
+def test_sync_fails_on_invalid_status(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: unknown_state\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "sync_doctrine_artifact_registry_status.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"
+    assert "invalid status" in payload["error"]
+
+
+def test_checker_fails_on_missing_doc_id(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: noid.pdf\n    status: missing\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"
+    assert "missing doc_id" in payload["error"]

--- a/tests/policy/test_doctrine_artifact_required.py
+++ b/tests/policy/test_doctrine_artifact_required.py
@@ -21,6 +21,8 @@ def test_required_doctrine_artifact_check_fails_until_artifacts_admitted():
     assert payload["check"] == "required_doctrine_artifacts"
     assert payload["missing_count"] >= 1
     assert payload["result"] == "fail"
+    assert isinstance(payload["present"], dict)
+    assert payload["status_mismatches"] == []
 
 
 def test_required_doctrine_artifact_check_writes_receipt(tmp_path: Path):
@@ -36,3 +38,5 @@ def test_required_doctrine_artifact_check_writes_receipt(tmp_path: Path):
     written = json.loads(out.read_text(encoding="utf-8"))
     assert written["check"] == "required_doctrine_artifacts"
     assert written["result"] == "fail"
+    assert isinstance(written["present"], dict)
+    assert isinstance(written["status_mismatches"], list)

--- a/tests/policy/test_run_doctrine_artifact_preflight.py
+++ b/tests/policy/test_run_doctrine_artifact_preflight.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_preflight_runner_produces_presence_input_with_missing_artifacts(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    outdir = tmp_path / "receipts"
+
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n  - filename: b.pdf\n    doc_id: kfm://doc/b\n    status: missing\n""",
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "run_doctrine_artifact_preflight.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+        "--output-dir",
+        str(outdir),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0
+    payload = json.loads(res.stdout)
+    assert payload["check_returncode"] == 1
+    assert payload["render_returncode"] == 0
+    assert payload["presence_input"] == {"present": {"a.pdf": False, "b.pdf": False}}
+    assert (outdir / "check_required_doctrine_artifacts.json").exists()

--- a/tests/policy/test_sync_doctrine_artifact_registry_status.py
+++ b/tests/policy/test_sync_doctrine_artifact_registry_status.py
@@ -1,0 +1,38 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_sync_registry_marks_present_when_artifact_exists(tmp_path: Path):
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "a.pdf").write_text("x", encoding="utf-8")
+
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n  - filename: b.pdf\n    doc_id: kfm://doc/b\n    status: present\n""",
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "sync_receipt.json"
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "sync_doctrine_artifact_registry_status.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+        "--output",
+        str(output),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["changed_count"] == 2
+    edited = registry.read_text(encoding="utf-8")
+    assert "status: present" in edited
+    assert "status: missing" in edited


### PR DESCRIPTION
### Motivation
- Provide a canonical preflight gate to verify required doctrine artifacts are present and their registry statuses are aligned before doctrine extraction. 
- Make registry validation explicit (duplicate filenames, missing `doc_id`, and allowed `status` values) to fail fast and avoid downstream surprises. 
- Produce a stable `present` input map for policy and automation consumers and provide a small runner to compose the check+render steps. 

### Description
- Add `scripts/maintenance/_doctrine_registry.py` with `parse_required_entries()` to parse and validate the required-documents registry (duplicate detection, allowed statuses, and required `doc_id`).
- Update `scripts/maintenance/check_required_doctrine_artifacts.py` to use the parser, emit a `present` map and `status_mismatches`, improve result semantics and error handling, and write JSON receipts.
- Add `scripts/maintenance/render_doctrine_presence_input.py` to convert check receipts into a simple `{"present": ...}` input for policy consumers.
- Add `scripts/maintenance/run_doctrine_artifact_preflight.py` to run the check and renderer in sequence and emit a summary receipt.
- Add `scripts/maintenance/sync_doctrine_artifact_registry_status.py` to reconcile and update `status:` lines in the registry file based on on-disk artifacts, and emit a JSON summary of changes.
- Add comprehensive tests under `tests/policy/` exercising registry validation, check semantics, renderer output, preflight runner behavior, and registry sync behavior.
- Update ADR `docs/adr/_next_move_log.md` with entries describing the moves and intent to admit doctrine artifact PDFs and close the prerequisite gate.

### Testing
- Added pytest tests under `tests/policy/` covering duplicate filename detection, missing `doc_id`, status validation, check output/receipt contents, renderer output, preflight runner composition, and registry sync behavior.
- Ran the policy test suite with `pytest tests/policy -q` and observed that the new tests execute and pass locally.
- Exercised the check and sync scripts via the tests which assert return codes and JSON payload shapes for success/failure and error cases.
- Confirmed that `check_required_doctrine_artifacts.py` writes receipts via the `--output` flag and that `render_doctrine_presence_input.py` consumes those receipts in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03941cec08832aa9e48c4756265b6d)