### PR TITLE
Add doctrine-artifact preflight tooling, schema, fixtures, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ configs/local/*
 # OS
 .DS_Store
 Thumbs.db
+receipts/

--- a/docs/adr/_next_move_log.md
+++ b/docs/adr/_next_move_log.md
@@ -21,3 +21,12 @@ Each run appends one block in this exact shape:
 - Slice shape: define a canonical doctrine-artifact preflight gate (descriptors + validator checks) so future runs can verify prerequisites before doctrine extraction
 - Deferred to future runs:
   - Full doctrine-vs-implementation gap extraction after primary doctrine artifacts are present
+
+
+### Run 2026-05-12 — Admit canonical doctrine artifacts and close prerequisite gate
+- Status: proposed
+- PR: n/a
+- Doctrine basis: prerequisite doctrine artifacts are still absent while registry+policy gate is already staged; blocker remains explicit in `docs/registers/DRIFT_REGISTER.md`.
+- Slice shape: land the three required doctrine PDFs under canonical doctrine artifacts home with descriptor records, registry status updates, and passing prerequisite checks to unblock doctrine-vs-implementation extraction.
+- Deferred to future runs:
+  - Full doctrine expectation extraction and anti-circling candidate selection after artifact admission is CONFIRMED

--- a/docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md
+++ b/docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md
@@ -1,0 +1,87 @@
+# Doctrine Artifact Preflight Runbook
+
+This runbook defines the standard operator/CI flow for validating required doctrine artifacts.
+
+## Prerequisites
+- Python available in PATH.
+- Registry file exists: `control_plane/document_registry_doctrine_required.yaml`.
+
+## Single-command preflight
+Run the composed preflight:
+
+```bash
+python scripts/maintenance/run_doctrine_artifact_preflight.py
+```
+
+For CI that must fail when artifacts are missing, use strict mode:
+
+```bash
+python scripts/maintenance/run_doctrine_artifact_preflight.py --strict
+```
+
+Expected behavior:
+- Exit `0` when the preflight executes correctly and rendering succeeds.
+- `check_returncode` in output indicates artifact state:
+  - `0`: all required artifacts present and aligned.
+  - `1`: one or more required artifacts missing and/or status mismatches.
+- Exit `2` indicates malformed registry input or runner-level execution failure.
+
+
+
+Emit a standalone presence-input artifact for downstream policy stages:
+
+```bash
+python scripts/maintenance/run_doctrine_artifact_preflight.py \
+  --presence-output receipts/doctrine_artifacts/presence_input.json
+```
+
+## Targeted validation commands
+Check registry/artifact alignment and write receipt:
+
+```bash
+python scripts/maintenance/check_required_doctrine_artifacts.py \
+  --registry control_plane/document_registry_doctrine_required.yaml \
+  --artifacts-dir docs/doctrine/artifacts \
+  --output receipts/doctrine_artifacts/check_required_doctrine_artifacts.json
+```
+
+Render policy input from receipt:
+
+```bash
+python scripts/maintenance/render_doctrine_presence_input.py \
+  receipts/doctrine_artifacts/check_required_doctrine_artifacts.json
+```
+
+Sync registry `status:` fields with disk state:
+
+```bash
+python scripts/maintenance/sync_doctrine_artifact_registry_status.py \
+  --registry control_plane/document_registry_doctrine_required.yaml \
+  --artifacts-dir docs/doctrine/artifacts \
+  --output receipts/doctrine_artifacts/sync_doctrine_artifact_registry_status.json
+```
+
+
+
+CI drift-check mode (no mutation, fail if registry drift exists):
+
+```bash
+python scripts/maintenance/sync_doctrine_artifact_registry_status.py \
+  --registry control_plane/document_registry_doctrine_required.yaml \
+  --artifacts-dir docs/doctrine/artifacts \
+  --dry-run --fail-on-change
+```
+
+## Failure interpretation
+- `result: "error"` means malformed registry (e.g., duplicate filename, invalid status, missing `doc_id`).
+- `result: "fail"` means registry is structurally valid but required artifacts are not yet in compliant state.
+
+
+Use `--stable-filenames` when deterministic receipt names are required by downstream tooling.
+
+
+## Regression test bundle
+
+```bash
+./scripts/maintenance/run_doctrine_artifact_test_suite.sh
+```

--- a/docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md
+++ b/docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md
@@ -1,13 +1,424 @@
-# Doctrine Artifact Preflight Runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-doctrine-artifact-preflight
+title: Doctrine Artifact Preflight Runbook
+type: standard
+version: v1
+status: draft
+owners: Docs steward + at least one subsystem owner (per Directory Rules §17)
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/registers/DRIFT_REGISTER.md
+  - docs/registers/VERIFICATION_BACKLOG.md
+  - docs/adr/ADR-0001-schema-home.md
+  - docs/adr/ADR-S-02-doctrine-artifact-placement.md
+  - docs/adr/ADR-S-13-drift-register-triage.md
+  - docs/adr/ADR-S-15-doctrine-artifact-lifecycle.md
+tags: [kfm, runbook, doctrine, preflight, governance, publication]
+notes:
+  - Path docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md is PROPOSED until mounted-repo verified.
+  - ADR-S-02 (doctrine artifact placement under docs/) and ADR-S-15 (doctrine artifact lifecycle) are PROPOSED in the open backlog.
+  - All ADR identifiers and badge endpoints below are placeholders pending repo verification.
+[/KFM_META_BLOCK_V2] -->
 
-This runbook defines the standard operator/CI flow for validating required doctrine artifacts.
+# 🛂 Doctrine Artifact Preflight Runbook
 
-## Prerequisites
-- Python available in PATH.
-- Registry file exists: `control_plane/document_registry_doctrine_required.yaml`.
+> **Pre-circulation governance check for KFM doctrine artifacts — Atlases, supplements, dossiers, encyclopedias, build manuals, ADRs, and doctrine docs — so that no doctrine artifact is treated as authoritative before its identity, evidence basis, terminology, placement, reproducibility, integrity, and supersession lineage are inspected.**
 
-## Single-command preflight
-Run the composed preflight:
+<!-- Badges: placeholders — replace targets after repo verification. -->
+![Status](https://img.shields.io/badge/status-draft-yellow)
+![Doc type](https://img.shields.io/badge/doc%20type-runbook-blue)
+![Authority](https://img.shields.io/badge/authority-doctrine--governing-9cf)
+![Policy label](https://img.shields.io/badge/policy%20label-public-brightgreen)
+![Updated](https://img.shields.io/badge/updated-2026--05--12-lightgrey)
+![CI](https://img.shields.io/badge/CI-TODO-lightgrey)
+
+| Field | Value |
+|---|---|
+| **Document type** | Runbook (standard doc) |
+| **Authority of these rules** | PROPOSED — depends on ADR-S-15 (doctrine artifact lifecycle) and ADR-S-02 (doctrine artifact placement) being accepted |
+| **Authority of any specific path quoted here** | PROPOSED until verified against mounted-repo evidence |
+| **Owner** | Docs steward |
+| **Reviewers required for change** | Docs steward + at least one subsystem owner; ADR required when this runbook is promoted to canonical |
+| **Lifecycle phase governed** | Pre-circulation / pre-citation of any doctrine artifact |
+| **Companion registers** | `docs/registers/DRIFT_REGISTER.md`, `docs/registers/VERIFICATION_BACKLOG.md` |
+
+---
+
+## 📑 Quick jump
+
+- [1. Scope](#1-scope)
+- [2. Repo fit](#2-repo-fit)
+- [3. Accepted inputs](#3-accepted-inputs)
+- [4. Exclusions](#4-exclusions)
+- [5. Preflight flow](#5-preflight-flow)
+- [6. Gate matrix](#6-gate-matrix)
+- [7. The eleven preflight steps](#7-the-eleven-preflight-steps)
+- [8. Decision outcomes](#8-decision-outcomes)
+- [9. Anti-patterns to deny on sight](#9-anti-patterns-to-deny-on-sight)
+- [10. Preflight receipt and lineage](#10-preflight-receipt-and-lineage)
+- [11. Maintenance CLI commands](#11-maintenance-cli-commands)
+- [12. Quickstart — five-minute pass](#12-quickstart--five-minute-pass)
+- [13. Task list — pin-to-PR checklist](#13-task-list--pin-to-pr-checklist)
+- [14. FAQ](#14-faq)
+- [15. Related docs](#15-related-docs)
+- [16. Appendix](#16-appendix)
+
+---
+
+## 1. Scope
+
+**A *doctrine artifact* is any document whose role is to establish, refine, register, or supersede KFM governance, architecture, terminology, policy posture, or release law** — not to *implement* it. Doctrine artifacts shape what gets built and what gets published; they do not by themselves constitute repo state.
+
+In scope for this preflight:
+
+| Artifact family | Examples |
+|---|---|
+| **Atlas** | Domains Culmination Atlas v1.0, v1.1; Master MapLibre Components-Functions-Features |
+| **Supplement / addendum** | Atlas Chapter 24; Atlas Appendix G; pass-level update packets |
+| **Dossier / idea index** | Pass 10 / Pass 18 idea indexes, category atlases, expansion dossiers |
+| **Encyclopedia / spine** | KFM Encyclopedia (object/source/capability spine) |
+| **Build manual** | Unified Implementation Architecture Build Manual |
+| **ADR** | Records under `docs/adr/` |
+| **Doctrine page** | Files under `docs/doctrine/` (e.g., `directory-rules.md`, `authority-ladder.md`, `truth-posture.md`, `trust-membrane.md`, `lifecycle-law.md`) |
+| **Register / runbook / standard** | Files under `docs/registers/`, `docs/runbooks/`, `docs/standards/` whose primary effect is governance, not implementation |
+
+> [!IMPORTANT]
+> **Doctrine artifacts and implementation artifacts have different preflights.** Implementation artifacts (PMTiles, COGs, GeoParquet, layer manifests, release manifests) follow promotion gates A–G under `release/` and the artifact-governance checklist for tiles/COGs. This runbook governs the *doctrine* lane only.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 2. Repo fit
+
+**Proposed home of this runbook:** `docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md`
+
+**Proposed home of doctrine artifacts** governed by this preflight:
+
+```text
+docs/
+├── doctrine/              # core doctrine pages (CONFIRMED rule / PROPOSED presence)
+├── atlases/               # ADR-S-02 OPEN: docs/dossiers/ vs docs/atlases/
+├── dossiers/              # ADR-S-02 OPEN
+├── adr/                   # accepted, proposed, superseded ADRs
+├── registers/             # DRIFT_REGISTER, VERIFICATION_BACKLOG, ADR_INDEX
+├── runbooks/              # this file lives here
+├── standards/             # SIGNING, PROVENANCE, CANONICALIZATION, etc.
+└── architecture/          # subsystem architecture pages
+```
+
+> [!NOTE]
+> Per **Directory Rules §3**, `docs/` is the canonical responsibility root for human-facing doctrine, ADRs, runbooks, and registers. The specific sub-paths above are **PROPOSED** until verified against mounted-repo evidence; `docs/dossiers/` vs `docs/atlases/` is open per **ADR-S-02**.
+
+**Upstream of this runbook:** Directory Rules (placement), Atlas / supplement supersession appendices (lineage), C13 reproducible documentation chain (build).
+
+**Downstream of this runbook:** Drift Register (open conflicts), Verification Backlog (NEEDS VERIFICATION items), `docs/registers/ADR_INDEX` (proposed ADRs raised by preflight), supersession appendices of the artifacts it gates.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 3. Accepted inputs
+
+A doctrine artifact MUST run through this preflight before any of the following:
+
+1. **First circulation** outside its working PR (e.g., posted as an attachment, exported as a PDF, linked from a README).
+2. **Promotion to canonical** (e.g., moving an Atlas from `working-drafts/` to `docs/atlases/`).
+3. **Citation in another doctrine artifact** as `CONFIRMED doctrine`.
+4. **Reference from machine-readable governance** (e.g., `control_plane/` indexes, ADR cross-links, register entries).
+5. **Public or semi-public release**, including PDF builds intended to be downloaded, archived, or institutionally cited.
+6. **Supersession** of a prior edition.
+
+What counts as "the artifact" for the preflight:
+
+| Component | Required |
+|---|---|
+| The source Markdown or LaTeX | ✅ |
+| The KFM Meta Block v2 (or stated exception) | ✅ |
+| Supersession header / appendix (when superseding prior edition) | ✅ |
+| Citations and cross-references | ✅ |
+| The built artifact bytes (PDF, HTML, exported zip) — when produced | ✅ |
+| The ARTIFACT_DIGEST sidecar — when a PDF is produced | ✅ |
+| Tool-versions pin (`tool-versions.yaml`) — when a build is involved | ✅ |
+| Signing material — when the artifact will be referenced from receipts | ✅ |
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 4. Exclusions
+
+This preflight does **not** run on:
+
+- **Lifecycle data artifacts** (RAW / WORK / QUARANTINE / PROCESSED / CATALOG / TRIPLET / PUBLISHED). Those follow data-lane promotion under `release/`.
+- **Tile, COG, GeoParquet, and 3D-tileset releases.** Those follow the artifact-governance checklist (immutable inputs, CRS, sidecars, digest logs, license/attribution) and Promotion Gates A–G.
+- **Code, schemas, contracts, policy bundles.** Schemas, contracts, and policy follow their own ADR-governed evolution (ADR-0001 schema home, policy-bundle promotion).
+- **Personal notes, scratch dossiers, exploratory packets.** Per `docs/intake/` discipline, exploratory packets are quarantined from doctrine until promoted; promotion *is* a trigger for this preflight.
+- **Routine typo or clarification edits** to already-published doctrine that do not change identity, terminology, or lineage. Such edits MAY skip preflight but MUST update the `updated:` field in the Meta Block.
+
+> [!CAUTION]
+> A doctrine artifact whose **content is correct but whose preflight has not been run** is still treated as **PROPOSED**. Correctness is not authority; preflight is what binds correctness to authority.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 5. Preflight flow
+
+```mermaid
+flowchart TD
+    A[Doctrine artifact draft] --> B{Identity &<br/>lineage}
+    B -- missing --> R[DENY / Fix]
+    B -- ok --> C{Truth labels &<br/>evidence basis}
+    C -- drift --> R
+    C -- ok --> D{Terminology<br/>integrity}
+    D -- drift --> R
+    D -- ok --> E{Placement vs<br/>Directory Rules}
+    E -- wrong --> R
+    E -- ok --> F{Repo-state<br/>containment}
+    F -- unbounded<br/>implementation claim --> R
+    F -- ok --> G{Reproducibility<br/>C13-01/02}
+    G -- fail --> R
+    G -- ok --> H{Accessibility<br/>C13-03 — PDFs}
+    H -- fail --> ABSTAIN[ABSTAIN /<br/>remediation backlog]
+    H -- ok --> I{Integrity<br/>ARTIFACT_DIGEST + sign}
+    I -- fail --> R
+    I -- ok --> J{Sensitivity,<br/>rights, review state}
+    J -- deny --> R
+    J -- restricted --> K[Staged-access<br/>release]
+    J -- ok --> L{Cross-references<br/>& supersession}
+    L -- broken --> R
+    L -- ok --> M{Open-ADR<br/>impact}
+    M -- raises ADR --> N[Open ADR;<br/>park artifact as PROPOSED]
+    M -- none --> P[Emit DoctrineArtifactPreflightReceipt<br/>ALLOW]
+
+    classDef ok fill:#e6f4ea,stroke:#137333,color:#0b6b2a;
+    classDef warn fill:#fff8e1,stroke:#a26a00,color:#5b4500;
+    classDef bad fill:#fce8e6,stroke:#a50e0e,color:#7a0c0c;
+    class P ok;
+    class K,N,ABSTAIN warn;
+    class R bad;
+```
+
+> [!NOTE]
+> The diagram is **NEEDS VERIFICATION** in one respect: the existence and exact name of a `DoctrineArtifactPreflightReceipt` object family is **PROPOSED**. The doctrine of *emitting a receipt for every governance-significant action* is CONFIRMED across `RunReceipt`, `PromotionReceipt`, `AIReceipt`, and `ReleaseManifest`; the doctrine-preflight variant is the natural extension but has no schema home yet.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 6. Gate matrix
+
+Each gate is **MUST**, **SHOULD**, or **MAY** in the RFC-2119 sense Directory Rules §2.2 already uses. The minimum-pass column says what evidence the gate accepts. The deny-on-fail column says what happens when the gate cannot be satisfied.
+
+| # | Gate | Strength | Minimum pass | Deny-on-fail |
+|---|---|---|---|---|
+| 1 | **Identity & lineage** | MUST | Meta Block v2 present; `doc_id`, `version`, `status`, `owners`, `created`, `updated` populated; supersedes entry when a prior edition exists | DENY |
+| 2 | **Truth labels & evidence basis** | MUST | CONFIRMED / PROPOSED / UNKNOWN / NEEDS VERIFICATION applied where confidence materially matters; no "memory as evidence"; no claim of compliance / enforcement / coverage without source-grounded support | DENY |
+| 3 | **Terminology integrity** | MUST | KFM compound terms preserved exactly (e.g., `EvidenceBundle`, `EvidenceRef`, `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`, `ReleaseManifest`, `CorrectionNotice`, `RollbackCard`, `RuntimeResponseEnvelope`, `spec_hash`, `ARTIFACT_DIGEST`) | DENY |
+| 4 | **Placement vs Directory Rules** | MUST | Path is justified by a Directory Rules section; ADR cited when §2.4 applies; per-root README aware | DENY or open drift entry |
+| 5 | **Repo-state containment** | MUST | No "the repo contains X" / "the route exists" / "the tests cover" / "the policy denies" claim without mounted-repo evidence; otherwise labeled PROPOSED / UNKNOWN / NEEDS VERIFICATION | DENY |
+| 6 | **Reproducibility (build only)** | MUST when artifact is built | Pandoc + XeLaTeX + Ghostscript + qpdf pinned in `tool-versions.yaml`; `SOURCE_DATE_EPOCH` set from commit time; Noto fonts embedded; `LC_ALL=C.UTF-8` (or equivalent) | DENY |
+| 7 | **Accessibility (PDF/UA)** | SHOULD (PROPOSED MUST) | Tagged structure, alt-text on non-decorative images, table-header semantics; result recorded in ARTIFACT_DIGEST sidecar | ABSTAIN — log to remediation backlog |
+| 8 | **Integrity** | MUST | `ARTIFACT_DIGEST` = SHA-256 of linearized PDF/A-2u, recorded in sidecar manifest; cosign-signed when artifact will be referenced from a receipt; provenance predicate emitted when SLSA target applies | DENY |
+| 9 | **Sensitivity, rights, review state** | MUST | No T2–T4 content surfaced without staged access; rights/attribution clear; review record current; living-person / DNA / sensitive-geometry deny lanes respected | DENY or restrict |
+| 10 | **Cross-references & supersession** | MUST | All citations resolve; supersession entry present when superseding; prior edition retained; lineage continuous | DENY |
+| 11 | **Open-ADR impact** | MUST | Any Directory Rules §2.4 trigger results in a `PROPOSED` ADR — not a silent path bend | Park artifact as PROPOSED; open ADR |
+
+> [!WARNING]
+> A doctrine artifact that fails **any MUST gate** is not "almost done." It is **PROPOSED** and **must not** be cited as authority, treated as canonical, or used as a foundation for downstream doctrine until the failing gate clears.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 7. The eleven preflight steps
+
+### 7.1 Identity & lineage
+
+The artifact MUST carry a **KFM Meta Block v2** at the top of the file with at minimum: `doc_id`, `title`, `type`, `version`, `status`, `owners`, `created`, `updated`, `policy_label`, `related`, `tags`. If the artifact supersedes a prior edition, it MUST include a **supersession header** with the following fields, modeled on Atlas v1.0 → v1.1:
+
+| Field | Value |
+|---|---|
+| **Prior edition** | Title, version, build date, page count or commit SHA |
+| **Current edition** | Title, version |
+| **Supersession mode** | Integrated extension / Replacement / Forking |
+| **Supersession scope** | Edition identity only / Doctrinal substance / Both |
+| **Reversibility** | Full / Partial / None |
+| **Conflict posture** | Which edition wins on overlapping claims |
+
+Prior editions are **retained, not deleted**. The supersession header is the lineage record.
+
+### 7.2 Truth labels & evidence basis
+
+Every material claim — particularly path claims, route claims, schema-home claims, policy-coverage claims, test-coverage claims, runtime claims, branch-state claims — MUST carry the narrowest truthful label among: **CONFIRMED**, **INFERRED**, **PROPOSED**, **UNKNOWN**, **NEEDS VERIFICATION**, or **EXTERNAL**. Memory is not evidence. Web-derived content used to satisfy a true external-tier gap MUST be cited inline and listed in the artifact's sources.
+
+> [!TIP]
+> A useful self-test: replace each declarative sentence with its label-explicit form. If the result reads "CONFIRMED that the repo contains `apps/governed-api/`," and the only basis is a prior plan or attached report, the original sentence was overclaiming.
+
+### 7.3 Terminology integrity
+
+Run a terminology pass against the **KFM terminology register** before signoff. Compound terms that are checked at minimum:
+
+- `EvidenceBundle`, `EvidenceRef`
+- `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`
+- `ReleaseManifest`, `MapReleaseManifest`, `LayerManifest`, `TileArtifactManifest`
+- `CorrectionNotice`, `RollbackCard`
+- `RuntimeResponseEnvelope` (ANSWER / ABSTAIN / DENY / ERROR)
+- `SourceDescriptor`, `SourceActivationDecision`, `PolicyDecision`, `PromotionReceipt`, `AIReceipt`, `RunReceipt`
+- `spec_hash`, `ARTIFACT_DIGEST`, `SOURCE_DATE_EPOCH`
+- `Promotion is a governed state transition, not a file move`
+- `Watcher-as-non-publisher`
+- `Cite-or-abstain`
+
+External-research phrasing is **not** allowed to overwrite these terms with generic industry equivalents.
+
+### 7.4 Placement vs Directory Rules
+
+The artifact's path MUST be defensible by a specific Directory Rules section. The PR description SHOULD name that section (per Directory Rules §16). If the placement requires a §2.4 trigger — adding/removing/renaming a canonical root, promoting a compatibility root, changing the schema-home rule, splitting/merging a lifecycle phase, creating a parallel home, or bending a §3 invariant — an **ADR** is required before the artifact is treated as canonical.
+
+### 7.5 Repo-state containment
+
+This is the strictest gate for doctrine artifacts. Doctrine describes what *should* be true; it must not invent what *is* true.
+
+- If the repo is **mounted in the preflight session**, repo-state claims MUST be checked directly.
+- If the repo is **not mounted**, repo-state claims MUST be labeled **PROPOSED / UNKNOWN / NEEDS VERIFICATION**.
+- An attached PDF, prior plan, generated tree, or external research result MUST NOT be promoted to "the repo contains X."
+- "Not visible in this workspace" ≠ "not present in the repository."
+
+### 7.6 Reproducibility (build only)
+
+For any artifact that produces a build output (PDF, HTML bundle, exported zip):
+
+- `tool-versions.yaml` MUST pin Pandoc, XeLaTeX, Ghostscript, and qpdf to specific versions, and the build MUST fail closed when discovered versions do not match the pin.
+- `SOURCE_DATE_EPOCH` MUST be set from the git commit time so timestamps are stable.
+- Fonts MUST be embedded (Noto family by default).
+- Locale MUST be neutralized (`LC_ALL=C.UTF-8` or equivalent).
+- Two clean runs on different machines, against the same source, MUST produce byte-identical output.
+
+### 7.7 Accessibility (PDF/UA)
+
+For PDF builds: tagged structure, alt-text on non-decorative images, and table-header markup SHOULD meet **PDF/UA** (ISO 14289). Status is **PROPOSED** until the build chain pins a preflight tool (e.g., verapdf). Until then, failures here ABSTAIN rather than DENY, and remediation items go on a public backlog rather than blocking circulation. As maturity rises, this gate is intended to become MUST.
+
+### 7.8 Integrity — ARTIFACT_DIGEST and signing
+
+For PDF builds:
+
+- The published PDF MUST be linearized via qpdf and emitted as PDF/A-2u.
+- The **ARTIFACT_DIGEST** = `SHA-256(linearized PDF/A-2u bytes)` MUST be computed **after** linearization and recorded in a sidecar manifest, in the catalog metadata, and in any receipt that cites the document.
+- When the artifact will be referenced from a `RunReceipt`, `PromotionReceipt`, `ReleaseManifest`, or any other receipt class, the artifact and its receipt MUST be **cosign-signed** — keyless by default via Sigstore (OIDC + Fulcio + Rekor) or with a pinned key pair when offline operation is required. The bundle digest MUST be recorded inside the receipt as `{type:"cosign", bundle_digest:"sha256:..."}`.
+- When SLSA alignment is the target, a SLSA-style in-toto provenance predicate MUST be emitted and cosign-attested alongside the signature.
+
+> [!IMPORTANT]
+> **A valid signature does NOT override missing evidence, unclear rights, unresolved provenance, sensitivity restrictions, or cultural review requirements.** Signing closes the integrity loop; it does not close the governance loop.
+
+### 7.9 Sensitivity, rights, and review state
+
+Before any non-internal circulation:
+
+- **Rights** — license/attribution clear; SPDX in allowlist when applicable.
+- **Sensitivity** — T0–T4 tier assigned per the sensitivity scheme (PROPOSED canonical per ADR-S-05); sensitive-lane content (archaeology coordinates, rare-species locations, infrastructure detail, living-person fields, DNA, person-parcel joins) defaults to **deny / restrict / generalize / quarantine** and is recorded.
+- **Review state** — ReviewRecord present and within the review-cycle tolerance for the lane.
+- **Living-person, DNA, archaeological-site, critical-infrastructure** content is **deny-by-default**.
+
+If any of these is unclear, the gate output is **ABSTAIN** (route to steward review) — never silent ALLOW.
+
+### 7.10 Cross-references and supersession
+
+- Every `[CITATION]` token (e.g., `[DIRRULES]`, `[ENCY]`, `[DOC-DIR]`, `[BLD-GREEN]`, `[IMPL-PIPE]`, `[UIAI-MASTER]`) resolves to a known source.
+- Every internal Markdown link resolves on GitHub (relative paths preferred; permalinks only for exact line pinning).
+- Prior editions are listed in a **supersession appendix** with `superseded_by` links; the prior edition file is retained.
+- The artifact's entry in `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md` (or equivalent register) is updated if one exists; otherwise the omission is logged.
+
+### 7.11 Open-ADR impact
+
+If the artifact raises any of the architectural questions on the Master Open-ADR Backlog (ADR-S-01 through ADR-S-15, or successors), the artifact is **parked as PROPOSED** and a corresponding ADR is opened *before* the artifact is treated as canonical. Doctrine artifacts must not silently resolve ADR-class questions in their prose.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 8. Decision outcomes
+
+A preflight produces exactly one finite outcome:
+
+| Outcome | Meaning | Required follow-up |
+|---|---|---|
+| **ALLOW** | All MUST gates passed; SHOULD gates passed or formally deferred | Emit DoctrineArtifactPreflightReceipt (PROPOSED object); circulate |
+| **ABSTAIN** | At least one SHOULD gate failed or unclear; no MUST gate failed | Log remediation backlog entry; restricted-circulation only |
+| **DENY** | At least one MUST gate failed | Do not circulate; do not cite as canonical; remediate and re-run |
+| **ERROR** | Preflight could not complete (missing inputs, tool failure, etc.) | Diagnose; re-run; never silently promote from ERROR |
+
+ALLOW is not retroactive. An artifact that previously cleared preflight but whose terminology, repo-state, or sensitivity context has since drifted MUST be re-run before being cited again as `CONFIRMED doctrine`.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 9. Anti-patterns to deny on sight
+
+The following patterns SHOULD trigger immediate DENY at the corresponding gate. The register here merges placement anti-patterns (Directory Rules §13) with doctrine-specific failure modes.
+
+| Anti-pattern | What goes wrong | Triggering gate |
+|---|---|---|
+| **"The repo contains X"** without mounted-repo verification | Doctrine smuggles in implementation claims that prior plans, attached PDFs, or external research cannot prove | Gate 5 (Repo-state containment) |
+| **Terminology drift to generic phrasing** | `EvidenceBundle` becomes "data package"; `RAW → WORK / QUARANTINE → …` becomes "pipeline" | Gate 3 (Terminology integrity) |
+| **Unsupported maturity claim** | "Compliance / enforced / integrated / automated / covered" without evidence | Gate 2 (Truth labels) |
+| **Silent supersession** | New edition replaces a prior edition without retaining the prior or recording lineage | Gate 1 (Identity) + Gate 10 (Supersession) |
+| **Doctrine declares an ADR-class decision in prose** | A path bend, parallel home, or invariant change appears as a sentence rather than as an accepted ADR | Gate 11 (Open-ADR impact) |
+| **Two parallel doctrine homes** | The same doctrine is authored in both `docs/dossiers/` and `docs/atlases/` (or similar) without ADR | Gate 4 (Placement) |
+| **Compatibility root used as authority** | Files that should be in `schemas/` or `policy/` end up in `jsonschema/` or `policies/` and harden into authority | Gate 4 (Placement) |
+| **ARTIFACT_DIGEST recorded before linearization** | The digest will not match what consumers fetch | Gate 8 (Integrity) |
+| **Receipt cites a moving PDF** | The PDF is not byte-reproducible because the toolchain is not pinned | Gate 6 (Reproducibility) + Gate 8 (Integrity) |
+| **Sensitive content surfaced without staged access** | Living-person, DNA, archaeological coordinates, or critical-infrastructure detail in a public artifact | Gate 9 (Sensitivity) |
+| **External research cited for KFM-specific repo-state claims** | Web results substituted for project knowledge or repo evidence | Gate 5 (Repo-state) + governing source hierarchy |
+| **Fluent generation in place of evidence** | AI-generated language smoothing over evidence gaps | Gate 2 (Truth labels) + cite-or-abstain |
+
+> [!CAUTION]
+> When a doctrine artifact bends an invariant, the artifact MUST state the tradeoff clearly. Bending without acknowledgment is itself a denying condition.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 10. Preflight receipt and lineage
+
+Every preflight run SHOULD emit a **DoctrineArtifactPreflightReceipt** (PROPOSED object family) that records:
+
+| Field | Intent |
+|---|---|
+| `receipt_id` | UUID for the preflight run |
+| `artifact_id` | Doctrine artifact identity (matches Meta Block `doc_id`) |
+| `artifact_version` | Edition / version under preflight |
+| `spec_hash` | Hash of the artifact source (and `ARTIFACT_DIGEST` of the built PDF, when applicable) |
+| `gates` | Per-gate result: PASS / ABSTAIN / FAIL with reason code |
+| `outcome` | ALLOW / ABSTAIN / DENY / ERROR |
+| `reviewer` | Docs steward + subsystem owner |
+| `evidence_refs` | Pointers to verifying evidence (Directory Rules section, ADR, repo SHA, prior edition) |
+| `open_questions` | ADR-class questions raised, with proposed ADR titles |
+| `superseded_by` / `supersedes` | Lineage links across editions |
+| `created` | ISO-8601 timestamp |
+| `signature` | cosign attestation (keyless or pinned-key) when integrity gate applies |
+
+**Proposed home of preflight receipts:** `data/receipts/doctrine_preflight/` (PROPOSED — sibling of other receipt classes; subject to ADR-S-03 receipt-class home decision).
+
+**Proposed schema home:** `schemas/contracts/v1/receipts/doctrine_preflight/` (PROPOSED — follows ADR-0001 schema-home convention; subject to verification).
+
+> [!NOTE]
+> Until an accepted ADR establishes the schema home and the receipt object family, preflight runs MAY record the outcome inline in the artifact's PR description and in `docs/registers/DRIFT_REGISTER.md` for failures, and SHOULD treat the receipt schema as PROPOSED.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 11. Maintenance CLI commands
+
+The following commands are provided by `scripts/maintenance/` for CI and operator use.
+
+### Single-command preflight
 
 ```bash
 python scripts/maintenance/run_doctrine_artifact_preflight.py
@@ -26,16 +437,17 @@ Expected behavior:
   - `1`: one or more required artifacts missing and/or status mismatches.
 - Exit `2` indicates malformed registry input or runner-level execution failure.
 
+Use `--stable-filenames` when deterministic receipt names are required by downstream tooling.
 
-
-Emit a standalone presence-input artifact for downstream policy stages:
+Use `--presence-output <path>` to persist the rendered presence input JSON to a file alongside the summary:
 
 ```bash
 python scripts/maintenance/run_doctrine_artifact_preflight.py \
   --presence-output receipts/doctrine_artifacts/presence_input.json
 ```
 
-## Targeted validation commands
+### Targeted validation commands
+
 Check registry/artifact alignment and write receipt:
 
 ```bash
@@ -61,8 +473,6 @@ python scripts/maintenance/sync_doctrine_artifact_registry_status.py \
   --output receipts/doctrine_artifacts/sync_doctrine_artifact_registry_status.json
 ```
 
-
-
 CI drift-check mode (no mutation, fail if registry drift exists):
 
 ```bash
@@ -72,16 +482,232 @@ python scripts/maintenance/sync_doctrine_artifact_registry_status.py \
   --dry-run --fail-on-change
 ```
 
-## Failure interpretation
+### Failure interpretation
 - `result: "error"` means malformed registry (e.g., duplicate filename, invalid status, missing `doc_id`).
 - `result: "fail"` means registry is structurally valid but required artifacts are not yet in compliant state.
 
-
-Use `--stable-filenames` when deterministic receipt names are required by downstream tooling.
-
-
-## Regression test bundle
+### Regression test bundle
 
 ```bash
 ./scripts/maintenance/run_doctrine_artifact_test_suite.sh
 ```
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 12. Quickstart — five-minute pass
+
+This is the fast path for an experienced reviewer. It is **not a substitute** for the full eleven steps; it is a triage pass that surfaces obvious denials early.
+
+```text
+1. Open the artifact. Confirm the KFM Meta Block v2 is present and populated.
+2. Find one repo-state claim. Ask: "Is this CONFIRMED with mounted-repo evidence, or PROPOSED?"
+3. Search the file for these tokens — each must appear with KFM casing:
+     EvidenceBundle | RAW → WORK | ReleaseManifest | CorrectionNotice |
+     RollbackCard  | spec_hash   | ARTIFACT_DIGEST  | cite-or-abstain
+4. Check the path against Directory Rules §3-§5. If the path requires §2.4, an ADR must be linked.
+5. If the artifact supersedes a prior edition, find the supersession header.
+6. If a PDF is produced, confirm tool-versions.yaml pin + ARTIFACT_DIGEST sidecar.
+7. If any sensitive lane is touched, confirm explicit deny / restrict / generalize / quarantine handling.
+```
+
+If any of the seven items fails, escalate to the full eleven-step preflight.
+
+### Reference commands (illustrative — PROPOSED)
+
+```bash
+# Verify build determinism for a doctrine PDF (PROPOSED — toolchain must be available)
+SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
+  LC_ALL=C.UTF-8 \
+  pandoc --metadata=date:"$(date -u -d @$SOURCE_DATE_EPOCH +%Y-%m-%d)" \
+         --pdf-engine=xelatex \
+         doctrine.md -o doctrine.pdf
+
+# Linearize and compute ARTIFACT_DIGEST (PROPOSED)
+qpdf --linearize doctrine.pdf doctrine.linearized.pdf
+sha256sum doctrine.linearized.pdf > doctrine.ARTIFACT_DIGEST
+
+# Cosign keyless sign of the digest (PROPOSED)
+COSIGN_EXPERIMENTAL=1 cosign sign-blob --yes doctrine.linearized.pdf \
+  --output-signature doctrine.sig \
+  --output-certificate doctrine.cert
+```
+
+> [!WARNING]
+> Commands above are **illustrative**. Exact flags, tool versions, and CI wiring depend on `tool-versions.yaml`, the cosign verifier allowlist of OIDC issuers, and the chosen SLSA level — all of which remain PROPOSED until repo verification.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 13. Task list — pin-to-PR checklist
+
+Copy this block into the PR description that proposes, revises, or supersedes a doctrine artifact.
+
+```markdown
+### Doctrine Artifact Preflight (docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md)
+
+- [ ] **Gate 1 — Identity & lineage.** KFM Meta Block v2 present and populated; supersession header included if applicable.
+- [ ] **Gate 2 — Truth labels.** CONFIRMED / PROPOSED / UNKNOWN / NEEDS VERIFICATION applied where confidence matters; no "memory as evidence."
+- [ ] **Gate 3 — Terminology integrity.** KFM compound terms preserved exactly; no generic-industry overwrite.
+- [ ] **Gate 4 — Placement.** Path defensible by a named Directory Rules section; ADR cited when §2.4 applies.
+- [ ] **Gate 5 — Repo-state containment.** No repo-state claim escapes its label; mounted-repo verification done or NEEDS VERIFICATION applied.
+- [ ] **Gate 6 — Reproducibility.** `tool-versions.yaml` pin / `SOURCE_DATE_EPOCH` / embedded fonts / neutral locale — or N/A (no build).
+- [ ] **Gate 7 — Accessibility.** PDF/UA preflight result recorded — or remediation backlog entry — or N/A (no PDF).
+- [ ] **Gate 8 — Integrity.** `ARTIFACT_DIGEST` recorded in sidecar; cosign signature when receipt-referenced — or N/A.
+- [ ] **Gate 9 — Sensitivity, rights, review state.** Tier assignment, rights/attribution, review record current; sensitive lanes deny-by-default.
+- [ ] **Gate 10 — Cross-references & supersession.** Citations resolve; prior edition retained; supersession lineage continuous.
+- [ ] **Gate 11 — Open-ADR impact.** Any §2.4-class question resolved by an ADR — not by prose.
+- [ ] **Rule cited.** This PR description names the Directory Rules section that justifies the placement.
+- [ ] **Reviewer separation.** Author ≠ approver when the artifact is materiality-significant.
+```
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 14. FAQ
+
+**Is this runbook itself a doctrine artifact?**
+Yes. It is intended to pass its own preflight. Its current `status:` is `draft`, its repo-state claims are labeled, its placement is PROPOSED, and the receipt object it proposes is itself PROPOSED. Promoting it to canonical will require ADR-S-15 to be accepted and the corresponding ADR for receipt-class home to be resolved.
+
+**Why a separate preflight for doctrine? Doesn't the promotion gate already cover this?**
+The promotion gate (A–G) governs **implementation artifacts** moving through the lifecycle. Doctrine artifacts shape what gets promoted but are not themselves PROMOTED in the lifecycle sense; they are CIRCULATED and CITED. A separate gate protects doctrine from being treated as repo-state and protects repo-state from being treated as doctrine.
+
+**What if the repo is not mounted in the preflight session?**
+Repo-state claims MUST be labeled `PROPOSED / UNKNOWN / NEEDS VERIFICATION`. The preflight does not pretend the repo is absent or empty; it labels what cannot be checked. See `<repository_preflight>` in the working-method governance for this stance.
+
+**Can external research satisfy Gate 5 (Repo-state containment)?**
+No. External research is permitted for version-sensitive standards, external tool behavior, security-relevant facts, or true gaps unresolved by project sources — and only with inline citation. It is **never** permitted as a substitute for mounted-repo evidence in repo-state claims.
+
+**What is the difference between ABSTAIN and DENY?**
+DENY blocks circulation. ABSTAIN routes to steward review and a remediation backlog entry; the artifact may circulate with restricted authority (e.g., "draft, accessibility-pending"). Until PDF/UA preflight is enforced, accessibility failures ABSTAIN rather than DENY.
+
+**Is preflight the same as review?**
+No. Preflight is the **machine-checkable + reviewer-glance** layer. **Review** is the steward-level read for substance, materiality, and judgment. Preflight clears the runway so review can focus on doctrine, not on terminology drift, missing meta blocks, or unbounded repo-state claims.
+
+**Where do failures go?**
+- MUST-gate failures → DENY → fix and re-run.
+- SHOULD-gate failures → ABSTAIN → entry in `docs/registers/DRIFT_REGISTER.md` and/or `docs/registers/VERIFICATION_BACKLOG.md`.
+- Open-ADR triggers → entry in the proposed ADR backlog; artifact parked as PROPOSED.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 15. Related docs
+
+- `docs/doctrine/directory-rules.md` — placement authority, §§2.4, 3, 5, 13–16.
+- `docs/doctrine/authority-ladder.md` — authority class taxonomy (PROPOSED home).
+- `docs/doctrine/truth-posture.md` — cite-or-abstain (PROPOSED home).
+- `docs/doctrine/trust-membrane.md` — public/internal boundary (PROPOSED home).
+- `docs/doctrine/lifecycle-law.md` — `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` (PROPOSED home).
+- `docs/registers/DRIFT_REGISTER.md` — open conflicts between repo and doctrine.
+- `docs/registers/VERIFICATION_BACKLOG.md` — open NEEDS VERIFICATION items.
+- `docs/standards/SIGNING.md` — cosign / Sigstore policy (PROPOSED home).
+- `docs/standards/PROVENANCE.md` — SLSA / in-toto predicate policy (PROPOSED home).
+- `docs/standards/CANONICALIZATION.md` — JCS vs URDNA2015 policy (PROPOSED home).
+- `docs/adr/ADR-0001-schema-home.md` — schema-home convention (PROPOSED ID).
+- `docs/adr/ADR-S-02-doctrine-artifact-placement.md` — `docs/dossiers/` vs `docs/atlases/` (PROPOSED).
+- `docs/adr/ADR-S-03-receipt-class-home.md` — receipt schema layout (PROPOSED).
+- `docs/adr/ADR-S-13-drift-register-triage.md` — drift triage cadence (PROPOSED).
+- `docs/adr/ADR-S-15-doctrine-artifact-lifecycle.md` — Atlas / supplement lifecycle (PROPOSED — directly authorizes this runbook).
+- `docs/runbooks/ui_VALIDATION.md`, `docs/runbooks/ui_LOCAL_DEV.md`, `docs/runbooks/ui_ROLLBACK.md` — sibling runbooks (PROPOSED).
+- `docs/runbooks/governed_ai_VALIDATION.md`, `docs/runbooks/governed_ai_LOCAL_DEV.md`, `docs/runbooks/governed_ai_ROLLBACK.md` — sibling runbooks (PROPOSED).
+
+> [!NOTE]
+> All paths above are **PROPOSED** under Directory Rules until mounted-repo evidence confirms presence. Their inclusion here records the intended cross-link graph, not current repo state.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 16. Appendix
+
+<details>
+<summary><strong>A. C13 reproducible-documentation chain — at a glance</strong></summary>
+
+| Element | Status | Purpose |
+|---|---|---|
+| Pandoc pin (e.g., 3.1.12.3) | CONFIRMED doctrine | Stable Markdown → intermediate conversion |
+| XeLaTeX pin (named TeX Live release) | CONFIRMED doctrine | Stable glyph metrics |
+| Ghostscript pin (named version) | CONFIRMED doctrine | Stable PDF object structure |
+| qpdf pin (named version) + linearize | CONFIRMED doctrine | Streaming PDF/A-2u output |
+| `tool-versions.yaml` | CONFIRMED doctrine | Build-time verifier; fail-closed on mismatch |
+| `SOURCE_DATE_EPOCH` from git commit time | CONFIRMED doctrine | Deterministic timestamps |
+| Embedded Noto font family | CONFIRMED doctrine | Eliminates system-font drift |
+| `LC_ALL=C.UTF-8` (or equivalent) | CONFIRMED doctrine | Locale-neutral output |
+| PDF/UA preflight (verapdf or equivalent) | PROPOSED | Accessibility conformance |
+| `ARTIFACT_DIGEST = SHA-256(linearized PDF/A-2u)` | CONFIRMED doctrine | Citation anchor |
+| cosign keyless signing (Sigstore + Fulcio + Rekor) | CONFIRMED doctrine | Signature on receipts and artifacts |
+| SLSA in-toto provenance predicate | CONFIRMED doctrine | Supply-chain attestation |
+
+</details>
+
+<details>
+<summary><strong>B. Atlas v1.0 → v1.1 supersession header — worked template</strong></summary>
+
+```text
+Prior edition:       <Title>, vX; PDF dated YYYY-MM-DD; <N> pages.
+Current edition:     <Title>, vY (this document).
+Supersession mode:   <Integrated extension | Replacement | Forking>
+Supersession scope:  <Edition identity only | Doctrinal substance | Both>
+Reversibility:       <Full | Partial | None>
+Conflict posture:    <Which edition wins on overlapping claims, and why>
+```
+
+Modeled on the Atlas v1.0 → v1.1 lineage (Domains Culmination Atlas), where v1.0 is retained verbatim as the interior of v1.1, and v1.1 adds only front matter, Chapter 24, and Appendix G — yielding **full reversibility**.
+
+</details>
+
+<details>
+<summary><strong>C. Open ADRs relevant to this runbook (PROPOSED)</strong></summary>
+
+| ADR | Why it matters here |
+|---|---|
+| **ADR-0001** | Schema-home convention (default `schemas/contracts/v1/...`) — governs where the preflight-receipt schema lives. |
+| **ADR-S-02** | Doctrine artifact placement under `docs/` — governs where this runbook and its sibling artifacts live. |
+| **ADR-S-03** | Receipt class home — governs where `DoctrineArtifactPreflightReceipt` lives. |
+| **ADR-S-05** | Sensitivity tier scheme T0–T4 — informs Gate 9. |
+| **ADR-S-09** | Reviewer role separation — governs author ≠ approver thresholds. |
+| **ADR-S-11** | Story / export receipt scope — informs whether a doctrine-export carries a preflight receipt. |
+| **ADR-S-13** | Drift register triage — governs the routing of preflight failures. |
+| **ADR-S-15** | Doctrine artifact lifecycle — directly authorizes this runbook; until accepted, this runbook is itself PROPOSED. |
+
+</details>
+
+<details>
+<summary><strong>D. Glossary (relevant subset)</strong></summary>
+
+| Term | Definition relevant to this runbook |
+|---|---|
+| **Doctrine artifact** | Document whose role is to establish or refine KFM governance, architecture, terminology, policy posture, or release law. |
+| **Implementation artifact** | Built data product (tile, COG, GeoParquet, layer manifest, release manifest, etc.) governed by promotion gates A–G. |
+| **Preflight** | Pre-circulation governance check; finite outcomes ALLOW / ABSTAIN / DENY / ERROR. |
+| **Cite-or-abstain** | Default truth posture: a claim either cites resolvable evidence or abstains. |
+| **EvidenceBundle / EvidenceRef** | Resolved evidence package, and pointer to it from a claim. EvidenceBundle outranks generated language. |
+| **`ARTIFACT_DIGEST`** | SHA-256 of the linearized PDF/A-2u output of a published artifact; the citation anchor. |
+| **Watcher-as-non-publisher** | Workers emit receipts and candidates only; they do not publish, mutate canonical records, or bypass review. |
+| **Promotion** | A governed state transition between lifecycle phases. Not a file move. |
+| **Supersession** | Replacement of a prior edition by a new one with explicit lineage retained. Atlases / supplements use the supersession-appendix pattern. |
+
+</details>
+
+<details>
+<summary><strong>E. What this runbook does NOT do</strong></summary>
+
+- It does not decide **whether** a doctrine artifact should exist.
+- It does not replace **review** for substance, materiality, or judgment.
+- It does not authorize **publication** by itself — publication still passes Gate 9 and the release authority's signoff.
+- It does not certify any **repo state**. Every repo-state claim in this runbook is PROPOSED or NEEDS VERIFICATION until mounted-repo evidence confirms it.
+
+</details>
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+> **Related:** [`directory-rules.md`](../doctrine/directory-rules.md) · [`DRIFT_REGISTER.md`](../registers/DRIFT_REGISTER.md) · [`VERIFICATION_BACKLOG.md`](../registers/VERIFICATION_BACKLOG.md) · [`ADR-S-15`](../adr/ADR-S-15-doctrine-artifact-lifecycle.md)
+> **Last updated:** 2026-05-12 · **Owner:** Docs steward · **Status:** draft · **Authority:** PROPOSED (pending ADR-S-15)
+> [⬆ Back to top](#-quick-jump)

--- a/docs/runbooks/EVIDENCE_CORRECTION.md
+++ b/docs/runbooks/EVIDENCE_CORRECTION.md
@@ -1,3 +1,647 @@
-# EVIDENCE_CORRECTION
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/evidence-correction
+title: Evidence Correction Runbook
+type: standard
+version: v1
+status: draft
+owners: [docs-steward, correction-reviewer]  # NEEDS VERIFICATION — confirm against CODEOWNERS / governance register
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/runbooks/README.md
+  - docs/runbooks/ROLLBACK.md                  # NEEDS VERIFICATION — exact filename
+  - docs/governance/SEPARATION_OF_DUTIES.md    # NEEDS VERIFICATION
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/trust-membrane.md
+  - docs/registers/DRIFT_REGISTER.md
+  - contracts/correction/correction_notice.md  # NEEDS VERIFICATION
+  - schemas/contracts/v1/correction/correction_notice.schema.json  # PROPOSED
+  - release/                                   # release decisions & rollback targets
+tags: [kfm, runbook, correction, evidence, governance, supersession, lifecycle]
+notes:
+  - Status PROPOSED until validators, schemas, CI gates, and CorrectionNotice schema land in repo evidence.
+  - Doctrine is CONFIRMED from attached corpus; operational paths, validator IDs, and CI commands remain PROPOSED until mounted-repo inspection.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+<a id="top"></a>
+
+# Evidence Correction Runbook
+
+> Governed procedure for correcting a **PUBLISHED** KFM claim, layer, catalog record, artifact, or AI answer when a defect is detected — without silently mutating the original release.
+
+<p align="center">
+  <b>Kansas Frontier Matrix — Evidence First · Cite or Abstain · Fail Closed · Reversible by Design</b>
+</p>
+
+<p align="center">
+  <img alt="Lifecycle" src="https://img.shields.io/badge/lifecycle-PUBLISHED%E2%86%92PUBLISHED'-blue">
+  <img alt="Posture" src="https://img.shields.io/badge/posture-fail--closed-red">
+  <img alt="Required" src="https://img.shields.io/badge/required-CorrectionNotice-orange">
+  <img alt="Separation of duties" src="https://img.shields.io/badge/SoD-author%E2%89%A0reviewer-purple">
+  <img alt="Status" src="https://img.shields.io/badge/status-draft-lightgrey">
+  <img alt="Doctrine" src="https://img.shields.io/badge/doctrine-CONFIRMED-green">
+  <img alt="Implementation" src="https://img.shields.io/badge/implementation-PROPOSED-yellow">
+</p>
+
+| Field | Value |
+|---|---|
+| **Status** | Draft (PROPOSED implementation; CONFIRMED doctrine) |
+| **Owners** | Docs steward · Correction reviewer · Release authority *(roles per Atlas §24.7; concrete owners NEEDS VERIFICATION)* |
+| **Last updated** | 2026-05-12 |
+| **Authority** | Lifecycle law · Trust membrane · Directory Rules §6.1 (`docs/runbooks/`) |
+| **Audience** | Stewards, reviewers, release authorities, defect detectors, on-call docs steward |
+
+---
+
+## Quick links
+
+- [1 · Purpose & scope](#1--purpose--scope)
+- [2 · When to use this runbook](#2--when-to-use-this-runbook)
+- [3 · Stale vs. wrong — the critical distinction](#3--stale-vs-wrong--the-critical-distinction)
+- [4 · Defect classification matrix](#4--defect-classification-matrix)
+- [5 · Roles and separation of duties](#5--roles-and-separation-of-duties)
+- [6 · The correction procedure (step by step)](#6--the-correction-procedure-step-by-step)
+- [7 · CorrectionNotice contract](#7--correctionnotice-contract)
+- [8 · Supersession lineage](#8--supersession-lineage)
+- [9 · Derivative invalidation](#9--derivative-invalidation)
+- [10 · Gate failures and reason codes](#10--gate-failures-and-reason-codes)
+- [11 · End-to-end flow (diagram)](#11--end-to-end-flow-diagram)
+- [12 · Worked examples (illustrative)](#12--worked-examples-illustrative)
+- [13 · Health indicators](#13--health-indicators)
+- [14 · Anti-patterns](#14--anti-patterns)
+- [15 · Related docs](#15--related-docs)
+- [16 · Appendix: checklists & references](#16--appendix-checklists--references)
+
+---
+
+## 1 · Purpose & scope
+
+> [!IMPORTANT]
+> **Correction is a publication requirement, not an afterthought.** A released claim, layer, catalog record, artifact, or AI answer must have a **visible correction path and a rollback target** before it is treated as safely publishable.
+> — *CONFIRMED doctrine: BLD-GREEN §20; BLD-COMP §§21-22; IMPL-PIPE §21; Atlas §24.6.1.*
+
+This runbook describes how KFM **corrects** a `PUBLISHED` claim when a defect is detected. It governs the lifecycle transition **`PUBLISHED → PUBLISHED'`** — the issuance of a *superseding* release.
+
+It is the operational companion to:
+
+- the **CorrectionNotice** object family (`contracts/correction/`, `schemas/contracts/v1/correction/`),
+- the **ReleaseManifest** and **RollbackCard** objects in `release/`,
+- the **review** flow that produces `ReviewRecord`s, and
+- the separation-of-duties policy in Atlas §24.7.
+
+### Out of scope
+
+| Concern | Where to look |
+|---|---|
+| Hard rollback to a prior release (no superseding fix yet) | `docs/runbooks/ROLLBACK.md` *(NEEDS VERIFICATION — exact filename)* |
+| Stale-state marking only (claim not wrong, just aged) | §3 below; UI stale-source badge guidance |
+| Source-level admission / rights changes | `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` *(PROPOSED)* |
+| Policy bundle change | ADR + `policy/<lane>/` |
+| Schema migration | ADR-class change; `migrations/` |
+
+[Back to top](#top)
+
+---
+
+## 2 · When to use this runbook
+
+Use this runbook whenever **any** of the following is detected against content already in `PUBLISHED`:
+
+- An **EvidenceBundle** referenced by a public claim no longer resolves, is wrong, or no longer supports the claim.
+- A **source role** was mis-classified (e.g., a *modeled* output was treated as *observed*).
+- **Rights** or **license** posture for a referenced source has changed.
+- **Sensitivity** disclosure has occurred (e.g., a sensitive geometry leaked through a tile, popup, or AI text channel).
+- A **geometry** or **temporal** error is present in a released artifact.
+- A **PolicyDecision** referenced by the release was superseded or evaluated against an outdated bundle.
+- A **validator** would now FAIL the release if re-run on current evidence.
+- A **rendering** or **API** defect changes the public meaning of the claim.
+- An **AI answer** was emitted in violation of cite-or-abstain or denied-class policy.
+- A **catalog** closure (proof, manifest, digest) is no longer intact.
+
+> [!TIP]
+> If the published surface is *aged* but not *wrong*, you may not need a correction — you may only need a **stale marker**. See §3.
+
+> [!CAUTION]
+> If sensitivity, rights, sovereignty, living-person/DNA, archaeology, infrastructure, or precise location exposure is involved, **default to immediate public-surface disablement first** (fail-closed), then proceed with the correction. Never let polish or process lag protect a sensitive leak. *(CONFIRMED doctrine: Build Manual defect-class table; Atlas §24.5.)*
+
+[Back to top](#top)
+
+---
+
+## 3 · Stale vs. wrong — the critical distinction
+
+KFM separates these states deliberately. *(CONFIRMED doctrine: Atlas §24.8.)*
+
+| State | Meaning | First action | Correction required? |
+|---|---|---|---|
+| **Stale** | Evidence, source freshness, dependent data, or context has aged past its declared tolerance. The claim **was** supportable. | Apply the appropriate **stale-state marker** in the Evidence Drawer; trigger steward review. | Only if review finds substance is also wrong. |
+| **Wrong** | The substance of the claim is incorrect, no longer supported, or violates policy/rights/sensitivity. | Disable affected surface where required; open this runbook. | **Yes** — emit `CorrectionNotice` and supersede. |
+
+### Stale-state markers (no `CorrectionNotice` required)
+
+| Marker | Triggered by | Required action |
+|---|---|---|
+| Source freshness expired | `SourceDescriptor` cadence passed without new admission | Re-admit or supersede; mark dependent claims stale |
+| Schema version drift | Schema upgraded past the published claim's schema version | Migrate, re-validate, re-release; or mark stale |
+| Geography version drift | `GeographyVersion` replaced; published claim still bound to prior | Rebind & re-release; or mark stale |
+| Time-scope outside support | Claim's temporal scope outside current data support window | Mark stale; do not silently refresh |
+| Model version superseded | `ModelRunReceipt` references older model than current | Re-run; supersede; or mark stale |
+| Review aged out | `ReviewRecord` older than review-cycle tolerance | Trigger steward review; potentially downgrade tier |
+| Rights status changed | Rights change in `SourceDescriptor` | Re-evaluate tier; **emit `CorrectionNotice` if necessary** |
+| Policy version changed | Policy referenced by `PolicyDecision` was superseded | Re-run gate; potentially supersede release |
+
+> [!NOTE]
+> "Rights status changed" and "policy version changed" sit on the boundary. If the change inverts the public posture of the claim (e.g., it is no longer releasable), treat it as **wrong** and proceed with full correction.
+
+[Back to top](#top)
+
+---
+
+## 4 · Defect classification matrix
+
+Classify the defect using the canonical class set. This decides correction posture **and** rollback posture. *(CONFIRMED doctrine: Build Manual defect-class table; BLD-GREEN §20; IMPL-PIPE §§21, 27; BLD-COMP §§21-23.)*
+
+| Defect class | Correction posture | Rollback posture |
+|---|---|---|
+| **Evidence gap** | `ABSTAIN` on the claim, or withdraw the unsupported claim entirely | Restore prior evidence-supported release |
+| **Source-role mis-classification** | Restore the correct source role; refuse upcast (e.g., modeled → observed) | Restore prior release if downstream cascaded |
+| **Rights defect** | `DENY` public use; quarantine source / artifact | Withdraw affected artifacts |
+| **Sensitivity leak** | Redact / generalize and notify stewards | **Immediate public disablement** |
+| **Geometry defect** | Rebuild derivative layer and evidence payload | Restore previous digest-pinned artifact |
+| **Temporal defect** | Correct `valid` / `source` / `retrieval` / `release` time | Mark stale until rebuilt |
+| **Policy defect** | Re-run policy and `DecisionEnvelope` | Disable route / layer if gate failed |
+| **Validation defect** | Re-run validators; emit corrected `ValidationReport` | Restore prior `ValidationReport`-pinned release |
+| **Rendering defect** | Fix renderer / style / tile pipeline; re-publish layer | Restore prior `MapReleaseManifest` |
+| **API defect** | Patch governed-API contract; re-emit `DecisionEnvelope` | Disable affected route; restore prior contract |
+| **AI answer defect** | Invalidate `AIReceipt` and `RuntimeResponseEnvelope` | Remove answer; **preserve EvidenceBundle** |
+| **Catalog defect** | Re-emit catalog closure after proof repair | Restore previous catalog state |
+
+> [!IMPORTANT]
+> Correction is a **state transition**, not a file edit. The original release record is **preserved**; a *superseding* release is issued. Silent mutation of a published artifact is a doctrine violation. *(CONFIRMED: Atlas §24.8.2 supersession lineage; Build Manual rollback model.)*
+
+[Back to top](#top)
+
+---
+
+## 5 · Roles and separation of duties
+
+*(CONFIRMED doctrine: Atlas §24.7.)*
+
+| Role | Responsibility in correction |
+|---|---|
+| **Detector / author** | Files the defect; assembles initial evidence and proposed correction class |
+| **Domain steward** | Confirms classification; owns the corrected EvidenceBundle and any contract/schema implications |
+| **Sensitivity reviewer** | Required when the defect involves sensitivity, redaction, generalization, or tier reassignment |
+| **Rights-holder representative** | Required when sovereignty, cultural heritage, or consent-based release is affected |
+| **Correction reviewer** | Reviews the `CorrectionNotice` and `RollbackCard` before they amend a `PUBLISHED` claim |
+| **Release authority** | Authorizes the superseding release; signs `ReleaseManifest`; names the rollback target |
+| **AI surface steward** | Required when an `AIReceipt` is invalidated or Focus Mode template/policy binding changes |
+| **Docs steward** | Confirms the public correction surface (UI banner, drawer note, manifest entry) and updates registers |
+
+### Separation-of-duties matrix (correction-specific)
+
+| Action | May author also approve? | Required separation |
+|---|---|---|
+| Routine correction (non-material) | Yes | Author + correction reviewer |
+| Steward-significant correction | **No** | Author / detector + correction reviewer + release authority |
+| Sensitive-lane correction (archaeology, fauna, flora, living-person/DNA, infrastructure) | **No** | Author + sensitivity reviewer + release authority + rights-holder rep |
+| AI-answer correction (template / policy binding) | **No** | AI surface steward + docs steward |
+
+> [!NOTE]
+> **Maturity note.** Atlas §24.7 and Directory Rules §2 treat separation of duties as *maturity-dependent*. Early-stage doctrine work may be authored and approved by the same actor when materiality is low. As the public trust surface expands, separation MUST be enforced through tooling — not custom. This runbook documents the destination posture; current enforcement is `PROPOSED`.
+
+[Back to top](#top)
+
+---
+
+## 6 · The correction procedure (step by step)
+
+The procedure preserves the original release record, identifies the defect, classifies it, emits a `CorrectionNotice`, updates the relevant `EvidenceBundle` and `ReleaseManifest`, and **publishes a superseding release** rather than silently mutating the old one. *(CONFIRMED doctrine: BLD-GREEN §20; IMPL-PIPE §§21, 27; BLD-COMP §§21-23.)*
+
+### Step 0 — Triage (within 1 working day of detection)
+
+1. **Confirm the defect** against current `PUBLISHED` surfaces (Evidence Drawer, Focus Mode, layer manifest, governed-API response).
+2. **Decide stale vs. wrong** using §3.
+3. **Sensitivity check.** If sensitivity / rights / sovereignty / living-person / DNA / archaeology / infrastructure / precise location is implicated, **disable the affected public surface immediately** (fail-closed) before proceeding. Record the disablement.
+4. **Open a tracking entry** in the correction queue (system of record `PROPOSED`; today, an issue or `docs/registers/DRIFT_REGISTER.md` entry).
+
+> [!WARNING]
+> Steps 1–3 happen **before** classification refinement. Sensitive leaks do not wait for a tidy classification.
+
+### Step 1 — Classify
+
+Pick exactly one primary defect class from the matrix in §4. If the defect spans classes, pick the **most release-blocking** class as primary and record the others as secondary.
+
+### Step 2 — Quarantine affected public surfaces
+
+Depending on class and severity:
+
+- **Sensitivity / rights leak** → disable layer, popup field, Focus Mode template, or governed-API route.
+- **Evidence gap / catalog defect** → `ABSTAIN` or `DENY` on the specific claim while leaving non-affected surfaces live.
+- **AI answer defect** → invalidate `AIReceipt`; remove the answer from any cached surface; preserve the underlying `EvidenceBundle`.
+- **Geometry / temporal / rendering defect** → mark layer stale; keep prior digest-pinned artifact live if safer than removal.
+
+Record the quarantine action so it can be unwound by the superseding release.
+
+### Step 3 — Gather corrected evidence
+
+- Pull the **affected `EvidenceBundle`(s)** by `spec_hash` / `bundle_id`.
+- Identify the **upstream `SourceDescriptor`** and confirm rights / sensitivity / cadence.
+- If new evidence is needed, route through normal admission (`— → RAW → WORK → …`). The correction lane does **not** bypass the gates.
+- If no replacement evidence is available, the correction posture becomes **`ABSTAIN` / withdraw** rather than re-state.
+
+### Step 4 — Build the superseding artifacts
+
+For each affected object class, produce the corrected artifact via the **same governed pipeline**:
+
+| Class | Corrected artifact(s) |
+|---|---|
+| Evidence | New `EvidenceBundle` with fresh `spec_hash`; old bundle retained for audit |
+| Geometry / layer | Rebuilt layer + `LayerManifest` + tile / COG / PMTiles artifacts with new digests |
+| Policy | Re-evaluated `PolicyDecision`; new `DecisionEnvelope` |
+| AI surface | Invalidated `AIReceipt`; corrected Focus Mode template / policy binding |
+| Catalog | Re-emitted `CatalogRecord` after proof repair |
+
+Each rebuild MUST emit its own `RunReceipt` and pass its lifecycle gates fail-closed. *(CONFIRMED doctrine: Atlas §24.6.1.)*
+
+### Step 5 — Emit the `CorrectionNotice`
+
+The `CorrectionNotice` is the **public record of the change**. It links the prior release, the defect class, the corrected artifacts, and the invalidated derivatives. See §7 for the contract.
+
+### Step 6 — Review (separation of duties)
+
+Route through the required reviewers per §5. Reviewer outcomes:
+
+- **APPROVE** → proceed to Step 7.
+- **HOLD** → release stays at prior state; reviewer note recorded; no public claim change.
+- **REJECT** → defect re-classified or evidence insufficient; loop to Step 1 or Step 3.
+
+> [!IMPORTANT]
+> A reviewer rejection **does not silently undo the quarantine** in Step 2. Sensitivity disablement remains in effect until either (a) the superseding release is published or (b) a rollback runbook is invoked.
+
+### Step 7 — Release the superseding version
+
+- The **release authority** (distinct from the author when materiality applies) signs the new `ReleaseManifest`.
+- The new manifest names a **valid rollback target** (the prior release).
+- The `CorrectionNotice` is **attached** to the new release and made visible on the affected public claim (banner, drawer note, manifest entry).
+- The original release record is **preserved**, marked as superseded, with a forward link to the new release.
+
+### Step 8 — Invalidate derivatives
+
+See §9. This is not optional — corrections that fail to name and invalidate downstream derivatives leave silent stale claims in the system.
+
+### Step 9 — Audit & close
+
+- Update `docs/registers/DRIFT_REGISTER.md` if the defect originated in drift.
+- Record **correction lead time** (detection → `CorrectionNotice`) for the health indicators in §13.
+- File a post-mortem if the defect was sensitivity-related, sovereignty-related, or required immediate disablement.
+
+[Back to top](#top)
+
+---
+
+## 7 · CorrectionNotice contract
+
+> [!NOTE]
+> The `CorrectionNotice` object is defined in `contracts/correction/` *(PROPOSED home; verify against `directory-rules.md §6.3`)*. Its machine schema lives at `schemas/contracts/v1/correction/correction_notice.schema.json` *(PROPOSED)*. The fields below reflect CONFIRMED doctrine from the Atlas and Encyclopedia.
+
+### Required fields (CONFIRMED doctrine; field names PROPOSED until schema lands)
+
+| Field | Meaning |
+|---|---|
+| `claim_ref` | Reference to the published claim (catalog record, layer, AI answer, etc.) being corrected |
+| `prior_release_ref` | The `ReleaseManifest` of the release being superseded |
+| `defect_class` | One of the canonical classes in §4 |
+| `change_summary` | Plain-language description of what changed and why |
+| `invalidates[]` | Derivatives, indexes, exports, tiles, AI answers, search summaries invalidated by this correction |
+| `evidence_bundle_refs[]` | Old and new `EvidenceBundle` references |
+| `review_ref` | `ReviewRecord` from the correction reviewer (and rights-holder rep when required) |
+| `release_manifest_ref` | The **new** `ReleaseManifest` carrying the superseding release |
+| `rollback_target` | The release to restore if the superseding release itself fails |
+| `time` | ISO-8601 UTC timestamp of the notice |
+
+### Illustrative example (PROPOSED — not a binding schema)
+
+<details>
+<summary>Show example <code>CorrectionNotice</code></summary>
+
+```json
+{
+  "schema_version": "v1",
+  "object_type": "CorrectionNotice",
+  "notice_id": "kfm://correction/<uuid>",
+  "claim_ref": "kfm://claim/<id>",
+  "prior_release_ref": "kfm://release/manifest/<prior-id>",
+  "defect_class": "geometry",
+  "change_summary": "Layer X reprojected; prior CRS metadata understated planar error by ~3.2m at scale 1:24k.",
+  "invalidates": [
+    "kfm://layer/X/tiles@<digest>",
+    "kfm://export/storysnapshot/<snapshot-id>"
+  ],
+  "evidence_bundle_refs": [
+    {"role": "prior", "spec_hash": "sha256:<old>"},
+    {"role": "current", "spec_hash": "sha256:<new>"}
+  ],
+  "review_ref": "kfm://review/<reviewrecord-id>",
+  "release_manifest_ref": "kfm://release/manifest/<new-id>",
+  "rollback_target": "kfm://release/manifest/<prior-id>",
+  "time": "2026-05-12T17:00:00Z"
+}
+```
+
+> **Status:** Illustrative only. Field names, URI schemes, and the exact JSON shape are `PROPOSED` until the `correction_notice.schema.json` is verified in the repo.
+
+</details>
+
+### What a CorrectionNotice does **not** do
+
+- It does **not** publish. The new `ReleaseManifest` publishes.
+- It does **not** approve itself. Review precedes emission.
+- It does **not** replace the prior release's record — the prior record stays, marked superseded.
+- It does **not** suppress audit. Old `EvidenceBundle`s are retained.
+
+[Back to top](#top)
+
+---
+
+## 8 · Supersession lineage
+
+Every object class has a supersession rule. *(CONFIRMED doctrine: Atlas §24.8.2.)*
+
+| Object class | Supersession rule | Required lineage artifact |
+|---|---|---|
+| `SourceDescriptor` | Replaced by newer descriptor; old retained with `superseded_by` link | Supersession entry in source register |
+| `EvidenceBundle` | Replaced when corrected; old bundle retained for audit | `EvidenceBundle` + `CorrectionNotice` + supersession link |
+| `GeographyVersion` | Replaced by newer version; both remain queryable for time-bound claims | Version register entry + crosswalk |
+| Schema (`schemas/contracts/v1/...`) | Replaced via ADR; old schema retained | ADR + supersession link in schema header |
+| Policy | Replaced via accepted ADR; old policy retained | ADR + supersession link |
+| `ReleaseManifest` | Replaced by next release; rollback target remains valid | Manifest history + rollback chain |
+| `AIReceipt` | **Never** superseded retroactively. Old answer retained; new answer is a new receipt | Two distinct `AIReceipt`s with cross-reference |
+| Atlas / supplement | Superseded by ADR-recorded new version; lineage retained | Atlas / supplement supersession appendix |
+
+> [!IMPORTANT]
+> **`AIReceipt` is special.** AI answers are never rewritten in place. A correction produces a **new** `AIReceipt` with a cross-reference to the prior one. This preserves the audit trail of what the system said when, even after the system says something different.
+
+[Back to top](#top)
+
+---
+
+## 9 · Derivative invalidation
+
+A correction MUST identify and invalidate downstream derivatives, or it leaves stale claims live on public surfaces. *(CONFIRMED doctrine: Atlas §24.11.2 "Derivative-invalidation coverage".)*
+
+### Typical derivatives to check
+
+| Derivative | Where to invalidate | Notes |
+|---|---|---|
+| Vector / raster tiles (MVT / PMTiles / COG) | `MapReleaseManifest`, CDN cache, tile artifact registry | Rebuild from corrected source; new digest |
+| Catalog records / search indexes | `CatalogRecord`, `SearchIndexManifest` | Search indexes are **derivative**; re-emit, don't trust |
+| Graph / triplet projections | `Triplet`, `GraphDelta` | Graph is derivative of canonical / catalog truth |
+| AI answers and exports | `AIReceipt`, `StorySnapshot`, `ExportReceipt` | Replace with new receipts; never silently rewrite |
+| Evidence Drawer payloads | `EvidenceDrawerPayload` cache | Rebuild against corrected `EvidenceBundle` |
+| Crosswalks / overlays | `Crosswalk`, `OverlayReceipt` | Cross-domain joins amplify defects — invalidate liberally |
+
+### CDN / cache discipline
+
+> [!CAUTION]
+> Public tile, COG, and PMTiles surfaces are commonly served through caches. A correction without a **cache-invalidation step** leaves the prior bytes reachable. Treat the cache invalidation as part of release, not a follow-up chore.
+
+[Back to top](#top)
+
+---
+
+## 10 · Gate failures and reason codes
+
+If a correction itself fails a gate, fail closed. *(CONFIRMED doctrine: Atlas §24.6.3 — PROPOSED reason-code catalog.)*
+
+| Failure family | Reason code (PROPOSED) | Gate(s) where it fires | Recovery path |
+|---|---|---|---|
+| Missing required artifact | `MISSING_RECEIPT`, `MISSING_EVIDENCE`, `MISSING_REVIEW` | Validation / Catalog / Release | Re-emit missing receipt; re-run review; re-validate |
+| Schema / contract mismatch | `SCHEMA_MISMATCH`, `CONTRACT_DRIFT` | Normalization / Validation | Schema fix and/or ADR; re-run validator |
+| Rights / sensitivity unresolved | `RIGHTS_UNKNOWN`, `SENSITIVITY_UNRESOLVED` | Admission / Validation / Catalog / Release | Steward review; rights resolution; tier reassignment |
+| Source-role collapse risk | `ROLE_COLLAPSE`, `ROLE_DOWNCAST_FORBIDDEN` | Validation / Catalog / Release | Restore source role; refuse upcast |
+| Review state inadequate | `REVIEW_NEEDED`, `REVIEW_INSUFFICIENT`, `REVIEW_REJECTED` | Catalog / Release | Run required review; supply `ReviewRecord` |
+| Release infrastructure error | `RELEASE_MANIFEST_INVALID`, `ROLLBACK_TARGET_MISSING` | Release | Manifest fix; supply rollback target |
+| Correction lineage broken | `CORRECTION_DERIVATIVES_UNRESOLVED`, `CORRECTION_PRIOR_RELEASE_MISSING` | Correction | Resolve derivatives; supersession entry |
+
+> [!NOTE]
+> A correction that triggers `CORRECTION_DERIVATIVES_UNRESOLVED` is **not** publishable. Either complete §9 (Derivative invalidation) or narrow the correction scope.
+
+[Back to top](#top)
+
+---
+
+## 11 · End-to-end flow (diagram)
+
+```mermaid
+flowchart TD
+    A[Defect detected] --> B{Stale or wrong?}
+    B -- Stale only --> S[Apply stale-state marker<br/>trigger steward review]
+    S --> Sx[Close: no CorrectionNotice]
+    B -- Wrong --> T[Triage Step 0]
+    T --> Q{Sensitivity / rights /<br/>sovereignty implicated?}
+    Q -- Yes --> D[Immediate public disablement<br/>fail-closed]
+    Q -- No --> C[Classify defect §4]
+    D --> C
+    C --> QU[Quarantine affected<br/>public surfaces]
+    QU --> E[Gather corrected evidence<br/>via governed pipeline]
+    E --> R[Rebuild superseding artifacts<br/>EvidenceBundle / Layer / Policy /<br/>AIReceipt / Catalog]
+    R --> N[Emit CorrectionNotice §7]
+    N --> RV{Review per §5}
+    RV -- Approve --> P[Release authority signs<br/>new ReleaseManifest<br/>names rollback target]
+    RV -- Hold --> H[Hold at prior state<br/>no public claim change]
+    RV -- Reject --> RJ[Re-classify or<br/>re-gather evidence]
+    RJ --> C
+    P --> I[Invalidate derivatives §9<br/>tiles · indexes · graphs ·<br/>AI answers · caches]
+    I --> AU[Audit & close §6.9<br/>record correction lead time]
+    AU --> END[PUBLISHED']
+
+    classDef danger fill:#fde2e2,stroke:#b00020,color:#900;
+    classDef ok fill:#e6f4ea,stroke:#1b5e20,color:#0b3d12;
+    classDef hold fill:#fff4cc,stroke:#a67c00,color:#5a3d00;
+    class D,RJ danger;
+    class P,END,Sx ok;
+    class H,RV hold;
+```
+
+> [!NOTE]
+> Diagram reflects the CONFIRMED doctrinal flow. Operational tooling (issue templates, validators, CI hooks, cache-purge automation) that would *enforce* this flow is `PROPOSED` until verified in the mounted repo.
+
+[Back to top](#top)
+
+---
+
+## 12 · Worked examples (illustrative)
+
+> All examples below are **illustrative**. They use fictional IDs and shapes; no specific historical defect is being described.
+
+### Example A — Evidence gap (Hydrology layer)
+
+A reviewer notices a Hydrology layer claim was anchored to an `EvidenceBundle` whose underlying gauge record has been re-classified as *modeled* rather than *observed*.
+
+- **Class:** Evidence gap + Source-role mis-classification.
+- **Posture:** `ABSTAIN` on the affected claim; restore correct source role; refuse upcast.
+- **Artifacts:** New `EvidenceBundle` with corrected role; `CorrectionNotice` invalidates the layer's prior tile digest; rebuilt `LayerManifest`.
+- **Reviewers:** Domain steward + correction reviewer + release authority.
+- **Derivatives:** Vector tiles, Evidence Drawer cache, any Focus Mode answer that cited the bundle.
+
+### Example B — Sensitivity leak (Archaeology popup)
+
+A clicked feature exposed an exact archaeological coordinate through a popup attribute that should have been generalized.
+
+- **Class:** Sensitivity leak.
+- **Posture:** **Immediate public disablement** of the layer's popup field (Step 2 quarantine *before* full classification finalized); redact and generalize; notify stewards.
+- **Artifacts:** `RedactionReceipt`; new `LayerManifest` with allowlisted popup fields; `CorrectionNotice`.
+- **Reviewers:** Author + sensitivity reviewer + release authority + rights-holder representative (sensitive lane — no author-only approval).
+- **Derivatives:** Tiles (rebuilt with field allowlist), Focus Mode answers (any `AIReceipt` referencing the feature invalidated and re-emitted as `DENY`), search indexes, exports.
+
+### Example C — AI answer defect (Focus Mode)
+
+A Focus Mode answer was emitted with a citation that no longer resolves to a published `EvidenceBundle`.
+
+- **Class:** AI answer defect (uncited claim → cite-or-abstain violation).
+- **Posture:** Invalidate the `AIReceipt`; remove the answer from any cached surface; **preserve the underlying `EvidenceBundle`** (it is not the defect).
+- **Artifacts:** New `AIReceipt` with cross-reference to prior; `CorrectionNotice`; updated `CitationValidationReport`.
+- **Reviewers:** AI surface steward + docs steward (policy binding) + correction reviewer.
+- **Derivatives:** No tile rebuild required, but any `StorySnapshot` or `ExportReceipt` that embedded the answer must be re-emitted.
+
+[Back to top](#top)
+
+---
+
+## 13 · Health indicators
+
+Track these signals to know whether KFM's correction posture is healthy. None of these is a *sufficient* condition for trust; together they describe a healthy posture. *(CONFIRMED doctrine: Atlas §24.11.2. Indicators are reported, not enforced — enforcement is the validator's job.)*
+
+| Indicator | What it measures | Healthy posture (PROPOSED) |
+|---|---|---|
+| **Release with rollback target** | % of `PUBLISHED` releases naming a valid rollback target | **100%** |
+| **Correction lead time** | Median time from defect detection to `CorrectionNotice` | Visibly tracked; trend not regressing |
+| **Derivative-invalidation coverage** | % of corrections that name and invalidate downstream derivatives | Approaches **100%** as coverage matures |
+| **Rollback rehearsal rate** | Rehearsed rollbacks per release window | Non-zero; periodic, scheduled |
+| **Supersession lineage gap** | Supersessions without a forward link | **Zero** |
+| **Sensitive-lane fail-closed rate** | % of unauthorized sensitive-lane requests that `DENY` at the first gate | **100%** at the first gate |
+| **EvidenceRef resolution rate** | % of public-surface `EvidenceRef`s that resolve to an `EvidenceBundle` | **> 99.9%** over the trailing release window |
+| **Cite-or-abstain compliance** | % of Focus Mode answers with non-empty, resolving evidence citations | **100%** (any miss is a defect to investigate) |
+
+[Back to top](#top)
+
+---
+
+## 14 · Anti-patterns
+
+> [!WARNING]
+> The following are **doctrine violations**. If you find yourself doing one, stop and re-read §1.
+
+- **Silent in-place mutation** of a published artifact, claim, or AI answer.
+- **Skipping the `CorrectionNotice`** because the change "feels small."
+- **Re-using the prior `ReleaseManifest` ID** for the corrected release.
+- **Republishing without naming a rollback target.**
+- **Letting AI-generated correction text stand in for review** — AI is interpretive, not the root truth source.
+- **Treating the search index, graph projection, vector index, or tile cache as sovereign truth.** They are derivatives; rebuild them.
+- **Author-approves-self on a sensitive-lane correction.**
+- **Marking a sensitive defect "stale" to avoid the harder correction path.** If exposure occurred, it is a leak, not staleness.
+- **Closing the correction before §9 (derivative invalidation) is complete.**
+- **Polishing a `CorrectionNotice` before disabling the leaking surface.** Disable first.
+
+[Back to top](#top)
+
+---
+
+## 15 · Related docs
+
+| Doc | Role |
+|---|---|
+| `docs/doctrine/lifecycle-law.md` | The `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` invariant |
+| `docs/doctrine/trust-membrane.md` | Why public surfaces never reach RAW / WORK / QUARANTINE / canonical stores |
+| `docs/doctrine/truth-posture.md` | Cite-or-abstain default |
+| `docs/runbooks/ROLLBACK.md` *(NEEDS VERIFICATION — exact filename)* | Hard rollback when no superseding fix is yet available |
+| `docs/runbooks/governed_ai_VALIDATION.md` *(PROPOSED)* | Focus Mode evidence / citation / policy validation |
+| `docs/governance/SEPARATION_OF_DUTIES.md` *(NEEDS VERIFICATION)* | Role definitions, reviewer matrix |
+| `docs/registers/DRIFT_REGISTER.md` | Drift entries linked to corrections |
+| `docs/registers/VERIFICATION_BACKLOG.md` | Open verification items spawned by corrections |
+| `contracts/correction/correction_notice.md` *(PROPOSED)* | Object meaning |
+| `schemas/contracts/v1/correction/correction_notice.schema.json` *(PROPOSED)* | Object shape |
+| `release/` | `ReleaseManifest`, `PromotionDecision`, `RollbackCard` homes |
+| `policy/` | Policy bundles re-evaluated during correction |
+
+[Back to top](#top)
+
+---
+
+## 16 · Appendix: checklists & references
+
+<details>
+<summary><b>Appendix A — Detector / author checklist</b></summary>
+
+- [ ] Defect reproduced on a live `PUBLISHED` surface (cite the surface + URL or ID).
+- [ ] Stale vs. wrong distinction made (§3).
+- [ ] Sensitivity / rights / sovereignty check performed.
+- [ ] Affected surfaces enumerated (claim, layer, tile, popup, AI answer, export, index).
+- [ ] Primary defect class selected from §4.
+- [ ] Tracking entry opened.
+- [ ] Required reviewers identified per §5.
+
+</details>
+
+<details>
+<summary><b>Appendix B — Correction reviewer checklist</b></summary>
+
+- [ ] Classification matches evidence.
+- [ ] Quarantine actions in Step 2 are appropriate for class and severity.
+- [ ] Corrected evidence routed through governed pipeline (not bypassed).
+- [ ] `CorrectionNotice` fields complete; supersession links resolve.
+- [ ] Derivative invalidation list (§9) appears complete.
+- [ ] Sensitivity reviewer / rights-holder rep present where required.
+- [ ] No author-approves-self violation.
+- [ ] Rollback target named and valid.
+
+</details>
+
+<details>
+<summary><b>Appendix C — Release-authority checklist</b></summary>
+
+- [ ] New `ReleaseManifest` signed.
+- [ ] Rollback target verifiably resolves to a prior safe release.
+- [ ] Prior release record preserved and marked superseded with forward link.
+- [ ] `CorrectionNotice` attached and visible on the public claim.
+- [ ] Cache / CDN invalidation step scheduled or executed.
+- [ ] `AIReceipt`s (if any) cross-reference predecessors.
+- [ ] Health-indicator entries updated (correction lead time, derivative-invalidation coverage).
+
+</details>
+
+<details>
+<summary><b>Appendix D — Doctrinal sources for this runbook</b></summary>
+
+| Topic | Source (CONFIRMED) |
+|---|---|
+| Correction and rollback are publication requirements | BLD-GREEN §20; BLD-COMP §§21-22; IMPL-PIPE §21 |
+| Correction flow (preserve, classify, notice, supersede) | BLD-GREEN §20; IMPL-PIPE §§21, 27; BLD-COMP §§21-23 |
+| Defect-class × correction × rollback matrix | Build Manual defect-class table |
+| Lifecycle gates (incl. Correction & Rollback) | Atlas §24.6.1 |
+| Reason-code catalog | Atlas §24.6.3 (PROPOSED) |
+| Reviewer roles | Atlas §24.7.1 |
+| Separation-of-duties matrix | Atlas §24.7.2 |
+| Stale vs. wrong | Atlas §24.8.1 |
+| Supersession lineage | Atlas §24.8.2 |
+| Health indicators | Atlas §24.11.1, §24.11.2 |
+| `CorrectionNotice` object | Encyclopedia capability table; Atlas §24.2 receipts catalog |
+| Finite outcomes (ANSWER / ABSTAIN / DENY / ERROR / HOLD) | Atlas §24.3 |
+| `docs/runbooks/` placement | `directory-rules.md` §6.1 |
+
+</details>
+
+[Back to top](#top)
+
+---
+
+> [!NOTE]
+> **Implementation maturity.** Operational tooling that would *enforce* this runbook — `CorrectionNotice` JSON schema, validator (`tools/validators/correction/...`), CI gates, cache-purge automation, correction queue UI, reviewer routing — is `PROPOSED` / `NEEDS VERIFICATION` until verified against mounted-repo evidence. The **doctrine** in this runbook is `CONFIRMED` from the attached corpus.
+
+---
+
+**Related docs:** [Lifecycle Law](../doctrine/lifecycle-law.md) · [Trust Membrane](../doctrine/trust-membrane.md) · [Rollback Runbook](./ROLLBACK.md) · [Drift Register](../registers/DRIFT_REGISTER.md)
+
+**Last updated:** 2026-05-12 · **Version:** v1 (draft) · [Back to top](#top)

--- a/docs/runbooks/FIRST_INGEST.md
+++ b/docs/runbooks/FIRST_INGEST.md
@@ -1,3 +1,691 @@
-# FIRST_INGEST
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbooks/first-ingest
+title: First Ingest — Contributor Runbook
+type: standard
+version: v1
+status: draft
+owners: <docs steward + ingest lane owner — NEEDS VERIFICATION>
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/trust-membrane.md
+  - docs/sources/SOURCE_DESCRIPTOR_STANDARD.md
+  - docs/standards/RUN_RECEIPT.md
+  - docs/runbooks/README.md
+  - connectors/README.md
+  - pipelines/ingest/README.md
+  - tools/validators/connector_gate/README.md
+  - tools/validators/promotion_gate/README.md
+  - schemas/contracts/v1/source/source-descriptor.json
+  - schemas/contracts/v1/receipts/run-receipt.json
+  - policy/ingest/admission.rego
+tags: [kfm, runbook, ingest, raw, work, processed, evidence, receipts, fail-closed]
+notes:
+  - First-time end-to-end ingest dry-run for a single source, one run, one domain.
+  - Strictly non-publishing — terminates at PROCESSED (with optional CATALOG dry-run).
+  - All concrete paths below the "Repo references" table are PROPOSED until verified against mounted repo evidence.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+<a id="top"></a>
+
+# First Ingest — Contributor Runbook
+
+> Stand up your first source-to-`PROCESSED` ingest slice on KFM **without publishing**, **without bypassing gates**, and with every step leaving an inspectable receipt.
+
+<p align="center">
+  <em>Evidence first · Watcher-as-non-publisher · Fail-closed · Reversible</em>
+</p>
+
+![Status](https://img.shields.io/badge/status-draft-orange)
+![Lifecycle](https://img.shields.io/badge/lifecycle-RAW→WORK→PROCESSED-blue)
+![Posture](https://img.shields.io/badge/posture-fail--closed-critical)
+![Publication](https://img.shields.io/badge/publication-NOT--PERMITTED-lightgrey)
+![Hash](https://img.shields.io/badge/spec__hash-jcs%3Asha256-success)
+![Receipts](https://img.shields.io/badge/receipts-required-purple)
+![Policy](https://img.shields.io/badge/policy-deny--by--default-important)
+
+<sub>**Status:** draft · **Owners:** docs steward + ingest lane owner *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-12</sub>
+
+---
+
+## Quick jump
+
+- [Who this is for](#who-this-is-for)
+- [What this runbook does not do](#what-this-runbook-does-not-do)
+- [Doctrinal posture](#doctrinal-posture)
+- [Prerequisites](#prerequisites)
+- [The first-ingest flow at a glance](#the-first-ingest-flow-at-a-glance)
+- [Step 0 — Choose a low-risk first source](#step-0--choose-a-low-risk-first-source)
+- [Step 1 — Author a SourceDescriptor](#step-1--author-a-sourcedescriptor)
+- [Step 2 — Register the source and run the connector (RAW)](#step-2--register-the-source-and-run-the-connector-raw)
+- [Step 3 — Normalize into WORK](#step-3--normalize-into-work)
+- [Step 4 — Validate (WORK → PROCESSED)](#step-4--validate-work--processed)
+- [Step 5 — Catalog closure dry-run (no PUBLISHED edge)](#step-5--catalog-closure-dry-run-no-published-edge)
+- [Step 6 — Inspect your receipts](#step-6--inspect-your-receipts)
+- [Definition of Done](#definition-of-done)
+- [Rollback and cleanup](#rollback-and-cleanup)
+- [Troubleshooting](#troubleshooting)
+- [Repo references](#repo-references)
+- [Related docs](#related-docs)
+- [Appendices](#appendices)
+
+---
+
+## Who this is for
+
+A first-time KFM contributor — connector author, domain editor, or steward apprentice — who needs to take a single, low-risk external source through one full governed loop on a developer machine and end with **receipts they can inspect**, not bytes they have shipped.
+
+The point of this runbook is **not** to teach you how to publish. It is to teach you how publishing *is denied to you by default* and how to produce the evidence that a release manager would later use, if and only if every gate clears.
+
+> [!IMPORTANT]
+> This runbook stops at `PROCESSED`. The transitions `PROCESSED → CATALOG/TRIPLET` and `CATALOG/TRIPLET → PUBLISHED` are governed by separate runbooks, separate reviewers, and separate release authority. A first-ingest contributor MUST NOT promote past `PROCESSED` on their own.
+
+---
+
+## What this runbook does not do
+
+- It does **not** publish anything to a public surface.
+- It does **not** mutate `data/catalog/`, `data/triplets/`, `data/published/`, or `release/`.
+- It does **not** authorize a connector to write outside `data/raw/<domain>/<source_id>/<run_id>/` or `data/quarantine/...`.
+- It does **not** waive any policy gate, validation gate, sensitivity check, or rights check.
+- It does **not** replace `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` for source-shape authority.
+- It does **not** establish a parallel home for receipts, proofs, manifests, or release artifacts.
+
+If any step below appears to bend an invariant, the step is wrong — not the invariant. Open a `docs/registers/DRIFT_REGISTER.md` entry instead of working around it.
+
+---
+
+## Doctrinal posture
+
+KFM's lifecycle invariant (CONFIRMED doctrine, per `docs/doctrine/lifecycle-law.md` and `docs/doctrine/directory-rules.md`):
+
+> **RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED**
+>
+> Promotion is a **governed state transition, not a file move.**
+
+Three rules dominate every step you will perform:
+
+1. **Watcher-as-non-publisher.** Connectors, watchers, and pipeline workers emit candidate records and receipts. They never publish. They never rewrite catalog truth.
+2. **Cite-or-abstain.** Anything you cannot resolve to an `EvidenceBundle` via an `EvidenceRef` is not safely citable. First ingest produces the *raw materials* for evidence, not finished evidence.
+3. **Deny-by-default for sensitive classes.** If your source touches any class in the [Sensitive class register](#a1--sensitive-class-quick-reference), this runbook is not the right entry point. Use the sensitive-lane intake runbook instead.
+
+> [!CAUTION]
+> A `data/raw/...` write is not a "preview" of publication. It is admitted source material under source identity, with no public surface and no AI context exposure. Treat it accordingly.
+
+---
+
+## Prerequisites
+
+| Prerequisite | Where it lives *(PROPOSED until verified)* | Why you need it |
+|---|---|---|
+| Git clone of the KFM repo with write access to a feature branch | Local workstation | All artifacts of a first ingest land on a branch, never on `main`. |
+| Python 3.11+ and Node toolchain matching the repo `.tool-versions` / `engines` | Local workstation | Validators and connector scaffolds rely on the pinned toolchain. *(NEEDS VERIFICATION: actual pinned versions.)* |
+| `jq`, `uuidgen`, a JCS implementation (RFC 8785) for canonical JSON | Local workstation | `spec_hash` is **only** valid when JCS-canonicalized before SHA-256. |
+| A SourceDescriptor schema reference | `schemas/contracts/v1/source/source-descriptor.json` *(PROPOSED per Directory Rules §7.4 and ADR-0001)* | The descriptor is the admission contract. |
+| RunReceipt schema reference | `schemas/contracts/v1/receipts/run-receipt.json` *(PROPOSED)* | Every step you perform emits a RunReceipt. |
+| Validator binaries / scripts | `tools/validators/connector_gate/`, `tools/validators/source_descriptor/`, `tools/validators/promotion_gate/` *(PROPOSED)* | Validators decide whether your run advances or quarantines. |
+| Policy bundle for ingest admission | `policy/ingest/admission.rego` *(PROPOSED)* | Deny-by-default rules for license, rights, sensitivity. |
+| Read access to `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` | Repo docs | Authoritative field-level shape for SourceDescriptor. |
+
+> [!NOTE]
+> All concrete paths in the "Where it lives" column are **PROPOSED** until inspected against mounted repository evidence. If your repo state differs, file a `DRIFT_REGISTER` entry and use the actual paths — do not force the doc's paths.
+
+---
+
+## The first-ingest flow at a glance
+
+```mermaid
+flowchart LR
+    A[Step 0<br/>Pick a low-risk source] --> B[Step 1<br/>Author SourceDescriptor]
+    B --> C[Step 2<br/>Connector run<br/>writes data/raw/...]
+    C -->|RawCaptureReceipt| R1[(receipts/ingest)]
+    C --> D[Step 3<br/>Normalize<br/>writes data/work/...]
+    D -->|TransformReceipt| R2[(receipts/pipeline)]
+    D --> E[Step 4<br/>Validate]
+    E -->|ValidationReport| R3[(proofs/validation_report)]
+    E -->|pass| F[data/processed/...]
+    E -->|fail| Q[data/quarantine/...<br/>QuarantineRecord]
+    F --> G[Step 5<br/>Catalog closure dry-run]
+    G -->|PolicyDecision + RunReceipt| R4[(receipts/pipeline)]
+    G --> X[STOP HERE<br/>no PUBLISHED edge]
+    classDef stop fill:#ffe6e6,stroke:#cc0000,color:#660000
+    class X stop
+```
+
+Five things to notice in the diagram:
+
+- Every transition emits a **receipt** or **proof object** to `data/receipts/` or `data/proofs/`.
+- A failed validation goes to `data/quarantine/`, not back to RAW. Quarantine is **not** a publishable staging area.
+- Catalog closure is a *dry run* in this runbook — it produces a `PolicyDecision` and a `RunReceipt` but does not transition to `PUBLISHED`.
+- The diagram is **PROPOSED** in its concrete file paths; the *shape* of the flow is CONFIRMED doctrine.
+- The renderer (MapLibre, Cesium, Focus Mode) is intentionally absent — first ingest never touches a public surface.
+
+---
+
+## Step 0 — Choose a low-risk first source
+
+A safe first source has **all** of these properties. If any is missing, pick a different source.
+
+| Property | Why it matters |
+|---|---|
+| Public-domain or permissive open license with a clear SPDX identifier (e.g., `CC0-1.0`, `CC-BY-4.0`, `PDDL-1.0`) | Unknown rights fail closed at the policy gate; you will not get past Step 4. |
+| Stable HTTP endpoint with `ETag` and `Last-Modified` headers | Required for deterministic source-head capture and conditional re-fetch. |
+| Small payload (target ≤ tens of megabytes, single file or tiny manifest) | First ingests should be fast and reviewable; large payloads obscure failures. |
+| No `living-person`, `DNA/genomic`, `rare-species exact location`, `archaeology`, `sacred place`, `critical infrastructure precise geometry`, or `private landowner` content | Every one of these is **deny-by-default**. See [Appendix A.1](#a1--sensitive-class-quick-reference). |
+| Source role is one of: `observed`, `regulatory`, `aggregate`, `administrative` — **not** `modeled`, `candidate`, or `synthetic` for a first run | These three carry additional descriptor burden (model run ref, candidate disposition, reality boundary note). |
+| Domain you already have read access to in `docs/domains/<domain>/` | The descriptor will live under that domain. |
+
+Good first-source examples (illustrative, **NEEDS VERIFICATION** that each is currently approved in your repo's source registry):
+
+- a single USGS public elevation tile metadata record
+- a single FEMA flood-hazard polygon excerpt for one Kansas county
+- a single NOAA daily-summary CSV for one station, one month
+- a single NLCD land-cover excerpt for one HUC-12
+
+> [!TIP]
+> If you are unsure, ask in the docs-steward channel and link a candidate URL. A first ingest is not the place to negotiate ambiguous rights.
+
+[Back to top](#top)
+
+---
+
+## Step 1 — Author a SourceDescriptor
+
+The `SourceDescriptor` is the admission contract. It carries source identity, rights, source role, sensitivity, cadence, and retrieval plan. **It is the only artifact that authorizes a connector run.**
+
+### 1.1 Draft the descriptor
+
+Create a file (illustrative path; verify against your repo's chosen home):
+
+```text
+data/registry/source_descriptors/<domain>/<source_id>.json    # PROPOSED
+```
+
+Minimum fields (drawn from KFM doctrine; **NEEDS VERIFICATION** against the live schema):
+
+```json
+{
+  "object_type": "SourceDescriptor",
+  "schema_version": "v1",
+  "source_id": "<stable id, e.g., usgs-3dep-tile-XXXX>",
+  "source_role": "observed",
+  "role_authority": "<issuing body>",
+  "domain": "<hydrology|soil|hazards|...>",
+  "rights": {
+    "spdx_id": "CC0-1.0",
+    "license_text_ref": "<uri to license>",
+    "redistribution_allowed": true,
+    "attribution_required": false
+  },
+  "sensitivity": "public",
+  "retrieval": {
+    "url": "<https endpoint>",
+    "method": "GET",
+    "expects_etag": true,
+    "expects_last_modified": true,
+    "cadence": "manual-first-ingest"
+  },
+  "fingerprint": {
+    "expected_content_types": ["application/json"],
+    "expected_max_bytes": 10485760
+  },
+  "stewardship": {
+    "owner": "<your handle or team>",
+    "intake_reason": "first-ingest dry-run"
+  }
+}
+```
+
+### 1.2 Compute the descriptor's `spec_hash`
+
+`spec_hash` is **only** valid when computed via RFC 8785 JCS canonicalization followed by SHA-256, and recorded as `jcs:sha256:<hex>` (CONFIRMED doctrine; see `docs/standards/CANONICALIZATION.md` — **PROPOSED** path).
+
+```bash
+# illustrative; replace with the repo's pinned tool when available
+python3 - <<'PY'
+import json, hashlib
+try:
+    import rfc8785 as jcs
+except ImportError:
+    import jcs  # alternative library
+with open("data/registry/source_descriptors/<domain>/<source_id>.json", "rb") as f:
+    canonical = jcs.canonicalize(json.load(f))
+print("jcs:sha256:" + hashlib.sha256(canonical).hexdigest())
+PY
+```
+
+> [!WARNING]
+> Do **not** hash the developer-formatted JSON. A trailing newline or a re-sorted key changes the hash and breaks every downstream gate. Always canonicalize first.
+
+### 1.3 Validate the descriptor
+
+```bash
+# PROPOSED command; verify against tools/validators/source_descriptor/README.md
+kfm-validate source-descriptor \
+  data/registry/source_descriptors/<domain>/<source_id>.json
+```
+
+The validator MUST fail closed if any of: `source_role`, `rights.spdx_id`, `sensitivity`, `retrieval.url`, or `source_id` is missing or `unknown`. If it does not, you are looking at a drift candidate — file a `DRIFT_REGISTER` entry.
+
+[Back to top](#top)
+
+---
+
+## Step 2 — Register the source and run the connector (RAW)
+
+### 2.1 Where the connector lives
+
+Connectors are source-specific fetch-and-admission code. They live under `connectors/<provider>/` (e.g., `connectors/usgs/`, `connectors/fema/`, `connectors/noaa/`, `connectors/nrcs/`, `connectors/kansas/` — per `directory-rules.md` §7.3, CONFIRMED). Connector output **MUST** land in:
+
+```text
+data/raw/<domain>/<source_id>/<run_id>/
+```
+
+Connectors **MUST NOT** write under `data/processed/`, `data/catalog/`, or `data/published/`.
+
+### 2.2 Run the connector
+
+```bash
+# PROPOSED command surface; verify against connectors/<provider>/README.md
+RUN_ID="$(uuidgen)"
+kfm-connector run \
+  --descriptor data/registry/source_descriptors/<domain>/<source_id>.json \
+  --domain <domain> \
+  --run-id "$RUN_ID" \
+  --no-publish      # belt and suspenders; the connector cannot publish anyway
+```
+
+### 2.3 What the connector emits
+
+A successful connector run produces, at minimum, a **`RawCaptureReceipt`** (CONFIRMED object family). Expected location (PROPOSED):
+
+```text
+data/receipts/ingest/<domain>/<source_id>/<run_id>/raw_capture_receipt.json
+```
+
+Required content (illustrative; **NEEDS VERIFICATION** against the live schema):
+
+| Field | Purpose |
+|---|---|
+| `object_type: "RawCaptureReceipt"` | Family discrimination. |
+| `schema_version` | Version of the receipt schema. |
+| `source_descriptor_ref` (`EvidenceRef` → SourceDescriptor) | Pins admission contract. |
+| `run_id` | Stable identity for this fetch. |
+| `source_head` (`etag`, `last_modified`, `content_length`) | Captures exact source state. |
+| `artifacts[]` with `{path, sha256, bytes}` | Per-file integrity, deterministic. |
+| `spec_hash: "jcs:sha256:..."` | Receipt's own canonical identity. |
+| `actor`, `runner_id`, `timestamp` | Audit reconstruction. |
+| `evidence_refs[]` | Reverse-lookup hooks. |
+
+> [!NOTE]
+> If `source_head` is missing `etag` or `last_modified`, the receipt is still emitted but the connector marks the run **degraded**. Step 4 will refuse to promote a degraded raw to `PROCESSED` without a steward override.
+
+### 2.4 What you should now see
+
+```text
+data/
+├── raw/<domain>/<source_id>/<run_id>/
+│     └── <files fetched, byte-for-byte from source>
+└── receipts/ingest/<domain>/<source_id>/<run_id>/
+      └── raw_capture_receipt.json
+```
+
+Confirm both exist. The `raw/...` contents are **not** for public viewing, AI context, or rendering. They are admitted source material under source identity.
+
+[Back to top](#top)
+
+---
+
+## Step 3 — Normalize into WORK
+
+Normalization transforms the raw source into a candidate domain record (or a candidate set). It lives under `pipelines/ingest/` and `pipelines/normalize/` per `directory-rules.md` §7.4 (CONFIRMED).
+
+### 3.1 Run the normalizer
+
+```bash
+# PROPOSED command surface
+kfm-pipeline normalize \
+  --raw-run data/raw/<domain>/<source_id>/<run_id> \
+  --domain <domain> \
+  --run-id "$RUN_ID"
+```
+
+### 3.2 What normalization emits
+
+Two artifacts (CONFIRMED object families):
+
+| Artifact | Where | Purpose |
+|---|---|---|
+| Normalized candidate records | `data/work/<domain>/<run_id>/` *(PROPOSED)* | Candidate assertions, not canonical truth. |
+| **`TransformReceipt`** | `data/receipts/pipeline/<domain>/<run_id>/transform_receipt.json` *(PROPOSED)* | Records transform identity, inputs, parameters, loss notes. |
+
+> [!IMPORTANT]
+> A `TransformReceipt` MUST record what the transform changed, including any field loss or interpretation. "Lossless rename" is still recorded. The receipt is the only place the transform is honestly described.
+
+### 3.3 What you must NOT do
+
+- Do **not** copy `work/` files to `processed/` by hand.
+- Do **not** edit the normalized record after the receipt is written; if you change something, re-run normalization with a new `run_id`.
+- Do **not** treat the normalized record as cite-able — it has no `EvidenceBundle` yet.
+
+[Back to top](#top)
+
+---
+
+## Step 4 — Validate (WORK → PROCESSED)
+
+Validation is the first transition that touches a **policy gate** and produces a **decision**. This is where most first ingests legitimately fail, and that is fine — quarantine is a normal outcome.
+
+### 4.1 Run the validator stack
+
+```bash
+# PROPOSED command surface; verify against tools/validators/promotion_gate/README.md
+kfm-validate promotion-gate \
+  --work-run data/work/<domain>/<run_id> \
+  --descriptor data/registry/source_descriptors/<domain>/<source_id>.json \
+  --domain <domain> \
+  --run-id "$RUN_ID"
+```
+
+### 4.2 What runs under the hood
+
+| Check | What it verifies | Failure outcome |
+|---|---|---|
+| Schema validation | Records match the domain contract in `schemas/contracts/v1/domains/<domain>/` *(PROPOSED)* | `QUARANTINE` with `schema_drift` reason |
+| Geometry validation | Geometries are well-formed; CRS recorded; not silently reprojected | `QUARANTINE` with `geometry_defect` reason |
+| Temporal validation | `observed`, `valid`, `source`, `retrieval` times distinct where material | `QUARANTINE` with `temporal_scope_missing` reason |
+| Rights validation | `spdx_id` known; redistribution flags consistent; `unknown` rights fail closed | `DENY` from policy gate |
+| Sensitivity validation | No precision-creep above the descriptor's declared sensitivity tier | `DENY` or `RESTRICT` |
+| Evidence closure | EvidenceRefs introduced by the transform resolve to candidate evidence | `ABSTAIN` until resolved |
+| `spec_hash` parity | Recomputed `spec_hash` matches the descriptor's recorded hash | `DENY` (`spec_hash_mismatch`) |
+
+### 4.3 What validation emits
+
+| Artifact | Where | Purpose |
+|---|---|---|
+| **`ValidationReport`** | `data/proofs/validation_report/<domain>/<run_id>/validation_report.json` *(PROPOSED)* | Pass/fail per check, deterministic inputs, validator id. |
+| **`PolicyDecision`** | `data/receipts/pipeline/<domain>/<run_id>/policy_decision.json` *(PROPOSED)* | Finite outcome: `ALLOW`, `RESTRICT`, `DENY`, `ABSTAIN`, or `ERROR`. |
+| **`RunReceipt`** | `data/receipts/pipeline/<domain>/<run_id>/run_receipt.json` *(PROPOSED)* | Process memory binding all the above. |
+
+### 4.4 Reading the outcome
+
+| Outcome | Where the run lands | What you do next |
+|---|---|---|
+| `ALLOW` + all validations pass | `data/processed/<domain>/<dataset_id>/<version>/` | Continue to Step 5. |
+| Any validation fail | `data/quarantine/<domain>/<reason>/<run_id>/` + `QuarantineRecord` | Read the report, fix the source/descriptor/transform, re-run from Step 1 or Step 3 with a **new** `run_id`. |
+| `RESTRICT` | Stays in `work/` with restriction notes | Engage a steward; not a first-ingest path. |
+| `DENY` | Run terminates; `QuarantineRecord` written | Read the report; if rights or sensitivity, pick a different source. |
+| `ABSTAIN` | Stays in `work/`; evidence resolution pending | Provide missing evidence or pick a different source. |
+| `ERROR` | Run terminates; no canonical promotion | File a bug. Do not retry until the underlying error is diagnosed. |
+
+> [!CAUTION]
+> Do **not** treat `QUARANTINE` as a temporary parking lot to be "fixed by promoting later." Quarantine is a governed terminal state for this `run_id`. A fix means a new descriptor or a new run, not an in-place mutation.
+
+[Back to top](#top)
+
+---
+
+## Step 5 — Catalog closure dry-run (no PUBLISHED edge)
+
+This step is a **dry run** in this runbook. It produces the artifacts a catalog closure would need, runs the policy gate in dry-run mode, and **stops short of writing to `data/catalog/` or `data/triplets/`** unless your reviewer explicitly approves.
+
+### 5.1 Run the dry-run
+
+```bash
+# PROPOSED command surface; verify against pipelines/catalog/README.md
+kfm-pipeline catalog-close \
+  --processed-run data/processed/<domain>/<dataset_id>/<version> \
+  --domain <domain> \
+  --run-id "$RUN_ID" \
+  --dry-run
+```
+
+### 5.2 What the dry-run produces
+
+| Artifact | Where | Purpose |
+|---|---|---|
+| Candidate `CatalogRecord` | scratch path, **not** `data/catalog/` | Discovery metadata draft. |
+| Candidate `EvidenceBundle` | scratch path, **not** `data/proofs/evidence_bundle/` | Source list, excerpts, provenance, policy posture. |
+| `PolicyDecision` (dry-run) | `data/receipts/pipeline/<domain>/<run_id>/policy_decision.catalog.json` *(PROPOSED)* | Finite outcome at catalog gate. |
+| `RunReceipt` (catalog dry-run) | `data/receipts/pipeline/<domain>/<run_id>/run_receipt.catalog.json` *(PROPOSED)* | Audit memory. |
+
+### 5.3 What the dry-run does NOT do
+
+- Does not write a `ReleaseManifest` (those live in `release/manifests/` and require release authority).
+- Does not touch `data/published/`.
+- Does not sign anything for release (DSSE / cosign signing of release artifacts is the release manager's job).
+- Does not create an `EvidenceRef` that resolves on the public surface.
+
+> [!IMPORTANT]
+> A `data/published/` write or a `release/manifests/` write at this stage is a governance violation regardless of how clean the upstream looked. Stop and engage a steward.
+
+[Back to top](#top)
+
+---
+
+## Step 6 — Inspect your receipts
+
+A first ingest is "done" only when **you can read your own work back as evidence**. This is the part most contributors skip and it is the most important part.
+
+For each of the receipts below, confirm:
+
+- The file exists at the expected path.
+- The `object_type` and `schema_version` are correct.
+- The `spec_hash` is `jcs:sha256:<hex>` and recomputes to the same value.
+- The receipt links **back** to the descriptor via an `EvidenceRef`, and **forward** to the run it describes.
+- The `actor`, `runner_id`, and `timestamp` are populated.
+
+| Receipt | Question it must answer |
+|---|---|
+| `RawCaptureReceipt` | What was fetched, from where, with which ETag, in what shape? |
+| `TransformReceipt` | What did the transform change, and what did it lose? |
+| `ValidationReport` | Which checks ran, which passed, which failed, and on which deterministic inputs? |
+| `PolicyDecision` (work→processed) | What finite outcome did the promotion gate return, and why? |
+| `RunReceipt` (work→processed) | Who ran this, with what tools, against what inputs, and when? |
+| `PolicyDecision` (catalog dry-run) | Would catalog closure have passed? On what conditions? |
+| `RunReceipt` (catalog dry-run) | Same audit trail at the catalog gate. |
+
+> [!TIP]
+> If a receipt is missing, do **not** synthesize it. A missing receipt is the system telling you a step did not run cleanly. Re-run the affected step with a new `run_id`.
+
+<details>
+<summary><strong>Optional: minimal jq inspection one-liner</strong></summary>
+
+```bash
+# Walk every receipt under this run and print object_type + spec_hash
+find "data/receipts" "data/proofs" -path "*/${RUN_ID}/*" -name "*.json" -print \
+  | while read -r f; do
+      printf "%s\t" "$f"
+      jq -r '[.object_type, .spec_hash] | @tsv' "$f"
+    done
+```
+
+</details>
+
+[Back to top](#top)
+
+---
+
+## Definition of Done
+
+A first ingest is **done** when **all** of the following are true:
+
+- [ ] A `SourceDescriptor` exists, validates, and has a recomputable `jcs:sha256` hash.
+- [ ] A connector run produced exactly the expected files under `data/raw/<domain>/<source_id>/<run_id>/`.
+- [ ] A `RawCaptureReceipt` exists, links to the descriptor, and records `etag` + `last_modified`.
+- [ ] A `TransformReceipt` exists and honestly describes the normalization.
+- [ ] A `ValidationReport` exists with every check accounted for.
+- [ ] A `PolicyDecision` exists for the WORK → PROCESSED transition.
+- [ ] If the outcome was `ALLOW`, the run landed under `data/processed/<domain>/<dataset_id>/<version>/`; if not, it landed under `data/quarantine/<domain>/<reason>/<run_id>/` with a `QuarantineRecord`.
+- [ ] A catalog closure dry-run produced a `PolicyDecision.catalog.json` **without** writing to `data/catalog/`, `data/triplets/`, `data/published/`, or `release/`.
+- [ ] No file outside the paths above was created, moved, or deleted by your run.
+- [ ] You can read your receipts back and explain to a reviewer what happened.
+
+> [!NOTE]
+> Publishing — i.e., a `CATALOG/TRIPLET → PUBLISHED` transition — is **not** a Definition of Done condition for this runbook. It is intentionally out of scope.
+
+---
+
+## Rollback and cleanup
+
+A first-ingest run is **reversible by construction** because nothing past `PROCESSED` ever happened. Cleanup is:
+
+1. **Receipts** — never delete. They are append-only evidence. If the run was a mistake, you correct it forward with a new `run_id` and a `CorrectionNotice` (steward-authored), not by erasing the past.
+2. **`data/raw/.../<run_id>/`** — may be safely deleted on a developer workstation. The `RawCaptureReceipt` still records what was fetched and can be re-fetched against the same `source_head` if needed.
+3. **`data/work/.../<run_id>/`** — may be safely deleted. The `TransformReceipt` records what would be re-derivable.
+4. **`data/processed/.../`** — do **not** delete on a shared environment. On a workstation, prefer a fresh branch over deletion. On any shared environment, request a steward-authored `RollbackCard`.
+5. **`data/quarantine/.../<run_id>/`** — leave it. Quarantine is governance evidence, not garbage.
+
+> [!WARNING]
+> A workstation cleanup is **not** a system rollback. System-level rollback uses `RollbackCard`s in `release/rollback_cards/` and is the release manager's responsibility — never a contributor's.
+
+---
+
+## Troubleshooting
+
+<details>
+<summary><strong>Connector says <code>missing etag</code> / <code>missing last_modified</code></strong></summary>
+
+The source did not expose validators. You have three options, in order of preference:
+1. Pick a different first source.
+2. Add a manifest checksum step (`sha256sum -c`) per `C3-02` doctrine and record it in `source_head.content_hash`. **NEEDS VERIFICATION** that your connector supports this.
+3. Engage a steward to attach a stewarded-fingerprint exception. Do **not** disable the check.
+</details>
+
+<details>
+<summary><strong>Validator reports <code>spec_hash_mismatch</code></strong></summary>
+
+You almost certainly canonicalized differently between descriptor authoring and run time. Re-derive the descriptor's hash with the **same** JCS implementation that the validator uses (see `docs/standards/CANONICALIZATION.md` — **PROPOSED**), recommit, and re-run.
+</details>
+
+<details>
+<summary><strong>Policy gate returns <code>DENY (unknown rights)</code></strong></summary>
+
+The descriptor's `rights.spdx_id` was missing, ambiguous, or not in the approved SPDX list. Fix the descriptor, recompute its hash, and re-run from Step 1. Do **not** patch the policy.
+</details>
+
+<details>
+<summary><strong>Policy gate returns <code>DENY (sensitivity)</code></strong></summary>
+
+Your source touched a sensitive class. Stop. Read [Appendix A.1](#a1--sensitive-class-quick-reference). This is not a first-ingest source.
+</details>
+
+<details>
+<summary><strong>Run lands in quarantine with <code>schema_drift</code></strong></summary>
+
+Either the source shape changed upstream (file a `DRIFT_REGISTER` entry; the connector or domain schema needs an update via the proper change path), or the descriptor's `fingerprint.expected_content_types` was wrong. Fix the descriptor; do not edit the domain schema as a first-ingest contributor.
+</details>
+
+<details>
+<summary><strong>I want to publish my first ingest</strong></summary>
+
+You don't. Publication is a governed state transition that requires: a `ReleaseManifest`, a `ReviewRecord` (where required), a rollback target, a correction path, separation of duties from the original author, and (for materiality) a release authority. None of those are first-ingest contributor responsibilities. Hand off cleanly via the receipts you produced.
+</details>
+
+[Back to top](#top)
+
+---
+
+## Repo references
+
+All paths in this table are **PROPOSED** per `directory-rules.md` and the project's doctrine documents. Each row is a place a first-ingest contributor will look but **NEEDS VERIFICATION** against actual mounted-repo state.
+
+| Reference | Proposed path | Source basis |
+|---|---|---|
+| Directory Rules | `docs/doctrine/directory-rules.md` | CONFIRMED — supplied artifact |
+| SourceDescriptor schema | `schemas/contracts/v1/source/source-descriptor.json` | PROPOSED — Directory Rules §7.4, ADR-0001 |
+| RunReceipt schema | `schemas/contracts/v1/receipts/run-receipt.json` | PROPOSED — `C1-01` receipt doctrine |
+| Canonicalization standard | `docs/standards/CANONICALIZATION.md` | PROPOSED — `C1-02` JCS doctrine |
+| Source descriptor standard | `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` | PROPOSED — Whole-UI/Governed-AI expansion plan |
+| Connector home | `connectors/<provider>/` | CONFIRMED — Directory Rules §7.3 |
+| Ingest pipelines | `pipelines/ingest/`, `pipelines/normalize/`, `pipelines/validate/`, `pipelines/catalog/` | CONFIRMED — Directory Rules §7.4 |
+| Validator binaries | `tools/validators/connector_gate/`, `tools/validators/promotion_gate/`, `tools/validators/source_descriptor/`, `tools/validators/evidence_bundle/` | CONFIRMED — Directory Rules §7.5 |
+| Ingest admission policy | `policy/ingest/admission.rego` | PROPOSED — Directory Rules §6 (policy as canonical home) |
+| Drift register | `docs/registers/DRIFT_REGISTER.md` | CONFIRMED — Directory Rules §2.5, §6.1 |
+| Verification backlog | `docs/registers/VERIFICATION_BACKLOG.md` | CONFIRMED — Directory Rules §6.1 |
+
+---
+
+## Related docs
+
+- [`docs/doctrine/directory-rules.md`](../doctrine/directory-rules.md) — placement authority.
+- [`docs/doctrine/lifecycle-law.md`](../doctrine/lifecycle-law.md) — RAW → … → PUBLISHED invariant.
+- [`docs/doctrine/trust-membrane.md`](../doctrine/trust-membrane.md) — why public clients never see `data/raw|work|quarantine`.
+- [`docs/sources/SOURCE_DESCRIPTOR_STANDARD.md`](../sources/SOURCE_DESCRIPTOR_STANDARD.md) — *(PROPOSED)* descriptor field shape.
+- [`docs/standards/RUN_RECEIPT.md`](../standards/RUN_RECEIPT.md) — *(PROPOSED)* receipt shape and required invariants.
+- [`docs/standards/CANONICALIZATION.md`](../standards/CANONICALIZATION.md) — *(PROPOSED)* JCS vs URDNA2015 decision matrix.
+- [`docs/runbooks/README.md`](./README.md) — *(PROPOSED)* runbooks index.
+- [`docs/registers/DRIFT_REGISTER.md`](../registers/DRIFT_REGISTER.md) — file drift here rather than working around it.
+- `connectors/README.md`, `pipelines/ingest/README.md`, `tools/validators/promotion_gate/README.md` — companion READMEs (*PROPOSED* until verified).
+
+---
+
+## Appendices
+
+### A.1 — Sensitive class quick reference
+
+If your candidate source touches **any** of the classes below, this is not a first-ingest source. Use the sensitive-lane intake path and engage a steward.
+
+| Class | Default outcome | Source basis |
+|---|---|---|
+| Living persons (personal data, residences, identity assertions) | DENY public exact | CONFIRMED — sensitivity register |
+| DNA / genomic / living-person relatives | DENY by default | CONFIRMED |
+| Rare-species exact taxa locations (nest, den, roost, spawning) | DENY public exact location | CONFIRMED |
+| Archaeology (site coordinates, burial, sacred/culturally sensitive) | DENY public exact location | CONFIRMED |
+| Sacred / culturally sensitive places (oral history, cultural routes) | DENY until steward review | CONFIRMED |
+| Critical infrastructure (exact facilities, dependencies, condition) | RESTRICT / DENY public precision | CONFIRMED |
+| Private landowner-sensitive data (field boundaries, owner identity) | DENY exact / public if private | CONFIRMED |
+| Exact sensitive locations (any point that increases harm risk) | DENY by default | CONFIRMED |
+| Emergency-warning misuse (life-safety substitution) | DENY life-safety replacement | CONFIRMED |
+| Source-rights-limited (licensed, restricted, no-redistribution, uncertain terms) | DENY public release until resolved | CONFIRMED |
+
+### A.2 — Lifecycle phase quick reference
+
+| Phase | Allowed | MUST NOT |
+|---|---|---|
+| `raw/` | Source-edge captures, immutable, with retrieval metadata and checksums | Public clients, AI context, UI layers, normalized records |
+| `work/` | Normalized intermediates, candidate assertions | Public API/UI, release aliases |
+| `quarantine/` | Failed validation, unresolved rights/sensitivity, schema drift, over-precise geometry | Promotion candidates without remediation |
+| `processed/` | Validated canonical records | Assumption of public/release status |
+| `catalog/` *(out of scope here)* | STAC/DCAT/PROV records, domain catalog | Uncited claims, unclosed identifiers |
+| `triplets/` *(out of scope here)* | Relationship projections and graph-compatible triples | Canonical replacement semantics |
+| `published/` *(out of scope here)* | Released public-safe artifacts | Raw, work, quarantine, exact restricted geometry |
+| `receipts/` | Process memory: run, validation, AI, ingest, release | Proof of release by themselves |
+| `proofs/` | EvidenceBundle, ProofPack, integrity bundle | Process-only receipts without release context |
+
+### A.3 — Finite outcome vocabulary
+
+KFM governed flows return a finite outcome from this set (CONFIRMED doctrine):
+
+| Outcome | Meaning at the promotion gate |
+|---|---|
+| `ALLOW` (or `ANSWER`) | All gates clear; transition permitted. |
+| `RESTRICT` | Conditionally permitted with obligations (e.g., redaction, generalization, staged access). |
+| `DENY` | Failed; transition refused; QuarantineRecord written. |
+| `ABSTAIN` | Insufficient evidence or unresolved policy state; no transition. |
+| `ERROR` | Tooling or runtime failure; no transition; bug to file. |
+
+### A.4 — Glossary (placement-relevant subset)
+
+| Term | Short meaning relevant to first ingest |
+|---|---|
+| **SourceDescriptor** | The admission contract for a source. Lives in `data/registry/source_descriptors/`. |
+| **RawCaptureReceipt** | The fetch receipt for a connector run. Lives in `data/receipts/ingest/`. |
+| **TransformReceipt** | The normalization receipt. Lives in `data/receipts/pipeline/`. |
+| **ValidationReport** | The pass/fail record for validators. Lives in `data/proofs/validation_report/`. |
+| **PolicyDecision** | The finite-outcome verdict from a policy gate. Lives in `data/receipts/pipeline/`. |
+| **RunReceipt** | Process memory for a run; binds inputs, tools, and outputs. Lives in `data/receipts/pipeline/`. |
+| **EvidenceBundle** | Resolved support package for a claim. Lives in `data/proofs/evidence_bundle/`. Not produced in a first ingest. |
+| **EvidenceRef** | A reference that MUST resolve to an `EvidenceBundle` before publication. |
+| **spec_hash** | `jcs:sha256:<hex>` — RFC 8785 JCS canonicalization + SHA-256. |
+| **Watcher-as-non-publisher** | Connectors and workers emit candidates and receipts; they do not publish. |
+| **Promotion** | A governed state transition between lifecycle phases. Not a file move. |
+
+---
+
+<sub><strong>Related docs:</strong> <a href="../doctrine/directory-rules.md">Directory Rules</a> · <a href="../doctrine/lifecycle-law.md">Lifecycle Law</a> · <a href="../doctrine/trust-membrane.md">Trust Membrane</a> · <a href="../sources/SOURCE_DESCRIPTOR_STANDARD.md">Source Descriptor Standard</a> · <a href="../standards/RUN_RECEIPT.md">RunReceipt Standard</a> · <a href="../registers/DRIFT_REGISTER.md">Drift Register</a></sub>
+
+<sub><strong>Last updated:</strong> 2026-05-12 · <strong>Status:</strong> draft · <a href="#top">Back to top</a></sub>

--- a/docs/runbooks/INCIDENT_RESPONSE.md
+++ b/docs/runbooks/INCIDENT_RESPONSE.md
@@ -1,3 +1,597 @@
-# INCIDENT_RESPONSE
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-incident-response
+title: Incident Response Runbook
+type: standard
+version: v1
+status: draft
+owners: [docs-steward, security-steward, release-steward]
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: restricted
+related:
+  - docs/runbooks/README.md
+  - docs/runbooks/governed_ai_ROLLBACK.md
+  - docs/runbooks/ui_ROLLBACK.md
+  - docs/security/README.md
+  - docs/doctrine/trust-membrane.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/registers/DRIFT_REGISTER.md
+  - docs/registers/VERIFICATION_BACKLOG.md
+  - release/rollback_cards/
+  - release/correction_notices/
+  - control_plane/policy_gate_register.yaml
+tags: [kfm, runbook, incident-response, security, rollback, correction, governance]
+notes:
+  - PROPOSED placement under docs/runbooks/ per Directory Rules §6.1 and the §10.3 instruction that a leaked-secret event must produce "a runbook entry in docs/runbooks/".
+  - Directory Rules §6.1 also lists docs/security/ as a home for "incident response"; relationship between the two homes is NEEDS VERIFICATION pending ADR.
+  - No repository mounted in this session; specific paths, owners, branches, and tool versions are PROPOSED or NEEDS VERIFICATION.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+<a id="top"></a>
+
+# Incident Response Runbook
+
+> Governed, fail-closed procedure for detecting, containing, correcting, and rolling back KFM incidents that threaten evidence integrity, sensitivity controls, the trust membrane, or release safety — without bypassing them.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
+  <img alt="Policy label: restricted" src="https://img.shields.io/badge/policy_label-restricted-orange">
+  <img alt="Posture: fail-closed" src="https://img.shields.io/badge/posture-fail--closed-critical">
+  <img alt="Authority: docs control plane" src="https://img.shields.io/badge/authority-docs%2Frunbooks-blue">
+  <img alt="Version: v1" src="https://img.shields.io/badge/version-v1-lightgrey">
+  <img alt="Last updated: 2026-05-12" src="https://img.shields.io/badge/last%20updated-2026--05--12-informational">
+</p>
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` — first publication of this runbook; no prior incident rehearsals attached. |
+| **Owners** | `docs-steward`, `security-steward`, `release-steward` *(roles; named individuals NEEDS VERIFICATION)* |
+| **Last updated** | 2026-05-12 |
+| **Policy label** | `restricted` — operational; references to sensitive procedures are non-public. |
+| **Authority class** | Operational runbook (`docs/` explains; it does not decide alone). |
+
+> [!IMPORTANT]
+> **KFM is never a life-safety authority.** This runbook handles incidents internal to the KFM trust path (data, evidence, publication, AI surfaces, infrastructure exposure). It does **not** instruct the public about hazards, emergencies, or real-world response. Emergency-alert authority lives with NWS, FEMA, state, and local agencies. KFM products that touch hazard or alert data must fail closed if they could be mistaken for life-safety instruction.
+
+---
+
+## Quick jump
+
+- [1. Scope and boundary](#1-scope-and-boundary)
+- [2. Roles and separation of duties](#2-roles-and-separation-of-duties)
+- [3. Incident classes](#3-incident-classes)
+- [4. Severity and SLO targets](#4-severity-and-slo-targets)
+- [5. Incident lifecycle](#5-incident-lifecycle)
+- [6. Detection signals](#6-detection-signals)
+- [7. Triage](#7-triage)
+- [8. Containment](#8-containment)
+- [9. Eradication and recovery](#9-eradication-and-recovery)
+- [10. Post-incident: correction, rollback, audit](#10-post-incident-correction-rollback-audit)
+- [11. Specific playbooks](#11-specific-playbooks)
+- [12. Communications](#12-communications)
+- [13. Related docs](#13-related-docs)
+- [Appendix A — Templates](#appendix-a--templates)
+- [Appendix B — Verification backlog](#appendix-b--verification-backlog)
+
+---
+
+## 1. Scope and boundary
+
+This runbook covers any event that violates, threatens, or weakens a KFM trust invariant — and any event whose **response** must itself stay inside the trust membrane rather than around it.
+
+In scope:
+
+- Trust-membrane violations (public surface reaching `RAW`, `WORK`, `QUARANTINE`, canonical/internal stores, model runtimes, unpublished candidates, source credentials).
+- Sensitivity exposure (archaeology, fauna/flora occurrence, infrastructure, living-person/DNA, culturally sensitive geometry, precise location leaked via tile, vector, 3D, screenshot, popup label, or AI text).
+- Evidence-chain failure (`EvidenceRef` fails to resolve at runtime while a public surface still renders content as authoritative).
+- Source integrity (mislabeled source role; rights/sovereignty status changed without re-evaluation; stale source published as current).
+- Release integrity (release lacks rollback target, manifest mismatch, mutable tag drift, unsigned artifact accepted, kill-switch bypassed, `spec_hash` drift).
+- Governed AI failure (uncited or weakly-cited answer; synthetic content presented as observed reality; direct browser-to-model path).
+- Operational security (real secret committed to `configs/` or any non-secret store; exposure beyond loopback; admin shortcut used as public path).
+- Renderer/map governance (sensitive geometry hidden only by style; unreleased tile load; popup substituting for the Evidence Drawer; uncited export).
+
+Out of scope:
+
+- Real-world emergencies. KFM does not issue alerts; route those to the authoritative agency.
+- Routine bug triage with no trust-membrane, evidence, sensitivity, or release implication — handle in normal engineering review.
+
+> [!NOTE]
+> **Trust-membrane invariants this runbook protects** (CONFIRMED doctrine across the project corpus):
+> `RAW → WORK/QUARANTINE → PROCESSED → CATALOG/TRIPLET → PUBLISHED`; public clients and normal UI surfaces use governed interfaces only; cite-or-abstain; deny-by-default for sensitive classes; promotion is a governed state transition; release decisions carry rollback targets; corrections supersede rather than silently mutate.
+
+[Back to top](#top)
+
+---
+
+## 2. Roles and separation of duties
+
+Separation of policy-significant duties is required for material incidents (CONFIRMED doctrine). The **detector** of an incident should not be the **decider** who publishes the correction or the **releaser** who restores public state.
+
+| Role *(PROPOSED titles; map to your actual on-call rotation)* | Responsibility |
+|---|---|
+| **Incident Commander (IC)** | Owns the timeline. Coordinates roles. Holds the kill-switch and feature-flag decisions. Writes the post-incident summary. |
+| **Security steward** | Owns operational security: secret rotation, exposure, audit, infra posture. |
+| **Release steward** | Owns the release path: `ReleaseManifest`, `RollbackCard`, `CorrectionNotice`, public state restoration. |
+| **Policy steward** | Owns gate logic: `policy/` rules, `PolicyDecision` outcomes, deny/abstain enforcement. |
+| **Subsystem owner(s)** | Owns the affected lane (UI, governed AI, map shell, domain pipeline, source connector, etc.). |
+| **Docs steward** | Owns lineage, drift register, verification backlog, runbook updates. |
+| **Reviewer (independent)** | Approves the correction/rollback prior to public re-emission when materiality applies. |
+
+> [!IMPORTANT]
+> **No single person should detect, decide, release, and audit a material incident.** Where the team is small, the Incident Commander **must not** simultaneously sign the corrected release; another reviewer signs. This is a hard rule, not a preference.
+
+[Back to top](#top)
+
+---
+
+## 3. Incident classes
+
+Defect class drives the correction posture and the rollback posture. The table below is the canonical mapping for KFM — every incident is given a class, and the class determines the recovery path. *(Defect classes CONFIRMED in project corpus; per-class procedures PROPOSED here.)*
+
+| Defect class | Typical trigger | Correction posture | Rollback posture |
+|---|---|---|---|
+| **Evidence gap** | `EvidenceRef` does not resolve to `EvidenceBundle`; published claim has no support. | `ABSTAIN` on or withdraw the unsupported claim; emit `CorrectionNotice`. | Restore prior evidence-supported release. |
+| **Source role** | Modeled output ingested as observation; authority source treated as observation; source-role upcast via paraphrase. | Re-label at `SourceDescriptor`; refuse upcast; re-promote through gates. | Restore prior correctly-labeled release. |
+| **Rights** | Source license/sovereignty status changed; unknown rights published. | Withdraw or generalize; record rights re-evaluation in `ReviewRecord`. | Restore prior rights-cleared release. |
+| **Sensitivity** | Exact archaeology / fauna / flora / infrastructure / living-person / DNA / culturally sensitive geometry exposed via tile, vector, 3D, screenshot, popup, label, export, or AI text. | Redact / generalize / restrict tier / deny; emit `RedactionReceipt`; supersede with public-safe release. | Restore prior public-safe release; invalidate caches, tiles, exports, screenshots, AI outputs that referenced exposed coordinates. |
+| **Geometry** | Invalid GeoJSON; bad CRS; precision claim outside source basis. | Re-validate; correct geometry; supersede. | Restore prior valid-geometry release. |
+| **Temporal** | Stale source published as current; valid-time / transaction-time confusion; expired operational context shown as current. | Add stale-state markers; re-promote; supersede with fresh release. | Restore prior fresh release. |
+| **Policy** | Policy gate skipped, bypassed, or evaluated incorrectly. | Re-evaluate; record `PolicyDecision`; supersede. | Restore prior policy-cleared release. |
+| **Validation** | Schema mismatch; contract drift; closure check passed in error. | Re-run validator; fix schema/contract; supersede. | Restore prior schema-valid release. |
+| **Rendering** | Map shell loads unreleased tile, hides sensitive geometry only by style, or treats popup as Evidence Drawer substitute. | Block layer; fix descriptor; supersede. | Disable layer via feature flag; restore prior `LayerManifest`. |
+| **API** | Public route reaches `RAW` / `WORK` / `QUARANTINE` / canonical stores; admin shortcut used as public path. | Close route; fix membrane; supersede. | Disable route via feature flag; restore prior route map. |
+| **AI output** | Uncited claim emitted; restricted prompt/output leakage; synthetic content presented as observed. | Force `ABSTAIN` or `DENY`; force `RealityBoundaryNote`; revalidate citations; supersede `AIReceipt`. | Disable Focus Mode adapter via kill-switch; restore prior `MockAdapter` baseline. |
+| **Operational security** | Real secret committed to `configs/` or repo; exposure beyond loopback; signing key custody loss. | Rotate; revoke; audit access; supersede infra config. | Restore prior secret-free state; rotate forward (no rollback of the rotation itself). |
+
+> [!CAUTION]
+> Defect class **operational security** has an asymmetric rollback rule. **You do not roll back a secret rotation.** A leaked secret is a one-way door: the new secret is the floor, and any artifact, log, or cache that contained the old secret is treated as compromised until proven otherwise.
+
+[Back to top](#top)
+
+---
+
+## 4. Severity and SLO targets
+
+Severity is qualitative and reviewer-assigned. Time targets below are **PROPOSED** placeholders — calibrate against actual on-call capacity and record the calibrated values in `control_plane/`.
+
+| Severity | Definition | Acknowledge | Contain | Public correction or rollback |
+|---|---|---|---|---|
+| **SEV-1** | Public exposure of sensitive geometry or living-person/DNA data; trust-membrane breach with public traffic; signing-key compromise. | ≤ 15 min *(PROPOSED)* | ≤ 1 hr *(PROPOSED)* | ≤ 24 hr *(PROPOSED)* |
+| **SEV-2** | Uncited or wrongly-attributed public claim; rights/source-role mislabel published; release missing rollback target. | ≤ 1 hr *(PROPOSED)* | ≤ 4 hr *(PROPOSED)* | ≤ 72 hr *(PROPOSED)* |
+| **SEV-3** | Non-public drift, validator gap, policy fixture stale, internal exposure with no public traffic. | ≤ 1 business day *(PROPOSED)* | ≤ 5 business days *(PROPOSED)* | Next release *(PROPOSED)* |
+| **SEV-4** | Near-miss; preventive note; documentation drift only. | ≤ 5 business days *(PROPOSED)* | n/a | Optional. |
+
+> [!WARNING]
+> If severity is **uncertain**, treat the incident as the **higher** severity. Fail-closed applies to severity assignment as it applies to publication.
+
+[Back to top](#top)
+
+---
+
+## 5. Incident lifecycle
+
+The lifecycle below mirrors KFM's lifecycle law: nothing exits a phase without the required artifacts and a recorded decision.
+
+```mermaid
+flowchart LR
+    A[Detect<br/>signal] --> B[Triage<br/>class + severity]
+    B --> C{Public<br/>exposure?}
+    C -- "yes" --> D[Contain<br/>kill-switch · flag · route off]
+    C -- "no" --> E[Contain<br/>internal hold]
+    D --> F[Eradicate<br/>fix root cause]
+    E --> F
+    F --> G{Recovery<br/>path}
+    G -- "supersede" --> H[Publish<br/>CorrectionNotice]
+    G -- "restore" --> I[Execute<br/>RollbackCard]
+    H --> J[Audit<br/>receipts · ledger · drift register]
+    I --> J
+    J --> K[Post-incident<br/>review + verification backlog]
+```
+
+Every transition between phases must leave a receipt. A phase is closed only when (i) required artifacts exist, (ii) every required artifact **resolves** the artifacts it depends on (`EvidenceRef` → `EvidenceBundle`, `source_id` → `SourceDescriptor`, `model_id` → `ModelRunReceipt`), and (iii) the policy gate evaluated and recorded its decision. Missing any of these means the transition **fails closed** and the prior state is preserved.
+
+[Back to top](#top)
+
+---
+
+## 6. Detection signals
+
+Detection is a multi-source problem. No single channel is authoritative; treat any of the following as an admissible signal until ruled out.
+
+- **Automated checks failing** — schema validation, OPA/Rego gates on `run_manifest.json`, Cosign/Rekor attestation lookups, `spec_hash` reproducibility checks, kill-switch fixture, STAC/DCAT/PROV acceptance harness.
+- **Cite-or-abstain violations** — Focus Mode `AIReceipt` showing `ANSWER` outcome without resolved citations; `EvidenceDrawerPayload` rendered without a resolvable `EvidenceBundle`.
+- **Policy denial bypassed** — `PolicyDecision` records absent for an action that should have hit a gate; admin route used in a public-facing flow.
+- **Source-head drift** — ETag / Last-Modified change on a fetched source without a new `RunReceipt`; rights field changed upstream.
+- **Renderer breach indicators** — `addSource` / `addLayer` against an asset lacking `LayerManifest`, `TileArtifactManifest`, valid release state, or rights field; sensitive geometry rendered without `RedactionReceipt`.
+- **External report** — researcher, steward, community member, or downstream consumer flags an issue. Treat these with the same weight as automated checks.
+- **Secret-scanning hit** — repo, CI logs, container image, or backup found to contain a real credential.
+- **Audit-ledger anomaly** — append-only ledger shows missing or out-of-order events; rollback executed without `RollbackCard`; release without rollback target.
+
+> [!TIP]
+> Detection signals should be wired into the **same** check-rollup that gates promotion (PROPOSED: a Checks API rollup that blocks merge until receipts verify). The incident commander should never be the only listener.
+
+[Back to top](#top)
+
+---
+
+## 7. Triage
+
+Triage assigns four things and nothing else:
+
+1. **Class** — pick from §3.
+2. **Severity** — pick from §4 (fail-closed: pick higher when uncertain).
+3. **Affected surfaces** — public clients, normal UI, governed API, AI surface, exports, screenshots, downstream derivatives (graphs, vector indexes, scenes, story snapshots, tiles, caches).
+4. **Containment plan** — feature flag off, route disable, layer block, kill-switch file, secret rotation, or "internal hold; no public action needed."
+
+<details>
+<summary><strong>Triage worksheet (copy and fill)</strong></summary>
+
+```text
+incident_id:             # short slug, e.g. inc-2026-05-12-001
+detected_at:             # ISO 8601 UTC
+detected_by:             # role or person
+detection_signal:        # which check, who reported, what tipped it
+class:                   # one of §3
+severity:                # one of §4 (escalate on uncertainty)
+public_exposure:         # yes | no | unknown
+affected_surfaces:       # list
+affected_releases:       # release_id(s) implicated
+affected_downstream:     # graphs / tiles / scenes / exports / AI outputs
+known_evidence_refs:     # EvidenceBundle ids in play
+known_source_refs:       # SourceDescriptor ids in play
+proposed_containment:    # flag off / route off / layer block / kill-switch / rotation
+ic:                      # incident commander
+witnesses:               # who else has eyes on it
+notes:                   # free text, signed and timed
+```
+</details>
+
+[Back to top](#top)
+
+---
+
+## 8. Containment
+
+Containment is **deny-by-default, fail-closed**. The right move is the one that stops the exposure or claim from being treated as authoritative, even if it stops legitimate traffic along with it. Restoring legitimate function is the next phase, not this one.
+
+### 8.1 Containment levers
+
+| Lever | When to use | Reversibility |
+|---|---|---|
+| **Kill-switch file** *(PROPOSED mechanism per ML-063-005)* | SEV-1; release or promotion path must fail closed across the board. | Reversible by removing the file after the underlying defect is fixed. |
+| **Feature flag off** | UI route, panel, Focus Mode, Story Mode, Export, or a layer should disappear from public clients without changing API contracts. | Fully reversible. |
+| **Layer block / `LayerManifest` deny** | A specific layer or tile artifact must stop loading. | Reversible via layer registry; emits a `LayerManifest` revision. |
+| **Route disable** | A governed API route is breaching the membrane. | Reversible via route map revision; old client builds may show `ERROR`. |
+| **AI adapter swap to `MockAdapter`** | Live provider is emitting uncited or restricted content. | Reversible after citation validation and policy gate review pass. |
+| **Cache / CDN purge** | Sensitive tile, PMTiles, COG, vector tile, or 3D asset has been served. | Forward-only for the purged copy; new release supersedes. |
+| **Secret rotation** | Real credential exposed. | **One-way** — never roll back the rotation. |
+| **Public surface withdrawal** | Released claim is unsupported and supersede is not yet ready. | Reversible by emitting a superseding release. |
+
+### 8.2 Containment rules
+
+> [!IMPORTANT]
+> Containment **must not** open a new untrusted path. Disabling the governed API route in favor of a "temporary direct read" against canonical stores is **not** containment — it is a second incident on top of the first. The trust membrane forbids any public client, any normal UI surface, and any released AI surface from reaching `RAW`, `WORK`, `QUARANTINE`, canonical/internal stores, graph internals, vector indexes, source APIs, or direct model runtimes during an incident.
+
+> [!CAUTION]
+> Style-only hiding is **not** containment for sensitive geometry. If sensitive coordinates were exposed via vector tile, COG, or 3D asset, the tile/COG/asset itself must be withdrawn or replaced with a public-safe derivative. Hiding a layer with a style filter leaves the geometry in the artifact.
+
+[Back to top](#top)
+
+---
+
+## 9. Eradication and recovery
+
+Eradication is fixing the root cause. Recovery is restoring a safe public state through the **same governed release path** the original publication used — never a hidden file copy, never a direct write to `data/published/`, never a hand-edit of a canonical record.
+
+### 9.1 Recovery decision
+
+Two paths, picked by defect class:
+
+- **Supersede (forward-fix correction).** Publish a new release that supersedes the defective one. Required when the right answer differs from the old answer (e.g., evidence updated, source role corrected, rights re-evaluated, sensitivity generalized).
+- **Rollback (restore prior).** Restore the most recent prior safe release. Required when the new release introduced the defect and the prior release was safe (e.g., release missing rollback target, broken `LayerManifest`, adapter regression).
+
+Both paths emit auditable artifacts; both paths must invalidate downstream derivatives.
+
+### 9.2 Closure rules
+
+The transition from "fixed" to "publicly safe" is closed only when:
+
+1. The defect's root cause is removed from `RAW` / `WORK` / `PROCESSED` / `CATALOG` as far upstream as the class requires.
+2. A `ValidationReport` records the re-run of every gate the defect bypassed or failed.
+3. A `PolicyDecision` records the explicit re-evaluation outcome.
+4. A `ReviewRecord` is attached when materiality applies and is signed by a reviewer **distinct from the author** of the corrected content.
+5. A `ReleaseManifest` is emitted (forward correction) or restored (rollback) — never silently swapped.
+6. A `CorrectionNotice` lists invalidated derivatives (graphs, vector indexes, scenes, story snapshots, exports, AI outputs, downstream tiles).
+7. A `RollbackCard` is recorded when rollback is the path, including the targeted prior release and the reason.
+8. Caches, CDN copies, OCI tags, and signed manifests pointing to the defective release are purged or redirected.
+9. Re-publication uses immutable digests, not mutable tags.
+10. The audit ledger has a coherent record across the full lifecycle of the incident.
+
+> [!NOTE]
+> Operational thresholds in any quarantine rules used during containment must be labeled explicitly (`policy_basis = operational_threshold` vs `scientific_basis = source-derived observation`) to prevent accidental regulatory interpretation or scientific overclaim.
+
+[Back to top](#top)
+
+---
+
+## 10. Post-incident: correction, rollback, audit
+
+The post-incident step is where the incident becomes legible to KFM's governance plane. Three artifacts are mandatory; a fourth is conditional.
+
+| Artifact | When | What it records |
+|---|---|---|
+| **`CorrectionNotice`** | Public claim was wrong, has been corrected, or has been withdrawn. | `claim_ref`, `prior_release_ref`, `change_summary`, `invalidates[]`, `review_ref`, `time`. |
+| **`RollbackCard`** | Rollback path was chosen. | `release_id`, `rollback_to`, `reason`, `invalidates[]`, `review_ref`, `time`. |
+| **Audit-ledger entry** | Always. | Detect → triage → contain → eradicate → recover → close, with timestamps and signatures. |
+| **`RealityBoundaryNote`** | AI surface, synthetic carrier, or reconstructed scene was implicated. | `scope`, `method_summary`, `evidence_refs[]`, `visibility`. |
+
+Register updates after every material incident:
+
+- `docs/registers/DRIFT_REGISTER.md` — defect class, surface, defect type, fix reference.
+- `docs/registers/VERIFICATION_BACKLOG.md` — anything left as NEEDS VERIFICATION, including gate coverage gaps.
+- `control_plane/contradiction_register.yaml` — if the incident revealed a doctrine/implementation conflict.
+- `control_plane/deprecation_register.yaml` — if a sunset was required.
+
+> [!IMPORTANT]
+> A correction is **not** complete until downstream derivatives are invalidated. Graphs, vector indexes, embeddings, scene caches, story snapshots, exports, screenshots, and AI summaries that referenced the defective content are all derivatives. Re-publishing the correction without listing the invalidations is a documented anti-pattern.
+
+[Back to top](#top)
+
+---
+
+## 11. Specific playbooks
+
+Each playbook below is a short, runnable procedure for one common defect class. They are deliberately compact. All paths inside them are PROPOSED until a mounted repository confirms them.
+
+<details>
+<summary><strong>11.1 Leaked secret in <code>configs/</code> or repo</strong></summary>
+
+**Trigger.** Secret-scanning hit, accidental commit, screenshot leak, log-leak, or a real secret found under `configs/dev/`, `configs/test/`, or any non-secret store. Directory Rules §10.3 names this case explicitly.
+
+**Class.** Operational security. **Severity.** SEV-1 if production; SEV-2 if local-only; assume SEV-1 until proven local.
+
+1. **Rotate the secret at the issuing system first** — before touching the repo, before opening a PR. The new secret is the floor.
+2. **Revoke the old secret.** Confirm revocation; verify the old credential no longer authenticates.
+3. **Audit access logs** for the window between secret creation and revocation. Record any access in the incident timeline.
+4. **Purge from repo history** if committed. `git filter-repo` or equivalent; force-push the rewritten history; coordinate with anyone with local clones.
+5. **Purge from caches** — CI artifact stores, container layers, backup snapshots, logs, build caches.
+6. **Open a `CorrectionNotice`** if any artifact derived from the leak was published.
+7. **Update `docs/registers/DRIFT_REGISTER.md`** with the leak class and fix.
+8. **Add a runbook update** if the leak class is new.
+9. **Verify**: secret scanning re-run is clean; new secret in environment store; audit logs preserved.
+
+> [!CAUTION]
+> Do not roll back the rotation. Do not "temporarily" restore the old secret to avoid disruption. The window of exposure is the window where the old secret existed; reducing that window is the priority that overrides convenience.
+</details>
+
+<details>
+<summary><strong>11.2 Sensitive geometry exposed via public tile, export, or AI text</strong></summary>
+
+**Trigger.** Exact archaeology / fauna / flora / infrastructure / living-person / DNA / culturally sensitive geometry served via PMTiles, COG, MVT, MLT, 3D Tiles, screenshot, story export, popup label, or AI answer.
+
+**Class.** Sensitivity. **Severity.** SEV-1.
+
+1. **Withdraw the asset** at the layer level — kill-switch / feature flag / `LayerManifest` deny. Do not rely on style hiding.
+2. **Purge caches** — CDN, OCI tags pointing to the defective digest, browser-side cached tiles where reachable.
+3. **Invalidate AI outputs and exports** that referenced the coordinates. List them in the `CorrectionNotice`.
+4. **Generate a public-safe derivative** — generalization (H3, geohash bucket, county/HUC aggregation), redaction, or restricted-tier reassignment. Emit a `RedactionReceipt`.
+5. **Re-validate the new artifact** — schema, geometry, sensitivity, rights, release state.
+6. **Publish the superseding release** with the public-safe derivative and an attached `RealityBoundaryNote` if any synthetic representation was used in mitigation.
+7. **Record review** — independent reviewer (cultural review for archaeology and culturally sensitive content; species/locality review for fauna/flora).
+8. **Update `docs/registers/DRIFT_REGISTER.md`** with the surface that leaked (tile / vector / 3D / screenshot / export / AI text).
+
+> [!WARNING]
+> Style-only hiding is not redaction. If the geometry was in the artifact, the artifact must be replaced.
+</details>
+
+<details>
+<summary><strong>11.3 Uncited or weakly-cited AI answer reached a public surface</strong></summary>
+
+**Trigger.** Focus Mode emitted `ANSWER` without resolved citations; `AIReceipt` shows missing citation validation; synthetic content presented as observed reality.
+
+**Class.** AI output. **Severity.** SEV-2 (escalate to SEV-1 if the answer touched sensitivity, rights, or life-safety-adjacent content).
+
+1. **Disable the live adapter via kill-switch.** Swap to `MockAdapter` if Focus Mode must remain on for non-public testing; otherwise feature-flag the Focus route off.
+2. **Force `ABSTAIN` or `DENY`** for any retry of the affected question class until citation validation is verified.
+3. **Audit the `AIReceipt` window** — sample answers from the period the defect was active; identify any that should also be withdrawn or corrected.
+4. **Attach a `RealityBoundaryNote`** if synthetic content was presented as observed.
+5. **Publish a `CorrectionNotice`** for each material answer that reached a public surface.
+6. **Re-validate citation validation** — fixtures pass; negative fixtures (uncited / weakly-cited / unsupported) still `DENY` or `ABSTAIN`.
+7. **Restore the live adapter** only after the policy precheck/postcheck contract is re-verified end-to-end.
+
+> [!IMPORTANT]
+> AI is interpretive, not the root truth source. Restoration of the AI surface comes **after** evidence, policy, citation validation, and finite response envelopes pass — never before.
+</details>
+
+<details>
+<summary><strong>11.4 Release published without a rollback target, or with a mutable tag</strong></summary>
+
+**Trigger.** OPA/Rego policy on `release_manifest` denied missing `rollback`, but a release got through; release references a moving symbolic tag instead of an immutable digest; `spec_hash` mismatch between manifest and run receipt.
+
+**Class.** Release integrity. **Severity.** SEV-2.
+
+1. **Hold further promotions** via kill-switch.
+2. **Locate the prior safe release** — verify digests, manifests, signatures, `EvidenceBundle` resolution, policy state.
+3. **Execute `RollbackCard`** referencing the prior safe release as the rollback target.
+4. **Emit rollback attestation** — every map/release rollback emits its own attestation.
+5. **Re-emit the corrected release** with an immutable digest reference, a complete `ReleaseManifest`, and a rollback target.
+6. **Verify** `spec_hash` reproducibility, signature presence, STAC/DCAT/PROV validation, and check-rollup blocking until receipts verify.
+7. **Update `docs/registers/DRIFT_REGISTER.md`** with the release integrity failure mode and fix.
+</details>
+
+<details>
+<summary><strong>11.5 Public client reached <code>RAW</code> / <code>WORK</code> / <code>QUARANTINE</code> or a canonical store</strong></summary>
+
+**Trigger.** Route audit reveals an `apps/explorer-web/`-equivalent fetch that bypassed `apps/governed-api/` (or the actual governed-API path); admin route used as the normal public path; direct model endpoint reachable from the browser.
+
+**Class.** API / trust-membrane breach. **Severity.** SEV-1.
+
+1. **Disable the offending route via feature flag.** If the route is unauthenticated and reachable from the public internet, also block at the reverse proxy.
+2. **Audit logs** for the exposure window — count requests, identify whether sensitive content was actually returned.
+3. **Patch the membrane** — route through the governed API, restore the policy gate, restore the `EvidenceBundle` resolution step.
+4. **Re-validate** with no-public-raw-path and no-unreleased-tile fixture tests.
+5. **Emit a `CorrectionNotice`** if sensitive content was returned.
+6. **ADR** if the route's existence implied a doctrine gap; record in `docs/adr/`.
+</details>
+
+<details>
+<summary><strong>11.6 Source rights or sovereignty changed upstream</strong></summary>
+
+**Trigger.** Source publisher changed license, withdrew permission, or updated sovereignty/CARE terms after KFM had published derived content.
+
+**Class.** Rights. **Severity.** SEV-2.
+
+1. **Hold further releases derived from the source.**
+2. **Withdraw or generalize** existing derived public artifacts. Sensitivity-class derivations may require full withdrawal.
+3. **Update `SourceDescriptor`** with the new rights state.
+4. **Re-run the `ValidationReport`** and `PolicyDecision` against the new rights.
+5. **Emit a `CorrectionNotice`** listing invalidated derivatives.
+6. **Document** in `docs/sources/` and `control_plane/source_authority_register.yaml`.
+</details>
+
+<details>
+<summary><strong>11.7 Source role collapse (modeled treated as observed)</strong></summary>
+
+**Trigger.** A modeled or analytical product was ingested or paraphrased into an observation-class claim. Often surfaced by source-role anti-collapse validators.
+
+**Class.** Source role. **Severity.** SEV-2.
+
+1. **Restore correct source role** at `SourceDescriptor`. Source role is fixed at admission; never upgraded by promotion.
+2. **Withdraw any claim** that treats the modeled product as observed.
+3. **AI surface check** — ban list of upcasting phrases; sample `AIReceipt` records for paraphrase-based upcasts.
+4. **Re-publish** with correct role labeling and an explicit caveat in the Evidence Drawer.
+5. **Emit `CorrectionNotice`** for material public claims.
+</details>
+
+[Back to top](#top)
+
+---
+
+## 12. Communications
+
+Communication is part of the trust posture. The principle is: **the public correction must be as visible as the original claim, and no more.**
+
+| Audience | Channel *(PROPOSED)* | What to share | What to withhold |
+|---|---|---|---|
+| Public consumers of the affected surface | Public-facing `CorrectionNotice`, status page, or in-product banner. | What changed, when, and why; how to find the corrected version; how to report related concerns. | Restricted geometry, secret material, exact source paths to sensitive content, internal route names. |
+| Affected source publishers and stewards | Direct contact via established channel. | What was misused; what has been withdrawn; what review is in progress. | Internal stack details unless required. |
+| Downstream consumers (data partners, AI surfaces, exports) | Machine-readable `CorrectionNotice` referenced in their feed. | Invalidated derivative list; rollback/correction release IDs; new digest references. | n/a. |
+| Internal team | Incident timeline + post-incident review. | Everything material to learning. | Avoid blame language; focus on system change. |
+| Regulators or rights-holders | Only when required by class (e.g., living-person/DNA exposure, cultural sensitivity breach). | Material facts, mitigation, timeline. | Speculation; uncertain attribution. |
+
+> [!NOTE]
+> KFM does not act as an emergency-alert channel. Hazard or alert content that prompted the incident must be referred back to its authoritative source (NWS, FEMA, state/local agency). KFM's communication describes its **own** correction, not the underlying real-world event.
+
+[Back to top](#top)
+
+---
+
+## 13. Related docs
+
+*(Targets are PROPOSED until the repository is mounted and verified.)*
+
+- `docs/runbooks/README.md` — runbook index. *(TODO link target)*
+- `docs/runbooks/governed_ai_ROLLBACK.md` — AI adapter rollback and kill switch. *(TODO link target)*
+- `docs/runbooks/ui_ROLLBACK.md` — UI feature-flag and schema deprecation steps. *(TODO link target)*
+- `docs/security/README.md` — threat model and exposure posture. *(TODO link target)*
+- `docs/doctrine/trust-membrane.md` — invariants this runbook protects. *(TODO link target)*
+- `docs/doctrine/lifecycle-law.md` — phase-by-phase governance. *(TODO link target)*
+- `docs/registers/DRIFT_REGISTER.md` — running record of drift entries. *(TODO link target)*
+- `docs/registers/VERIFICATION_BACKLOG.md` — open verification items. *(TODO link target)*
+- `release/rollback_cards/` — `RollbackCard` instances. *(TODO link target)*
+- `release/correction_notices/` — `CorrectionNotice` instances. *(TODO link target)*
+- `control_plane/policy_gate_register.yaml` — gate inventory and outcomes. *(TODO link target)*
+
+[Back to top](#top)
+
+---
+
+## Appendix A — Templates
+
+<details>
+<summary><strong>A.1 <code>CorrectionNotice</code> field skeleton (PROPOSED)</strong></summary>
+
+```text
+object_type:        CorrectionNotice
+claim_ref:          # reference to the corrected claim
+prior_release_ref:  # release_id that contained the defect
+change_summary:     # what changed and why (public-safe text)
+invalidates:        # list of derivative artifact refs (graphs, exports, scenes, AI outputs)
+review_ref:         # ReviewRecord id; reviewer distinct from author when material
+time:               # ISO 8601 UTC
+notice_visibility:  # public | restricted
+```
+</details>
+
+<details>
+<summary><strong>A.2 <code>RollbackCard</code> field skeleton (PROPOSED)</strong></summary>
+
+```text
+object_type:    RollbackCard
+release_id:     # the defective release being rolled back
+rollback_to:    # the prior safe release_id
+reason:         # short text; class + brief cause
+invalidates:    # derivative artifact refs affected
+review_ref:     # ReviewRecord id
+time:           # ISO 8601 UTC
+```
+</details>
+
+<details>
+<summary><strong>A.3 Post-incident review skeleton (PROPOSED)</strong></summary>
+
+```text
+incident_id:
+summary:                  # one paragraph, public-safe where possible
+class:                    # §3
+severity:                 # §4
+timeline:                 # detect → contain → eradicate → recover → close, with timestamps
+artifacts:                # CorrectionNotice / RollbackCard / RedactionReceipt / RealityBoundaryNote ids
+detection_assessment:     # what worked, what missed
+containment_assessment:   # what worked, what missed
+recovery_assessment:      # what worked, what missed
+gate_gaps:                # validator / policy / receipt gaps revealed
+register_updates:         # DRIFT_REGISTER / VERIFICATION_BACKLOG entries opened
+followups:                # owned, dated
+```
+</details>
+
+<details>
+<summary><strong>A.4 Incident timeline format (PROPOSED)</strong></summary>
+
+```text
+HH:MM UTC  ROLE  event
+HH:MM UTC  IC    Triage: class=<...>, severity=<...>, exposure=<yes|no>
+HH:MM UTC  ...   Containment lever engaged: <flag|route|layer|kill-switch|rotation>
+HH:MM UTC  ...   ValidationReport re-run: PASS|FAIL on <gate>
+HH:MM UTC  ...   ReviewRecord signed by <role>
+HH:MM UTC  ...   ReleaseManifest <id> superseded by <id>  OR  RollbackCard <id> executed
+HH:MM UTC  IC    Close: registers updated, public state verified
+```
+</details>
+
+[Back to top](#top)
+
+---
+
+## Appendix B — Verification backlog
+
+Items below are NEEDS VERIFICATION and should be resolved as the repository is inspected and as the runbook is exercised.
+
+- Confirm whether the runbook home is `docs/runbooks/INCIDENT_RESPONSE.md` (this file) **and** a peer page lives at `docs/security/incident-response.md`, or whether `docs/security/` redirects here. Directory Rules §6.1 lists both candidate homes.
+- Confirm severity time targets in §4 against actual on-call capacity; record in `control_plane/`.
+- Confirm the exact kill-switch mechanism for KFM's release pipeline (PROPOSED to mirror ML-063-005 kill-switch file).
+- Confirm whether `release/rollback_cards/` and `release/correction_notices/` exist as the canonical homes (PROPOSED).
+- Confirm the named individuals behind each role; placeholders used here.
+- Confirm the public correction surface (status page, in-product banner, public `CorrectionNotice` feed).
+- Confirm rights-change detection cadence across third-party sources (CONFIRMED gap in the v1.0 risk register).
+- Confirm AI surface paraphrase-detection coverage and ban-list maintenance.
+- Confirm cross-surface lint coverage for sensitivity leaks via popup labels, exports, screenshots, and AI text (CONFIRMED gap in the v1.0 risk register).
+
+[Back to top](#top)
+
+---
+
+**Related:** [Runbooks index](#13-related-docs) · [Trust membrane doctrine](#13-related-docs) · [Lifecycle law](#13-related-docs) · [Drift register](#13-related-docs)
+
+**Last updated:** 2026-05-12 · **[Back to top](#top)**

--- a/docs/runbooks/NO_NETWORK_TEST_RUNBOOK.md
+++ b/docs/runbooks/NO_NETWORK_TEST_RUNBOOK.md
@@ -1,3 +1,503 @@
-# NO_NETWORK_TEST_RUNBOOK
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-no-network-test
+title: No-Network Test Runbook
+type: standard
+version: v1
+status: draft
+owners: <Docs steward + Validation subsystem owner — NEEDS VERIFICATION>
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/runbooks/README.md
+  - docs/runbooks/ui_VALIDATION.md
+  - docs/runbooks/governed_ai_VALIDATION.md
+  - docs/adr/ADR-0001-schema-home.md
+  - directory-rules.md
+  - contracts/OBJECT_MAP.md
+  - schemas/contracts/v1/
+  - tests/runtime_proof/
+  - fixtures/
+tags: [kfm, runbook, testing, ci, no-network, fail-closed, fixtures, governance]
+notes:
+  - "Defines the no-network test discipline that is the FIRST KFM CI pipeline."
+  - "Repo-shape claims (commands, paths, workflow names) are PROPOSED until repo mount verifies."
+  - "Sensitive-lane fixtures MUST be public-safe transforms — never real coordinates, DNA, or living-person records."
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# 🌐 No-Network Test Runbook
+
+> The deterministic, fixture-only, fail-closed test discipline that proves the KFM trust spine **before** any live source, network endpoint, or runtime is touched.
+
+<!-- Badges: placeholder targets until CI workflow names and dashboards are verified -->
+![Status: Draft](https://img.shields.io/badge/status-draft-yellow)
+![Doc Type: Runbook](https://img.shields.io/badge/doc--type-runbook-informational)
+![Authority: PROPOSED](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Posture: Fail-closed](https://img.shields.io/badge/posture-fail--closed-critical)
+![Network: Deny by default](https://img.shields.io/badge/network-deny--by--default-success)
+![Phase: No-Network Baseline](https://img.shields.io/badge/phase-no--network%20baseline-blue)
+
+| | |
+|---|---|
+| **Status** | Draft (under review) |
+| **Owners** | `<Docs steward + Validation subsystem owner — NEEDS VERIFICATION>` |
+| **Last updated** | 2026-05-12 |
+| **Authority of doctrine in this doc** | **CONFIRMED** — supported by BLD-GREEN, BLD-COMP, IMPL-PIPE, ENCY, WUI/GAI, and ML-063-057 |
+| **Authority of any concrete path / command / workflow name** | **PROPOSED** until mounted-repo evidence confirms |
+| **Companion docs** | [`docs/runbooks/ui_VALIDATION.md`](./ui_VALIDATION.md) · [`docs/runbooks/governed_ai_VALIDATION.md`](./governed_ai_VALIDATION.md) · [`directory-rules.md`](../../directory-rules.md) |
+
+---
+
+## 🧭 Quick jump
+
+- [1 · Purpose & scope](#1--purpose--scope)
+- [2 · What "no-network" means in KFM](#2--what-no-network-means-in-kfm)
+- [3 · Doctrinal basis](#3--doctrinal-basis)
+- [4 · Pre-requisites](#4--pre-requisites)
+- [5 · Run flow (diagram)](#5--run-flow-diagram)
+- [6 · Test classes](#6--test-classes)
+- [7 · Fixture taxonomy](#7--fixture-taxonomy)
+- [8 · The run sequence](#8--the-run-sequence)
+- [9 · Network egress posture](#9--network-egress-posture)
+- [10 · Sensitive-lane handling](#10--sensitive-lane-handling)
+- [11 · Anti-patterns](#11--anti-patterns)
+- [12 · Failure triage](#12--failure-triage)
+- [13 · Verification backlog](#13--verification-backlog)
+- [14 · Related docs](#14--related-docs)
+- [Appendix A · Illustrative commands and stubs](#appendix-a--illustrative-commands-and-stubs)
+- [Appendix B · KFM terminology used in this doc](#appendix-b--kfm-terminology-used-in-this-doc)
+
+---
+
+## 1 · Purpose & scope
+
+KFM's first CI pipeline is **no-network by default**. This runbook tells contributors and reviewers how to design, execute, and audit that pipeline so that the trust spine — source admission, lifecycle state, validation, evidence resolution, policy decision, catalog/proof closure, release decision, governed API envelope, correction, and rollback — is provable **without any live source, network endpoint, model runtime, or runtime store**.
+
+**In scope**
+
+- The minimum no-network test discipline that every KFM PR must satisfy before any live-source or runtime test is permitted to run.
+- The fixture taxonomy that proves both positive and negative outcomes.
+- How a watcher / connector / promotion gate proves itself via **dry-run receipts** rather than live fetches.
+- How sensitive-lane fixtures are transformed before they enter `tests/` or `fixtures/`.
+
+**Out of scope**
+
+- Live-source connector exercises, external endpoint smoke tests, package-version checks, runtime smoke tests, and any deployment surface. These belong in **separate, opt-in, source-activated jobs**, *after* this no-network suite is green. **CONFIRMED doctrine** (see §3); concrete job names are PROPOSED.
+- UI accessibility, e2e, and visual-trust runs — covered by [`docs/runbooks/ui_VALIDATION.md`](./ui_VALIDATION.md) (PROPOSED CREATE).
+- Governed AI / Focus Mode adapter validation — covered by [`docs/runbooks/governed_ai_VALIDATION.md`](./governed_ai_VALIDATION.md) (PROPOSED CREATE).
+- Rollback drills against a real release — covered by the rollback runbook (PROPOSED CREATE).
+
+> [!IMPORTANT]
+> **The doctrine in this runbook is CONFIRMED. The exact CI workflow file names, runner labels, test commands, package managers, and per-lane fixture paths are PROPOSED** until verified against a mounted repository. Do not treat any specific command or path in this file as proof of implementation maturity.
+
+---
+
+## 2 · What "no-network" means in KFM
+
+A test run is "no-network" when **every** statement below is true:
+
+1. **No outbound network calls** are made by tests, fixtures, validators, policy bundles, or harness code. Watchers, connectors, and resolvers run in **dry-run** mode against fixed local inputs.
+2. **No live source fetch** occurs. HTTP validators (ETag, Last-Modified), `spec_hash`, and `RunReceipt` fields are produced from **canned fixture values**, not live `curl`/`HEAD` probes.
+3. **No model runtime** is invoked. Governed-AI surfaces exercise the **MockAdapter** only; live `Ollama`, OpenAI, or other provider adapters are not loaded.
+4. **No internal stores** (database, graph store, vector index, object store) are read or written. Tests bind against fixture inputs and emit fixture outputs.
+5. **No release publication** occurs. Promotion runs as a **dry-run**: it produces auditable gate outputs (`PolicyDecision`, `ValidationReport`, `RunReceipt`, dry-run `ReleaseManifest`) without flipping any artifact to `data/published/`.
+6. **No secrets** are required to make the suite pass. The suite is reproducible on a developer laptop and on a clean CI runner with the same code.
+
+The first implementation **MAY** be entirely no-network and deterministic; this is explicitly endorsed as the starting posture for watchers and source-driven pipelines (see ML-063-057 in [`Master_MapLibre_Components-Functions-Features.pdf`](../../Master_MapLibre_Components-Functions-Features_compressed.pdf), §U).
+
+---
+
+## 3 · Doctrinal basis
+
+| Source (attached project doc) | What it establishes | Label |
+|---|---|---|
+| **BLD-GREEN §§17, 24** (Unified Build Manual) | The first pipeline **should be no-network by default** and run path-role checks, schema validation, fixture validation, validator tests, policy tests, evidence-resolution tests, finite-envelope tests, promotion dry-run, release-deny tests, catalog-closure tests, and rollback-reference tests. | **CONFIRMED doctrine** |
+| **BLD-COMP §§5.3, 20, 30** | Fixture rule: every major object family has at least one **valid**, one **invalid**, one **denied**, one **abstention**, and one **rollback/correction** fixture. | **CONFIRMED doctrine** |
+| **IMPL-PIPE §§22, 23** | Live-source, endpoint, and runtime tests must be **separate, opt-in, source-activated** jobs until rights, rate limits, secrets, and terms are verified. | **CONFIRMED doctrine** |
+| **ML-063-057** (Master MapLibre, §U) | Watcher dry-run receipts emit `RunReceipt` shapes and validate structure **without live ports or network side effects**. First implementation can be no-network and deterministic. | **CONFIRMED evidence** |
+| **KFM Encyclopedia §14, PR-00** | Reversible PR plan opens with a `no-network fixture` PR creating fixtures for `SourceDescriptor`, `EvidenceBundle`, `LayerManifest`, `ReleaseManifest`, plus one hydrology object; **acceptance is "Fixture validation passes; no network access."** | **CONFIRMED doctrine / PROPOSED implementation** |
+| **WUI/GAI Report §20** | Mock and fixture layer: every mock payload must be **schema-valid**, must include an **obvious mock marker**, must not be confused with released evidence, and must exercise **both positive and negative states**. Fixtures are not publication artifacts. | **CONFIRMED doctrine** |
+| **New Ideas pack — Suggested CI Gates** | Includes `PR-INGEST-007 no-network dry-run` as a named CI gate alongside schema validation, deterministic hash verification, invalid fixture rejection, quarantine enforcement, provenance completeness, signature verification, and public-safe manifest validation. | **CONFIRMED doctrine** |
+| **`directory-rules.md` §6.1** | `docs/runbooks/` is the canonical home for **ops procedures, rollback drills, validation runs** — including this one. | **CONFIRMED** |
+
+> [!NOTE]
+> Anywhere this runbook references a specific path under `tests/`, `fixtures/`, `tools/`, `pipelines/`, `policy/`, `schemas/`, or `.github/workflows/`, treat the path as **PROPOSED** until the mounted repo confirms it. The doctrine — *that such a path must exist and what it must enforce* — remains CONFIRMED.
+
+---
+
+## 4 · Pre-requisites
+
+Before running the no-network suite, the following objects MUST exist (with truth labels):
+
+| Object | Canonical home (per Directory Rules) | Status |
+|---|---|---|
+| `SourceDescriptor` semantic doc | `contracts/source/` | **PROPOSED** — create per PR-00 |
+| `SourceDescriptor` schema | `schemas/contracts/v1/source/` | **PROPOSED** — per ADR-0001 (schema-home rule) |
+| `EvidenceRef`, `EvidenceBundle` schemas | `schemas/contracts/v1/evidence/` | **PROPOSED** |
+| `RunReceipt`, `AIReceipt`, decision envelopes | `schemas/contracts/v1/runtime/` | **PROPOSED** |
+| `ReleaseManifest`, `RollbackCard` | `schemas/contracts/v1/release/` | **PROPOSED** |
+| Valid + invalid fixtures per family | `fixtures/valid/`, `fixtures/invalid/` *or* `tests/fixtures/<family>/` | **PROPOSED** — must not split into two competing fixture homes (Directory Rules §6.6) |
+| Policy bundle + negative fixtures | `policy/<lane>/`, `policy/fixtures/` | **PROPOSED** |
+| One domain proof slice (e.g., hydrology) | `tests/domains/hydrology/`, `fixtures/domains/hydrology/` | **PROPOSED** |
+| Path-and-drift check tooling | `tools/validators/`, `scripts/` | **PROPOSED** |
+
+> [!TIP]
+> Mock payloads MUST carry an **obvious mock marker** (e.g., a `_kfm_mock: true` field, a `mock://` URI prefix, or a fixture-only `policy_label`). This guarantees a mock can never be mistaken for a released `EvidenceBundle` if it accidentally escapes the fixture tree.
+
+---
+
+## 5 · Run flow (diagram)
+
+The diagram below reflects the **CONFIRMED doctrine** sequence from BLD-GREEN §17 and the BLD-COMP test pyramid. Concrete tool/job names are PROPOSED.
+
+```mermaid
+flowchart TD
+    A["Fixtures<br/>(valid / invalid / denied / abstain / rollback)"]:::pre
+    B[Path &amp; drift scan<br/>Directory Rules + ADR discipline]:::stage
+    C[Schema validation<br/>schemas/contracts/v1/* vs fixtures]:::stage
+    D[Contract tests<br/>object meaning + lifecycle role]:::stage
+    E[Validator unit tests]:::stage
+    F[Policy negative tests<br/>deny-by-default + reason codes]:::stage
+    G[Evidence resolution<br/>EvidenceRef → EvidenceBundle or ABSTAIN]:::stage
+    H[Lifecycle / state-transition tests]:::stage
+    I[Receipt / proof tests<br/>RunReceipt, spec_hash, digest closure]:::stage
+    J[Release-manifest tests<br/>+ rollback-reference]:::stage
+    K[Finite envelope tests<br/>ANSWER / ABSTAIN / DENY / ERROR]:::stage
+    L[Promotion dry-run<br/>auditable gates, no publication]:::gate
+    M{{All gates green?}}:::decision
+    N[No-network suite PASS<br/>downstream live-source jobs MAY run]:::ok
+    P[FAIL closed<br/>block merge; quarantine candidate]:::fail
+
+    A --> B --> C --> D --> E --> F --> G --> H --> I --> J --> K --> L --> M
+    M -- yes --> N
+    M -- no --> P
+
+    classDef pre fill:#eef,stroke:#557,color:#113;
+    classDef stage fill:#f7f7ff,stroke:#557,color:#113;
+    classDef gate fill:#ffe9c2,stroke:#a76,color:#311;
+    classDef decision fill:#fff,stroke:#557,color:#113;
+    classDef ok fill:#dff5e0,stroke:#377,color:#113;
+    classDef fail fill:#fde2e2,stroke:#a33,color:#311;
+```
+
+> [!NOTE]
+> The diagram is **structural** — it shows responsibility boundaries and ordering, not specific binaries. The arrow into "live-source jobs MAY run" is gated by green status on this whole suite. A red square anywhere upstream is a hard merge block.
+
+[⬆ Back to top](#-no-network-test-runbook)
+
+---
+
+## 6 · Test classes
+
+Adapted directly from **BLD-COMP §5.3** (Unified Manual, Phase 5 Assembly). Default status is **PROPOSED** per the source.
+
+| # | Test class | Example assertion | Required in no-network suite? |
+|---|---|---|---|
+| 1 | **Path & drift** | Every changed file lives under a responsibility root per `directory-rules.md`. No new parallel schema/policy/release home appears without an ADR. | **MUST** |
+| 2 | **Schema test** | Required fields and `schema_version` present; invalid fixtures fail. | **MUST** |
+| 3 | **Contract test** | Object meaning matches vocabulary and lifecycle role (e.g., `EvidenceBundle` cannot live in `data/raw/`). | **MUST** |
+| 4 | **Source-role test** | A `SourceDescriptor` is not used outside its declared authority (e.g., NFHL is not allowed to assert observed flood). | **MUST** |
+| 5 | **Validator unit test** | Schema, evidence, rights, sensitivity, temporal, geometry validators fail on the negative fixtures and pass on the positive ones. | **MUST** |
+| 6 | **Policy test (negative)** | Unknown rights, unknown sensitivity, missing release state, or missing review state all DENY with explicit `reason_code`. | **MUST** |
+| 7 | **Evidence-resolution test** | `EvidenceRef` resolves to an `EvidenceBundle`, or the surface ABSTAINS. Missing-bundle case is exercised explicitly. | **MUST** |
+| 8 | **Lifecycle / state-transition test** | RAW → WORK/QUARANTINE → PROCESSED → CATALOG/TRIPLET → PUBLISHED transitions are only permitted via the governed promotion path. File-move-as-promotion is rejected. | **MUST** |
+| 9 | **Receipt / proof test** | `RunReceipt`, `spec_hash` (e.g., `jcs:sha256:<hex>`), digest closure, and Merkle-style integrity patterns verify against canned inputs. | **MUST** |
+| 10 | **Release / rollback test** | A dry-run `ReleaseManifest` carries proof, correction path, and rollback target. A `RollbackCard` resolves back to the candidate it would replace. | **MUST** |
+| 11 | **Finite-envelope test** | Governed API surfaces return only `ANSWER` / `ABSTAIN` / `DENY` / `ERROR` (with `HOLD` / `PASS` / `FAIL` for validator-class outcomes). No silent fallthrough. | **MUST** |
+| 12 | **UI trust test** | Evidence Drawer renders ABSTAIN/DENY/ERROR/stale/restricted states distinctly and without revealing internal store handles. | SHOULD (UI-bearing PRs) |
+| 13 | **AI boundary test** | MockAdapter cannot return an `ANSWER` without an admissible `EvidenceBundle`. Missing citation → ABSTAIN; restricted → DENY. | SHOULD (AI-bearing PRs) |
+
+> [!IMPORTANT]
+> Tests 1–11 are **the no-network spine**. Tests 12–13 are layered on top when a PR touches UI or governed-AI code. Live-source, runtime smoke, accessibility e2e, and deployment checks are explicitly **out** of this suite.
+
+---
+
+## 7 · Fixture taxonomy
+
+Every major object family ships at minimum the following fixture set (BLD-COMP §§20, 30; WUI/GAI §20):
+
+| Fixture role | Purpose | Expected outcome | Notes |
+|---|---|---|---|
+| **valid** | Confirms the happy path. | `ANSWER` / `PASS` / `allow` | Includes `obvious mock marker` and a non-publishable `policy_label`. |
+| **invalid** | Triggers a structural / schema rejection. | `FAIL` (validator) | Schema-shape errors only — distinct from policy denial. |
+| **denied** | Triggers a policy denial (unknown rights, restricted sensitivity, unapproved provider, missing `spec_hash`, missing release state). | `DENY` with explicit `reason_code` | Per ML-063-055: missing provider or missing `spec_hash` denies promotion. |
+| **abstain** | Triggers an evidence-resolution failure (missing or stale bundle, no citation available). | `ABSTAIN` with reason | Per Master Decision Outcome Envelope (`KFM_Domains_Culmination_Atlas_v1_1.pdf` §24.3). |
+| **error** | Triggers a contract / infrastructure failure (malformed input, contract violation). | `ERROR` with diagnostic code | No claim leakage; no silent fallthrough to a different lane. |
+| **rollback / correction** | Exercises a `RollbackCard` against a prior dry-run candidate, or a `CorrectionNotice` against a corrected claim. | `ANSWER` with rollback/correction lineage | Required even on first PR per the encyclopedia roadmap. |
+
+> [!CAUTION]
+> **Sensitive-lane fixtures MUST be public-safe transforms.** Do not put real exact locations, living-person records, DNA/genomic material, rare-species coordinates, archaeological site geometry, or critical-infrastructure detail into `fixtures/` or `tests/fixtures/`. Use generalized, synthetic, or jittered values. Record the transform reason in the fixture's accompanying README. See §10.
+
+---
+
+## 8 · The run sequence
+
+### 8.1 Local developer loop (PROPOSED)
+
+1. Identify the lane the change touches (e.g., `domains/hydrology`, `runtime`, `release`).
+2. Run the **path & drift** check first — it's the cheapest signal a PR is misplaced.
+3. Run **schema** + **contract** tests for the affected families.
+4. Run **validator unit tests** for the affected validators.
+5. Run **policy negative tests** for the affected policy lane.
+6. Run **evidence resolution** + **lifecycle** + **receipt/proof** + **release/rollback** tests if any DTO touched is in the trust spine.
+7. Run **finite-envelope tests** if a governed-API contract changed.
+8. Run **promotion dry-run** for the lane.
+9. If, and only if, all of the above are green: **OPTIONALLY** invoke any opt-in live-source job.
+
+> [!TIP]
+> Step 1 ("which lane?") is not a formality — picking the wrong lane is the most common reason a fixture or schema lands in the wrong responsibility root and trips the path-and-drift gate later.
+
+### 8.2 CI loop (PROPOSED)
+
+The CI sequence mirrors §8.1, with a fail-closed posture:
+
+- A red square in **any** of test classes 1–11 is a hard merge block.
+- Live-source / external endpoint / runtime smoke jobs **MUST NOT** be permitted to run if any class 1–11 job is red, missing, skipped, or untrusted.
+- Promotion gates **MUST** fail closed on: unresolved evidence, unknown rights, unknown sensitivity, missing `SourceActivationDecision`, missing proof pack, invalid catalog closure, stale source state, missing rollback target, missing correction path, public RAW/WORK/QUARANTINE access, or direct model-client access (BLD-GREEN §§17, 19, 24; BLD-COMP §§20–23; IMPL-PIPE §§21, 23–24).
+
+[⬆ Back to top](#-no-network-test-runbook)
+
+---
+
+## 9 · Network egress posture
+
+The runner posture for a no-network job is **deny-by-default outbound**, audit-able, and reproducible.
+
+| Requirement | What it means in practice | Status |
+|---|---|---|
+| Outbound network is denied by default for no-network jobs | Runner-level firewall / job-level network policy blocks egress except to package mirrors (if any are required) and the workspace itself. | **PROPOSED** — concrete mechanism (e.g., GitHub Actions runner config, container netns, OPA-gated proxy) is **NEEDS VERIFICATION**. |
+| If any outbound dependency is required (e.g., package install), it MUST be pinned, attested, and verifiable | Tool-pinning per the C13-01 / `tool-versions.yaml` pattern; SBOM (`sbom.yaml`) present; verification reproducible offline. | **NEEDS VERIFICATION** |
+| The job MUST NOT require any secret to pass | Suite is reproducible on a clean runner. | **MUST** |
+| Watcher / connector / resolver code paths invoked by tests run in **dry-run mode** | `RunReceipt` shape is asserted from canned `(URL, ETag, Last-Modified, spec_hash)` fixtures; no live `HEAD`/`GET` issued. | **CONFIRMED doctrine** (ML-063-057) / **PROPOSED implementation** |
+| Egress attempts during a no-network run MUST be logged and treated as test failures | A spurious DNS lookup or socket connect is a fail signal, not a warning. | **PROPOSED** |
+
+> [!WARNING]
+> Do not assume the absence of an explicit "online" flag means the suite is offline. **Prove** offline-ness by inspecting the runner's network posture or by asserting it in-process (e.g., a guard that fails the test if any socket / DNS attempt is observed). Status: **NEEDS VERIFICATION** in the current repo.
+
+---
+
+## 10 · Sensitive-lane handling
+
+KFM domains carry asymmetric publication risk. The no-network suite **MUST** exercise these without ever staging real sensitive content:
+
+| Lane | Public-safe fixture rule | Default outcome on real-data leak |
+|---|---|---|
+| `domains/people-dna-land/` | Living-person, DNA, and land-tie data → synthetic personas + generalized geometry; no real DNA bytes. | **DENY** (policy); rights/sensitivity validators fail closed. |
+| `domains/fauna/` and `domains/flora/` | Rare-species / SINC / sensitive-occurrence localities → coarse polygons or fully synthetic; nest / den / hibernacula / spawning / roost coordinates **never** in fixtures. | **DENY** (policy) per `DOM-FAUNA`, `DOM-FLORA`, `DOM-HF`. |
+| `domains/archaeology/` | Site geometry → generalized or absent; cultural sensitivity field set. | **DENY** by default unless steward-reviewed. |
+| `domains/settlements-infrastructure/` | Critical-infrastructure precise geometry → generalized; no detailed asset attributes. | **DENY** unless cleared. |
+| `domains/hazards/` | Living-person and private-property implications → generalized; no individual-resolution data. | **DENY** unless cleared. |
+
+> [!CAUTION]
+> The no-network suite is precisely the place to **prove** these denials work. If a fixture in the sensitive lane returns `ANSWER` instead of `DENY`, that is a test failure on the **policy** side, not a license to relax the fixture. CARE/locality restriction transform rules — **NEEDS VERIFICATION** against any specific deployment.
+
+---
+
+## 11 · Anti-patterns
+
+Reject these in review even when they appear convenient:
+
+- ❌ **Live `curl` / `HEAD` calls in the test suite.** Use canned `RunReceipt` inputs; the network shape is doctrine, not a runtime dependency for the suite.
+- ❌ **Tests that pass without exercising the negative fixture.** A passing valid-only suite proves nothing about fail-closed behavior.
+- ❌ **Fixtures without an obvious mock marker.** A mock that looks like real released evidence is a near-miss for trust-membrane bypass.
+- ❌ **Two competing fixture homes** (e.g., `fixtures/` *and* `tests/fixtures/` with overlapping content and no README distinguishing scope). Directory Rules §6.6 explicitly forbids this.
+- ❌ **Live model adapter** loaded for governed-AI tests. MockAdapter only.
+- ❌ **Schema or policy duplicated** in `contracts/` and `schemas/`, or in `policy/` and `policies/`. Per ADR-0001, machine schema home is `schemas/contracts/v1/...`.
+- ❌ **Promotion via file move.** Promotion is a governed state transition. A test that "promotes" by writing into `data/published/` is wrong by construction.
+- ❌ **Suite that silently skips a class** (e.g., policy tests not run because no policy bundle was found). Missing tests fail the suite; they do not pass it.
+- ❌ **Real sensitive coordinates** in `fixtures/domains/<lane>/`. See §10.
+- ❌ **Generated AI output treated as evidence.** A fluent answer with no `EvidenceBundle` is an ABSTAIN, not an ANSWER.
+
+---
+
+## 12 · Failure triage
+
+| Symptom | First inspection | Likely class | Resolution direction |
+|---|---|---|---|
+| Path & drift gate red | Diff vs `directory-rules.md` §3–§6; check for new root-level domain folders | **Path** | Move the file under the proper responsibility root; if doctrine bends, open an ADR per §2.4. |
+| Schema test fails on a valid fixture | Inspect schema version in fixture; check `schemas/contracts/v1/<…>` path per ADR-0001 | **Schema** | Bump the fixture's `schema_version` or migrate the schema; do not weaken the schema. |
+| Policy negative test passes (i.e., a DENY case was allowed) | Inspect `reason_code` emission and bundle digest pinning | **Policy** | The bundle is misconfigured or stale. Re-pin the bundle and re-run. |
+| Evidence-resolution test passes when bundle is missing | Inspect resolver: does it return `ANSWER` or `ABSTAIN`? | **Evidence** | Resolver must ABSTAIN; this is the trust-spine invariant. |
+| Receipt test reproducibility fails (hash mismatch on identical input) | Inspect canonicalization (RFC 8785 JCS) and serializer | **Receipt** | Pin a JCS implementation; canonicalize before hashing. See C1-02 / C8-05. |
+| Lifecycle test allows file-move promotion | Inspect promotion path; reject `data/raw/` → `data/published/` writes by code path | **Lifecycle** | Promotion is a governed state transition. Wire through the promotion gate, not the filesystem. |
+| Egress attempt observed in no-network job | Inspect connectors and validators for live calls | **Network posture** | Refactor to use canned fixtures; add an in-process egress guard. |
+| Sensitive-lane fixture contains real coordinates | Inspect fixture provenance | **Sensitivity** | Replace with public-safe transform; record reason in fixture README. |
+
+[⬆ Back to top](#-no-network-test-runbook)
+
+---
+
+## 13 · Verification backlog
+
+Items that this runbook cannot resolve without mounted-repo evidence:
+
+- **NEEDS VERIFICATION** — Exact CI workflow file name(s) for the no-network suite (`.github/workflows/<name>.yml`).
+- **NEEDS VERIFICATION** — Whether `tests/fixtures/` or root `fixtures/` is the chosen authority; whether a single READMEd convention exists today.
+- **NEEDS VERIFICATION** — Concrete egress-deny mechanism on the runner (firewall, netns, proxy, etc.).
+- **NEEDS VERIFICATION** — Pinned JCS implementation per language (Python, TypeScript, Go), and which library is canonical.
+- **NEEDS VERIFICATION** — Existence and naming of `tools/validators/`, `tools/attest/`, and `tools/spec_hash/` per the encyclopedia roadmap.
+- **NEEDS VERIFICATION** — Whether `policy/` vs `policies/` is resolved (ADR pending per Directory Rules §0).
+- **NEEDS VERIFICATION** — Names and authority status of the path-and-drift checker, the schema runner (`jsonschema`, `ajv`, or other), and the policy runner (`conftest`, `opa`, or other).
+- **NEEDS VERIFICATION** — Owner team for this runbook (placeholder currently).
+- **OPEN** — How no-network signal is composed into branch protection (Checks API rollup vs single workflow status). ML-063-004 documents the doctrine; the exact wiring is unverified.
+- **OPEN** — Whether the no-network suite is a single workflow or a matrix of lane-scoped workflows.
+
+> [!NOTE]
+> File a verification item in [`docs/registers/VERIFICATION_BACKLOG.md`](../registers/VERIFICATION_BACKLOG.md) (PROPOSED CREATE) when any of the above is resolved, with a forward link to the resolving ADR or commit.
+
+---
+
+## 14 · Related docs
+
+- [`directory-rules.md`](../../directory-rules.md) — Authority for `docs/runbooks/` and the test/fixture homes.
+- [`docs/adr/ADR-0001-schema-home.md`](../adr/ADR-0001-schema-home.md) — Schema-home rule referenced throughout (**PROPOSED** path).
+- [`docs/runbooks/ui_VALIDATION.md`](./ui_VALIDATION.md) — UI validation, accessibility, contract, e2e smoke (**PROPOSED CREATE**).
+- [`docs/runbooks/ui_LOCAL_DEV.md`](./ui_LOCAL_DEV.md) — Local UI setup and mock fixture runbook (**PROPOSED CREATE**).
+- [`docs/runbooks/ui_ROLLBACK.md`](./ui_ROLLBACK.md) — UI rollback, feature flag, schema deprecation (**PROPOSED CREATE**).
+- [`docs/runbooks/governed_ai_LOCAL_DEV.md`](./governed_ai_LOCAL_DEV.md) — MockAdapter + provider-adapter local dev (**PROPOSED CREATE**).
+- [`docs/runbooks/governed_ai_VALIDATION.md`](./governed_ai_VALIDATION.md) — Focus Mode evidence / citation / policy validation (**PROPOSED CREATE**).
+- [`docs/runbooks/governed_ai_ROLLBACK.md`](./governed_ai_ROLLBACK.md) — AI adapter rollback and kill switch (**PROPOSED CREATE**).
+- [`contracts/OBJECT_MAP.md`](../../contracts/OBJECT_MAP.md) — DTO ↔ schema ↔ fixture crosswalk (**PROPOSED CREATE**).
+- [`docs/standards/CANONICALIZATION.md`](../standards/CANONICALIZATION.md) — JCS vs URDNA2015 decision matrix (**PROPOSED CREATE**, per C1-02 / C8-05).
+- [`docs/standards/RUN_RECEIPT.md`](../standards/RUN_RECEIPT.md) — Canonical receipt fields and validation (**PROPOSED CREATE**, per C1-01).
+- [`docs/registers/DRIFT_REGISTER.md`](../registers/DRIFT_REGISTER.md) — Where to file conflicts found while running this suite (**PROPOSED CREATE**).
+
+---
+
+## Appendix A · Illustrative commands and stubs
+
+> [!NOTE]
+> The blocks below are **illustrative**. Tool names (`jsonschema`, `ajv`, `conftest`, `opa`, `npm` / `pnpm` / `yarn`) and workflow names are PROPOSED until mounted-repo evidence confirms what is actually wired. Commands are shown to make the doctrine concrete, not to assert that exactly these commands exist today.
+
+<details>
+<summary><strong>A.1 · Illustrative local invocation (PROPOSED — pseudocode)</strong></summary>
+
+```text
+# 1. Path & drift
+<repo-path-drift-checker> --rules directory-rules.md
+
+# 2. Schema validation
+<schema-runner> schemas/contracts/v1/ fixtures/valid/ fixtures/invalid/
+
+# 3. Contract + validator tests
+<test-runner> tests/contracts/ tests/validators/
+
+# 4. Policy negative tests
+<policy-runner> -p policy/ -i fixtures/invalid/ -i fixtures/denied/
+
+# 5. Evidence resolution + lifecycle + receipt/proof + release/rollback
+<test-runner> tests/runtime_proof/
+
+# 6. Finite-envelope tests
+<test-runner> tests/api/ tests/runtime_proof/
+
+# 7. Promotion dry-run
+<promotion-runner> --dry-run --lane <domain>
+```
+
+</details>
+
+<details>
+<summary><strong>A.2 · Illustrative GitHub Actions skeleton (PROPOSED — workflow name and runner labels NEEDS VERIFICATION)</strong></summary>
+
+```yaml
+# .github/workflows/no-network.yml   # PROPOSED filename
+name: no-network
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  no-network-suite:
+    runs-on: ubuntu-latest        # PROPOSED — runner label NEEDS VERIFICATION
+    permissions:
+      contents: read
+    env:
+      KFM_NETWORK_MODE: "deny"    # PROPOSED — egress-guard env contract
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Path & drift
+        run: <path-and-drift-checker>           # PROPOSED
+
+      - name: Schema validation
+        run: <schema-runner> schemas/contracts/v1/ fixtures/
+
+      - name: Contract + validator + policy + envelope tests
+        run: <test-runner> tests/
+
+      - name: Promotion dry-run
+        run: <promotion-runner> --dry-run --lane all
+
+      - name: Assert no outbound network occurred
+        run: <egress-guard-asserter>            # PROPOSED — fails closed on any observed egress
+```
+
+</details>
+
+<details>
+<summary><strong>A.3 · Illustrative fixture skeleton (PROPOSED)</strong></summary>
+
+```json
+{
+  "_kfm_mock": true,
+  "object_type": "EvidenceBundle",
+  "schema_version": "v1",
+  "bundle_id": "eb-<deterministic-id>",
+  "spec_hash": "jcs:sha256:<hex>",
+  "policy_label": "mock-only",
+  "rights_status": "mock-only",
+  "sensitivity": "public",
+  "evidence_refs": [],
+  "source_refs": [],
+  "release_review": "n/a-mock",
+  "notes": "Public-safe synthetic fixture; not a published evidence bundle."
+}
+```
+
+Pair every `fixtures/valid/<name>.json` with a sibling `fixtures/invalid/<name>.bad-<reason>.json` that flips exactly one required invariant, so the failure is attributable.
+
+</details>
+
+<details>
+<summary><strong>A.4 · Expected outcome matrix per family (PROPOSED minima)</strong></summary>
+
+| Family | valid | invalid | denied | abstain | error | rollback |
+|---|---|---|---|---|---|---|
+| `SourceDescriptor` | PASS | FAIL | DENY (unknown rights / unapproved provider) | — | ERROR (malformed) | — |
+| `EvidenceRef` / `EvidenceBundle` | ANSWER | FAIL | DENY (restricted) | ABSTAIN (missing bundle) | ERROR (bad ref) | — |
+| `RunReceipt` | PASS | FAIL | DENY (missing `spec_hash`) | — | ERROR (canonicalization fail) | — |
+| `ReleaseManifest` | ANSWER | FAIL | DENY (missing proof / rollback target) | — | ERROR | RollbackCard resolves |
+| Governed API envelope | ANSWER | FAIL | DENY | ABSTAIN | ERROR | — |
+| Focus Mode (MockAdapter) | ANSWER | — | DENY (no citation / restricted) | ABSTAIN (no evidence) | ERROR | — |
+
+</details>
+
+[⬆ Back to top](#-no-network-test-runbook)
+
+---
+
+## Appendix B · KFM terminology used in this doc
+
+| Term | Short definition (per project doctrine) |
+|---|---|
+| **No-network** | A run that makes no outbound network calls, no live source fetch, no model invocation, no internal-store access, no release publication, and requires no secrets. |
+| **Dry-run** | A governed promotion run that produces auditable gate outputs (`PolicyDecision`, `RunReceipt`, dry-run `ReleaseManifest`) without flipping any artifact to public release. |
+| **EvidenceBundle / EvidenceRef** | Resolved support package for claims, and the reference to it. Lives in `data/proofs/`. |
+| **RunReceipt** | One-line provenance object: `dataset_id`, `dataset_version`, `fetch_time`, `source_url`, `http_validators` (ETag, Last-Modified), `spec_hash`, `run_id`, `orchestrator`, `transform_git_sha`, `artifacts`, `rights_spdx`, `attestations`. |
+| **spec_hash** | `jcs:sha256:<hex>` — SHA-256 over the RFC 8785 JCS canonical form of the spec. |
+| **MockAdapter** | The no-network AI adapter used to prove citation, finite-envelope, and abstention behavior without a live model. |
+| **Promotion** | A governed state transition between lifecycle phases. **Not a file move.** |
+| **Trust membrane** | The boundary that prevents raw / unreviewed / model-generated / internal state from becoming public truth. Operational form: `apps/governed-api/`. |
+| **Finite outcomes** | `ANSWER` / `ABSTAIN` / `DENY` / `ERROR` (plus `HOLD` / `PASS` / `FAIL` for validator-class results). |
+
+---
+
+<sub>**Doctrine sources (attached):** `KFM_Unified_Implementation_Architecture_Build_Manual.pdf` (BLD-GREEN, BLD-COMP, IMPL-PIPE §§16–24); `KFM_Whole_UI_Governed_AI_Expansion_Report.pdf` §20; `Master_MapLibre_Components-Functions-Features_compressed.pdf` (ML-063-052 through ML-063-057); `kfm_encyclopedia.pdf` §14 (PR-00); `KFM_Domains_Culmination_Atlas_v1_1.pdf` §24.3 (Master Decision Outcome Envelope); `New_Ideas_5-8-26.pdf` (Suggested CI Gates, PR-INGEST-007); `KFM_Components_Pass_10_Idea_Index_Category_Atlas_and_Expansion_Dossier.pdf` (C1-01, C1-02, C3-01, C5-02, C8-05, C14-01); `directory-rules.md` (§§3, 6.1, 6.6). Repo-shape claims are **PROPOSED** until mounted-repo evidence verifies.</sub>
+
+---
+
+**Related runbooks:** [`ui_VALIDATION.md`](./ui_VALIDATION.md) · [`ui_LOCAL_DEV.md`](./ui_LOCAL_DEV.md) · [`ui_ROLLBACK.md`](./ui_ROLLBACK.md) · [`governed_ai_VALIDATION.md`](./governed_ai_VALIDATION.md) · [`governed_ai_LOCAL_DEV.md`](./governed_ai_LOCAL_DEV.md) · [`governed_ai_ROLLBACK.md`](./governed_ai_ROLLBACK.md)
+
+**Last updated:** 2026-05-12 · [⬆ Back to top](#-no-network-test-runbook)

--- a/docs/runbooks/PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/PROMOTION_RUNBOOK.md
@@ -1,3 +1,560 @@
-# PROMOTION_RUNBOOK
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/promotion
+title: KFM Promotion Runbook — Governed Transitions RAW → PUBLISHED
+type: standard
+version: v1
+status: draft
+owners: [TODO docs-steward, TODO release-authority]
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/trust-membrane.md
+  - docs/architecture/governed-api.md
+  - docs/runbooks/ROLLBACK_DRILL.md
+  - policy/promotion/
+  - policy/release/
+  - schemas/contracts/v1/
+tags: [kfm, runbook, promotion, lifecycle, governance, release, rollback]
+notes:
+  - Operating procedure for promotion as a governed state transition.
+  - Promotion is never a file move; bytes alone do not earn a phase.
+  - All paths PROPOSED until verified against mounted-repo evidence.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+<a id="top"></a>
+
+# KFM Promotion Runbook
+
+> Operating procedure for moving objects through KFM's governed lifecycle — **RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED** — without bypassing evidence, policy, review, or rollback.
+
+<p align="center">
+  <b>Evidence-first • Policy-aware • Fail-closed • Reversible</b>
+</p>
+
+---
+
+## Badges
+
+![Status](https://img.shields.io/badge/status-draft-orange)
+![Doctrine](https://img.shields.io/badge/doctrine-CONFIRMED-success)
+![Implementation](https://img.shields.io/badge/implementation-PROPOSED-yellow)
+![Lifecycle](https://img.shields.io/badge/lifecycle-governed-informational)
+![Posture](https://img.shields.io/badge/posture-fail--closed-critical)
+![Truth](https://img.shields.io/badge/truth-cite--or--abstain-blueviolet)
+![Updated](https://img.shields.io/badge/updated-TODO-lightgrey)
+
+| Field | Value |
+|---|---|
+| **Status** | Draft (PROPOSED implementation; CONFIRMED doctrine) |
+| **Owners** | `TODO` docs steward · `TODO` release authority |
+| **Last updated** | `TODO` |
+| **Authority** | Lifecycle Law, Directory Rules §6.1, §6.5, §9 |
+| **Applies to** | All KFM domain lanes; all PUBLISHED-bound artifacts |
+| **Companion runbooks** | `docs/runbooks/ROLLBACK_DRILL.md`, `docs/runbooks/CORRECTION.md` (both `TODO`) |
+
+---
+
+## Quick Jump
+
+- [1. Scope](#1-scope)
+- [2. Doctrine recap](#2-doctrine-recap)
+- [3. When to use this runbook](#3-when-to-use-this-runbook)
+- [4. Prerequisites](#4-prerequisites)
+- [5. Promotion flow at a glance](#5-promotion-flow-at-a-glance)
+- [6. Gate-by-gate procedure](#6-gate-by-gate-procedure)
+- [7. Promotion dry-run](#7-promotion-dry-run)
+- [8. Rollback drill](#8-rollback-drill)
+- [9. Correction path](#9-correction-path)
+- [10. Roles and separation of duties](#10-roles-and-separation-of-duties)
+- [11. Decision outcomes](#11-decision-outcomes)
+- [12. Failure codes and fail-closed reference](#12-failure-codes-and-fail-closed-reference)
+- [13. Anti-patterns](#13-anti-patterns)
+- [14. Receipt and artifact reference](#14-receipt-and-artifact-reference)
+- [15. Related docs](#15-related-docs)
+- [16. Open questions](#16-open-questions)
+
+---
+
+## 1. Scope
+
+This runbook is the **operating procedure** for KFM promotion. It tells a steward, reviewer, or release authority *what to do, in what order, with which receipts, and what to do when something fails closed.*
+
+It is **not** the doctrine itself. Doctrine lives in:
+
+- `docs/doctrine/lifecycle-law.md` — the invariant and what it means.
+- `docs/doctrine/directory-rules.md` — where things live and why a path move is not a promotion.
+- `docs/doctrine/trust-membrane.md` — why public clients never read RAW/WORK/QUARANTINE.
+
+This runbook **operationalizes** those documents. Where the two disagree, **doctrine wins**, and the discrepancy is filed in `docs/registers/DRIFT_REGISTER.md`.
+
+> [!IMPORTANT]
+> **Promotion is a governed state transition, not a file move.** A path-level move that bypasses validators, policy gates, evidence-bundle creation, catalog closure, or release-decision recording is a violation of the lifecycle invariant — regardless of which directory the bytes end up in. — *Directory Rules §9.1; Lifecycle Law (CONFIRMED doctrine).*
+
+---
+
+## 2. Doctrine recap
+
+KFM's lifecycle invariant — preserved verbatim:
+
+> **RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED**
+
+Five governed transitions, five sets of admissible artifacts, five fail-closed outcomes. No phase is earned by being in the right directory; each is earned by producing the receipts and decisions that the next phase's gate requires.
+
+The cite-or-abstain rule is in force throughout: every consequential claim resolves `EvidenceRef → EvidenceBundle`. When evidence cannot be resolved, the system **abstains**; it does not invent support.
+
+| Pillar | Behavior |
+|---|---|
+| **Evidence first** | `EvidenceBundle` outranks generated language, tiles, maps, graphs, AI text. |
+| **Trust membrane** | Public clients read only through `apps/governed-api/`. RAW/WORK/QUARANTINE are never public. |
+| **Cite-or-abstain** | If support cannot be resolved, return `ABSTAIN`, never invent. |
+| **Fail-closed** | Unknown rights, unresolved sensitivity, missing review state → `DENY` / `HOLD`. |
+| **Reversibility** | Every PUBLISHED claim carries a correction path and rollback target. |
+| **Separation of duties** | Where materiality applies, the release authority is not the author. |
+
+---
+
+## 3. When to use this runbook
+
+Run this procedure when any of the following is happening:
+
+- A domain steward wants to advance a candidate object from one lifecycle phase to the next.
+- A release authority is preparing a `ReleaseManifest` for one or more layers, catalog records, or domain claims.
+- A correction reviewer is staging a `CorrectionNotice` against a PUBLISHED claim.
+- A reviewer is exercising a **rollback drill** (PR-10–class exercise, PROPOSED) against a dry-run release.
+- CI is gating a merge that touches `data/`, `release/`, `policy/promotion/`, or `policy/release/`.
+
+> [!TIP]
+> If you are tempted to "just move the files," stop. Use [§7 — Promotion dry-run](#7-promotion-dry-run) first. Dry-run is cheap; bypassing the gate is not reversible without a correction and rollback.
+
+---
+
+## 4. Prerequisites
+
+Before running any gate, confirm the following supports are present **for the object you are promoting**. Missing supports are not blockers to running this runbook — they are blockers to passing the gate. The point of the runbook is to surface them before they cause a fail-closed denial in CI or at release time.
+
+| Prerequisite | Where it lives (PROPOSED) | Why |
+|---|---|---|
+| `SourceDescriptor` for every contributing source | `data/registry/source_descriptors/` | Source role, rights, sensitivity, cadence must be known. |
+| Rights status resolved | `control_plane/source_authority_register.yaml` | `RIGHTS_UNKNOWN` is a hard `DENY`. |
+| Sensitivity tag set | `control_plane/source_authority_register.yaml`, `policy/sensitivity/` | Sensitive lanes default to `DENY`. |
+| Schema target identified | `schemas/contracts/v1/<domain>/` | Validators need a target. |
+| Policy bundle compiled | `policy/promotion/`, `policy/release/` | The Rego/OPA gates evaluate this bundle. |
+| Identity strategy chosen | `contracts/` per object family | Deterministic identity preferred where practical. |
+
+> [!NOTE]
+> **CONFIRMED doctrine / PROPOSED implementation:** the exact filenames and paths above follow Directory Rules and the Domains Atlas. They are PROPOSED until verified against current mounted-repo evidence.
+
+[⬆ Back to top](#top)
+
+---
+
+## 5. Promotion flow at a glance
+
+```mermaid
+flowchart LR
+    A["— (not admitted)"]:::ext
+    R["RAW"]:::raw
+    W["WORK"]:::work
+    Q["QUARANTINE"]:::quar
+    P["PROCESSED"]:::proc
+    C["CATALOG / TRIPLET"]:::cat
+    PUB["PUBLISHED"]:::pub
+
+    A -- "Admission: SourceDescriptor + payload hash" --> R
+    R -- "Normalization: TransformReceipt + ValidationReport" --> W
+    R -- "FAIL → QUARANTINE (reason recorded)" --> Q
+    W -- "Validation: ValidationReport pass<br/>RedactionReceipt if sensitive" --> P
+    Q -. "remediation + steward review" .-> W
+    P -- "Catalog closure: EvidenceBundle resolved<br/>catalog matrix + digest closure" --> C
+    C -- "Release: ReleaseManifest + rollback target<br/>+ ReviewRecord (if required)" --> PUB
+    PUB -. "CorrectionNotice / RollbackCard" .-> PUB
+
+    classDef ext fill:#eee,stroke:#666,color:#333
+    classDef raw fill:#fff3e0,stroke:#e65100,color:#000
+    classDef work fill:#e3f2fd,stroke:#0d47a1,color:#000
+    classDef quar fill:#ffebee,stroke:#b71c1c,color:#000
+    classDef proc fill:#e8f5e9,stroke:#1b5e20,color:#000
+    classDef cat fill:#f3e5f5,stroke:#4a148c,color:#000
+    classDef pub fill:#e0f7fa,stroke:#006064,color:#000
+```
+
+The diagram shows the five governed transitions and the receipt requirement for each. The dashed line from PUBLISHED back to itself is *not* a no-op — it is the post-publication correction loop, governed by `CorrectionNotice` and `RollbackCard` (see [§9](#9-correction-path)).
+
+---
+
+## 6. Gate-by-gate procedure
+
+Each gate has the same shape: **pre-condition → required artifacts → run → outcome.** A gate that cannot prove its required artifacts emits a `FAIL` / `DENY` and the object stays in its prior phase. No silent advancement.
+
+### 6.1 Gate A — Admission ( — → RAW )
+
+**Pre-condition.** Source identity and rights are minimally established at discovery; source-role intent is set.
+
+**Required artifacts (PROPOSED minimum).**
+
+- `SourceDescriptor` — role (`observed | modeled | aggregate | regulatory | administrative`), authority, rights, sensitivity, cadence.
+- Payload hash or stable reference (`spec_hash` over canonical bytes).
+
+**Procedure.**
+
+1. Resolve the source against `control_plane/source_authority_register.yaml`. If unknown → `HOLD` for steward review.
+2. Emit `SourceDescriptor` under `data/raw/<domain>/<source_id>/<run_id>/`.
+3. Capture the immutable payload (or pointer + content hash) in the same `run_id` directory.
+4. Append an ingest receipt under `data/receipts/ingest/`.
+
+**Fail-closed outcomes.** Unknown rights → not admitted. Source-role collapse risk → not admitted. Logged as candidate awaiting steward.
+
+### 6.2 Gate B — Normalization ( RAW → WORK / QUARANTINE )
+
+**Pre-condition.** Schema, geometry, time, identity, evidence, rights, and policy rules are runnable for this lane.
+
+**Required artifacts (PROPOSED minimum).**
+
+- `TransformReceipt` — what normalization ran, on what bytes, with what tool versions.
+- `ValidationReport` (working set) — validator outcome from `{ANSWER, ABSTAIN, DENY, ERROR}`.
+- `PolicyDecision` — initial admissibility check.
+- For sensitive lanes: a tentative `RedactionReceipt` if any redaction occurred during normalization.
+
+**Procedure.**
+
+1. Run the normalization pipeline. Output lands in `data/work/<domain>/<run_id>/`.
+2. On any validator failure, route the object to `data/quarantine/<domain>/<reason>/<run_id>/` with a `quarantine_reason` field. **Do not silently promote.**
+3. Emit `TransformReceipt` and the working-set `ValidationReport` under `data/receipts/validation/`.
+
+> [!CAUTION]
+> Source role is **fixed at admission**. Normalization MUST NOT upcast a modeled source to observed, an aggregate to per-place, or an administrative reference to a regulatory authority. Source-role collapse is a fail-closed condition (`ROLE_COLLAPSE`, `ROLE_DOWNCAST_FORBIDDEN`). — *Domains Atlas §24.6, §24.9.*
+
+### 6.3 Gate C — Validation ( WORK → PROCESSED )
+
+**Pre-condition.** Validators are deterministic and tied to fixtures; required receipts present.
+
+**Required artifacts.**
+
+- `ValidationReport` with `outcome == "ANSWER"` (pass).
+- `RedactionReceipt` if sensitivity applies.
+- `AggregationReceipt` if the object is a derived aggregate.
+
+**Procedure.**
+
+1. Run the full validator suite for the domain (`tests/validators/<domain>/` — PROPOSED).
+2. Confirm fixtures-vs-validator parity (the validator must also fail closed against negative fixtures).
+3. Promote the normalized object to `data/processed/<domain>/<dataset_id>/<version>/`.
+4. Cross-link receipts via `EvidenceRef`.
+
+**Fail-closed outcomes.** Any validator returning `DENY` / `ERROR` / `FAIL` → stay in WORK. Structured `FAIL` outcome recorded.
+
+### 6.4 Gate D — Catalog closure ( PROCESSED → CATALOG / TRIPLET )
+
+**Pre-condition.** `EvidenceRef` values resolve; catalog matrix and digests close.
+
+**Required artifacts.**
+
+- `CatalogMatrix` entry (STAC + DCAT + PROV projection, PROPOSED v1 profile).
+- `EvidenceBundle` — content-addressed JSON-LD package binding claim, receipts, and authority crosswalks.
+- Graph / triplet projection (if applicable to the lane).
+
+**Procedure.**
+
+1. Resolve every `EvidenceRef` for the candidate against `data/proofs/evidence_bundle/`. Any unresolved reference → `ABSTAIN` and `HOLD` at PROCESSED.
+2. Emit the catalog record under `data/catalog/<stac|dcat|prov|domain>/`.
+3. Emit the `EvidenceBundle` under `data/proofs/evidence_bundle/<bundle_id>/` with a `spec_hash` computed via JCS + SHA-256 (PROPOSED canonicalization).
+4. If a triplet/graph projection applies, emit under `data/triplets/` — **never** as canonical truth, always as derived projection.
+
+> [!WARNING]
+> `EvidenceBundle` is **content-addressed**. Republishing the same logical bundle under a different hash silently invalidates every receipt that points at it. If the bundle must change, emit a new bundle with a new hash and supersede the old one through a `CorrectionNotice`.
+
+### 6.5 Gate E — Release ( CATALOG / TRIPLET → PUBLISHED )
+
+**Pre-condition.** Review state where required; release authority distinct from the original author when materiality applies.
+
+**Required artifacts.**
+
+- `ReleaseManifest` — release contents, version, digests, evidence refs, **rollback target**.
+- `ReviewRecord` (when required by the domain's sensitivity / materiality posture).
+- A signed attestation (DSSE / cosign — PROPOSED) binding the manifest to its inputs.
+- Confirmed correction path.
+
+**Procedure.**
+
+1. Stage the release candidate under `release/candidates/<domain>/`.
+2. Run `policy/release/*` against the candidate envelope. On `DENY` for any reason listed in [§12](#12-failure-codes-and-fail-closed-reference), stop here.
+3. Run the required review:
+   - **Routine, non-sensitive lane:** domain steward review.
+   - **Sensitive lane:** domain steward + sensitivity reviewer + release authority + rights-holder representative (where applicable). The author **MUST NOT** also be the release authority. — *Atlas §24.7.2 (PROPOSED).*
+4. Emit `ReleaseManifest` under `release/manifests/<release_id>/`.
+5. Sign the manifest (DSSE / cosign — PROPOSED).
+6. Activate the release: publish artifacts to `data/published/<api_payloads|layers|pmtiles|geoparquet|reports|stories>/` and update the layer registry / catalog pointers.
+7. Confirm the public surface via the governed API smoke check (`apps/governed-api/` — PROPOSED).
+
+**Fail-closed outcomes.** Missing manifest → `RELEASE_MANIFEST_INVALID`. Missing rollback target → `ROLLBACK_TARGET_MISSING`. Review insufficient → `REVIEW_INSUFFICIENT`. Any of these → `HOLD` at CATALOG, no public surface change.
+
+[⬆ Back to top](#top)
+
+---
+
+## 7. Promotion dry-run
+
+The dry-run is the **PR-09 pattern** from the Encyclopedia roadmap (PROPOSED): validate a release candidate end-to-end without publishing it to a public surface. It is the safe way to discover that something is missing.
+
+```text
+# Conceptual command shape — PROPOSED; verify against tools/ before running.
+kfm release dry-run \
+  --candidate release/candidates/<domain>/<candidate_id>/ \
+  --policy policy/release/ \
+  --no-public-write
+```
+
+The dry-run MUST:
+
+1. Run every gate in [§6](#6-gate-by-gate-procedure) against the candidate.
+2. Build the `ReleaseManifest` but **not** activate any public surface.
+3. Emit a `PromotionReceipt` (PROPOSED object) recording gate IDs, inputs, proofs, release target, and rollback target.
+4. Confirm that `no-public-write` is enforced — the dry-run's own test suite includes a negative case that fails CI if a public write occurred.
+
+> [!TIP]
+> Treat dry-run failures as **structural information**, not noise. A repeated dry-run failure for the same reason is a signal that a doctrine document, a fixture, or a validator is wrong — not that the gate is too strict.
+
+---
+
+## 8. Rollback drill
+
+The rollback drill (PR-10 pattern, PROPOSED) is how KFM proves that a release is reversible *before* it has to be reversed in anger. Run a drill at least once per release, ideally during dry-run.
+
+**Required artifacts (drill).**
+
+- A target `ReleaseManifest` to roll back from.
+- A prior `ReleaseManifest` (the `rollback_target`) to roll back to.
+- A `RollbackCard` recording the decision, the reason, the invalidated derivatives, and the review reference.
+
+**Procedure (drill — non-public).**
+
+1. Pick a recent dry-run release.
+2. Author a `RollbackCard` under `release/rollback_cards/<rollback_id>/` referencing the dry-run's `release_id` and the prior `release_id`.
+3. Run the rollback tool (PROPOSED `tools/release/rollback`) against the manifest pair.
+4. Confirm:
+   - Public-surface payloads return to the prior release's digests.
+   - Catalog records point at the prior `EvidenceBundle` versions.
+   - Any derivative layers, tiles, or graph projections are invalidated and rebuilt or withdrawn.
+5. Emit a drill receipt under `data/receipts/release/` and link it from the `RollbackCard`.
+
+> [!IMPORTANT]
+> **A release is not safe until a rollback drill has succeeded against it.** Directory Rules §6.5 places rollback policy in `policy/release/` and rollback decisions in `release/rollback_cards/`. The Encyclopedia identifies "Release without `ReleaseManifest` or rollback target" as an anti-pattern that breaks the trust membrane. — *Atlas §24.9.2.*
+
+See `docs/runbooks/ROLLBACK_DRILL.md` (`TODO`) for the full drill checklist and rehearsal cadence.
+
+---
+
+## 9. Correction path
+
+A correction is the **only** way to amend a PUBLISHED claim. Edits in place are forbidden — the durable public unit is the inspectable claim, and silent edits break every receipt that points at the prior version.
+
+| Trigger | Required artifacts | Outcome |
+|---|---|---|
+| Detected error in PUBLISHED claim | `CorrectionNotice` + `ReviewRecord` | New release supersedes prior; prior remains inspectable |
+| New evidence invalidates a claim | `CorrectionNotice` + `ReviewRecord` + revised `EvidenceBundle` | Same as above; supersession entry recorded |
+| Failed release detected post-publish | `RollbackCard` + `ReviewRecord` | Rollback to prior `rollback_target` |
+| Rights / sensitivity escalation | `RedactionReceipt` + `ReviewRecord` (Steward + rights-holder where applicable) | Demote to a more restricted tier; prior release withdrawn |
+
+A `CorrectionNotice` MUST enumerate the derivatives it invalidates (tiles, layers, graph edges, AI summaries, story exports). Re-publishing a corrected claim without invalidating derivatives is a fail-closed anti-pattern. — *Atlas §24.9.2.*
+
+---
+
+## 10. Roles and separation of duties
+
+CONFIRMED doctrine (operating-law invariant 9): KFM separates policy-significant release duties when maturity justifies it. — *Domains Atlas §24.7.*
+
+| Role | What they own |
+|---|---|
+| **Source steward** | Admission, rights confirmation, sensitivity tag for a source family. |
+| **Domain steward** | Object-family meaning, contracts, validators for a domain. |
+| **Sensitivity reviewer** | Redaction, generalization, withholding, tier decisions. |
+| **Rights-holder representative** | Sovereignty / consent decisions for archaeology, people-DNA-land, fauna/flora geoprivacy. |
+| **Release authority** | Issues `ReleaseManifest`s and authorizes PUBLISHED transitions. |
+| **Correction reviewer** | Reviews `CorrectionNotice` / `RollbackCard` before amendment. |
+| **AI surface steward** | Reviews Focus Mode templates and AI policy bindings. |
+| **Docs steward** | Governance docs, ADR index, drift register, Atlas integrity. |
+
+**Separation-of-duties matrix (PROPOSED, from Atlas §24.7.2):**
+
+| Action | Author may also approve? | Required separation |
+|---|---|---|
+| Source admission | Routine: yes; sovereign / unresolved rights: no | Source steward + rights-holder rep (if applicable) |
+| Normalization receipts | Routine: yes; sensitivity-relevant: no | Domain steward; sensitivity reviewer if applicable |
+| Validator authorship and run | Yes (deterministic) | Domain steward; periodic audit by docs steward |
+| Promotion to PROCESSED / CATALOG | Non-sensitive: yes; sensitive: no | Domain steward + sensitivity reviewer (sensitive) |
+| **Release to PUBLISHED** | **No when materiality applies** | **Author ≠ release authority; rights-holder rep where applicable** |
+| Sensitive-lane release | **No** | Author + sensitivity reviewer + release authority + rights-holder rep |
+| Correction / rollback | No when steward-significant | Author / detector + correction reviewer + release authority |
+
+> [!NOTE]
+> Maturity note (CONFIRMED doctrine): early-stage doctrine work MAY be authored and approved by the same actor when materiality is low. As public trust surface expands, separation MUST be enforced through tooling, not custom. — *Directory Rules §2; Atlas §24.7.2.*
+
+[⬆ Back to top](#top)
+
+---
+
+## 11. Decision outcomes
+
+Every governed API surface, validator, policy gate, and Focus Mode answer returns one of a finite set of outcomes. The promotion flow uses the same vocabulary, so a CI failure speaks the same language as a runtime answer.
+
+| Outcome | When | Promotion effect |
+|---|---|---|
+| **ANSWER** | Evidence sufficient, policy permits, release state allows, review recorded. | Gate passes. |
+| **ABSTAIN** | Evidence insufficient or unresolvable; AI surface cannot cite; stale with no released alternative. | Gate holds; object stays in prior phase. |
+| **DENY** | Policy, rights, sensitivity, or release state forbids. | Gate fails closed; object stays or is quarantined. |
+| **ERROR** | Governed API / validator cannot evaluate (schema, contract, infrastructure). | Gate fails closed with diagnostic; no silent fall-through. |
+| **HOLD** | Pending steward / rights-holder / policy review. | Surface stays in prior state; no silent replacement. |
+| **PASS** | Validator-class: input acceptable. | Internal; permits next-gate evaluation. |
+| **FAIL** | Validator-class: input unacceptable. | Promotion blocked; quarantine where appropriate. |
+
+`PromotionDecision` and `RuntimeResponseEnvelope` are the two contract objects that carry these outcomes across the trust membrane. — *Master MapLibre §11; Atlas §24.3.*
+
+---
+
+## 12. Failure codes and fail-closed reference
+
+Codes are drawn from the Master Failure / Outcome Code Reference (Atlas §24.6, PROPOSED). They are the canonical reason vocabulary; do not invent new ones inline.
+
+<details>
+<summary><b>Click to expand the full fail-closed code table</b></summary>
+
+| Code | Phase | Resolution |
+|---|---|---|
+| `RIGHTS_UNKNOWN` | Admission / Validation / Catalog / Release | Steward review; rights resolution; tier reassignment. |
+| `SENSITIVITY_UNRESOLVED` | Admission / Validation / Catalog / Release | Steward review; rights resolution; tier reassignment. |
+| `ROLE_COLLAPSE` | Validation / Catalog / Release | Restore source role; refuse upcast. |
+| `ROLE_DOWNCAST_FORBIDDEN` | Validation / Catalog / Release | Restore source role; refuse upcast. |
+| `REVIEW_NEEDED` | Catalog / Release | Run required review; supply `ReviewRecord`. |
+| `REVIEW_INSUFFICIENT` | Catalog / Release | Run required review; supply `ReviewRecord`. |
+| `REVIEW_REJECTED` | Catalog / Release | Address review reasons; resubmit. |
+| `RELEASE_MANIFEST_INVALID` | Release | Repair manifest; resubmit. |
+| `ROLLBACK_TARGET_MISSING` | Release | Supply rollback target; resubmit. |
+| `CORRECTION_DERIVATIVES_UNRESOLVED` | Correction | Resolve derivatives; supersession entry. |
+| `CORRECTION_PRIOR_RELEASE_MISSING` | Correction | Locate prior release; restore lineage. |
+
+</details>
+
+A gate that produces any of these codes **MUST** record them in the receipt trail. Silent fall-through is forbidden.
+
+---
+
+## 13. Anti-patterns
+
+The Encyclopedia and the Atlas name these explicitly. They appear here so a reviewer can call them out at PR time, not after publication.
+
+> [!CAUTION]
+> **Trust-membrane anti-patterns** (Atlas §24.9.2):
+> - Public client reads RAW / WORK / QUARANTINE.
+> - Map shell consumes canonical / internal store directly.
+> - AI returns uncited language.
+> - AI answers from RAW / WORK rather than `EvidenceBundle`.
+> - Sensitive content released without redaction.
+> - Aggregate cited as per-place observation.
+> - Synthetic surface presented without `RealityBoundaryNote`.
+> - KFM used as alert / instruction authority.
+> - **Release without `ReleaseManifest` or rollback target.**
+> - AI generation routed through an admin shortcut.
+
+> [!CAUTION]
+> **Governance-process anti-patterns** (Atlas §24.9.3):
+> - Documenting a change instead of validating it.
+> - Approving one's own release on a sensitive lane.
+> - Treating an Atlas summary or matrix as evidence.
+> - Silent migrations between schema or policy homes.
+> - Promotion that "upgrades" a source role (e.g., modeled → observed).
+> - Re-publishing a corrected claim without invalidating derivatives.
+
+---
+
+## 14. Receipt and artifact reference
+
+<details>
+<summary><b>Receipt × lifecycle-phase matrix (Atlas §24.2.2; CONFIRMED doctrine)</b></summary>
+
+A `•` means the receipt is normally emitted, amended, or referenced at that phase. Receipts created earlier remain referenced (not duplicated) at later phases via `EvidenceRef`.
+
+| Receipt | RAW | WORK / QUAR. | PROCESSED | CATALOG / TRIPLET | PUBLISHED |
+|---|:-:|:-:|:-:|:-:|:-:|
+| `SourceDescriptor` | • | • | • | • | • |
+| `TransformReceipt` |  | • | • | • |  |
+| `RedactionReceipt` |  | • | • | • | • |
+| `AggregationReceipt` |  | • | • | • | • |
+| `ModelRunReceipt` |  | • | • | • | • |
+| `RepresentationReceipt` |  |  | • | • | • |
+| `AIReceipt` |  |  | • | • | • (Focus Mode only) |
+| `ReviewRecord` |  | • | • | • | • |
+| `PolicyDecision` | • | • | • | • | • |
+| `ValidationReport` |  | • | • | • |  |
+| `ReleaseManifest` |  |  |  |  | • |
+| `CorrectionNotice` |  |  |  |  | • |
+| `RollbackCard` |  |  |  |  | • |
+| `RealityBoundaryNote` |  |  | • | • | • |
+| `MatrixCellReceipt` |  |  | • | • | • |
+| `StorySnapshot` |  |  |  |  | • |
+
+</details>
+
+<details>
+<summary><b>Where each artifact lives (PROPOSED, per Directory Rules)</b></summary>
+
+| Artifact | Proposed home |
+|---|---|
+| `SourceDescriptor` | `data/registry/source_descriptors/` |
+| `TransformReceipt`, `ValidationReport` | `data/receipts/validation/`, `data/receipts/pipeline/` |
+| `EvidenceBundle` | `data/proofs/evidence_bundle/<bundle_id>/` |
+| `CatalogMatrix` / catalog records | `data/catalog/<stac\|dcat\|prov\|domain>/` |
+| `ReleaseManifest` | `release/manifests/<release_id>/` |
+| `RollbackCard` | `release/rollback_cards/<rollback_id>/` |
+| `CorrectionNotice` | `release/correction_notices/<notice_id>/` |
+| `PromotionReceipt`, gate decision logs | `data/receipts/release/` (PROPOSED) |
+| `ReviewRecord` | `release/review_records/` (PROPOSED) |
+
+All paths PROPOSED until verified against mounted-repo evidence. NEEDS VERIFICATION: whether `data/manifests/` exists as a separate home, or whether all manifests live under `release/manifests/`. — *Directory Rules §18.*
+
+</details>
+
+[⬆ Back to top](#top)
+
+---
+
+## 15. Related docs
+
+- [`docs/doctrine/lifecycle-law.md`](../doctrine/lifecycle-law.md) — the invariant and what counts as a violation.
+- [`docs/doctrine/directory-rules.md`](../doctrine/directory-rules.md) — where things live; why a path move is not a promotion.
+- [`docs/doctrine/trust-membrane.md`](../doctrine/trust-membrane.md) — the public-surface boundary the runbook protects.
+- [`docs/architecture/governed-api.md`](../architecture/governed-api.md) — the trust-membrane interface.
+- [`docs/runbooks/ROLLBACK_DRILL.md`](./ROLLBACK_DRILL.md) — `TODO` — drill cadence and full checklist.
+- [`docs/runbooks/CORRECTION.md`](./CORRECTION.md) — `TODO` — post-publication correction procedure.
+- [`docs/adr/`](../adr/) — accepted ADRs that may amend this runbook.
+- [`policy/promotion/`](../../policy/promotion/) — promotion-gate policy.
+- [`policy/release/`](../../policy/release/) — release-gate policy.
+- [`control_plane/release_state_register.yaml`](../../control_plane/release_state_register.yaml) — the machine-readable release-state index.
+
+---
+
+## 16. Open questions
+
+These are the verification items that block parts of this runbook from being upgraded from PROPOSED to CONFIRMED implementation. They are not blockers to running the procedure as documented — they are blockers to claiming the procedure is wired up.
+
+- **NEEDS VERIFICATION** — Does `apps/governed-api/` exist in the current repo, and what is its release-state surface?
+- **NEEDS VERIFICATION** — Is the policy engine OPA / Conftest, or something else? — *Build Manual §3, Reconciliation Note.*
+- **NEEDS VERIFICATION** — Does `release/manifests/` exist as a canonical home, or is `data/manifests/` also present? — *Directory Rules §18.*
+- **NEEDS VERIFICATION** — Is `JCS + SHA-256` or `URDNA2015` the canonicalization for `EvidenceBundle` hashes? — *Components Pass 10 §11.2.*
+- **UNKNOWN** — Are dry-run and rollback drill tools (PR-09 / PR-10 pattern) implemented or only proposed?
+- **UNKNOWN** — Is the `PromotionReceipt` schema present under `schemas/contracts/v1/`, or is it still PROPOSED?
+- **OPEN** — Is `policy/release/` the canonical home, or is release policy split across `policy/promotion/` and `policy/release/`? An ADR may be needed.
+
+Entries here are migrated to `docs/registers/VERIFICATION_BACKLOG.md` (PROPOSED) when accepted as the canonical backlog.
+
+---
+
+<hr/>
+
+**Last updated:** `TODO`  ·  **Doc id:** `kfm://doc/runbook/promotion`  ·  **Status:** draft (PROPOSED implementation; CONFIRMED doctrine)
+
+**See also:** [Lifecycle Law](../doctrine/lifecycle-law.md) · [Directory Rules](../doctrine/directory-rules.md) · [Trust Membrane](../doctrine/trust-membrane.md) · [Rollback Drill](./ROLLBACK_DRILL.md)
+
+[⬆ Back to top](#top)

--- a/docs/runbooks/QUARANTINE_HANDLING.md
+++ b/docs/runbooks/QUARANTINE_HANDLING.md
@@ -1,3 +1,518 @@
-# QUARANTINE_HANDLING
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-quarantine-handling
+title: Quarantine Handling Runbook
+type: standard
+version: v1
+status: draft
+owners: TODO — Docs steward + Source steward + Domain stewards (per affected lane)
+created: TODO-YYYY-MM-DD
+updated: TODO-YYYY-MM-DD
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/truth-posture.md
+  - docs/doctrine/trust-membrane.md
+  - docs/architecture/governed-api.md
+  - docs/runbooks/governed_ai_VALIDATION.md
+  - contracts/governance/  # ReviewRecord, decision/correction families
+  - schemas/contracts/v1/  # QuarantineRecord home — PROPOSED, ADR pending
+tags: [kfm, runbook, lifecycle, governance, quarantine]
+notes:
+  - "All concrete repo paths and schema home claims are PROPOSED until verified against the mounted repository."
+  - "Quarantine is governance state, not a storage convention."
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Quarantine Handling Runbook
+
+> Operational guide for routing material into `QUARANTINE`, recording defects, clearing or retiring quarantined records, and never letting a quarantined object reach a public surface by accident.
+
+![status: draft](https://img.shields.io/badge/status-draft-orange)
+![doc class: runbook](https://img.shields.io/badge/doc--class-runbook-blue)
+![lifecycle: RAW%E2%86%92PUBLISHED](https://img.shields.io/badge/lifecycle-RAW%E2%86%92PUBLISHED-informational)
+![authority: doctrine--anchored](https://img.shields.io/badge/authority-doctrine--anchored-success)
+![last updated: TODO](https://img.shields.io/badge/last%20updated-TODO-lightgrey)
+
+**Status:** draft — content doctrine-anchored, implementation references PROPOSED
+**Owners:** *TODO* — Docs steward + Source steward + per-domain stewards
+**Last reviewed:** *TODO-YYYY-MM-DD*
+
+---
+
+## Quick jump
+
+- [1. Scope](#1-scope)
+- [2. When to use this runbook](#2-when-to-use-this-runbook)
+- [3. Lifecycle context](#3-lifecycle-context)
+- [4. Quarantine entry — automatic conditions](#4-quarantine-entry--automatic-conditions)
+- [5. Quarantine entry — review-driven conditions](#5-quarantine-entry--review-driven-conditions)
+- [6. Reason codes and defect classes](#6-reason-codes-and-defect-classes)
+- [7. What a `QuarantineRecord` MUST carry](#7-what-a-quarantinerecord-must-carry)
+- [8. Path placement](#8-path-placement)
+- [9. Clearance procedures](#9-clearance-procedures)
+- [10. Promotion gates after clearance](#10-promotion-gates-after-clearance)
+- [11. Roles and separation of duties](#11-roles-and-separation-of-duties)
+- [12. Health indicators](#12-health-indicators)
+- [13. Anti-patterns](#13-anti-patterns)
+- [14. Related docs](#14-related-docs)
+- [15. Appendix](#15-appendix)
+
+---
+
+## 1. Scope
+
+This runbook governs how Kansas Frontier Matrix (KFM) handles material that enters the `QUARANTINE` state during the canonical data lifecycle:
+
+> **RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED** *(CONFIRMED doctrine)*
+
+`QUARANTINE` is a **governed holding state** for inputs that exhibit defects in rights, sensitivity, validation, source-role, evidence, temporal logic, or policy posture. It is **not** a staging area, not a publication candidate, and not visible to public clients.
+
+> [!IMPORTANT]
+> **Quarantine is not a publishable staging area.** The encyclopedia is explicit: `QuarantineRecord` holds *failed, sensitive, rights-unknown or malformed inputs*, and quarantine MUST NOT become a back door into public surfaces. Promotion out of quarantine is a **governed state transition, not a file move.**
+
+**In scope:**
+
+- Entry conditions (automatic + review-driven) that route material into `QUARANTINE`.
+- Required `QuarantineRecord` content and path placement under `data/quarantine/`.
+- Clearance, re-evaluation, retirement, and supersession procedures.
+- Promotion gates that quarantined material MUST pass to re-enter `WORK` or progress further.
+- Role responsibilities and separation-of-duties expectations.
+
+**Out of scope:**
+
+- Object **meaning** (lives in `contracts/`) and **shape** (lives in `schemas/`) — this runbook references them but does not define them.
+- The full policy authoring guide (lives under `policy/`).
+- Release-side rollback and correction mechanics — see the dedicated runbooks under `docs/runbooks/` *(PROPOSED neighbors: `governed_ai_ROLLBACK.md`, future `RELEASE_ROLLBACK.md`)*.
+- Source admission before `RAW` — see `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` *(PROPOSED path)*.
+
+---
+
+## 2. When to use this runbook
+
+Reach for this document whenever:
+
+| Trigger | What you’re doing here |
+|---|---|
+| A validator emitted `FAIL` for a record | Decide whether the failure routes to `WORK` retry or `QUARANTINE` hold; record the reason. |
+| A policy gate returned `deny`, `quarantine`, `escalate`, or `unknown` | Open a `QuarantineRecord`; do not silently retry. |
+| Rights, license, sensitivity, or source-role are unresolved at admission or normalization | Quarantine with the corresponding reason code; do not promote past `WORK`. |
+| A signature, DSSE envelope, evidence ref, or spec hash failed verification | Fail closed into `QUARANTINE`; treat as a release-gate violation. |
+| A previously-published claim was corrected and its source/evidence must be re-held | Demote to `QUARANTINE` per the correction posture in the manual’s defect-class table. |
+| A steward review marked a candidate `REVIEW_REJECTED` or `REVIEW_INSUFFICIENT` | Route to quarantine until the review record is resolved. |
+
+> [!NOTE]
+> If you are looking at material that is **stale but not defective**, you usually do **not** use this runbook. Stale-state markers and supersession have their own path — see the master stale-state reference in the Domains Culmination Atlas (Chapter 24).
+
+[Back to top](#quick-jump)
+
+---
+
+## 3. Lifecycle context
+
+`QUARANTINE` is a peer of `WORK`, not a phase between `RAW` and `PROCESSED`. The arrows below show governed transitions; **no edge in this diagram is a file move.** Each transition requires the artifacts named in §4–§10.
+
+```mermaid
+flowchart LR
+  classDef governed fill:#eef,stroke:#225,stroke-width:1px,color:#112;
+  classDef quarantine fill:#fee,stroke:#822,stroke-width:1px,color:#411;
+  classDef public fill:#efe,stroke:#272,stroke-width:1px,color:#141;
+
+  ADM([Admission gate]):::governed
+  RAW[RAW<br/>admitted source]:::governed
+  WORK[WORK<br/>candidates]:::governed
+  Q[QUARANTINE<br/>defect hold]:::quarantine
+  PROC[PROCESSED<br/>validated]:::governed
+  CAT[CATALOG / TRIPLET<br/>discovery & proof closure]:::governed
+  PUB[PUBLISHED<br/>public-safe]:::public
+  RET[Retire / Supersede]:::quarantine
+
+  ADM -->|SourceDescriptor| RAW
+  RAW -->|Normalization gate| WORK
+  RAW -->|defect at normalization| Q
+  WORK -->|Validation pass| PROC
+  WORK -->|Validation fail / policy block| Q
+  Q -->|Remediated + re-validated| WORK
+  Q -->|Unrecoverable / rights denied| RET
+  PROC -->|Catalog closure| CAT
+  CAT -->|ReleaseManifest + ReviewRecord| PUB
+  PUB -.->|CorrectionNotice / withdrawal| Q
+```
+
+> [!CAUTION]
+> The dashed `PUBLISHED → QUARANTINE` edge is a **correction posture**, not a normal flow. A previously-released claim that is defective in rights, sensitivity, geometry, temporal logic, or policy can be demoted under a `CorrectionNotice`, with derivatives invalidated. See `docs/runbooks/` correction/rollback neighbors *(PROPOSED)* for the full procedure.
+
+[Back to top](#quick-jump)
+
+---
+
+## 4. Quarantine entry — automatic conditions
+
+The following conditions MUST route material to `QUARANTINE` with the indicated reason. These are detected by validators and policy gates and require no human judgment to *enter* quarantine (they always require human judgment to *leave* it).
+
+| Condition | Reason code (PROPOSED) | Detected at | Citation |
+|---|---|---|---|
+| Missing signature on a release receipt or attestation | `MISSING_SIGNATURE` | Attestation gate | New Ideas (governed change intake), Unified Manual §7 |
+| Invalid DSSE envelope (payload / payloadType / signature shape) | `INVALID_DSSE` | Attestation gate | New Ideas (validator expectations) |
+| Unknown or non-allowlisted SPDX license | `UNKNOWN_LICENSE` | License gate | New Ideas (license posture verification) |
+| Missing or unresolvable `EvidenceRef` | `MISSING_EVIDENCE` | Evidence resolution gate | Encyclopedia §K; Atlas §24.6.1 |
+| Policy mismatch (decision ≠ allow) | `POLICY_MISMATCH` | Policy evaluation gate | New Ideas (promotion preconditions) |
+| `spec_hash` mismatch between recomputed and signed payload | `HASH_MISMATCH` | Spec-hash verification | New Ideas (verification step 1) |
+| Operational / temporal context expired | `EXPIRED_CONTEXT` | Freshness / temporal validator | New Ideas; Atlas §24.6.1 |
+| Schema validation failure on a required object family | `SCHEMA_INVALID` | Schema validator | Atlas §24.6.1 (normalization gate) |
+| Geometry invalid or over-precise for sensitivity class | `GEOMETRY_INVALID` / `GEOMETRY_OVERPRECISE` | Geometry validator + sensitivity gate | Directory Rules §9.1; Atlas §24.6.1 |
+
+> [!WARNING]
+> **Fail closed is mandatory.** A gate that cannot evaluate its inputs MUST emit `ERROR` (or route to `QUARANTINE` for review-shaped ambiguity) — never silent allow, never silent retry until the result changes. The watcher / pipeline pattern in the project notes is explicit: *"Deny by default: missing signatures, unclear provenance, or policy mismatch → fail-closed."*
+
+[Back to top](#quick-jump)
+
+---
+
+## 5. Quarantine entry — review-driven conditions
+
+These conditions reflect human judgment by a steward, reviewer, or rights-holder representative. They produce a `ReviewRecord` (or an equivalent recorded decision) that drives the quarantine action.
+
+| Condition | Reason code (PROPOSED) | Who decides |
+|---|---|---|
+| Rights status unresolved or contested | `RIGHTS_UNKNOWN` | Source steward + rights-holder rep (where applicable) |
+| Sensitivity class unresolved or escalated | `SENSITIVITY_UNRESOLVED` | Sensitivity reviewer |
+| Source-role collapse risk (e.g., modeled cited as observed) | `ROLE_COLLAPSE` | Domain steward |
+| Source-role downcast attempted (post-admission upgrade forbidden) | `ROLE_DOWNCAST_FORBIDDEN` | Domain steward |
+| Review required but not yet performed | `REVIEW_NEEDED` | Domain steward |
+| Review performed but insufficient | `REVIEW_INSUFFICIENT` | Reviewer (escalation to release authority) |
+| Review explicitly rejected the candidate | `REVIEW_REJECTED` | Reviewer |
+| Release manifest invalid or rollback target missing | `RELEASE_MANIFEST_INVALID` / `ROLLBACK_TARGET_MISSING` | Release authority |
+| Correction-time derivatives unresolved | `CORRECTION_DERIVATIVES_UNRESOLVED` | Correction reviewer |
+| Prior release missing for a correction lineage | `CORRECTION_PRIOR_RELEASE_MISSING` | Correction reviewer |
+
+> [!NOTE]
+> Reason codes above are normalized from the Atlas’s master gate-failure reference (§24.6.x) and the New Ideas governed-change-intake notes. Exact enum spelling, casing, and namespace MUST be fixed by an ADR before any contract/schema treats them as canonical (see Atlas §24.12 ADR-S-12: "Connector cadence and quarantine recovery policy").
+
+[Back to top](#quick-jump)
+
+---
+
+## 6. Reason codes and defect classes
+
+Reason codes (above) are the **operational vocabulary**. Defect classes are the **correction / rollback posture** — they tell you what to do next, and they map cleanly to the manual’s defect table.
+
+| Defect class | Correction posture *(CONFIRMED, from Unified Manual)* | Rollback posture |
+|---|---|---|
+| Rights defect | DENY public use; quarantine source/artifact | Withdraw affected artifacts |
+| Sensitivity leak | Redact / generalize and notify stewards | Immediate public disablement |
+| Geometry defect | Rebuild derivative layer and evidence payload | Restore previous digest-pinned artifact |
+| Temporal defect | Correct valid / source / retrieval / release time | Mark stale until rebuilt |
+| Policy defect | Re-run policy and decision envelope | Disable route / layer if gate failed |
+| Validation defect | Re-run validators against fixtures; fix inputs | Hold at `WORK`; do not promote |
+| AI answer defect | Invalidate `AIReceipt` and response envelope | Remove answer; preserve `EvidenceBundle` |
+| Catalog defect | Re-emit catalog closure after proof repair | Restore previous catalog state |
+| Evidence gap | `ABSTAIN` or withdraw unsupported claim | Restore prior evidence-supported release |
+
+The mapping from a single reason code to a defect class is **not always 1:1.** A `POLICY_MISMATCH` might be caused by a rights defect, a sensitivity defect, or a stale evidence gap. The reviewer is responsible for classifying — the runbook does not pre-decide.
+
+[Back to top](#quick-jump)
+
+---
+
+## 7. What a `QuarantineRecord` MUST carry
+
+`QuarantineRecord` is named as a KFM object family in the encyclopedia. The exact schema is **PROPOSED** until an ADR confirms its home under `schemas/contracts/v1/...`. The following content is the **doctrine-derived minimum** any concrete schema MUST satisfy.
+
+```jsonc
+// PROPOSED minimum content — not the final schema.
+// Field names and casing MUST be fixed by ADR before treating this as canonical.
+{
+  "object_type": "QuarantineRecord",
+  "schema_version": "v1",
+  "quarantine_id": "<deterministic id: source + role + scope + digest>",
+  "decision_id": "<join key to PolicyDecision / RunReceipt>",
+  "spec_hash": "<sha256 over canonicalized payload (e.g., JCS)>",
+  "source_refs": ["<SourceDescriptor refs>"],
+  "ingest_lane": "RAW->WORK | WORK->PROCESSED | CATALOG->PUBLISHED | PUBLISHED'",
+  "reason_code": "RIGHTS_UNKNOWN | POLICY_MISMATCH | ...",
+  "defect_class": "rights | sensitivity | geometry | temporal | policy | validation | evidence | catalog | ai_answer",
+  "evidence_refs": ["<EvidenceRef uris — MUST resolve to EvidenceBundle>"],
+  "validation_report_ref": "<ValidationReport id, if applicable>",
+  "policy_decision_ref": "<PolicyDecision id, if applicable>",
+  "review_record_ref":  "<ReviewRecord id, if applicable>",
+  "actor": "<watcher | validator | policy_gate | steward | release_authority>",
+  "created": "<ISO-8601>",
+  "expected_remediation": "<clearance | retire | supersede | abstain | escalate>",
+  "rollback_target_ref": "<release id, when demoted from PUBLISHED>"
+}
+```
+
+> [!TIP]
+> The `decision_id` field is the **join key** across `PolicyDecision`, `RunReceipt`, attestation, and any `published_manifest` — it is how an auditor follows a quarantined record from cause to disposition. Preserve it.
+
+[Back to top](#quick-jump)
+
+---
+
+## 8. Path placement
+
+Per Directory Rules §9.1 *(CONFIRMED)*, quarantined payloads and their records live under:
+
+```text
+data/quarantine/<domain>/<reason>/<run_id>/
+```
+
+The Directory Rules summary makes the constraints explicit:
+
+| Phase | Allowed | MUST NOT |
+|---|---|---|
+| `quarantine/` | Failed validation, unresolved rights/sensitivity, schema drift, over-precise geometry | Promotion candidates without remediation |
+
+Adjacent emitted-artifact homes (also CONFIRMED in Directory Rules §9.1):
+
+| Artifact | Home |
+|---|---|
+| Run, validation, ingest, AI, release receipts | `data/receipts/...` |
+| `EvidenceBundle`, proof packs, validation reports, citation validations | `data/proofs/...` |
+| Release decisions and rollback cards | `release/` |
+
+> [!IMPORTANT]
+> **No quarantined payload appears under `data/processed/`, `data/catalog/`, `data/triplets/`, or `data/published/`.** That is not a styling rule — it is the trust membrane. Public clients consume **governed APIs and released artifacts only**; there is no admin shortcut from `data/quarantine/` to a public surface.
+
+If a quarantined record is being **demoted from `PUBLISHED`** under a `CorrectionNotice`, the original release record is preserved (it is **not** deleted); the `QuarantineRecord` carries the `rollback_target_ref` linking back to the now-invalidated release.
+
+[Back to top](#quick-jump)
+
+---
+
+## 9. Clearance procedures
+
+Clearance is the **only legitimate way out** of `QUARANTINE` other than retirement. It is **always** a governed state transition — never a file move.
+
+### 9.1 Standard clearance (quarantine → WORK)
+
+1. **Read the `QuarantineRecord`.** Identify `reason_code`, `defect_class`, `evidence_refs`, and `expected_remediation`.
+2. **Resolve the defect at its source.**
+   - Rights defect → confirm license / source terms / rights-holder consent.
+   - Sensitivity defect → produce a `RedactionReceipt` *(or `AggregationReceipt` if generalization applies)*.
+   - Validation / schema / geometry / temporal defect → fix inputs and re-run validators against fixtures.
+   - Policy defect → re-run the policy bundle and capture a fresh `PolicyDecision`.
+   - Evidence gap → resolve `EvidenceRef`s to a closed `EvidenceBundle`, or downgrade the claim to `ABSTAIN`.
+3. **Re-run the gate that originally failed.** Do not skip; do not substitute a different gate.
+4. **Record a `ReviewRecord`** with the reviewer’s decision (`APPROVE` / `REJECT` / `ESCALATE` / `ABSTAIN`).
+5. **If approved,** transition the record into `WORK` with a fresh `RunReceipt` (status: `cleared`), referencing the original `quarantine_id` for lineage.
+6. **If rejected or unresolved,** keep the record in `QUARANTINE`; either retire it (§9.3) or escalate (§9.4).
+
+> [!CAUTION]
+> Clearance MUST emit a `RunReceipt` regardless of outcome. The doctrine: *"each outcome (APPROVE / QUARANTINE / ABSTAIN / DENY / ERROR) emits a `RunReceipt`."* No silent clearances.
+
+### 9.2 Sensitive-lane clearance
+
+Sensitive lanes — archaeology, fauna sensitive sites, flora sensitive sites, people / DNA / land — add separation-of-duties: **author ≠ sensitivity reviewer ≠ release authority**, plus rights-holder representative where applicable. See §11.
+
+### 9.3 Retirement / supersession
+
+When clearance is not possible (rights denied, source withdrawn, defect irrecoverable):
+
+- Emit a final `RunReceipt` with status `retired` and reason.
+- If the quarantined record had any downstream derivatives or prior public releases, list them and propagate invalidation per the manual’s correction-lineage rules.
+- Preserve the `QuarantineRecord` *append-only* — do not delete; retirement is also a public-trust act.
+
+### 9.4 Escalation
+
+Escalation routes are by reason:
+
+- Rights / sovereignty → rights-holder representative + source steward.
+- Sensitivity → sensitivity reviewer + (for sensitive lanes) release authority.
+- Policy bundle ambiguity → docs steward + policy owner; consider an ADR if a vocabulary or rule needs to change.
+- Release-side defects (`RELEASE_MANIFEST_INVALID`, `ROLLBACK_TARGET_MISSING`) → release authority + correction reviewer.
+
+[Back to top](#quick-jump)
+
+---
+
+## 10. Promotion gates after clearance
+
+A cleared record re-enters the lifecycle at `WORK`. To progress further, it MUST pass the lifecycle gates per Atlas §24.6.1 *(CONFIRMED doctrine)*. Promotion preconditions for `CATALOG → TRIPLET → PUBLISHED` per the governed-change-intake notes:
+
+- Receipt schema validation
+- DSSE / attestation validation
+- Signature verification
+- Policy decision = `allow`
+- Evidence resolution (every `EvidenceRef` resolves to an `EvidenceBundle`)
+- Rights verification
+- `spec_hash` parity
+- Promotion authorization (separation of duties where materiality applies)
+
+Each transition has its own failure-closed outcome:
+
+| Transition | Failure-closed outcome |
+|---|---|
+| `RAW → WORK / QUARANTINE` | Quarantine with reason; never silently promotes. |
+| `WORK → PROCESSED` | Stay in `WORK`; structured `FAIL`. |
+| `PROCESSED → CATALOG / TRIPLET` | HOLD at `PROCESSED`; no public edge. |
+| `CATALOG / TRIPLET → PUBLISHED` | HOLD at `CATALOG`; no public surface change. |
+
+> [!NOTE]
+> A cleared `QuarantineRecord` does **not** entitle the record to skip downstream gates. Clearance gets you back to `WORK`; everything after still runs.
+
+[Back to top](#quick-jump)
+
+---
+
+## 11. Roles and separation of duties
+
+Per Atlas §24.7 *(PROPOSED reference for ADR discussion; doctrine CONFIRMED for separation principle)*:
+
+| Role | Quarantine-relevant scope |
+|---|---|
+| **Source steward** | Owns admission, rights confirmation, sensitivity tag for a named source family. First reviewer for `RIGHTS_UNKNOWN`, `SENSITIVITY_UNRESOLVED` at admission. |
+| **Domain steward** | Owns domain object families, contracts, validators. Reviewer for validation, source-role, schema, geometry, temporal defects. |
+| **Sensitivity reviewer** | Reviews redaction, generalization, withholding, and tier decisions. Required separation for sensitive-lane clearance. |
+| **Rights-holder representative** | Confirms sovereignty / cultural-heritage / consent-based release decisions. Required for archaeology, sovereign data, living-person data, DNA data. |
+| **Release authority** | Issues `ReleaseManifest`s; authorizes `PUBLISHED` transitions; distinct from the original author when materiality applies. Reviewer for release-side quarantines. |
+| **Correction reviewer** | Reviews `CorrectionNotice` / `RollbackCard` before they amend a `PUBLISHED` claim. Reviewer for correction-class quarantines. |
+| **AI surface steward** | Reviews Focus Mode templates, `AIReceipt`s, and policy bindings. Reviewer for AI-answer-defect quarantines. |
+| **Docs steward** | Owns governance docs, ADR index, drift register. Periodic audit role for vocabulary drift in reason codes. |
+
+**Separation-of-duties expectations** (PROPOSED, maturity-dependent):
+
+| Quarantine action | Author ≠ Approver? |
+|---|---|
+| Routine validation / schema / temporal clearance | Author MAY approve. |
+| Sensitivity-class clearance | Author MUST NOT approve; sensitivity reviewer required. |
+| Release-side quarantine clearance | Author MUST NOT approve; release authority required. |
+| Correction-class clearance | Author / detector MUST NOT approve; correction reviewer required. |
+| Sensitive lanes (archaeology, fauna sensitive sites, people / DNA / land) | Author + sensitivity reviewer + release authority + rights-holder rep where applicable. |
+
+[Back to top](#quick-jump)
+
+---
+
+## 12. Health indicators
+
+`QUARANTINE` health is a leading indicator of governance maturity. The Atlas §24.11 PROPOSED indicators relevant to this runbook:
+
+| Indicator | What it measures | Healthy posture *(PROPOSED)* |
+|---|---|---|
+| Quarantine throughput | % of admitted records that quarantine and rate of clearance | Visible, with cause distribution; sustained high backlog is a defect. |
+| Sensitive-lane fail-closed rate | % of unauthorized sensitive-lane requests that `DENY` at the first gate | 100% at the first gate. |
+| `RedactionReceipt` coverage | % of public-safe transformations that emit a `RedactionReceipt` | 100% for sensitive lanes. |
+| Rights-change response time | Median time from rights-change detection to tier reassignment | Within tolerance per source family. |
+| `EvidenceRef` resolution rate | % of public-surface `EvidenceRef`s that resolve to an `EvidenceBundle` | > 99.9% over trailing release window. |
+
+> [!TIP]
+> Indicators are **reported, not enforced.** Enforcement is the validator’s job. A dashboard that shows quarantine cause distribution and clearance lead time will tell you more about KFM’s health than any single doctrinal statement.
+
+[Back to top](#quick-jump)
+
+---
+
+## 13. Anti-patterns
+
+| Anti-pattern | Why it’s wrong | Counter-rule |
+|---|---|---|
+| Using `data/quarantine/` as a soft staging area before publication | Quarantine is a defect-hold state; promotion is a governed transition, not a directory move. | Clear into `WORK` with receipts; never copy bytes upward. |
+| Public client reads `data/quarantine/` | Trust membrane bypassed; quarantine is not a public surface. | Public clients use the governed API only. |
+| Watcher or connector writes directly to `data/processed/` or `data/published/` to "skip" quarantine | Watcher-as-non-publisher invariant; lifecycle skip. | Connectors emit to `data/raw/` or `data/quarantine/`; pipelines promote. |
+| Silent retry of a failed policy gate until it returns `allow` | Fail-closed posture broken; receipts misleading. | Each gate run emits a receipt; clearance MUST resolve the defect, not loop until lucky. |
+| Deleting a `QuarantineRecord` after clearance | Audit lineage broken. | Records are append-only; clearance adds a receipt, never removes the record. |
+| Approving one’s own sensitive-lane clearance | Separation-of-duties broken. | Author ≠ reviewer ≠ release authority on sensitive lanes. |
+| Promoting a record upgraded from `modeled` source role to `observed` to clear quarantine | Source role is fixed at admission; never upgraded by promotion. | Quarantine and either correct the source descriptor or retire the record. |
+| Treating `RIGHTS_UNKNOWN` as a temporary parking state | Unknown rights fail closed; "unknown" is not a green-lit posture. | Resolve rights or retire. |
+
+[Back to top](#quick-jump)
+
+---
+
+## 14. Related docs
+
+- [`docs/doctrine/directory-rules.md`](../doctrine/directory-rules.md) — canonical placement rules, §9.1 lifecycle invariant, §9.1 phase table. *CONFIRMED.*
+- [`docs/doctrine/lifecycle-law.md`](../doctrine/lifecycle-law.md) — lifecycle invariant detail. *PROPOSED path.*
+- [`docs/doctrine/truth-posture.md`](../doctrine/truth-posture.md) — cite-or-abstain, fail-closed posture. *PROPOSED path.*
+- [`docs/doctrine/trust-membrane.md`](../doctrine/trust-membrane.md) — why quarantine is never public. *PROPOSED path.*
+- [`docs/architecture/governed-api.md`](../architecture/governed-api.md) — the only legitimate public surface. *PROPOSED path.*
+- [`docs/sources/SOURCE_DESCRIPTOR_STANDARD.md`](../sources/SOURCE_DESCRIPTOR_STANDARD.md) — admission and source identity. *PROPOSED path.*
+- [`docs/registers/DRIFT_REGISTER.md`](../registers/DRIFT_REGISTER.md) — file here when this runbook conflicts with mounted repo state. *PROPOSED path.*
+- [`docs/runbooks/governed_ai_VALIDATION.md`](./governed_ai_VALIDATION.md) — Focus Mode evidence/citation/policy validation. *PROPOSED (named in Whole-UI report).*
+- *Related future neighbors:* `RELEASE_ROLLBACK.md`, `CORRECTION_LIFECYCLE.md` *(PROPOSED, not yet present).*
+- *Schema home for `QuarantineRecord`:* `schemas/contracts/v1/...` — exact subdirectory **PROPOSED**, ADR-S-12 recommended.
+
+[Back to top](#quick-jump)
+
+---
+
+## 15. Appendix
+
+<details>
+<summary><strong>A. Reason code → defect class quick map (PROPOSED)</strong></summary>
+
+| Reason code | Most common defect class | Most common clearance path |
+|---|---|---|
+| `MISSING_SIGNATURE` | policy / release | Sign and re-attest; re-run release gate. |
+| `INVALID_DSSE` | policy / release | Rebuild envelope to spec; re-run attestation gate. |
+| `UNKNOWN_LICENSE` | rights | Resolve SPDX; update `SourceDescriptor`; re-run license gate. |
+| `MISSING_EVIDENCE` | evidence | Resolve `EvidenceRef` to closed `EvidenceBundle`, or downgrade to `ABSTAIN`. |
+| `POLICY_MISMATCH` | policy (root cause varies) | Re-run policy bundle after upstream cause is fixed. |
+| `HASH_MISMATCH` | validation / integrity | Recompute against canonical (e.g., JCS) payload; investigate tamper. |
+| `EXPIRED_CONTEXT` | temporal | Refresh source or mark stale + retire. |
+| `SCHEMA_INVALID` | validation | Repair input or schema; re-run validator. |
+| `GEOMETRY_INVALID` | geometry | Repair geometry; rebuild derivative layer. |
+| `GEOMETRY_OVERPRECISE` | sensitivity | Generalize via `AggregationReceipt` or redact via `RedactionReceipt`. |
+| `RIGHTS_UNKNOWN` | rights | Resolve with rights-holder rep, or retire. |
+| `SENSITIVITY_UNRESOLVED` | sensitivity | Sensitivity reviewer assigns tier; emit `RedactionReceipt` if applicable. |
+| `ROLE_COLLAPSE` / `ROLE_DOWNCAST_FORBIDDEN` | source-role | Restore source role; refuse upcast; retire if irreconcilable. |
+| `REVIEW_NEEDED` / `REVIEW_INSUFFICIENT` / `REVIEW_REJECTED` | governance | Run required review; supply `ReviewRecord`. |
+| `RELEASE_MANIFEST_INVALID` / `ROLLBACK_TARGET_MISSING` | release | Manifest fix; supply rollback target. |
+| `CORRECTION_DERIVATIVES_UNRESOLVED` / `CORRECTION_PRIOR_RELEASE_MISSING` | correction | Resolve derivatives; emit supersession entry. |
+
+> Illustrative mapping. Exact enums and recommended clearance paths MUST be fixed by ADR before being treated as canonical.
+
+</details>
+
+<details>
+<summary><strong>B. Skeleton clearance flow (pseudocode, illustrative)</strong></summary>
+
+```python
+# Illustrative, not production. Field names PROPOSED.
+def attempt_clearance(quarantine_id: str, actor: str) -> str:
+    qr = read_quarantine(quarantine_id)               # append-only read
+    if qr["expected_remediation"] == "retire":
+        return retire(quarantine_id, actor=actor)     # emits RunReceipt(status="retired")
+
+    fixed = remediate(qr)                             # rights | redaction | schema | etc.
+    if not fixed:
+        return escalate(quarantine_id, actor=actor)   # emits RunReceipt(status="escalated")
+
+    # Re-run the original gate, NOT a different gate.
+    gate_outcome = rerun_gate(qr["ingest_lane"], fixed)
+    if gate_outcome != "PASS":
+        return hold(quarantine_id, reason=gate_outcome, actor=actor)
+
+    review = require_review_if_material(qr)            # sensitive-lane / release-side
+    if review and review["decision"] != "APPROVE":
+        return hold(quarantine_id, reason="REVIEW_REJECTED", actor=actor)
+
+    return clear_to_work(
+        quarantine_id=quarantine_id,
+        run_receipt={"status": "cleared", "actor": actor},
+        review_record_ref=review["id"] if review else None,
+    )
+```
+
+</details>
+
+<details>
+<summary><strong>C. Verification backlog for this runbook</strong></summary>
+
+- **NEEDS VERIFICATION:** Whether `QuarantineRecord` schema lives under `schemas/contracts/v1/lifecycle/` or `schemas/contracts/v1/governance/` — ADR required (Directory Rules §2.4(5)).
+- **NEEDS VERIFICATION:** Exact reason-code enum vocabulary, casing, and namespace.
+- **NEEDS VERIFICATION:** Whether `data/quarantine/<domain>/<reason>/<run_id>/` is the form actually used in the mounted repo (Directory Rules §9.1 specifies the shape; mounted-repo conformance has not been checked in this session).
+- **NEEDS VERIFICATION:** Whether a separate `release/quarantine/` lane exists for release-side defects, or whether `data/quarantine/` carries them under a release-side `<reason>`.
+- **NEEDS VERIFICATION:** Whether retired `QuarantineRecord`s are archived under `docs/archive/` lineage or remain in place append-only.
+- **NEEDS VERIFICATION:** Owners — file `CODEOWNERS` entry for `docs/runbooks/` should be confirmed.
+- **OPEN ADR:** ADR-S-12 (Atlas §24.12) — "Connector cadence and quarantine recovery policy."
+
+</details>
+
+---
+
+**Related docs:** see [§14](#14-related-docs).
+**Last updated:** *TODO-YYYY-MM-DD*
+
+[Back to top](#quick-jump)

--- a/docs/runbooks/habitat/SOURCE_REFRESH_RUNBOOK.md
+++ b/docs/runbooks/habitat/SOURCE_REFRESH_RUNBOOK.md
@@ -1,3 +1,659 @@
-# habitat :: SOURCE_REFRESH runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-habitat-source-refresh
+title: Habitat Source Refresh Runbook
+type: standard
+version: v0.1
+status: draft
+owners: Habitat lane steward + Docs steward (TBD — assign via per-root README)
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/domains/habitat/README.md
+  - docs/sources/SOURCE_DESCRIPTOR_STANDARD.md
+  - docs/standards/SMART_SYNC.md
+  - docs/standards/RUN_RECEIPT.md
+  - docs/runbooks/governed_ai_VALIDATION.md
+  - docs/registers/VERIFICATION_BACKLOG.md
+tags: [kfm, runbook, habitat, sources, lifecycle, governance]
+notes:
+  - PROPOSED placement; nested vs flat runbook layout is NEEDS VERIFICATION
+  - All source endpoints, cadences, and rights statuses are NEEDS VERIFICATION
+  - Implementation maturity (routes, schemas, watcher code) is PROPOSED
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Habitat Source Refresh Runbook
+
+> **How the Habitat lane re-admits, re-validates, and re-promotes evidence from upstream ecological sources without bypassing the trust membrane.** Refresh is a *governed state transition*, not a file refresh. No bytes change public state until validators, policy gates, evidence-bundle closure, and release decisions all pass — every time.
+
+<p align="left">
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-orange">
+  <img alt="Authority: PROPOSED" src="https://img.shields.io/badge/authority-PROPOSED-yellow">
+  <img alt="Domain: Habitat" src="https://img.shields.io/badge/domain-habitat-2e7d32">
+  <img alt="Lifecycle: RAW%20→%20PUBLISHED" src="https://img.shields.io/badge/lifecycle-RAW%E2%86%92PUBLISHED-blue">
+  <img alt="Posture: fail-closed" src="https://img.shields.io/badge/posture-fail--closed-critical">
+  <img alt="License-or-policy: public-or-restricted" src="https://img.shields.io/badge/policy-mixed%20public%2Frestricted-lightgrey">
+  <!-- TODO: replace with real Shields.io endpoints once CI surface is wired -->
+</p>
+
+| Field | Value |
+|---|---|
+| **Document type** | Runbook (operational procedure) |
+| **Status** | `draft` — PROPOSED placement and content |
+| **Lane** | Habitat — see `docs/domains/habitat/` (PROPOSED) |
+| **Owners** | Habitat lane steward + Docs steward (TBD; **placeholder** — confirm via per-root README) |
+| **Last reviewed** | `2026-05-12` (initial draft) |
+| **Authority for procedure** | KFM core invariants → Directory Rules → Habitat dossier → this runbook |
+| **Authority for *any specific path* quoted here** | **PROPOSED** until verified against the mounted repo |
+
+---
+
+## Quick jump
+
+- [1. Purpose & scope](#1-purpose--scope)
+- [2. Authority & invariants](#2-authority--invariants)
+- [3. Preconditions](#3-preconditions)
+- [4. Habitat source families](#4-habitat-source-families)
+- [5. End-to-end refresh flow](#5-end-to-end-refresh-flow)
+- [6. Conditional GET & smart sync](#6-conditional-get--smart-sync)
+- [7. Watcher-as-non-publisher](#7-watcher-as-non-publisher)
+- [8. Stale-state markers & supersession](#8-stale-state-markers--supersession)
+- [9. Sensitivity, rights & geoprivacy gates](#9-sensitivity-rights--geoprivacy-gates)
+- [10. Validation & policy gates](#10-validation--policy-gates)
+- [11. Promotion, correction & rollback](#11-promotion-correction--rollback)
+- [12. Operator checklist](#12-operator-checklist)
+- [13. Failure modes & responses](#13-failure-modes--responses)
+- [14. Verification backlog](#14-verification-backlog)
+- [15. Related docs](#15-related-docs)
+- [Appendix A — Example artifacts](#appendix-a--example-artifacts)
+
+---
+
+## 1. Purpose & scope
+
+This runbook governs **how Habitat lane sources are refreshed** — re-checked for change, re-fetched when warranted, re-normalized, re-validated, re-bundled, and re-promoted — without bypassing any KFM gate.
+
+It applies whenever any of the following triggers a check against an upstream source for the Habitat lane:
+
+- Scheduled cadence on a registered `SourceDescriptor`.
+- Object-store event or push notification (where the upstream is event-capable).
+- Steward-initiated re-admission (e.g., after a rights or sensitivity change).
+- Schema, geography, model, or policy version drift detected against an already-published claim.
+
+**In scope.** Procedure, gates, receipts, sensitivity posture, stale handling, supersession, rollback, and the artifacts each step must produce.
+
+**Out of scope.**
+
+- Object-family meaning (lives in `contracts/`).
+- Field-level schema shape (lives in `schemas/contracts/v1/…`).
+- Admissibility logic itself (lives in `policy/`).
+- Source identity, rights, sensitivity at registration time (lives in `data/registry/` and the `SourceDescriptor` standard).
+- Habitat *modeling* — model-card, suitability, connectivity training/eval. This runbook only governs refresh of *inputs* to such models and supersession when an input changes.
+
+> [!IMPORTANT]
+> **Refresh is a governed state transition, not a file move.** A new fetch into `data/raw/habitat/...` does not, by itself, change any public state. Public state changes only when promotion, validation, and policy gates pass with the artifacts named in this runbook.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 2. Authority & invariants
+
+When this runbook conflicts with other sources, resolve in this order (mirrors Directory Rules §2.1):
+
+1. **KFM core invariants** — lifecycle law, cite-or-abstain, trust membrane, authority ladder, watcher-as-non-publisher.
+2. **Accepted ADRs** amending Directory Rules or Habitat schema/policy homes.
+3. **Directory Rules** (`docs/doctrine/directory-rules.md`).
+4. **Habitat dossier** (`docs/domains/habitat/`) and the Habitat+Fauna thin-slice plan.
+5. **This runbook.**
+6. **Per-root READMEs** in the affected lane.
+
+### Invariants this runbook preserves
+
+| Invariant | Operational form for Habitat refresh |
+|---|---|
+| **Lifecycle law** | `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` — no skipping, no silent promotion. |
+| **Watcher-as-non-publisher** | Watchers emit `RunReceipt` and candidate decisions only; they **never** write to `data/catalog/`, `data/published/`, or `release/`. |
+| **Cite-or-abstain** | A Habitat claim without a resolvable `EvidenceRef → EvidenceBundle` cannot be re-promoted. |
+| **Trust membrane** | Public clients consume only released layer manifests; refresh never bypasses `apps/governed-api/`. |
+| **Deny-by-default sensitivity** | Regulatory critical habitat, exact rare-species occurrence joins, and unresolved rights remain restricted until proven releasable. |
+| **Reversibility** | Every promotion in this flow has a named `RollbackCard` target before it is allowed. |
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 3. Preconditions
+
+Before any operator runs a Habitat refresh, **all** of the following must be true. If any is `false` or `unknown`, stop and route to the Habitat lane steward.
+
+- [ ] The source has a current `SourceDescriptor` in `data/registry/sources/habitat/` *(PROPOSED path; see Directory Rules §12)* with source_id, source_role, authority, rights, sensitivity, and cadence.
+- [ ] The `SourceDescriptor` rights status is one of `open | controlled | restricted` — **never** `unknown`. Unknown rights fail closed.
+- [ ] The watcher entry (e.g., `tools/ingest/watchers/<habitat>_*.yaml`) is **signed** and registered. *(PROPOSED location.)*
+- [ ] A `RollbackCard` template exists for the affected release, or one will be authored before promotion (see §11).
+- [ ] Operator has access to required artifact stores and to the policy bundle version pinned by the current release.
+- [ ] Adjacent doctrine documents (`docs/sources/SOURCE_DESCRIPTOR_STANDARD.md`, `docs/standards/SMART_SYNC.md`, `docs/standards/RUN_RECEIPT.md`) are read.
+
+> [!CAUTION]
+> If a `SourceDescriptor` is missing, this is **not** a "refresh" — it is an **admission**, which is a different governed transition (`— → RAW`) and requires the source-admission runbook *(PROPOSED, NEEDS VERIFICATION)*. Do not improvise.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 4. Habitat source families
+
+The Habitat lane consumes the following families. **All rights, cadence, and endpoint details are `NEEDS VERIFICATION`** against the current upstream terms-of-service and the live `SourceDescriptor`; treat the table as a checklist, not a contract.
+
+| Source family | Typical source role | Sensitivity posture | Cadence (placeholder — NEEDS VERIFICATION) |
+|---|---|---|---|
+| **USFWS ECOS / critical habitat services** | `authority` | Public, but joins to sensitive species fail closed | Source-vintage-driven |
+| **KDWP state review context** | `authority / observation` | State-controlled; some fields restricted | Steward-cadence |
+| **NLCD land cover** | `authority / observation` | Public raster; derivatives PROPOSED public | Periodic, multi-year |
+| **NWI wetlands** | `authority / observation` | Public, but joins to listed-species occurrence restricted | Vintage-driven |
+| **GAP / LANDFIRE** | `authority / context / model` | Public; model labels MUST stay visible | Periodic |
+| **NatureServe + controlled biodiversity** | `authority` (controlled) | Often controlled; rights MUST be honored | License-driven |
+| **GBIF / iNaturalist / iDigBio occurrence inputs** | `observation` (often as Habitat context only) | **Geoprivacy-sensitive**; exact location DENY by default | Continuous / API-driven |
+| **PAD-US stewardship context** | `authority / context` | Public; sensitivity flags travel through | Periodic |
+| **State ecological inventories / restoration projects** | `observation / context` | Mixed; per-source rights | Project-driven |
+| **Remote-sensing vegetation indices** | `observation / model as source` | Public products; model labels preserved | Sensor-cadence |
+| **Field surveys & steward-reviewed habitat models** | `observation / model as source` | Steward-controlled; review state required | Steward-cadence |
+
+<details>
+<summary><strong>Citation:</strong> sources for the table above</summary>
+
+Source basis enumerated in the Habitat dossier (`[DOM-HAB]`) and KFM Encyclopedia §7.4 / Appendix D ("Source families and source roles"). The Habitat lane scope is **CONFIRMED doctrine** — the *implementation*, including which source IDs are admitted in the current repo state, is **PROPOSED / NEEDS VERIFICATION** until the source ledger is inspected.
+
+</details>
+
+> [!NOTE]
+> The Habitat lane explicitly **does not own** species occurrence truth, plant taxonomy, or fauna taxonomy. It *joins* to Fauna and Flora through governed relationships. A Habitat refresh that pulls occurrence data is consuming it as *context*, never as authoritative occurrence evidence — those refreshes are governed by the **Fauna** and **Flora** source-refresh runbooks *(PROPOSED, NEEDS VERIFICATION — author parallel runbooks per lane)*.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 5. End-to-end refresh flow
+
+The diagram below shows the canonical refresh flow. Every transition between phases is a **gate**, not a copy; phases correspond to the lifecycle invariant. The diagram reflects **CONFIRMED doctrine**; specific gate implementations (`gate.A`–`gate.G`, validator scripts, policy bundle IDs) are **PROPOSED / NEEDS VERIFICATION** against the mounted repo.
+
+```mermaid
+flowchart TD
+    A[Refresh trigger<br/>schedule · event · steward · drift] --> B{Conditional<br/>GET<br/>or push}
+    B -- 304 / no-change --> Bn[Emit no-op<br/>RunReceipt<br/>heartbeat]
+    Bn --> Z[End: no public state change]
+
+    B -- 200 / changed --> C[Fetch into<br/>data/raw/habitat/&lt;source_id&gt;/&lt;run_id&gt;/]
+    C --> D[Normalize:<br/>schema · geometry · time<br/>identity · evidence · rights]
+    D -- pass --> E[data/work/habitat/&lt;run_id&gt;/]
+    D -- fail --> Q[data/quarantine/habitat/&lt;reason&gt;/&lt;run_id&gt;/<br/>reason recorded]
+    Q --> R[Steward review<br/>or supersede]
+
+    E --> F[Validate:<br/>ValidationReport · PolicyDecision<br/>RedactionReceipt if sensitive]
+    F -- pass --> G[data/processed/habitat/&lt;dataset_id&gt;/&lt;version&gt;/]
+    F -- fail --> Q
+
+    G --> H[Catalog closure:<br/>EvidenceBundle · CatalogMatrix<br/>graph/triplet projection]
+    H --> I{Sensitivity<br/>policy gate}
+    I -- DENY --> Q
+    I -- ABSTAIN --> R
+    I -- ALLOW --> J[ReleaseCandidate<br/>+ RollbackCard target]
+
+    J --> K[Release gate:<br/>ReleaseManifest · ReviewRecord<br/>signatures · correction path]
+    K -- pass --> P[PUBLISHED<br/>data/published/layers/habitat/<br/>via apps/governed-api/]
+    K -- hold --> R
+```
+
+**Read the diagram as:** the right-hand spine (`A → C → E → G → H → J → K → P`) is the only path to a public state change. The left-hand spine (`B → Bn → Z`) is the most common outcome — **most refreshes change nothing publicly** and that is correct. The `Q` lane (quarantine) is healthy operation, not failure: it is how unresolved evidence stays auditable instead of leaking.
+
+<details>
+<summary><strong>Gate-by-gate artifact requirements</strong> (consolidated from KFM Domains Atlas §24.6.1)</summary>
+
+| Gate (transition) | Pre-condition | Required artifacts | Fail-closed outcome |
+|---|---|---|---|
+| **Admission** (`— → RAW`) | `SourceDescriptor` exists; rights ≠ unknown | `SourceDescriptor`; payload hash or reference | Not admitted; logged as candidate awaiting steward |
+| **Normalization** (`RAW → WORK / QUARANTINE`) | Schema, geometry, time, identity, evidence, rights rules runnable | `TransformReceipt`; `ValidationReport` (working); `PolicyDecision`; `QUARANTINE` for failures | Quarantine with reason; never silently promotes |
+| **Validation** (`WORK → PROCESSED`) | Validators deterministic and tied to fixtures | `ValidationReport` pass; `RedactionReceipt` if sensitivity applies; `AggregationReceipt` if applies | Stay in WORK; structured FAIL outcome |
+| **Catalog closure** (`PROCESSED → CATALOG / TRIPLET`) | `EvidenceRef`s resolve; catalog matrix + digests close | `CatalogMatrix` entry; `EvidenceBundle`; graph/triplet projections | HOLD at PROCESSED; no public edge |
+| **Release** (`CATALOG / TRIPLET → PUBLISHED`) | Review state where required; release authority distinct from author when material | `ReleaseManifest`; rollback target; correction path; `ReviewRecord` (if required) | HOLD at CATALOG; no public surface change |
+| **Correction** (`PUBLISHED → PUBLISHED′`) | Detected error or new evidence | `CorrectionNotice` + new `ReleaseManifest` + supersession link | Old release retained for audit |
+
+</details>
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 6. Conditional GET & smart sync
+
+**Polling is conditional. Always.** The first network call on every refresh is a validator probe, not a download.
+
+### 6.1 Order of preference
+
+1. **Object-store event subscription** (preferred when available, e.g., partner-granted S3 / GCS notifications): handler receives the event, compares the recorded validator, performs an optional defensive `HEAD`, then fetches.
+2. **HTTP conditional GET with `If-None-Match`** (strong ETag preferred; weak ETag is advisory).
+3. **`If-Modified-Since`** fallback (Last-Modified-based).
+4. **Manifest SHA-256 verification** if the publisher exposes a checksum manifest.
+5. **Polite full GET** only when none of the above is available — and in that case the watcher MUST record `validators_absent: true` in the `RunReceipt` so downstream gates can downgrade evidence quality.
+
+### 6.2 What gets recorded on a 304 / no-change
+
+A no-change response is **not** a no-op. It is an audited event.
+
+```json
+{
+  "spec_hash": "jcs:sha256:<unchanged>",
+  "source_head": {
+    "etag": "\"<unchanged>\"",
+    "last_modified": "<ISO8601>",
+    "content_length": 0,
+    "source_commit": null
+  },
+  "source_url": "<provider URI>",
+  "decision_log": {
+    "decision_id": "<uuid>",
+    "policy_id": "gate.A.identity",
+    "decision": "no_change",
+    "obligations": []
+  },
+  "target_zone": "RAW",
+  "result": "heartbeat",
+  "kfm_spec_version": "vNext",
+  "timestamp": "<ISO8601 UTC>"
+}
+```
+
+> [!NOTE]
+> A 304 heartbeat **MUST NOT** trigger new STAC items, DCAT distributions, PROV entities, cache invalidation, or layer-manifest churn. The hydrology-domain precedent applies to Habitat: *"Confirmed no-change responses should not create new STAC/DCAT/PROV entities."* Treat any layer-manifest update on a no-change refresh as a regression.
+
+### 6.3 Debounce / coalesce for event-driven sources
+
+For event-driven Habitat inputs (e.g., a partner-granted bucket emitting many small object events), aggregate events into a **delta manifest** over a per-source debounce window. Materialization only happens when the `spec_hash` actually changes.
+
+| Source class (PROPOSED) | Debounce window |
+|---|---|
+| High-churn sensor (e.g., near-real-time vegetation index updates) | 5–30 s |
+| Moderate feed (e.g., partner habitat correction stream) | 30–120 s |
+| Heavy batch (NLCD vintage drop, LANDFIRE release) | 120–300 s |
+
+Window starting numbers are **PROPOSED**; calibrate per source and record per-source materialization rates over time.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 7. Watcher-as-non-publisher
+
+This is the most-violated invariant in source refresh systems and KFM treats it as a **MUST**:
+
+> **A watcher emits receipts and candidate decisions. A watcher does not publish, mutate canonical records, write to `data/catalog/`, write to `data/published/`, write to `release/`, or invalidate caches.**
+
+| Watcher MAY | Watcher MUST NOT |
+|---|---|
+| Fetch into `data/raw/habitat/<source_id>/<run_id>/` | Write to `data/processed/`, `data/catalog/`, `data/published/`, `release/` |
+| Emit `RunReceipt` (signed) | Emit a `ReleaseManifest` |
+| Emit a `RunReceipt` with `decision: quarantine` | Bypass the policy gate by setting `target_zone: PUBLISHED` |
+| Update its own `validators` checkpoint (ETag, Last-Modified, SHA-256) | Update a public-facing layer cache, CDN, or tile host |
+| Mark itself superseded; emit a final receipt | Activate or deactivate layers in the renderer |
+| Hand off to a downstream promotion job via a queue or candidate dossier | Sign anything other than its own `RunReceipt` envelope |
+
+> [!WARNING]
+> A watcher that writes to `data/catalog/`, `data/published/`, or `release/` is a trust-membrane breach. Treat it as a security incident: rotate credentials if the watcher had write paths it should not have had, audit the affected artifacts, and write a runbook entry in `docs/runbooks/` describing the breach and the remediation.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 8. Stale-state markers & supersession
+
+KFM distinguishes **stale** (evidence has aged past its declared tolerance) from **wrong** (substance is incorrect). Both have visible markers; both have traceable lifecycles. A source refresh is one of several events that can resolve stale state — or expose it.
+
+| Marker | Trigger | UI signal | Required action |
+|---|---|---|---|
+| **Source freshness expired** | Cadence in `SourceDescriptor` passed without re-admission | "Stale source" badge in Evidence Drawer | Re-admit via this runbook, or supersede; otherwise mark dependent claims stale |
+| **Schema version drift** | Object schema upgraded past the published claim's version | "Schema drift" badge; link to migration ADR | Migrate, re-validate, re-release; or mark stale |
+| **Geography version drift** | `GeographyVersion` replaced; claim still bound to prior | "Geography version" banner with prior-version citation | Rebind to current `GeographyVersion`; re-release; or mark stale |
+| **Time-scope outside support** | Claim's temporal scope falls outside current support window | "Time out of support" indicator | Mark stale; do not refresh silently |
+| **Model version superseded** | `ModelRunReceipt` references an older model than current | "Model version" badge with new model identity | Re-run; supersede; or mark stale |
+| **Review aged out** | `ReviewRecord` older than the review-cycle tolerance for the lane | "Review aged" badge | Trigger steward review; potentially downgrade tier |
+| **Rights status changed** | Rights change in `SourceDescriptor` | "Rights changed" badge | Re-evaluate tier; potentially downgrade; emit `CorrectionNotice` if necessary |
+| **Policy version changed** | Policy referenced by `PolicyDecision` superseded | "Policy version" badge | Re-run gate; potentially supersede release |
+
+### Supersession behavior
+
+When a Habitat refresh produces a *changed* normalized output, the prior published claim is **not** deleted — it is **superseded**:
+
+- The old `SourceDescriptor` is retained with `superseded_by: <new_source_descriptor_id>` and an entry in the source register.
+- The old `EvidenceBundle` is retained and linked to a `CorrectionNotice` if the change reflects an error rather than a vintage update.
+- The old `ReleaseManifest` becomes the rollback target for the new one.
+- `GeographyVersion` and `Schema` supersession both produce ADR entries and version-register crosswalks.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 9. Sensitivity, rights & geoprivacy gates
+
+Habitat sits next to several sensitive registers. A refresh that flattens that sensitivity is a far worse outcome than a refresh that fails closed.
+
+### 9.1 Deny-by-default register relevant to Habitat
+
+| Class | Default | Required to release | Citation |
+|---|---|---|---|
+| **Rare-species occurrence** (joined to Habitat as context) | DENY exact location | Geoprivacy transform + `RedactionReceipt` + steward review | `[DOM-FAUNA]` / `[DOM-FLORA]` |
+| **Sacred / culturally sensitive places** intersecting Habitat polygons | DENY exact public output | Cultural / steward review + sensitivity transform | `[DOM-ARCH]` |
+| **Source-rights-limited records** (e.g., controlled NatureServe data) | DENY public release | Rights resolution; attribution; no public derivative if barred | `[ENCY]` |
+| **Exact sensitive locations** (rare patch, last-known-population polygon) | DENY by default | Redaction / generalization + audit | `[DOM-DIR]` |
+| **Living-person joins** (private landowner-sensitive context) | DENY exact / public if unclear | Aggregation; permissions; policy review | `[DOM-PEOPLE]` |
+
+### 9.2 Critical habitat vs modeled habitat
+
+The Habitat ubiquitous language is specific here and **must not be flattened**:
+
+- **Regulatory critical habitat** is a designated regulatory category sourced from authoritative agency services (e.g., USFWS ECOS). It carries legal meaning.
+- **Modeled habitat** is a KFM- or partner-produced suitability surface. It carries probabilistic meaning.
+
+A refresh **MUST NOT** allow modeled habitat to be presented as regulatory critical habitat at any surface — drawer, layer, focus, export, or downstream graph. The `modeled-as-critical denial` test is one of the lane's named negative fixtures.
+
+### 9.3 Style filters are not protection
+
+Hiding a sensitive layer in the MapLibre style is **not** a sensitivity protection — the bytes can still be inspected. Sensitive geometry MUST be transformed before publication, not styled away. Sensitivity transforms require receipts and `EvidenceBundle` linkage before publication.
+
+> [!CAUTION]
+> If a refresh produces output that *requires* a style filter to keep something hidden, it is in the wrong place. Roll it back to `WORK` or `QUARANTINE` and apply the geoprivacy transform there.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 10. Validation & policy gates
+
+Each gate produces a structured decision; each decision goes in the `RunReceipt` for that run. The shape below is **PROPOSED** until the mounted policy bundle and validator suite are inspected.
+
+| Gate | Family | Purpose | Pass criterion (PROPOSED) | Fail outcome |
+|---|---|---|---|---|
+| **A — Identity & integrity** | `gate.A.identity` | spec_hash via RFC 8785 JCS + SHA-256; `source_head` validators recorded | `spec_hash` recomputes; validators non-empty (or `validators_absent: true` recorded) | QUARANTINE |
+| **B — License & provenance** | `gate.B.license` | SPDX license recorded and on allowlist | `license.spdx_id` ∈ allowlist; provenance link resolves | QUARANTINE (UNKNOWN → fail) |
+| **C — Schema & geometry QA** | `gate.C.qa` | Schema validates; geometry repair report attached if repairs occurred | Schema valid; area drift within threshold; topology repaired | QUARANTINE |
+| **D — Policy evaluation** | `gate.D.policy` | Rights, sensitivity, source role, release state policy check | `decision == "allow"`; obligations resolvable | DENY / HOLD |
+| **E — Evidence closure** | `gate.E.evidence` | `EvidenceRef → EvidenceBundle` resolves | Bundle resolves; required fields present | ABSTAIN |
+| **F — Attestation** | `gate.F.attest` | DSSE envelope; cosign signature; optional Rekor index | Signature verifies; (if keyless) Rekor inclusion proof valid | DENY |
+| **G — Release** | `gate.G.release` | `ReleaseManifest` + rollback target + review state | All bound; release authority distinct from author when material | HOLD |
+
+### Fail-closed rules before promotion
+
+Any of the following force `target_zone = QUARANTINE` and block promotion:
+
+- Missing or unverifiable signature.
+- `spec_hash` mismatch on recompute.
+- License verdict `fail` or `UNKNOWN`.
+- OPA decision ≠ `allow`.
+- Missing required `evidence_refs`.
+- `confidence_score < 0.6` (where the source produces a confidence field).
+- Sensitivity transform required but receipt absent.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 11. Promotion, correction & rollback
+
+### 11.1 Promotion is a state transition
+
+Promotion to `PUBLISHED` is the act of binding a `ReleaseManifest`. It is **not** the act of copying bytes to `data/published/`. A pipeline that writes to `data/published/` without a bound `ReleaseManifest` has violated the lifecycle invariant.
+
+`ReleaseManifest` references that MUST be present for a Habitat refresh promotion:
+
+- `EvidenceBundle` reference(s)
+- `LayerManifest` reference(s) — public-safe only
+- `PolicyDecision` reference (current bundle version)
+- `ReviewRecord` reference (where required — e.g., for sensitive joins)
+- `RollbackCard` target — pointer to the prior release manifest, artifact digests, and cache-invalidation steps
+- Correction path — how a future `CorrectionNotice` would be issued
+- Signature artifacts (`release/signatures/…`)
+
+### 11.2 Correction lineage
+
+Corrections **never erase lineage**. The old release is retained; the new release supersedes it; a `CorrectionNotice` documents what changed and why. The published catalog continues to expose both the new release and the supersession link.
+
+### 11.3 Rollback drill
+
+Before a Habitat refresh that materially changes a published surface can promote, a rollback drill MUST be runnable against the candidate release:
+
+1. Identify the current `ReleaseManifest` for the affected layer(s).
+2. Author a `RollbackCard` naming: prior manifest digest, artifact digests to restore, cache/CDN invalidation steps, and replay steps.
+3. Dry-run the rollback in a non-public environment; produce a rollback receipt.
+4. Attach the rollback receipt to the release-candidate dossier.
+5. Promotion proceeds **only** after rollback is proven reversible.
+
+> [!IMPORTANT]
+> A release without a tested rollback target is not eligible for promotion. This is non-negotiable for Habitat surfaces because Habitat layers anchor downstream Fauna and Flora joins; a wrong publication propagates fast.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 12. Operator checklist
+
+For a single Habitat source refresh, work top-to-bottom. If any item fails, stop and either remediate or quarantine.
+
+### Pre-flight
+
+- [ ] Confirm `SourceDescriptor` present, current, and `rights ≠ unknown`.
+- [ ] Confirm watcher entry is registered and signed.
+- [ ] Confirm policy bundle version is current and pinned.
+- [ ] Confirm rollback target is identified (even if not yet authored).
+
+### Fetch
+
+- [ ] Conditional probe runs first (`HEAD` / `If-None-Match` / event subscription).
+- [ ] On 304 / no-change: emit heartbeat `RunReceipt`. **STOP.** No public state change.
+- [ ] On change: fetch into `data/raw/habitat/<source_id>/<run_id>/` with retrieval metadata and checksum.
+
+### Normalize & validate
+
+- [ ] Run schema, geometry, time, identity, evidence, and rights validators.
+- [ ] Pass → emit `TransformReceipt` and move to `data/work/habitat/<run_id>/`.
+- [ ] Fail → emit `QUARANTINE` receipt with reason; stop the run; route to steward.
+
+### Catalog closure
+
+- [ ] Resolve all `EvidenceRef`s to `EvidenceBundle`s.
+- [ ] Emit `CatalogMatrix` entry; emit graph/triplet projection.
+- [ ] Run sensitivity policy gate. Apply `RedactionReceipt` / `AggregationReceipt` if needed.
+
+### Promotion
+
+- [ ] Bind `ReleaseManifest` with rollback target.
+- [ ] Run release-gate; obtain signatures.
+- [ ] Activate via `apps/governed-api/` — never directly.
+
+### Post-flight
+
+- [ ] Verify drawer, layer, and focus surfaces reflect the new release (or that 304 heartbeat surfaces unchanged).
+- [ ] File a brief incident entry if any gate failed unexpectedly.
+- [ ] Update the Habitat verification backlog if a `NEEDS VERIFICATION` item was resolved.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 13. Failure modes & responses
+
+| Symptom | Probable cause | Response |
+|---|---|---|
+| 304 response but a new layer manifest was generated anyway | Watcher emitted a manifest on a no-change tick (regression) | Treat as bug; do not promote; capture as negative fixture |
+| Publisher dropped ETag; full GET returned identical bytes | Validator stripping on republish | Compare SHA-256 against prior; emit `validators_absent: true`; downgrade evidence quality label |
+| Policy decision `unknown` | Missing license SPDX or unresolved rights | QUARANTINE; route to rights resolution; do **not** promote |
+| Modeled suitability surface inadvertently joined to "critical habitat" label | Source-role flattening | DENY; reject candidate; run `modeled-as-critical-denial` test; correct labeling pipeline |
+| Sensitive species occurrence reaches `PROCESSED` with exact coordinates | Geoprivacy transform skipped or misconfigured | Roll back to `WORK`; apply geoprivacy transform with receipt; re-run gates |
+| `GeographyVersion` changed mid-refresh | Concurrent geography supersession | Pause refresh; rebind to current `GeographyVersion`; restart from validation |
+| `ReleaseManifest` bound but rollback drill never ran | Out-of-order promotion | Treat as governance breach; immediately author and run a rollback drill; issue `CorrectionNotice` if a public state changed |
+| Watcher wrote to `data/catalog/` or `data/published/` | Trust-membrane breach | Rotate credentials; audit; runbook entry; revert affected artifacts; add static grep test to CI |
+
+<details>
+<summary><strong>Incident escalation path</strong> (PROPOSED — NEEDS VERIFICATION against current governance)</summary>
+
+1. Operator records the failure in the run log with `run_id` and `spec_hash`.
+2. Habitat lane steward acknowledges; classifies as `stale`, `wrong`, `sensitive`, or `membrane breach`.
+3. If `wrong` or `sensitive` reached a public surface: issue `CorrectionNotice`, run rollback, notify Docs steward.
+4. If `membrane breach`: treat per security runbook (TBD — see Directory Rules §10 reference to `docs/runbooks/` for secrets/leak incidents).
+5. Drift entry recorded in `docs/registers/DRIFT_REGISTER.md` if the failure reveals a doctrine vs. implementation gap.
+
+</details>
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 14. Verification backlog
+
+These items are explicitly **not** resolved in this draft. They should be tracked in `docs/registers/VERIFICATION_BACKLOG.md` and addressed via ADR, per-root README, or a follow-up PR.
+
+- **NEEDS VERIFICATION:** Exact path placement of this runbook. The Whole-UI / Governed-AI expansion plan attests flat naming (e.g., `docs/runbooks/ui_LOCAL_DEV.md`). This file uses nested naming (`docs/runbooks/habitat/SOURCE_REFRESH_RUNBOOK.md`). Resolve via a short per-root README in `docs/runbooks/` or an ADR.
+- **NEEDS VERIFICATION:** Whether `data/registry/sources/habitat/` or `data/registry/habitat/` is the live registry home for Habitat `SourceDescriptor`s.
+- **NEEDS VERIFICATION:** Official `SourceDescriptor` records for USFWS critical habitat, KDWP, NLCD, NWI, GAP/LANDFIRE, NatureServe, and PAD-US — current rights, cadence, and endpoints.
+- **NEEDS VERIFICATION:** Habitat geoprivacy transform implementation and the `Geoprivacy transform` field shape on `SourceDescriptor`.
+- **NEEDS VERIFICATION:** Model-card requirements for suitability products under refresh-driven supersession.
+- **NEEDS VERIFICATION:** Habitat MapLibre overlay registry and Focus Mode behavior on stale-state badges.
+- **NEEDS VERIFICATION:** Watcher implementation paths (`tools/ingest/watchers/`) and signing convention.
+- **NEEDS VERIFICATION:** Policy bundle version and Conftest / OPA rule IDs (`gate.A` … `gate.G`).
+- **OPEN:** Should this runbook be paired with a `docs/runbooks/habitat/SOURCE_ADMISSION_RUNBOOK.md` (initial `— → RAW`) and `docs/runbooks/habitat/ROLLBACK_DRILL_RUNBOOK.md`? PROPOSED yes; defer to ADR.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## 15. Related docs
+
+- [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) — placement and lifecycle doctrine
+- [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) *(PROPOSED)* — `RAW → PUBLISHED` invariants
+- [`docs/doctrine/trust-membrane.md`](../../doctrine/trust-membrane.md) *(PROPOSED)* — public-path discipline
+- [`docs/domains/habitat/README.md`](../../domains/habitat/README.md) *(PROPOSED)* — Habitat lane overview
+- [`docs/sources/SOURCE_DESCRIPTOR_STANDARD.md`](../../sources/SOURCE_DESCRIPTOR_STANDARD.md) *(PROPOSED)* — standard descriptor fields
+- [`docs/standards/SMART_SYNC.md`](../../standards/SMART_SYNC.md) *(PROPOSED)* — conditional-GET and event-driven ingest standard
+- [`docs/standards/RUN_RECEIPT.md`](../../standards/RUN_RECEIPT.md) *(PROPOSED)* — canonical `RunReceipt` schema
+- [`docs/runbooks/ui_VALIDATION.md`](../ui_VALIDATION.md) *(PROPOSED)* — UI-side validation that surfaces refresh outcomes
+- [`docs/runbooks/governed_ai_VALIDATION.md`](../governed_ai_VALIDATION.md) *(PROPOSED)* — Focus Mode evidence / citation gates
+- [`docs/registers/VERIFICATION_BACKLOG.md`](../../registers/VERIFICATION_BACKLOG.md) *(PROPOSED)* — verification items home
+- [`docs/registers/DRIFT_REGISTER.md`](../../registers/DRIFT_REGISTER.md) *(PROPOSED)* — drift entries
+
+> [!NOTE]
+> Linked paths follow the canonical responsibility-root layout in Directory Rules. They are **PROPOSED** until verified against the mounted repo; some may currently live in compatibility roots or not yet exist.
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+## Appendix A — Example artifacts
+
+> [!NOTE]
+> The shapes below are **illustrative**. Field names follow the recurring conventions in the Habitat dossier, Encyclopedia, and `New Ideas` `run_receipt` skeleton. They are **PROPOSED** until pinned by a JSON Schema in `schemas/contracts/v1/receipts/` and ratified by ADR.
+
+<details>
+<summary><strong>A.1 — Illustrative <code>RunReceipt</code> for a 304 / no-change Habitat refresh</strong></summary>
+
+```json
+{
+  "spec_hash": "jcs:sha256:<unchanged>",
+  "source_head": {
+    "etag": "\"unchanged-etag\"",
+    "last_modified": "2026-04-01T00:00:00Z",
+    "content_length": 0,
+    "source_commit": null
+  },
+  "source_url": "https://example.gov/nlcd/<vintage>",
+  "decision_log": {
+    "decision_id": "<uuid>",
+    "policy_id": "gate.A.identity",
+    "decision": "no_change",
+    "obligations": []
+  },
+  "license": {
+    "spdx_id": "CC0-1.0",
+    "license_text_ref": "<provider terms URL>"
+  },
+  "evidence_refs": [],
+  "runner_id": "<CI run id>",
+  "timestamp": "2026-05-12T00:00:00Z",
+  "kfm_spec_version": "vNext",
+  "target_zone": "RAW",
+  "result": "heartbeat"
+}
+```
+
+</details>
+
+<details>
+<summary><strong>A.2 — Illustrative <code>RunReceipt</code> for a successful Habitat catalog candidate</strong></summary>
+
+```json
+{
+  "spec_hash": "jcs:sha256:<new-hash>",
+  "source_head": {
+    "etag": "\"new-etag\"",
+    "last_modified": "2026-05-10T00:00:00Z",
+    "content_length": 123456789,
+    "source_commit": "<provider build id>"
+  },
+  "source_url": "https://example.gov/nlcd/<vintage+1>",
+  "decision_log": {
+    "decision_id": "<uuid>",
+    "policy_id": "gate.D.policy",
+    "decision": "allow",
+    "obligations": []
+  },
+  "license": {
+    "spdx_id": "CC0-1.0",
+    "license_text_ref": "<provider terms URL>"
+  },
+  "evidence_refs": [
+    {"type": "evidenceBundle", "uri": "kfm://bundle/<habitat-patch-bundle>"}
+  ],
+  "runner_id": "<CI run id>",
+  "timestamp": "2026-05-12T00:00:00Z",
+  "kfm_spec_version": "vNext",
+  "target_zone": "CATALOG"
+}
+```
+
+</details>
+
+<details>
+<summary><strong>A.3 — Illustrative watcher config snippet for an NLCD-style source</strong></summary>
+
+```yaml
+# tools/ingest/watchers/habitat/nlcd_landcover.yaml   (PROPOSED path)
+id: habitat.nlcd.landcover.v1
+type: http
+source_id: src.habitat.nlcd
+source_role: authority/observation
+rights:
+  spdx_id: CC0-1.0
+  text_ref: <provider terms URL>      # NEEDS VERIFICATION
+cadence:
+  mode: periodic
+  hint: vintage-driven                # actual schedule NEEDS VERIFICATION
+validators:
+  prefer: ["etag", "last-modified"]
+  fallback: "manifest-sha256"
+fail_closed_on_missing:
+  - license_spdx
+  - source_head
+  - spec_hash
+emit:
+  raw_root: data/raw/habitat/${source_id}/${run_id}/
+  receipts_root: data/receipts/ingest/habitat/${run_id}/
+publish: false   # watcher-as-non-publisher: never true
+```
+
+</details>
+
+<sub><a href="#quick-jump">↑ Back to top</a></sub>
+
+---
+
+<sub>**Status:** draft · **Last reviewed:** 2026-05-12 · **Owners:** Habitat lane steward + Docs steward *(TBD)* · **Authority:** PROPOSED until verified against mounted repo</sub>
+
+<sub><a href="#habitat-source-refresh-runbook">↑ Back to top</a></sub>

--- a/docs/runbooks/hazards/NO_NETWORK_TEST_RUNBOOK.md
+++ b/docs/runbooks/hazards/NO_NETWORK_TEST_RUNBOOK.md
@@ -1,3 +1,561 @@
-# hazards :: NO_NETWORK_TEST runbook
+# 🌪️ Hazards — No-Network Test Runbook
 
-Greenfield placeholder.
+> **Run the Hazards domain thin-slice tests against synthetic fixtures with no live source fetches, no network egress, and no public publication path active.** This runbook operationalizes PR-00 (`no-network fixture`) for the Hazards lane: schema validation, source-role anti-collapse, temporal-role validation, emergency-alert denial, operational expiry/freshness, catalog closure, Evidence Drawer disclaimer, and UI no-direct-source — all offline, all evidence-bounded, all reversible.
+
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-hazards-no-network-test
+title: Hazards — No-Network Test Runbook
+type: standard
+version: v1
+status: draft
+owners: TODO (Hazards lane steward + Docs steward + Validation steward)
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/truth-posture.md
+  - docs/doctrine/trust-membrane.md
+  - docs/domains/hazards/README.md
+  - docs/runbooks/README.md
+  - docs/runbooks/governed_ai_VALIDATION.md
+  - docs/adr/ADR-0001-schema-home.md
+tags: [kfm, hazards, runbook, no-network, validation, fixtures, governance]
+notes:
+  - Repository not mounted in this session; all repo-shaped claims are PROPOSED until verified.
+  - This runbook governs the Hazards lane only; cross-domain runs use the runbook root.
+[/KFM_META_BLOCK_V2] -->
+
+[![Status: draft](https://img.shields.io/badge/status-draft-orange)](#)
+[![Authority: PROPOSED](https://img.shields.io/badge/authority-PROPOSED-yellow)](#)
+[![Lane: hazards](https://img.shields.io/badge/lane-hazards-red)](#)
+[![Mode: no--network](https://img.shields.io/badge/mode-no--network-blueviolet)](#)
+[![Lifecycle: RAW%20%E2%86%92%20PUBLISHED](https://img.shields.io/badge/lifecycle-RAW%20%E2%86%92%20PUBLISHED-informational)](#)
+[![Truth posture: cite--or--abstain](https://img.shields.io/badge/truth-cite--or--abstain-success)](#)
+[![Policy: deny--by--default](https://img.shields.io/badge/policy-deny--by--default-critical)](#)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` |
+| **Authority of the runbook structure** | PROPOSED — derived from KFM doctrine; not yet executed against a mounted repo |
+| **Authority of doctrine cited** | CONFIRMED (Directory Rules, lifecycle law, Hazards lane non-emergency posture) |
+| **Owners** | TODO — Hazards lane steward · Validation steward · Docs steward |
+| **Last updated** | 2026-05-12 |
+| **Applies to** | Hazards domain only; cross-domain runs use `docs/runbooks/NO_NETWORK_TEST_RUNBOOK.md` (PROPOSED) |
+| **Not for** | Live source fetches · public publication · life-safety alerting · production rollouts |
+
+---
+
+## 🔭 Quick jump
+
+- [1. Purpose](#1-purpose)
+- [2. Repo fit and placement basis](#2-repo-fit-and-placement-basis)
+- [3. When to use this runbook](#3-when-to-use-this-runbook)
+- [4. Scope and non-goals](#4-scope-and-non-goals)
+- [5. Preconditions](#5-preconditions)
+- [6. Flow at a glance](#6-flow-at-a-glance)
+- [7. The runbook](#7-the-runbook)
+- [8. Expected finite outcomes](#8-expected-finite-outcomes)
+- [9. Hazards source-role posture under no-network](#9-hazards-source-role-posture-under-no-network)
+- [10. Failure handling](#10-failure-handling)
+- [11. Rollback path](#11-rollback-path)
+- [12. Receipts and proof artifacts emitted](#12-receipts-and-proof-artifacts-emitted)
+- [13. Anti-patterns this runbook protects against](#13-anti-patterns-this-runbook-protects-against)
+- [14. Related docs](#14-related-docs)
+- [15. Verification backlog](#15-verification-backlog)
+- [16. Appendix — fixture skeletons](#16-appendix--fixture-skeletons)
+
+---
+
+## 1. Purpose
+
+> **CONFIRMED doctrine / PROPOSED procedure.** The Hazards lane must be able to demonstrate its trust spine — source admission, evidence resolution, policy decision, validation, release state, UI trust payload, correction path, and rollback target — for at least one public-safe proof slice **without contacting any live source and without writing to any public surface.**
+
+This runbook is the operational form of that requirement. It executes the Hazards thin slice — *historical flood / severe-weather event fixture plus NFHL flood context plus exposure summary, with warning feeds disabled or contextual-only* — against synthetic fixtures. It treats the **absence of network** as a first-class invariant of the run, not a deployment accident.
+
+The runbook serves three readers: a developer working a Hazards PR locally; a steward rehearsing release/correction/rollback before broad activation; and a CI workflow whose job is to fail closed on any regression in the Hazards trust posture.
+
+> [!IMPORTANT]
+> **KFM Hazards is not an emergency alert system and must not provide life-safety instructions.** This runbook explicitly tests the denial path that enforces that boundary. If you are operating Hazards material as if it were an alerting product, stop and read [`docs/domains/hazards/README.md`](../../domains/hazards/README.md) (PROPOSED) first.
+
+---
+
+## 2. Repo fit and placement basis
+
+| Aspect | Decision |
+|---|---|
+| **Responsibility root** | `docs/` (human-facing control plane) |
+| **Sub-area** | `docs/runbooks/` (operational procedures) |
+| **Domain segment** | `hazards/` — per Domain Placement Law |
+| **Full path** | `docs/runbooks/hazards/NO_NETWORK_TEST_RUNBOOK.md` |
+| **Directory Rules basis** | §4 Step 1 (responsibility = explains humans → `docs/`); §4 Step 3 (domain appears as a segment, never as a root); §6.1 (`docs/runbooks/` named as a canonical sub-area); §12 (Domain Placement Law) |
+| **Authority of this path** | PROPOSED until verified against mounted-repo evidence |
+
+> [!NOTE]
+> Prior PROPOSED runbook examples in the corpus use a flat naming pattern (e.g. `docs/runbooks/ui_LOCAL_DEV.md`). This runbook adopts the **domain-segment** form (`docs/runbooks/hazards/...`) on the basis that Hazards is one of many domains that will need parallel runbooks; segmenting prevents the `runbooks/` directory from becoming a flat dumping ground as lanes multiply. If a mounted-repo ADR settles a different convention, migrate via §14 of Directory Rules and preserve this file as lineage.
+
+**Inputs accepted here:** lane-specific Hazards operational procedures that run against fixtures only.
+**Inputs that do NOT belong here:**
+- Cross-domain runbooks → `docs/runbooks/` root (no domain segment).
+- ADRs about Hazards schema or policy → `docs/adr/`.
+- Hazards doctrine, source-family analysis, ubiquitous language → `docs/domains/hazards/`.
+- Fixture files themselves → `fixtures/domains/hazards/` (PROPOSED).
+- Validator implementations → `tools/validators/` (PROPOSED).
+- Test specs → `tests/domains/hazards/` (PROPOSED).
+
+---
+
+## 3. When to use this runbook
+
+Use this runbook when:
+
+- You are opening or reviewing a Hazards PR that touches schemas, policy, fixtures, or the governed API surface, and need a deterministic pre-merge gate.
+- You are rehearsing the Hazards thin slice before any live source activation (PR-00 acceptance: *fixture validation passes; no network access*).
+- You are practicing a **rollback drill** against a dry-run Hazards release and need a deterministic baseline to roll back to.
+- A live source endpoint, credential, or rights determination is unresolved and you need to keep building.
+- CI is running on a runner that **must not** have egress (air-gapped or restricted-network environments).
+
+Do **not** use this runbook when:
+
+- You are trying to validate a live source endpoint's current behavior — that is the job of a separate connector acceptance runbook (PROPOSED; not yet authored).
+- You are trying to publish a Hazards layer to a public surface. This runbook intentionally lacks any publish path.
+- You need to test emergency-alert content. KFM does not author or test such content; redirect to official sources.
+
+---
+
+## 4. Scope and non-goals
+
+**In scope.**
+The Hazards lane object families: `HazardEvent`, `HazardObservation`, `WarningContext`, `AdvisoryContext`, `DisasterDeclaration`, `FloodContext`, `WildfireDetection`, `SmokeContext`, `DroughtIndicator`, `EarthquakeEvent`, `HeatColdEvent`, `ExposureSummary`, `ResilienceSummary`, `HazardTimeline`, `ImpactArea`. Their `SourceDescriptor`, `EvidenceRef` → `EvidenceBundle` resolution, `LayerManifest`, `ReleaseManifest`, `CorrectionNotice`, `RollbackCard`, and `RunReceipt` artifacts as exercised by synthetic fixtures.
+
+**Out of scope.**
+- Live NOAA Storm Events, NWS API, FEMA OpenFEMA / NFHL, USGS Earthquake Catalog, NASA FIRMS, NOAA HMS, USGS Water, drought monitor, or state emergency-management endpoints.
+- Real exact sensitive geometry of any kind.
+- Public publication, public tile activation, or any write outside `tests/`, `fixtures/`, `data/work/hazards/`, or local receipt locations.
+- Any AI/Focus Mode interaction with a non-mock adapter.
+
+---
+
+## 5. Preconditions
+
+> [!WARNING]
+> All commands and paths below are **PROPOSED**. The KFM repository was not mounted in this session, so script names, runner choice, and exact CLI flags have not been verified. Treat the commands as a template; align them with mounted-repo conventions during the first execution, and update this runbook with an ADR-tracked change.
+
+| Precondition | What it means | Verification (PROPOSED) |
+|---|---|---|
+| Repo cloned at a known SHA | Reproducibility anchor for receipts | `git rev-parse HEAD` recorded into the run receipt |
+| Network egress disabled or absent | No live source can leak in | Loopback-only environment or runner with no egress |
+| Hazards fixture set present | Synthetic SourceDescriptor / EvidenceBundle / LayerManifest / ReleaseManifest + one HazardEvent | `fixtures/domains/hazards/` populated |
+| Validators present | Schema, source-role, temporal, evidence-closure, policy, citation, release-manifest validators | `tools/validators/` (PROPOSED home) |
+| Policy engine available offline | Conftest/OPA bundle and obligations resolvable from disk | `policy/domains/hazards/` (PROPOSED) |
+| MockAdapter only | No live model provider | `runtime/ai/` adapter pinned to MockAdapter |
+| RunReceipt sink writable | Local receipt directory writable; signing in offline / pinned-key mode if used | `data/receipts/hazards/` (PROPOSED) |
+
+> [!TIP]
+> If keyless cosign would normally sign receipts and Sigstore is unreachable, use the documented pinned-key fallback for the offline run. Record the signing mode in the run receipt so a verifier can tell offline-signed receipts apart from keyless ones.
+
+---
+
+## 6. Flow at a glance
+
+```mermaid
+flowchart TD
+    subgraph No-Network Environment
+        A([Start: clean checkout, no egress]) --> B[Load Hazards synthetic fixtures]
+        B --> C[Schema validation]
+        C --> D[Source-role + temporal-role validators]
+        D --> E[Evidence closure / EvidenceRef → EvidenceBundle]
+        E --> F[Policy gates: rights, sensitivity, emergency-alert denial]
+        F --> G[Catalog / proof closure dry-run]
+        G --> H[LayerManifest + Evidence Drawer payload check]
+        H --> I[Focus Mode via MockAdapter only]
+        I --> J[ReleaseManifest dry-run + RollbackCard drill]
+        J --> K[Emit + verify RunReceipt]
+        K --> L{All finite outcomes match expectations?}
+        L -- yes --> M([PASS — record receipt, link in PR])
+        L -- no --> N([FAIL closed — open DRIFT entry, do not promote])
+    end
+```
+
+> [!NOTE]
+> The diagram reflects the doctrinal flow. **NEEDS VERIFICATION** against actual validator wiring once the repo is mounted; the order of steps C–J may be reordered by validator dependencies surfaced in `tools/validators/` and `tests/domains/hazards/`.
+
+[⬆ Back to top](#-hazards--no-network-test-runbook)
+
+---
+
+## 7. The runbook
+
+Steps are written in execution order. Each step lists a goal, a representative command template, and a fail-closed expectation. Commands are templates — adapt to the mounted repo's actual runner and script names.
+
+### 7.1 Disable egress and confirm the environment
+
+**Goal.** Make network failure the default. A test that passes by accidentally reaching the internet is not a no-network test.
+
+```bash
+# PROPOSED — verify against repo's actual offline-runner setup
+unset HTTP_PROXY HTTPS_PROXY ALL_PROXY
+export NO_PROXY="*"
+# Optional: deny egress at the OS / container level (mounted-repo specific)
+```
+
+> [!CAUTION]
+> If a step in this runbook ever appears to need network — to fetch a schema, validate a citation, resolve a source endpoint, sign a receipt against a transparency log — **stop**. That step has drifted out of no-network scope and must be either re-pointed at a local mirror, switched to pinned-key/offline mode, or moved to a different runbook.
+
+### 7.2 Load Hazards synthetic fixtures
+
+**Goal.** Bring up the minimum object set the Hazards lane needs to demonstrate a closed trust spine.
+
+Required synthetic objects (one valid + one invalid + one denied + one abstention + one rollback/correction for each — see §16 for skeletons):
+
+- `SourceDescriptor` for each Hazards source family (authority / observation / context / model role variants).
+- `HazardEvent` (historical), `FloodContext` (regulatory), `WildfireDetection` (remote-sensing), `WarningContext` (operational, expired), `DisasterDeclaration` (administrative).
+- `EvidenceBundle` for at least one HazardEvent feature.
+- `LayerManifest` for the public-safe historical event layer.
+- `ReleaseManifest` with a release candidate and `rollback_target` pointing to a prior fixture release.
+- `CorrectionNotice` and `RollbackCard` skeletons.
+- One `sensitive-geometry deny fixture` (public-safe transformed; **never** real exact location).
+- One `stale-source fixture` (expired `WarningContext`).
+
+### 7.3 Schema validation
+
+**Goal.** Every object validates against its schema; every invalid fixture fails as expected.
+
+```bash
+# PROPOSED — substitute with mounted-repo validator entry point
+kfm-validate schemas \
+  --root schemas/contracts/v1/domains/hazards \
+  --fixtures fixtures/domains/hazards \
+  --strict --no-network
+```
+
+Expected: all valid fixtures pass; every invalid fixture fails with a deterministic reason code. **NEEDS VERIFICATION** of exact tool name, flags, and exit semantics.
+
+### 7.4 Source-role and temporal-role validators
+
+**Goal.** Prove that a source authorized as `observation` cannot be silently used as `authority`, and that `event time`, `valid time`, `issue/expiry time`, `source time`, `retrieval time`, `release time`, and `correction time` stay distinct where material.
+
+Key denial cases:
+
+- Operational warning used as historical event of record → **DENY**.
+- Model output presented as observation → **DENY**.
+- Regulatory NFHL flood context represented as observed inundation → **DENY**.
+
+### 7.5 Evidence closure
+
+**Goal.** Every claim in a Hazards `EvidenceDrawerPayload` resolves to an `EvidenceBundle` via its `EvidenceRef`. Claims that cannot resolve cause **ABSTAIN**, not silent omission.
+
+### 7.6 Policy gates
+
+**Goal.** Run the Hazards policy bundle (rights, sensitivity, emergency-alert denial, redaction, freshness, release-state) against fixtures.
+
+Required denials (all **DENY**):
+
+- Unreviewed exact sensitive Hazards locations → public path.
+- Unknown rights or unresolved source role → public promotion.
+- Operational warning whose `expiry` is past → presented as current.
+- Any attempt to phrase Hazards output as life-safety instruction.
+
+### 7.7 Catalog / proof closure dry-run
+
+**Goal.** A release candidate's `CatalogMatrix`, `DatasetVersion`, `ValidationReport`, and `EvidenceBundle` set must form a closed proof — no orphan artifacts, no broken refs.
+
+### 7.8 LayerManifest and Evidence Drawer payload check
+
+**Goal.** The proposed public-safe Hazards layer's `LayerManifest` is well-formed and reads only released manifests. The `EvidenceDrawerPayload` for a clicked feature surfaces source role, rights, sensitivity, freshness, release state, and limitations — including the Hazards **not-for-life-safety** disclaimer.
+
+### 7.9 Focus Mode via MockAdapter only
+
+**Goal.** A Focus Mode question routed to the governed API returns a finite `RuntimeResponseEnvelope` (`ANSWER` / `ABSTAIN` / `DENY` / `ERROR`) with an `AIReceipt` and a `CitationValidationReport`. No live model provider is reachable; the adapter is pinned to MockAdapter.
+
+Required behaviors:
+
+- Question backed by a resolvable `EvidenceBundle` → **ANSWER** with valid citations.
+- Question whose evidence is missing → **ABSTAIN**.
+- Question that asks for life-safety guidance or sensitive exact geometry → **DENY**.
+- Adapter failure → **ERROR** (never a fabricated answer).
+
+### 7.10 ReleaseManifest dry-run and rollback drill
+
+**Goal.** Produce a `ReleaseManifest` *candidate* — never a published release — with a `rollback_target`, `correction_notice` path, and `RollbackCard`. Execute the rollback drill against the dry-run release and verify the receipt.
+
+```bash
+# PROPOSED
+kfm-release dry-run \
+  --domain hazards \
+  --candidate <id> \
+  --no-public-write
+kfm-rollback drill \
+  --release <id> \
+  --target <prior-release-id>
+```
+
+### 7.11 Emit and verify the RunReceipt
+
+**Goal.** A signed `RunReceipt` records inputs (fixture set, git SHA), outputs (validator outcomes, decision envelopes), `spec_hash`, tool versions, actor, timestamps, signing mode, and `source_head` markers (which, in no-network mode, are the fixture digests rather than upstream `ETag`/`Last-Modified`). The receipt is the proof that this run happened, on this code, with these fixtures, and produced these decisions.
+
+[⬆ Back to top](#-hazards--no-network-test-runbook)
+
+---
+
+## 8. Expected finite outcomes
+
+Every Hazards governed surface returns one of four outcomes. The no-network run pins fixtures to make these outcomes deterministic.
+
+| Surface | Outcome under valid fixture | Outcome under invalid / restricted fixture |
+|---|---|---|
+| Hazards feature/detail resolver | `ANSWER` | `ABSTAIN` (evidence) · `DENY` (rights / sensitivity / emergency) · `ERROR` (malformed) |
+| Hazards layer manifest resolver | `ANSWER` | `DENY` (unreleased / sensitive) · `ERROR` |
+| Hazards Evidence Drawer payload | `ANSWER` | `ABSTAIN` · `DENY` · `ERROR` |
+| Hazards Focus Mode answer (MockAdapter) | `ANSWER` | `ABSTAIN` · `DENY` · `ERROR` |
+| ReleaseManifest dry-run | promotion candidate produced | candidate rejected with reasons |
+| Rollback drill | `RollbackCard` receipt | drill failure recorded; no public effect |
+
+> [!IMPORTANT]
+> A passing run produces **zero** uncited public claims, **zero** life-safety phrasings, and **zero** writes to `data/published/`. If any of those three counters is nonzero, the run has not passed regardless of validator green-checks.
+
+---
+
+## 9. Hazards source-role posture under no-network
+
+| Source family (PROPOSED) | Permitted roles | Forbidden uses in this run |
+|---|---|---|
+| NOAA Storm Events / NCEI-style records | authority / observation / context (historical) | Used as live warning surface |
+| NWS alerts / warnings / advisories / watches | context (operational, dated) | Used as life-safety alert · used past expiry · used as observed event |
+| FEMA Disaster Declarations / OpenFEMA | authority (administrative) | Used to imply current emergency |
+| FEMA NFHL / MSC flood hazard | context (regulatory) | Used as observed inundation |
+| USGS Earthquake Catalog | authority / observation | Used as forecast or warning |
+| NOAA HMS Fire and Smoke | observation / context | Used as life-safety instruction |
+| NASA FIRMS active fire | observation (detection) | Used as confirmed ground truth without corroboration |
+| Kansas / local emergency context | context | Used as primary truth source |
+
+> [!CAUTION]
+> Rights and current terms for every source listed above are **NEEDS VERIFICATION**. No-network mode does not absolve the rights determination — it defers the *fetch*, not the *posture*. Sensitive joins remain fail-closed.
+
+---
+
+## 10. Failure handling
+
+When a step fails, prefer **honest incompleteness** over a green build. The procedure below is reversible and audit-friendly.
+
+1. **Capture.** Save the failing output, the run receipt (if emitted), and the affected fixture IDs.
+2. **Classify.** Is the failure (a) a validator finding a real defect, (b) a fixture authoring error, (c) a validator bug, (d) drift between schemas and contracts, or (e) drift between Directory Rules and repo structure?
+3. **Open a drift or backlog entry.**
+   - Real defect → fix in the PR; re-run.
+   - Fixture error → fix the fixture; do **not** weaken the validator.
+   - Validator bug → open an issue; pin the validator if needed; do not silence it.
+   - Schema/contract drift → resolve via ADR; mark affected paths `PROPOSED / CONFLICTED`.
+   - Directory-Rules drift → add entry in `docs/registers/DRIFT_REGISTER.md` per Directory Rules §2.5.
+4. **Do not promote.** The release candidate stays in `release/candidates/hazards/` until the next clean run.
+
+> [!WARNING]
+> Never adjust a Hazards fixture to make a denial test pass. The denial tests *are the product*: they prove the lane cannot be turned into an emergency alert system, cannot publish sensitive geometry, and cannot present stale warnings as current.
+
+---
+
+## 11. Rollback path
+
+For this runbook itself:
+
+- This file is doctrine; reverting the PR that added it restores the prior state. No data is moved by adopting or reverting the runbook.
+
+For a Hazards run executed against this runbook:
+
+| Symptom | Rollback action |
+|---|---|
+| Dry-run ReleaseManifest accidentally referenced a real (non-fixture) source | Revert the candidate; open a drift entry; verify `no-public-write` invariant restored |
+| Rollback drill failed to restore the prior `ReleaseManifest` | Restore the prior `release_id` manually and record the discrepancy in the run receipt |
+| RunReceipt signing failed | Re-run with pinned-key fallback; do not promote unsigned receipts |
+| MockAdapter silently fell through to a live provider | Disable adapter; treat as a `WARNING`-class governance incident; review `runtime/ai/` config |
+
+---
+
+## 12. Receipts and proof artifacts emitted
+
+| Artifact | Schema (PROPOSED home) | What it proves |
+|---|---|---|
+| `RunReceipt` | `schemas/contracts/v1/proofs/run_receipt.schema.json` | What ran, on what code, against which fixtures, with which tool versions |
+| `ValidationReport` | `schemas/contracts/v1/proofs/validation_report.schema.json` | Schema, source-role, temporal, evidence, and policy outcomes |
+| `CitationValidationReport` | `schemas/contracts/v1/evidence/citation_validation_report.schema.json` | Every cited `EvidenceRef` resolved within scope |
+| `PolicyDecision` | `schemas/contracts/v1/policy/policy_decision.schema.json` | Allow/deny with finite outcome and obligations |
+| `PromotionDecision` | `schemas/contracts/v1/release/promotion_decision.schema.json` | Gate outcomes, reviewer, rollback target |
+| `AIReceipt` | `schemas/contracts/v1/ai/ai_receipt.schema.json` | MockAdapter execution audit trail |
+| `ReleaseManifest` (candidate) | `schemas/contracts/v1/release/release_manifest.schema.json` | Dry-run release with rollback target |
+| `RollbackCard` | `schemas/contracts/v1/release/rollback_card.schema.json` | Rollback drill receipt |
+| `CorrectionNotice` (skeleton) | `schemas/contracts/v1/release/correction_notice.schema.json` | Correction path is live, not theoretical |
+
+All schema paths above are **PROPOSED** per Directory Rules §7.4 / ADR-0001; mounted-repo conventions may differ.
+
+---
+
+## 13. Anti-patterns this runbook protects against
+
+| Anti-pattern | What it would look like | What this runbook does about it |
+|---|---|---|
+| Generation-as-truth | A MockAdapter "answer" presented without an `EvidenceBundle` | `CitationValidationReport` forces **ABSTAIN** |
+| Operational warning as historical event | An expired `WarningContext` written into `HazardEvent` | Source-role + temporal-role validators **DENY** |
+| Sensitive-geometry leak | Exact location reaching a fixture or a candidate `LayerManifest` | Sensitive-geometry deny fixture **DENY** |
+| Direct browser-to-canonical fetch | UI reading `data/processed/` or RAW sources | UI no-direct-source test fails the run |
+| Life-safety phrasing | Output drifts toward "evacuate" / "shelter" instructions | Emergency-alert denial test **DENY** |
+| Silent promotion | Release written without proof closure | Catalog closure + ReleaseManifest dry-run **REJECT** |
+| Irreversible release | No `rollback_target` recorded | Rollback drill **FAIL** before promotion |
+| Network "convenience" call | A validator quietly fetches a schema or asset | No-network environment makes the call **ERROR** |
+
+---
+
+## 14. Related docs
+
+- [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) — placement authority; §4 Step 3 and §12 cited above.
+- [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED.
+- [`docs/doctrine/truth-posture.md`](../../doctrine/truth-posture.md) — cite-or-abstain.
+- [`docs/doctrine/trust-membrane.md`](../../doctrine/trust-membrane.md) — governed-API boundary.
+- [`docs/domains/hazards/README.md`](../../domains/hazards/README.md) — Hazards lane identity, scope, non-ownership, ubiquitous language. **PROPOSED**.
+- [`docs/runbooks/README.md`](../README.md) — runbooks root README. **PROPOSED**.
+- [`docs/runbooks/governed_ai_VALIDATION.md`](../governed_ai_VALIDATION.md) — Focus Mode validation runbook. **PROPOSED**.
+- [`docs/runbooks/ui_VALIDATION.md`](../ui_VALIDATION.md) — UI validation runbook (cross-lane). **PROPOSED**.
+- [`docs/adr/ADR-0001-schema-home.md`](../../adr/ADR-0001-schema-home.md) — schema home decision underpinning the schema paths quoted here.
+
+> [!NOTE]
+> Every related path is **PROPOSED** until verified against mounted-repo evidence. If a target file is named differently in the actual repo, fix the link rather than the convention, and record the rename via a Directory Rules §14 migration note.
+
+---
+
+## 15. Verification backlog
+
+| Item | What would settle it | Status |
+|---|---|---|
+| Exact validator entry-point names and flags | Mounted-repo `tools/validators/` and CI workflow files | NEEDS VERIFICATION |
+| Hazards fixture directory and file names | Mounted-repo `fixtures/domains/hazards/` | NEEDS VERIFICATION |
+| Policy bundle for Hazards (rights, sensitivity, emergency-alert) | Mounted-repo `policy/domains/hazards/` | NEEDS VERIFICATION |
+| Schema homes for Hazards object families | Mounted-repo `schemas/contracts/v1/domains/hazards/` | NEEDS VERIFICATION |
+| Receipt signing mode (keyless vs. pinned-key fallback) | Mounted-repo signing config + offline policy | NEEDS VERIFICATION |
+| Runbook flat-naming vs. domain-segment convention | Accepted ADR or §14 migration note | PROPOSED |
+| Cross-domain `NO_NETWORK_TEST_RUNBOOK.md` parent | `docs/runbooks/NO_NETWORK_TEST_RUNBOOK.md` | PROPOSED |
+| Live source rights / endpoints for every Hazards source | Source descriptor entries with rights + cadence + steward | NEEDS VERIFICATION |
+| Emergency-alert boundary enforcement coverage | Negative tests + policy denials passing on red lane | NEEDS VERIFICATION |
+| Release / correction / rollback drill record for Hazards | Drilled `ReleaseManifest` + `RollbackCard` receipts | NEEDS VERIFICATION |
+
+---
+
+## 16. Appendix — fixture skeletons
+
+> [!NOTE]
+> These skeletons are **illustrative**. Field names track the corpus's object-family conventions; exact JSON Schema shape is **NEEDS VERIFICATION** against `schemas/contracts/v1/...`.
+
+<details>
+<summary><b>Synthetic <code>SourceDescriptor</code> (Hazards observation role)</b></summary>
+
+```json
+{
+  "source_id": "fixture:hazards:noaa-storm-events:historical",
+  "source_family": "NOAA Storm Events",
+  "role": "observation",
+  "rights_status": "fixture/synthetic",
+  "sensitivity": "public",
+  "cadence": "historical",
+  "freshness_state": "static",
+  "limitations": [
+    "synthetic fixture; not a real source admission",
+    "not for life-safety use under any circumstance"
+  ],
+  "spec_hash": "sha256:<computed>",
+  "fixture_marker": true
+}
+```
+
+</details>
+
+<details>
+<summary><b>Synthetic <code>HazardEvent</code> (historical flood)</b></summary>
+
+```json
+{
+  "id": "fixture:hazards:hazard-event:hist-flood-1903",
+  "object_role": "historical_event_record",
+  "kind": "flood",
+  "geometry": { "type": "Polygon", "coordinates": [[/* public-safe generalized */]] },
+  "time": {
+    "event_time": "1903-05-29",
+    "valid_time": { "start": "1903-05-29", "end": "1903-06-06" },
+    "source_time": "fixture-authoring",
+    "retrieval_time": null,
+    "release_time": null,
+    "correction_time": null
+  },
+  "source_refs": ["fixture:hazards:noaa-storm-events:historical"],
+  "evidence_refs": ["fixture:hazards:evidence-bundle:hist-flood-1903"],
+  "fixture_marker": true
+}
+```
+
+</details>
+
+<details>
+<summary><b>Synthetic <code>WarningContext</code> (expired — should ABSTAIN/DENY as current)</b></summary>
+
+```json
+{
+  "id": "fixture:hazards:warning-context:expired-2024-04-15",
+  "object_role": "operational_warning",
+  "issued_at": "2024-04-15T18:00:00Z",
+  "expires_at": "2024-04-15T22:00:00Z",
+  "freshness_state": "expired",
+  "source_refs": ["fixture:hazards:nws:context"],
+  "expected_outcome_for_current_state_query": "DENY",
+  "fixture_marker": true
+}
+```
+
+</details>
+
+<details>
+<summary><b>Sensitive-geometry deny fixture (must never publish)</b></summary>
+
+```json
+{
+  "id": "fixture:hazards:sensitive-geometry-deny",
+  "geometry": { "type": "Point", "coordinates": [/* public-safe transformed */] },
+  "sensitivity_label": "restricted_exact_location",
+  "attempted_public_artifact": "data/published/layers/hazards/<would-be-layer>",
+  "expected_policy_outcome": "DENY",
+  "fixture_marker": true
+}
+```
+
+</details>
+
+<details>
+<summary><b>Skeleton <code>RunReceipt</code> for a no-network run</b></summary>
+
+```json
+{
+  "run_id": "run:hazards:no-network:<utc-timestamp>",
+  "inputs": {
+    "git_sha": "<commit>",
+    "fixture_set": "fixtures/domains/hazards@<sha>",
+    "validator_versions": { "<validator>": "<version>" }
+  },
+  "outputs": {
+    "validation_report_ref": "data/proofs/hazards/<id>.json",
+    "policy_decisions": ["..."],
+    "release_candidate_ref": "release/candidates/hazards/<id>.json"
+  },
+  "spec_hash": "sha256:<computed>",
+  "actor": "<runner-or-user>",
+  "signing_mode": "pinned-key-offline | keyless",
+  "network_egress": false,
+  "source_head": { "note": "no-network — fixture digests substitute for ETag/Last-Modified" },
+  "fixture_marker": true
+}
+```
+
+</details>
+
+[⬆ Back to top](#-hazards--no-network-test-runbook)
+
+---
+
+> _Related: [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) · [`docs/domains/hazards/README.md`](../../domains/hazards/README.md) · [`docs/runbooks/README.md`](../README.md)_
+> _Last updated: 2026-05-12 · Status: `draft` · Authority: PROPOSED until verified against mounted-repo evidence._
+> _[⬆ Back to top](#-hazards--no-network-test-runbook)_

--- a/docs/runbooks/hazards/PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/hazards/PROMOTION_RUNBOOK.md
@@ -1,3 +1,566 @@
-# hazards :: PROMOTION runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-hazards-promotion
+title: Hazards Promotion Runbook
+type: standard
+version: v1
+status: draft
+owners: TODO — Hazards domain steward + Release authority
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/truth-posture.md
+  - docs/doctrine/trust-membrane.md
+  - docs/domains/hazards/README.md
+  - docs/runbooks/ui_VALIDATION.md
+  - docs/runbooks/ui_ROLLBACK.md
+  - release/manifests/README.md
+tags: [kfm, hazards, runbook, promotion, governance, lifecycle, release]
+notes:
+  - Procedural counterpart to the Hazards domain README and lifecycle doctrine.
+  - All implementation-specific paths, validator names, and CI workflow names are PROPOSED until verified against the mounted repository.
+  - Path itself (docs/runbooks/hazards/PROMOTION_RUNBOOK.md) is PROPOSED — see §2 of the companion notes.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Hazards Promotion Runbook
+
+> **Step-by-step, fail-closed procedure for promoting Hazards-domain candidates from `RAW` through `PUBLISHED`. KFM Hazards is not a life-safety alerting system. Promotion is a governed state transition, not a file move.**
+
+![Status: draft](https://img.shields.io/badge/status-draft-orange)
+![Domain: Hazards](https://img.shields.io/badge/domain-hazards-8a1f1f)
+![Lifecycle: RAW→PUBLISHED](https://img.shields.io/badge/lifecycle-RAW%E2%86%92PUBLISHED-2b6cb0)
+![Policy: fail-closed](https://img.shields.io/badge/policy-fail--closed-555)
+![Truth posture: cite-or-abstain](https://img.shields.io/badge/truth-cite--or--abstain-1f7a3f)
+![Last updated: 2026-05-12](https://img.shields.io/badge/updated-2026--05--12-lightgrey)
+
+<!-- Badge targets are TODO placeholders until CI surface names and ADR coordinates are verified against the mounted repo. -->
+
+| Status | Owners | Reviewers (PROPOSED) | Last updated |
+|---|---|---|---|
+| `draft` | TODO — Hazards domain steward | Hazards domain steward · Source steward · Sensitivity reviewer · Release authority · Docs steward | 2026-05-12 |
+
+---
+
+## Quick jump
+
+- [1. Purpose](#1-purpose)
+- [2. Scope and explicit non-ownership](#2-scope-and-explicit-non-ownership)
+- [3. Pipeline at a glance](#3-pipeline-at-a-glance)
+- [4. Promotion preconditions](#4-promotion-preconditions)
+- [5. Promotion gates (Hazards profile)](#5-promotion-gates-hazards-profile)
+- [6. Roles and separation of duties](#6-roles-and-separation-of-duties)
+- [7. Step-by-step procedure](#7-step-by-step-procedure)
+- [8. Hazards-specific denial conditions](#8-hazards-specific-denial-conditions)
+- [9. Validators, tests, and fixtures](#9-validators-tests-and-fixtures)
+- [10. Correction and rollback](#10-correction-and-rollback)
+- [11. Worked example and negative fixtures](#11-worked-example-and-negative-fixtures)
+- [12. FAQ and common decisions](#12-faq-and-common-decisions)
+- [13. Related docs](#13-related-docs)
+- [14. Verification backlog](#14-verification-backlog)
+
+---
+
+## 1. Purpose
+
+This runbook describes **how a Hazards-domain candidate becomes a publicly released artifact** inside Kansas Frontier Matrix (KFM). It is the operational complement to:
+
+- **`docs/doctrine/lifecycle-law.md`** — the lifecycle invariant (`RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`). [CONFIRMED doctrine]
+- **`docs/doctrine/trust-membrane.md`** — the rule that public surfaces consume governed APIs, never canonical/internal stores. [CONFIRMED doctrine]
+- **`docs/doctrine/truth-posture.md`** — cite-or-abstain. [CONFIRMED doctrine]
+- **`docs/domains/hazards/README.md`** — Hazards domain scope, source families, and object families. [PROPOSED path; CONFIRMED content origin]
+
+The runbook is **prescriptive for stewards and reviewers** and **descriptive for everyone else**. It does not invent doctrine; it operationalizes it for one domain.
+
+> [!IMPORTANT]
+> **KFM Hazards is not an emergency-alert system.** It governs historical events, regulatory context, modeled derivatives, and operational warning/advisory/watch *context only*. All life-safety routing flows to official sources. Promotion that would let KFM read as a life-safety authority MUST be denied. *[CONFIRMED doctrine — see Domains Culmination Atlas §12.B and Encyclopedia §7.10.A.]*
+
+---
+
+## 2. Scope and explicit non-ownership
+
+### 2.1 In scope (Hazards owns)
+
+CONFIRMED doctrine / PROPOSED field realization. The Hazards domain owns the following object families and promotes them through this runbook:
+
+| Object family | Purpose summary |
+|---|---|
+| `HazardEvent` | Historical event record (storm, flood, wildfire, etc.). |
+| `HazardObservation` | Scientific or remote-sensing observation. |
+| `WarningContext` | Operational warning *as context only*, never as life-safety authority. |
+| `AdvisoryContext` | Operational advisory as context only. |
+| `DisasterDeclaration` | Administrative declaration (FEMA / state). |
+| `FloodContext` | Regulatory flood context (NFHL / MSC) — **not** observed inundation. |
+| `WildfireDetection` | Remote-sensing detection (e.g., FIRMS) — detection, not ground truth. |
+| `SmokeContext` | Smoke product (e.g., NOAA HMS). |
+| `DroughtIndicator` | Drought monitor indicator. |
+| `EarthquakeEvent` | USGS earthquake catalog record. |
+| `HeatColdEvent` | Heat/cold operational or historical event. |
+| `ExposureSummary` / `ResilienceSummary` | Derived analytical summaries. |
+| `HazardTimeline` / `ImpactArea` | Role-aware timeline and impact-area derivatives. |
+
+*[Object-family list CONFIRMED from Encyclopedia §7.10.C and Domains Culmination Atlas §12.E.]*
+
+### 2.2 Out of scope (Hazards does **not** own)
+
+> [!WARNING]
+> A promotion request that crosses these lines MUST be denied at the policy gate, regardless of approval signals elsewhere.
+
+- **Life-safety instructions / emergency-alert authority.** Always redirect to official sources. *[CONFIRMED doctrine.]*
+- **Hydrology canonical claims** (HUC, gauges, observed flood evidence) — owned by Hydrology, even when Hazards links to them.
+- **Atmosphere/Air canonical claims** (AQI, weather observation, climate normals) — owned by Atmosphere/Air.
+- **Settlements / Infrastructure canonical claims** — owned by Settlements/Infrastructure; Hazards may reference exposure but does not own asset identity.
+- **Roads / Rail canonical claims** — owned by Roads/Rail; Hazards may reference closure/detour context with role separation.
+
+---
+
+## 3. Pipeline at a glance
+
+The Hazards lane follows the CONFIRMED lifecycle invariant. **Each transition is governed; none is a file copy.**
+
+```mermaid
+flowchart LR
+    A[RAW<br/>SourceDescriptor exists] -->|ingest receipt| B[WORK / QUARANTINE<br/>schema · geometry · time · identity · evidence · rights · policy]
+    B -->|validation + policy pass| C[PROCESSED<br/>EvidenceRef · ValidationReport · digest closure]
+    B -.->|fail-closed hold| Q[(QUARANTINE<br/>reason recorded)]
+    C -->|catalog closure| D[CATALOG / TRIPLET<br/>EvidenceBundle · graph projection · release candidate]
+    D -->|ReleaseManifest + rollback target + review state| E[PUBLISHED<br/>served via governed APIs]
+    E -.->|CorrectionNotice| F[Superseding release]
+    E -.->|RollbackCard| G[Prior safe release]
+
+    classDef gov fill:#fef3c7,stroke:#92400e,stroke-width:1px;
+    classDef pub fill:#dcfce7,stroke:#166534,stroke-width:1px;
+    classDef quar fill:#fee2e2,stroke:#991b1b,stroke-width:1px;
+    class A,B,C,D gov;
+    class E,F pub;
+    class Q,G quar;
+```
+
+> [!NOTE]
+> *Promotion is a governed state transition, not a file move.* *[CONFIRMED — Directory Rules §0; Lifecycle invariant.]* The diagram is logical; the underlying objects (`SourceDescriptor`, `EvidenceBundle`, `ReleaseManifest`, `RollbackCard`) live in their canonical homes per Directory Rules §6.
+
+---
+
+## 4. Promotion preconditions
+
+A Hazards candidate MUST satisfy **all** of the following before any reviewer is asked to approve PUBLISHED state. Missing any condition is grounds for `HOLD`, `DENY`, or `QUARANTINE`.
+
+| # | Precondition | Artifact / evidence | Status |
+|---|---|---|---|
+| 1 | Source admission complete | `SourceDescriptor` with role, rights, sensitivity, citation, time, hash | CONFIRMED requirement / PROPOSED schema home |
+| 2 | Schema validation green | `ValidationReport` against `schemas/contracts/v1/domains/hazards/…` | PROPOSED schema path |
+| 3 | Identity rule applied | Deterministic id: source id + object role + temporal scope + normalized digest | PROPOSED basis |
+| 4 | Temporal-role validation green | Source / observed / valid / retrieval / release / correction times remain distinct where material | CONFIRMED doctrine |
+| 5 | Source-role anti-collapse green | No upcast of observation→authority, model→observation, etc. | PROPOSED test |
+| 6 | Rights resolved | SPDX / terms recorded; ambiguous → `QUARANTINE` | CONFIRMED doctrine |
+| 7 | Sensitivity resolved | Tier assigned; sensitive joins fail closed | CONFIRMED doctrine |
+| 8 | Evidence closure | `EvidenceRef` resolves to `EvidenceBundle`; bundle digest closed | CONFIRMED doctrine |
+| 9 | Catalog closure | `DatasetVersion` + `ValidationReport` present and consistent | CONFIRMED doctrine |
+| 10 | `spec_hash` parity | Recorded `spec_hash` equals fresh JCS+SHA-256 recomputation | CONFIRMED pattern *(corpus: New Ideas 5-8-26, C5-04)* |
+| 11 | Release review state | `ReviewRecord` with required reviewer signatures | CONFIRMED doctrine / PROPOSED implementation |
+| 12 | `ReleaseManifest` valid | Manifest present, schema-valid, points to closed bundle | CONFIRMED doctrine |
+| 13 | Rollback target present | `RollbackCard` references a prior safe release | CONFIRMED doctrine |
+| 14 | Correction path declared | Public correction route defined for this release | CONFIRMED doctrine |
+| 15 | Emergency-alert boundary check | Candidate is **not** framed or routed as a life-safety authority | CONFIRMED doctrine |
+
+> [!CAUTION]
+> If **any** of conditions 1–8 are unresolved, the only valid outcomes are `QUARANTINE` (gather evidence), `DENY` (policy violation), or `ABSTAIN` (insufficient evidence). Do not "soft-promote" into `CATALOG / TRIPLET` to make the queue look healthier.
+
+---
+
+## 5. Promotion gates (Hazards profile)
+
+KFM uses a default-deny promotion-gate pattern. The structural gate is CONFIRMED in attached doctrine; the gate **labels** and **CI job names** below are PROPOSED until verified against the mounted repository.
+
+| Gate | What it checks | Hazards specifics | Status |
+|---|---|---|---|
+| **A — Identity & integrity** | `spec_hash` parity; source HEAD probe (`ETag`, `Last-Modified`) | Stamp source role (`authority` / `observation` / `context` / `model`) on the receipt | CONFIRMED doctrine / PROPOSED gate name |
+| **B — Rights & provenance** | SPDX allowlist; `SourceDescriptor` rights confirmed | NOAA / NWS / FEMA / USGS / NASA / Kansas-local terms recorded | CONFIRMED doctrine / PROPOSED allowlist |
+| **C — Sensitivity & policy** | Sensitivity tier; redaction obligations satisfied | Sensitive joins fail closed (e.g., infrastructure exposure joined to private parcels) | CONFIRMED doctrine |
+| **D — Evidence closure** | `EvidenceRef` → `EvidenceBundle`; bundle digest closed | One Hazard object → one resolvable bundle | CONFIRMED doctrine |
+| **E — Temporal & source-role anti-collapse** | Times remain distinct; no role upcast | **Stale operational warning MUST NOT appear as current warning state.** | CONFIRMED doctrine |
+| **F — Review state** | `ReviewRecord` present and sufficient | Sensitivity reviewer required for any sensitive-join derivative | CONFIRMED doctrine |
+| **G — Release infrastructure** | `ReleaseManifest` valid; rollback target present; correction path declared | Cite-or-abstain UI behavior verified for the candidate layer | CONFIRMED doctrine |
+
+The structural rule, lifted from the attached policy starter, is:
+
+```rego
+# PROPOSED — minimal promotion check, illustrative.
+# Real policy bundle is pinned by OCI digest in CI; this is a documentation excerpt.
+package gates.promotion
+
+import data.common
+
+default allow = false
+default reasons = []
+
+allow {
+    input.action == "promote"
+    input.resource.policy_label != ""
+    input.resource.spec_hash != ""
+    input.resource.release_review == "approved"
+    count(blockers) == 0
+}
+
+blockers := [o |
+    o := obligations[_]
+    o.type == "hold" or o.type == "deny"
+]
+```
+
+> [!NOTE]
+> The snippet above is illustrative and follows the corpus pattern (`New_Ideas_5-8-26.pdf` — Conftest/OPA starter). The actual bundle, fixture paths, and CI workflow names are PROPOSED until verified against the mounted repository.
+
+---
+
+## 6. Roles and separation of duties
+
+KFM separates policy-significant release duties when materiality justifies it. *[CONFIRMED doctrine — Operating-Law Invariant 9.]*
+
+| Role | Owns | Hazards-specific responsibility |
+|---|---|---|
+| **Source steward** | `SourceDescriptor` lifecycle; admission gate | Confirms NOAA / NWS / FEMA / USGS / FIRMS terms; tags source role |
+| **Hazards domain steward** | Object-family meaning; validators | Approves contract changes; reviews domain-internal promotions |
+| **Sensitivity reviewer** | Redaction / generalization / withholding | Reviews any exposure summary that joins to sensitive infrastructure or private data |
+| **Release authority** | Issues `ReleaseManifest`; authorizes `PUBLISHED` | Distinct from candidate author when the candidate is policy-significant |
+| **Correction reviewer** | `CorrectionNotice` / `RollbackCard` | Approves post-publication corrections and rollback decisions |
+| **AI surface steward** | Focus Mode templates; AIReceipt audits | Confirms cite-or-abstain on any Hazards-summarizing AI surface |
+| **Docs steward** | This runbook; ADR index; drift register | Records placement/path decisions and runbook drift |
+
+> [!IMPORTANT]
+> **Author ≠ approver** for any release that touches life-safety-adjacent surfaces, sensitive joins, or first-time source admissions. *[CONFIRMED doctrine.]* The default for routine, low-significance promotions is that the author may also approve; the cases requiring separation are listed in Atlas §24.7.2.
+
+---
+
+## 7. Step-by-step procedure
+
+Each step records its outcome in the standard finite-outcome envelope: `ANSWER` / `ABSTAIN` / `DENY` / `ERROR`. *[CONFIRMED doctrine — Decision Envelope.]*
+
+### Step 1 — Confirm candidate is in `CATALOG / TRIPLET`
+
+The candidate MUST already have passed Stages 1–3 (admission, work/quarantine, processed). If it has not, this runbook is the wrong tool — return to the upstream ingest runbook.
+
+```text
+Candidate state:        CATALOG / TRIPLET    (PROPOSED stage label)
+Required artifacts:     EvidenceBundle, ValidationReport, DatasetVersion,
+                        SourceDescriptor, draft ReleaseManifest, draft RollbackCard
+```
+
+### Step 2 — Run the preflight checklist (§4)
+
+All fifteen preconditions must resolve to `present` or `green`. Any `missing`, `quarantine`, or `error` blocks further steps. Record the outcome in the `RunReceipt`.
+
+### Step 3 — Confirm source-role and temporal posture
+
+- The Hazards candidate's source role (`authority` / `observation` / `context` / `model`) is preserved from RAW through PUBLISHED.
+- Operational warning / advisory / watch context **carries an explicit expiry** and may not be promoted as current after expiry.
+- Historical event records carry observed/valid time distinct from release time.
+
+### Step 4 — Run the Hazards-specific validators
+
+See [§9](#9-validators-tests-and-fixtures). All listed validators MUST be green or the gate fails closed.
+
+### Step 5 — Confirm emergency-alert boundary
+
+This step is non-skippable for any candidate that touches `WarningContext`, `AdvisoryContext`, or `DisasterDeclaration`.
+
+> [!WARNING]
+> **The candidate, its layer manifest, its popup copy, its Evidence Drawer disclaimer, and any AI Focus Mode template that reads it MUST NOT present KFM as an authoritative source for life-safety action.** Official-source redirection MUST be visible at every surface. *[CONFIRMED doctrine — Encyclopedia §7.10.A; Atlas §12.B and §20.5.]*
+
+### Step 6 — Policy gate evaluation
+
+Run the promotion bundle (Conftest / OPA) against the candidate's promotion-input JSON. The bundle MUST be pinned by OCI digest or git SHA matching the production PDP. *[CONFIRMED pattern — C5-03 "Policy Parity: CI Equals Runtime."]*
+
+```text
+Outcomes:
+  allow      → proceed to Step 7
+  hold       → return to candidate author with reasons; do not approve
+  deny       → record DENY, close candidate, file CorrectionNotice if it was previously released
+  quarantine → move artifact set to QUARANTINE with reason recorded
+```
+
+### Step 7 — Review state and authorization
+
+- `ReviewRecord` is attached.
+- Release authority confirms separation of duties applies and is satisfied.
+- For Hazards candidates touching sensitive joins, sensitivity reviewer signature is required.
+
+### Step 8 — Emit `ReleaseManifest` and confirm rollback target
+
+- `ReleaseManifest` is schema-valid and references a closed `EvidenceBundle`.
+- `RollbackCard` references a prior safe release (or, for first releases, an explicit "no prior — withdrawal path is unpublish" note).
+- Correction path is declared.
+
+### Step 9 — Transition to `PUBLISHED`
+
+- The release authority issues the `PUBLISHED` transition.
+- Public surfaces (map shell, Evidence Drawer, governed API, Focus Mode) read **only** the released `LayerManifest` and `EvidenceBundle` projection.
+- A run receipt is emitted and attested (e.g., cosign / Rekor) per the attestation pattern. *[CONFIRMED pattern — Master MapLibre ML-057-035..038; PROPOSED implementation.]*
+
+### Step 10 — Post-publication smoke tests
+
+- Released layer click opens the Evidence Drawer.
+- Evidence Drawer carries the **not-for-life-safety** disclaimer where applicable.
+- AI Focus Mode answers over the released bundle pass citation validation.
+- No public surface resolves to `RAW`, `WORK`, or `QUARANTINE`.
+
+---
+
+## 8. Hazards-specific denial conditions
+
+These conditions extend the standard deny matrix and apply specifically to Hazards.
+
+| Condition | Required outcome | Source |
+|---|---|---|
+| Candidate framed as life-safety authority | **DENY** | Atlas §20.5 deny-by-default register; Encyclopedia §7.10.A |
+| Stale operational warning re-released as current | **DENY** | Atlas §12.K (operational expiry/freshness); §12.I |
+| Source role unknown or ambiguous | **QUARANTINE** | Atlas §12.K (source-role anti-collapse) |
+| NFHL regulatory context relabeled as "observed flood" | **DENY** | Hydrology §4.I and cross-lane constraint with Hazards |
+| Wildfire detection (FIRMS) presented as ground-verified perimeter | **DENY** or **ABSTAIN** | Encyclopedia §7.10.B–C (remote_sensing_detection role) |
+| Exposure summary joining to sensitive infrastructure precision without review | **DENY** until reviewed | Atlas §20.5 (Infrastructure sensitivity) |
+| `EvidenceRef` cannot resolve to `EvidenceBundle` | **ABSTAIN** | Truth-posture doctrine; Atlas §12.L |
+| Rights unclear, sensitivity unresolved, or release state absent | **DENY** (block public promotion) | Atlas §12.I; Directory Rules trust-membrane |
+| Operational warning lacks valid / issue / expiry triple | **DENY** | Encyclopedia §7.10.D (spatial-temporal model) |
+
+> [!CAUTION]
+> A surface that **reads correctly** but **routes incorrectly** is still a violation. The denial conditions apply to every published surface — layer, popup, Evidence Drawer payload, Focus Mode answer, export, story node, dashboard tile — not just the catalog record.
+
+---
+
+## 9. Validators, tests, and fixtures
+
+The validator set below is PROPOSED at the implementation level; the **requirement** that each exists before a Hazards candidate may be promoted is CONFIRMED doctrine. *[Domains Culmination Atlas §12.K.]*
+
+| Validator / test | What it proves | Status |
+|---|---|---|
+| Source-role anti-collapse | No upcast of `observation`/`context`/`model` → `authority` | PROPOSED |
+| Temporal-role validator | Source / observed / valid / retrieval / release / correction times distinct where material | PROPOSED |
+| Emergency-alert denial | Any candidate framed as life-safety routes to `DENY` | PROPOSED |
+| Operational expiry / freshness | Expired operational context cannot appear as current | PROPOSED |
+| Catalog closure | `DatasetVersion` + `ValidationReport` + `EvidenceBundle` consistent | PROPOSED |
+| Evidence Drawer disclaimer | Hazards-specific disclaimer visible where required | PROPOSED |
+| UI no-direct-source | No public surface bypasses governed APIs to read `RAW` / `WORK` / `QUARANTINE` | PROPOSED |
+| `spec_hash` parity | Stored `spec_hash` matches fresh JCS+SHA-256 recomputation | CONFIRMED pattern |
+| Negative fixtures | Each gate has a failing fixture proving it actually fails closed | CONFIRMED practice |
+
+### Proposed fixture layout
+
+```text
+fixtures/domains/hazards/
+├── good_hazard_event.json            # PROPOSED — passes all gates
+├── stale_warning.json                # PROPOSED — fails E (operational expiry)
+├── role_upcast_observation.json      # PROPOSED — fails E (anti-collapse)
+├── nfhl_relabeled_observed.json      # PROPOSED — fails C (policy)
+├── missing_evidence_ref.json         # PROPOSED — fails D (evidence closure)
+├── life_safety_phrasing.json         # PROPOSED — fails C (emergency-alert boundary)
+└── README.md
+```
+
+> [!NOTE]
+> Paths are PROPOSED per Directory Rules §4 (domain segments live under responsibility roots). Verify against mounted-repo evidence before treating them as canonical. *[Directory Rules basis: `fixtures/domains/<domain>/`.]*
+
+---
+
+## 10. Correction and rollback
+
+### 10.1 Correction flow (PROPOSED operational shape)
+
+Per CONFIRMED doctrine, a correction **preserves the original release record**, classifies the defect, emits a `CorrectionNotice`, updates the relevant `EvidenceBundle` and `ReleaseManifest`, and publishes a **superseding release** rather than silently mutating the old one. *[Unified Build Manual §3.x; Atlas §12.M; Encyclopedia §7.10.]*
+
+```mermaid
+flowchart TB
+    P[PUBLISHED release R_n] --> D{Defect detected}
+    D -->|classify| C[CorrectionNotice<br/>evidence · source-role · rights · sensitivity · geometry · temporal · policy · AI-output]
+    C --> U[Update EvidenceBundle + ReleaseManifest]
+    U --> S[Superseding release R_n+1<br/>PUBLISHED via same governed path]
+    S -.->|preserve| P
+    P --> Audit[Audit receipts retained]
+```
+
+### 10.2 Rollback flow
+
+A rollback identifies the affected release, locates the prior safe artifact set, verifies digests and manifests, disables or withdraws affected public surfaces, preserves audit receipts, marks stale or withdrawn UI state, and restores or republishes the rollback target through the same governed release path. *[CONFIRMED doctrine — Build Manual §3.x; Atlas §12.M.]*
+
+| Defect class (Hazards) | Correction posture | Rollback posture |
+|---|---|---|
+| Stale operational warning published as current | Withdraw; publish `CorrectionNotice` | Restore prior safe release; mark affected layer stale |
+| Source-role upcast | Withdraw upcast claim; supersede with role-correct release | Restore prior release; audit receipt of the upcast incident |
+| NFHL relabeled as observed flood | Withdraw; publish `CorrectionNotice` clarifying regulatory-only context | Restore prior safe release |
+| Sensitive-join exposure leak | Withdraw layer; review sensitivity tier | Restore prior generalized release; sensitivity reviewer audit |
+| AI Focus Mode uncited claim over Hazards | Disable AI surface for the affected scope | AI adapter rollback per `governed_ai_ROLLBACK` runbook |
+
+> [!NOTE]
+> Rollback is never a hidden file copy. Every rollback emits a rollback attestation and a receipt. *[CONFIRMED pattern — Master MapLibre ML-063-006.]*
+
+---
+
+## 11. Worked example and negative fixtures
+
+<details>
+<summary><strong>Worked example — successful Hazards <code>HazardEvent</code> promotion (PROPOSED, illustrative)</strong></summary>
+
+The shape below is illustrative, derived from corpus patterns in `New_Ideas_5-8-26.pdf`. Field set is PROPOSED; final names follow `contracts/` and `schemas/contracts/v1/`.
+
+```json
+{
+  "actor":  { "id": "steward-haz-01", "roles": ["domain_steward", "release_authority"] },
+  "action": "promote",
+  "resource": {
+    "kind": "EvidenceBundle",
+    "domain": "hazards",
+    "object_family": "HazardEvent",
+    "source_role": "observation",
+    "policy_label": "public",
+    "sensitivity": "public",
+    "spec_hash": "sha256:…",
+    "release_review": "approved",
+    "evidence_refs": [
+      { "type": "evidenceBundle", "uri": "kfm://evidence/hazards/event-…" }
+    ],
+    "rollback_target": "release/manifests/hazards/…/R_prev.json",
+    "correction_path": "release/correction_notices/hazards/…"
+  }
+}
+```
+
+Expected outcome: `allow` with empty `blockers`.
+
+</details>
+
+<details>
+<summary><strong>Negative fixture — stale operational warning (PROPOSED, illustrative)</strong></summary>
+
+```json
+{
+  "actor":  { "id": "steward-haz-02", "roles": ["domain_steward"] },
+  "action": "promote",
+  "resource": {
+    "kind": "EvidenceBundle",
+    "domain": "hazards",
+    "object_family": "WarningContext",
+    "source_role": "context",
+    "policy_label": "public",
+    "sensitivity": "public",
+    "spec_hash": "sha256:…",
+    "release_review": "approved",
+    "operational": {
+      "issued_at":  "2026-03-04T17:12:00Z",
+      "expires_at": "2026-03-04T19:00:00Z"
+    }
+  }
+}
+```
+
+Expected outcome: **`deny`** at Gate E (operational expiry) because `expires_at` precedes the promotion attempt. The gate produces a deny reason such as `expired_operational_context`; the candidate is moved to `QUARANTINE` with reason recorded.
+
+</details>
+
+<details>
+<summary><strong>Negative fixture — source-role upcast (PROPOSED, illustrative)</strong></summary>
+
+```json
+{
+  "action": "promote",
+  "resource": {
+    "kind": "EvidenceBundle",
+    "domain": "hazards",
+    "object_family": "WildfireDetection",
+    "source_role_recorded": "remote_sensing_detection",
+    "source_role_claimed":  "authority",
+    "policy_label": "public",
+    "spec_hash": "sha256:…",
+    "release_review": "approved"
+  }
+}
+```
+
+Expected outcome: **`deny`** at Gate E (source-role anti-collapse). Remote-sensing detection cannot be promoted as authoritative ground-verified perimeter.
+
+</details>
+
+---
+
+## 12. FAQ and common decisions
+
+<details>
+<summary><strong>"The NWS feed is current. Can I publish it as the live warning surface?"</strong></summary>
+
+**No.** KFM Hazards is not a life-safety alerting system. NWS content may be ingested as `WarningContext` (`source_role = context`), but the public surface MUST redirect life-safety action to NWS / official sources. The Evidence Drawer disclaimer is non-optional.
+
+</details>
+
+<details>
+<summary><strong>"FEMA NFHL polygons are public. Can the layer popup say 'flooded area'?"</strong></summary>
+
+**No.** NFHL is regulatory flood context, not observed inundation. Relabeling regulatory context as observed evidence is a CONFIRMED denial condition. Use language consistent with `regulatory_context`. *[Encyclopedia §7.10.C; Hydrology §4.B.]*
+
+</details>
+
+<details>
+<summary><strong>"FIRMS detected a fire. Can I draw a perimeter?"</strong></summary>
+
+**Not without a ground-source observation joined under a separate role.** Remote-sensing detection is a detection, not a verified perimeter. Promote it under `WildfireDetection` with `source_role = remote_sensing_detection`. A separate authoritative or observed perimeter must come from a different source under the appropriate role.
+
+</details>
+
+<details>
+<summary><strong>"The candidate looks clean but has no rollback target. Can I publish?"</strong></summary>
+
+**No.** Rollback target absence is a CONFIRMED denial condition at Gate G. Publication without a rollback target violates the lifecycle invariant. For first releases of a new layer, declare an explicit "withdrawal-as-rollback" path and record it.
+
+</details>
+
+<details>
+<summary><strong>"AI Focus Mode summarized a Hazards bundle. Does this need a receipt?"</strong></summary>
+
+**Yes.** Every AI Focus Mode answer over Hazards must carry an `AIReceipt` and pass citation validation. AI is interpretive; it is never root truth. *[CONFIRMED doctrine — Governed AI.]*
+
+</details>
+
+---
+
+## 13. Related docs
+
+- [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) — placement authority
+- [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — `RAW → PUBLISHED` invariant
+- [`docs/doctrine/truth-posture.md`](../../doctrine/truth-posture.md) — cite-or-abstain
+- [`docs/doctrine/trust-membrane.md`](../../doctrine/trust-membrane.md) — governed-API boundary
+- [`docs/domains/hazards/README.md`](../../domains/hazards/README.md) — Hazards domain README *(PROPOSED path)*
+- [`docs/architecture/governed-api.md`](../../architecture/governed-api.md) — governed-API contract
+- [`docs/runbooks/ui_VALIDATION.md`](../ui_VALIDATION.md) — UI validation runbook
+- [`docs/runbooks/ui_ROLLBACK.md`](../ui_ROLLBACK.md) — UI rollback runbook
+- [`docs/runbooks/governed_ai_VALIDATION.md`](../governed_ai_VALIDATION.md) — Focus Mode validation runbook
+- [`docs/runbooks/governed_ai_ROLLBACK.md`](../governed_ai_ROLLBACK.md) — AI adapter rollback runbook
+- [`release/manifests/README.md`](../../../release/manifests/README.md) — release manifest conventions
+- [`policy/domains/hazards/README.md`](../../../policy/domains/hazards/README.md) — Hazards policy bundle *(PROPOSED path)*
+- [`fixtures/domains/hazards/README.md`](../../../fixtures/domains/hazards/README.md) — Hazards fixtures *(PROPOSED path)*
+
+All relative links are PROPOSED until verified against the mounted repository. If the repo's runbook convention is flat (e.g., `docs/runbooks/hazards_PROMOTION.md`) rather than nested (`docs/runbooks/hazards/PROMOTION_RUNBOOK.md`), this file's anchors hold but its path requires migration. See §14.
+
+---
+
+## 14. Verification backlog
+
+| Item to verify | Evidence that would settle it | Status |
+|---|---|---|
+| Runbook path convention (`docs/runbooks/<domain>/<RUNBOOK>.md` vs. flat `docs/runbooks/<domain>_<RUNBOOK>.md`) | Mounted repo `docs/runbooks/` listing; ADR; per-root README | NEEDS VERIFICATION |
+| Schema home for `schemas/contracts/v1/domains/hazards/...` | ADR-0001 or successor; mounted-repo evidence | NEEDS VERIFICATION |
+| Policy bundle home for `policy/domains/hazards/...` | Mounted repo; policy bundle README | NEEDS VERIFICATION |
+| Fixture home for `fixtures/domains/hazards/...` | Mounted repo | NEEDS VERIFICATION |
+| CI workflow names for promotion gates A–G | `.github/workflows/`; per-job decision logs | NEEDS VERIFICATION |
+| `ReleaseManifest` / `RollbackCard` / `CorrectionNotice` schemas | `schemas/contracts/v1/release/...` | NEEDS VERIFICATION |
+| Hazards `SourceDescriptor` registry entries (NOAA, NWS, FEMA, USGS, FIRMS, drought monitors, Kansas-local) | `data/registry/sources/hazards/...`; rights/terms records | NEEDS VERIFICATION |
+| AI Focus Mode hazards template citation validation | `governed_ai_VALIDATION` runbook; tests | NEEDS VERIFICATION |
+| Emergency-alert boundary enforcement in policy bundle | Policy bundle; negative fixture; CI green | NEEDS VERIFICATION |
+| Owners, reviewer roster, and badge targets in this file | `CODEOWNERS`; team-charter; Shields.io endpoints | TODO — placeholders |
+
+---
+
+<sub>**Doc home (PROPOSED):** `docs/runbooks/hazards/PROMOTION_RUNBOOK.md` — see §14 for the path-convention verification item.</sub>
+
+---
+
+**Related:** [Directory Rules](../../doctrine/directory-rules.md) · [Lifecycle Law](../../doctrine/lifecycle-law.md) · [Hazards domain README](../../domains/hazards/README.md) *(PROPOSED)* · [UI rollback runbook](../ui_ROLLBACK.md) · [Governed AI rollback runbook](../governed_ai_ROLLBACK.md)
+
+**Last updated:** 2026-05-12 · **Version:** v1 (draft) · [Back to top ↑](#hazards-promotion-runbook)

--- a/docs/runbooks/hazards/ROLLBACK_RUNBOOK.md
+++ b/docs/runbooks/hazards/ROLLBACK_RUNBOOK.md
@@ -1,3 +1,664 @@
-# hazards :: ROLLBACK runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-hazards-rollback
+title: Hazards — Rollback Runbook
+type: standard
+version: v1
+status: draft
+owners: Docs steward; Hazards domain steward; Release authority
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related: [
+  docs/doctrine/directory-rules.md,
+  docs/doctrine/lifecycle-law.md,
+  docs/doctrine/trust-membrane.md,
+  docs/domains/hazards/README.md,
+  docs/runbooks/README.md,
+  docs/governance/separation-of-duties.md,
+  release/rollback_cards/,
+  release/manifests/,
+  release/correction_notices/,
+  schemas/contracts/v1/release/
+]
+tags: [kfm, runbook, hazards, rollback, release, governance]
+notes: [
+  "Path placement PROPOSED — see Section 2 on docs/runbooks/<domain>/ vs flat <domain>_ROLLBACK.md convention.",
+  "All concrete paths, validator names, CI job names PROPOSED until mounted-repo evidence verifies them."
+]
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Hazards — Rollback Runbook
+
+> Procedure for reverting a PUBLISHED Hazards release to a prior safe release, with correction lineage, downstream invalidation, and the life-safety boundary preserved.
+
+![status: draft](https://img.shields.io/badge/status-draft-yellow)
+![doc: runbook](https://img.shields.io/badge/doc-runbook-informational)
+![domain: hazards](https://img.shields.io/badge/domain-hazards-orange)
+![scope: PUBLISHED rollback](https://img.shields.io/badge/scope-PUBLISHED%20rollback-blue)
+![policy: not-life-safety](https://img.shields.io/badge/policy-not%20life%20safety-critical)
+![last-updated: 2026-05-12](https://img.shields.io/badge/last--updated-2026--05--12-lightgrey)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` |
+| **Owners** | Docs steward · Hazards domain steward · Release authority |
+| **Last updated** | 2026-05-12 |
+| **Authority of this procedure** | CONFIRMED doctrine; PROPOSED implementation |
+| **Authority of specific paths quoted here** | PROPOSED until verified against mounted-repo evidence |
+| **Supersedes** | none |
+
+> [!CAUTION]
+> **KFM Hazards is not an emergency alert system.** A rollback in this domain MUST NOT delay, replace, or compete with life-safety guidance from official sources (NWS, NWS API, FEMA, state emergency management, local EM). If a release error has placed life-safety content, expired warnings, or unredirected advisory context in front of users, the first action is **public disablement of the affected surface and a visible redirect to official sources** — the rollback decision and lineage artifacts follow that disablement, they do not gate it.
+
+---
+
+## Quick jump
+
+- [1. Scope and life-safety boundary](#1-scope-and-life-safety-boundary)
+- [2. Repo fit](#2-repo-fit)
+- [3. Inputs — what triggers a rollback](#3-inputs--what-triggers-a-rollback)
+- [4. Exclusions — what this runbook does not cover](#4-exclusions--what-this-runbook-does-not-cover)
+- [5. Roles and separation of duties](#5-roles-and-separation-of-duties)
+- [6. Preconditions and required artifacts](#6-preconditions-and-required-artifacts)
+- [7. The rollback flow](#7-the-rollback-flow)
+- [8. Defect-class rollback postures](#8-defect-class-rollback-postures)
+- [9. Hazards-specific variants](#9-hazards-specific-variants)
+- [10. Cross-lane fanout](#10-cross-lane-fanout)
+- [11. Stale vs. wrong](#11-stale-vs-wrong)
+- [12. UI and public-surface state during rollback](#12-ui-and-public-surface-state-during-rollback)
+- [13. Records emitted by a rollback](#13-records-emitted-by-a-rollback)
+- [14. Rollback drill and replay verification](#14-rollback-drill-and-replay-verification)
+- [15. Failure modes and reason codes](#15-failure-modes-and-reason-codes)
+- [16. Anti-patterns](#16-anti-patterns)
+- [17. Open questions and verification backlog](#17-open-questions-and-verification-backlog)
+- [18. Related docs](#18-related-docs)
+- [Appendix A — RollbackCard fields](#appendix-a--rollbackcard-fields)
+- [Appendix B — Worked example: stale NWS warning context release](#appendix-b--worked-example-stale-nws-warning-context-release)
+
+---
+
+## 1. Scope and life-safety boundary
+
+This runbook applies to PUBLISHED Hazards releases — historical hazard events, regulatory hazard areas, scientific observations, remote-sensing detections, modeled derivatives, exposure summaries, resilience summaries, and **contextual** (not live-safety) operational warning/advisory/declaration projections — and to any Hazards-bound layer, catalog record, EvidenceBundle, Evidence Drawer payload, or governed AI answer derived from them.
+
+CONFIRMED doctrine: **correction and rollback are publication requirements, not afterthoughts.** A Hazards claim, layer, catalog record, artifact, or governed AI answer is treated as safely publishable only if it has a visible correction path and a rollback target before release. Rollback is a **governed state transition through the same release path** that produced the original release — never a hidden file copy and never a silent edit.
+
+### What "rollback" means inside Hazards
+
+| Term | Meaning in this runbook |
+|---|---|
+| **Rollback** | Revert a PUBLISHED Hazards release to a previously released, safe artifact set. Public state held at the prior release until rollback is validated. |
+| **Correction** | Emit a `CorrectionNotice` plus a superseding release; the original release record is preserved, not mutated. |
+| **Disablement** | Immediately remove a public surface (route, layer, tile bundle, Evidence Drawer payload, AI answer) without a complete rollback — used when sensitivity, rights, or life-safety risk requires speed. Always followed by a rollback or correction within the same governed flow. |
+| **Tombstone** | A signed record that an item is retracted; lineage and audit remain explorable, but public views hide the tombstoned item. (PROPOSED reference — see [Related docs](#18-related-docs).) |
+
+[Back to top](#quick-jump)
+
+---
+
+## 2. Repo fit
+
+PROPOSED placement (see Section 2 of Notes for the convention question):
+
+```text
+docs/
+└── runbooks/
+    └── hazards/
+        ├── ROLLBACK_RUNBOOK.md        ← this file
+        ├── VALIDATION_RUNBOOK.md      (PROPOSED sibling)
+        └── LOCAL_DEV_RUNBOOK.md       (PROPOSED sibling)
+```
+
+Per the Directory Rules canonical tree, `docs/runbooks/` is the canonical home for "ops procedures, rollback drills, validation runs," and Hazards is a domain **segment** inside that root — not a root-level folder of its own.
+
+**Upstream doctrine** (consult before editing this runbook):
+
+- `docs/doctrine/lifecycle-law.md` — RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED.
+- `docs/doctrine/trust-membrane.md` — no public client touches RAW / WORK / QUARANTINE / canonical / model runtime.
+- `docs/doctrine/truth-posture.md` — cite-or-abstain default.
+- `docs/doctrine/directory-rules.md` — placement law for release artifacts and runbooks.
+- `docs/domains/hazards/README.md` — Hazards domain identity, source families, object families, sensitivity posture.
+- `docs/architecture/governed-api.md` — the only public route through which a rolled-back state becomes visible.
+
+**Downstream artifacts** (produced or referenced when this procedure runs):
+
+- `release/manifests/<release_id>.json` — the new `ReleaseManifest` that revert-points to the prior release.
+- `release/rollback_cards/<rollback_id>.json` — the `RollbackCard` decision record.
+- `release/correction_notices/<correction_id>.json` — paired `CorrectionNotice`.
+- `data/rollback/hazards/<alias>/<receipt_id>.json` — data-plane alias-revert receipts.
+- `data/published/layers/hazards/...` — restored layer artifacts (digest-pinned).
+- `data/proofs/hazards/...` — `EvidenceBundle` references that the rolled-back release continues to satisfy.
+
+[Back to top](#quick-jump)
+
+---
+
+## 3. Inputs — what triggers a rollback
+
+A rollback is initiated when a PUBLISHED Hazards release fails one or more of the conditions below. The trigger list is not exhaustive; any condition that breaks a closure rule of the Release gate (see [§6](#6-preconditions-and-required-artifacts)) is a candidate.
+
+| Trigger | Source of detection (PROPOSED) | Default first action |
+|---|---|---|
+| Expired operational warning context appearing as current state | Freshness/expiry validator; UI stale-state probe; user correction | **Disable** affected layer/payload; open rollback |
+| Source-role collapse (observation rendered as regulatory, model rendered as observed, etc.) | Source-role anti-collapse test; reviewer | Disable; rollback to last release whose source roles validated cleanly |
+| Sensitive-location exposure (e.g., archaeological, rare-species, infrastructure precision crossing into a Hazards layer) | Sensitivity reviewer; redaction-receipt audit | **Immediate disablement**; sensitive-lane rollback |
+| Rights change / takedown (NOAA, FEMA, NWS, USGS, NASA FIRMS, state EM, rights-holder communication) | Rights register; rights-holder rep | Withdraw affected artifacts; rollback |
+| Geometry defect (CRS error, polygon flip, projection drift, NFHL clip wrong) | Geometry validator; visual regression | Rollback to last digest-pinned artifact |
+| Temporal defect (event time / valid / issue / expiry / retrieval / release time confused) | Temporal-role validator | Mark stale; rollback if cannot be corrected in place |
+| Policy version drift / OPA rebuild | `PolicyDecision` re-run | Re-run gate; supersede if needed; rollback if not recoverable |
+| Validation regression after a schema migration | `ValidationReport` failure on a re-run | Rollback to last release validated by the prior schema; coordinate ADR |
+| Catalog defect (`EvidenceRef` no longer resolves to `EvidenceBundle`) | Catalog closure check | Rollback to last release whose catalog closure passed |
+| API or layer manifest defect (route returns wrong envelope, `LayerManifest` invalid) | Contract tests; runtime monitoring | Disable route; rollback |
+| Governed AI answer defect (uncited claim, abstention bypassed, restricted answer leaked) | `AIReceipt` audit; citation validator | Invalidate `AIReceipt`; remove answer; preserve `EvidenceBundle` |
+| Release-infrastructure error (`ReleaseManifest` invalid, signature failure, missing rollback target) | Release CI; release authority | Block; fix manifest; re-run release; rollback if already public |
+| External life-safety conflict (KFM contextual content visibly conflicts with current official guidance) | UI stale probe; correction queue; partner report | **Immediate disablement** and visible redirect to the official source |
+
+> [!IMPORTANT]
+> If two or more triggers fire together, treat the most restrictive (sensitivity, rights, life-safety conflict) as authoritative. The principle is fail-closed: when posture is uncertain, hide the surface and roll back.
+
+[Back to top](#quick-jump)
+
+---
+
+## 4. Exclusions — what this runbook does not cover
+
+This runbook does **not** cover:
+
+- **Live-safety alerting or emergency instructions.** KFM Hazards is not an emergency alert system. Issuing, retracting, amending, or "rolling back" an official NWS warning, FEMA declaration, or any other authoritative emergency notice is owned by the official source, not by KFM.
+- **Source admission rollback in RAW.** Withdrawing a raw payload or quarantine entry uses the admission/quarantine procedure, not this runbook. RAW and QUARANTINE never reach a public surface, so there is no PUBLISHED release to revert.
+- **Schema migrations as such.** A schema change that requires re-validation lives under the schema ADR + migration procedure. This runbook only describes the **release-side** rollback that may accompany it.
+- **Hydrology, Atmosphere/Air, Settlements/Infrastructure, Roads/Rail rollbacks.** Cross-lane derivatives may need to be invalidated by a Hazards rollback (see [§10](#10-cross-lane-fanout)), but each owning lane runs its own rollback procedure.
+- **Story / export / atlas snapshot rollback.** `StorySnapshot` and `ExportReceipt` rollbacks are covered by the Story / export runbook(s); this runbook only handles the Hazards layer/catalog/EvidenceBundle/AI surfaces those snapshots depend on.
+- **Tile-only rebuilds without an evidence change.** A pure tile rebuild that preserves identical evidence, source roles, and policy still goes through the release path, but is generally a forward fix rather than a rollback.
+
+[Back to top](#quick-jump)
+
+---
+
+## 5. Roles and separation of duties
+
+CONFIRMED doctrine: **author ≠ release authority when materiality applies**, and the correction reviewer is distinct from the original detector for steward-significant corrections. For sensitive lanes (rare-species locations, archaeological coordinates, infrastructure precision, living-person data joins), the rights-holder representative is required.
+
+| Role | Responsibility in a Hazards rollback | Required when |
+|---|---|---|
+| **Hazards domain steward** | Owns Hazards object families, validators, and the rollback initiation decision. Approves rollback target selection. | Always |
+| **Release authority** | Issues the new `ReleaseManifest` that pins the rollback target. Distinct from the original author when materiality applies. | Always for PUBLISHED |
+| **Correction reviewer** | Reviews the paired `CorrectionNotice`. May be a different steward than the detector. | Steward-significant correction |
+| **Sensitivity reviewer** | Reviews redaction / withholding / tier downgrade decisions tied to the rollback. | Sensitive-content rollback |
+| **Rights-holder representative** | Confirms sovereignty / cultural / consent-based decisions. | Rights or cultural-sensitivity rollback |
+| **Source steward** | Confirms source rights and source-role posture after the rollback. | Source-rights or source-role rollback |
+| **AI surface steward** | Reviews and signs off on Focus Mode answer invalidation; audits `AIReceipt` consequences. | AI-answer rollback |
+| **Docs steward** | Updates this runbook, registers, drift entries, ADR linkage. | Any rollback that surfaces a doctrine or path question |
+
+> [!NOTE]
+> Separation of duties is **maturity-dependent**. Early-stage releases with low materiality may be authored and approved by the same actor; as the public trust surface expands, separation must be enforced through tooling rather than custom. This runbook assumes the higher-maturity posture by default and notes where lighter-touch separation is acceptable.
+
+[Back to top](#quick-jump)
+
+---
+
+## 6. Preconditions and required artifacts
+
+A Hazards rollback is **closed** only when all of the following exist and resolve. Missing any one means the transition fails closed and the prior public state is preserved.
+
+| Required artifact | Purpose | Default home (PROPOSED) |
+|---|---|---|
+| `ReleaseManifest` (current, failed) | Identifies the release being rolled back | `release/manifests/<failed_release_id>.json` |
+| `ReleaseManifest` (rollback target) | Identifies the prior safe release; its digests and signatures must still verify | `release/manifests/<rollback_target_id>.json` |
+| `RollbackCard` | The rollback decision record; names `release_id`, `rollback_to`, reason, invalidates, reviewer, time | `release/rollback_cards/<rollback_id>.json` |
+| `CorrectionNotice` | Public-facing notice of what changed and why; paired with the `RollbackCard` | `release/correction_notices/<correction_id>.json` |
+| `ReviewRecord` | Records the steward / release authority / sensitivity / rights-holder reviews that approved the rollback | Linked from `RollbackCard.review_ref` |
+| `PolicyDecision` (re-run) | Records the policy gate evaluating the rollback target against the current policy bundle | Linked from `RollbackCard` |
+| `EvidenceBundle` (still resolving) | Confirms the rollback target's `EvidenceRef`s still resolve | `data/proofs/hazards/...` |
+| Alias-revert receipts (data plane) | Records the layer/tile/URL alias pointer change | `data/rollback/hazards/<alias>/<receipt_id>.json` |
+| Invalidation list | Names downstream derivatives (catalog records, graph projections, vector index entries, Evidence Drawer payloads, `AIReceipt`s) to invalidate | Embedded in `RollbackCard.invalidates[]` |
+| Stale-state UI markers | Visible to users on any surface that depended on the failed release until cache propagation completes | UI state; tracked by cache-invalidation record |
+
+**Universal closure rule** (CONFIRMED doctrine): a transition is closed only when the required artifacts above exist, every required artifact **resolves** the artifacts it depends on (`EvidenceRef → EvidenceBundle`, `source_id → SourceDescriptor`, `model_id → ModelRunReceipt`), and the policy gate has evaluated and recorded its decision.
+
+[Back to top](#quick-jump)
+
+---
+
+## 7. The rollback flow
+
+```mermaid
+flowchart TD
+  A["Trigger detected<br/>(see §3)"] --> B{"Life-safety<br/>or sensitivity<br/>conflict?"}
+  B -- "Yes" --> C["IMMEDIATE<br/>disablement<br/>+ redirect"]
+  B -- "No" --> D["Identify affected<br/>release_id"]
+  C --> D
+  D --> E["Locate rollback target<br/>(prior safe release)"]
+  E --> F["Verify target digests,<br/>signatures, EvidenceBundle"]
+  F --> G{"Target<br/>verifies?"}
+  G -- "No" --> H["Escalate:<br/>no safe target.<br/>Hold at current<br/>state; correction path."]
+  G -- "Yes" --> I["Re-run policy gate<br/>against current bundle"]
+  I --> J{"Policy<br/>passes?"}
+  J -- "No" --> H
+  J -- "Yes" --> K["Steward / release authority<br/>review + ReviewRecord"]
+  K --> L["Emit RollbackCard<br/>+ CorrectionNotice"]
+  L --> M["Issue superseding<br/>ReleaseManifest pinning<br/>rollback target"]
+  M --> N["Repoint aliases;<br/>emit data-plane<br/>revert receipts"]
+  N --> O["Invalidate downstream<br/>derivatives<br/>(see §10)"]
+  O --> P["Cache invalidation<br/>+ stale-state UI markers"]
+  P --> Q["Replay verification<br/>(see §14)"]
+  Q --> R{"Verification<br/>passes?"}
+  R -- "No" --> H
+  R -- "Yes" --> S["Rollback closed.<br/>Public state =<br/>rollback target."]
+```
+
+### Numbered procedure
+
+The steps below correspond to the diagram and are the canonical sequence. Skipping a step is a failure and must be recorded as a `RollbackCard` exception with reason.
+
+1. **Detect and classify.** Record the trigger ([§3](#3-inputs--what-triggers-a-rollback)) and the defect class ([§8](#8-defect-class-rollback-postures)). The defect class determines the **rollback posture**.
+2. **Life-safety / sensitivity short-circuit.** If life-safety conflict, sensitive-location exposure, rights takedown, or any other condition demands speed: **disable the affected public surface immediately and post a visible redirect to the official source.** Disablement is fail-closed; the rollback proceeds underneath.
+3. **Identify the failed `release_id`.** Pull the current `ReleaseManifest` for the affected Hazards surface(s).
+4. **Locate the rollback target.** Walk the `rollback_target` chain on each affected `ReleaseManifest` until a candidate prior release is found whose `EvidenceBundle`s, `PolicyDecision`s, source roles, and digests can still be expected to verify.
+5. **Verify the target.** Re-check digests and signatures of the prior release's artifacts. Re-resolve `EvidenceRef → EvidenceBundle`. If any reference fails to resolve, the target is **not** a safe rollback; escalate per Step 12.
+6. **Re-run the policy gate** against the **current** policy bundle. A target that passed under an old policy may now fail; if it does, escalate per Step 12. A passing decision yields a new `PolicyDecision` that is referenced from the `RollbackCard`.
+7. **Convene the required reviewers** ([§5](#5-roles-and-separation-of-duties)). Record decisions in `ReviewRecord`s. For sensitive lanes, the rights-holder representative is required.
+8. **Emit the `RollbackCard`** ([Appendix A](#appendix-a--rollbackcard-fields)) and the paired `CorrectionNotice`. The `RollbackCard.invalidates[]` array enumerates downstream derivatives.
+9. **Issue a superseding `ReleaseManifest`** that pins the rollback target as the new public state. The original failed `ReleaseManifest` is **not deleted or mutated** — it is preserved and superseded.
+10. **Repoint aliases** (layer URLs, tile bundle pointers, route → manifest bindings) and emit data-plane alias-revert receipts under `data/rollback/hazards/<alias>/`.
+11. **Invalidate downstream derivatives.** Walk the invalidation list (see [§10](#10-cross-lane-fanout)): catalog records, graph/triplet projections, vector index entries, Evidence Drawer payloads, `AIReceipt`s that referenced the failed release.
+12. **Cache invalidation.** Emit a cache-invalidation record. Mark UI state stale or withdrawn for any view that may still hold the failed release pending cache propagation.
+13. **Replay verification** ([§14](#14-rollback-drill-and-replay-verification)). Run the rollback drill fixture: same evidence + same inputs + same pinned tooling MUST produce the same receipt hashes as the rollback target's original release. Failure here means the rollback is **not closed.**
+14. **Close the rollback.** Update the release register; update the drift register if the rollback exposed a doctrine question; update this runbook if the procedure itself surfaced a gap.
+
+> [!TIP]
+> A rollback is closed only after replay verification passes. Before that point, public state remains held at the rollback target and the `RollbackCard` is in an interim "verifying" state. Releases and corrections downstream of the affected surface should be paused until verification completes.
+
+[Back to top](#quick-jump)
+
+---
+
+## 8. Defect-class rollback postures
+
+CONFIRMED doctrine: every published claim has both a **correction posture** and a **rollback posture** keyed to defect class. The table below restates the general rules for Hazards.
+
+| Defect class | Correction posture | Rollback posture (Hazards default) |
+|---|---|---|
+| **Evidence gap** | ABSTAIN or withdraw unsupported claim | Restore prior evidence-supported release |
+| **Rights defect** | DENY public use; quarantine source/artifact | Withdraw affected artifacts; rollback to last rights-clean release |
+| **Sensitivity leak** | Redact / generalize and notify stewards | **Immediate public disablement**, then rollback |
+| **Geometry defect** | Rebuild derivative layer and Evidence payload | Restore previous digest-pinned artifact |
+| **Temporal defect** (issue/expiry/valid/retrieval/release/correction time confused) | Correct the time fields | Mark stale until rebuilt; rollback if cannot correct in place |
+| **Policy defect** | Re-run policy and `DecisionEnvelope` | Disable route/layer if the gate failed; rollback if the policy itself is rolled back |
+| **AI answer defect** | Invalidate `AIReceipt` and response envelope | Remove answer; preserve `EvidenceBundle`; new `AIReceipt` is a new record, not a retroactive supersession |
+| **Catalog defect** | Re-emit catalog closure after proof repair | Restore previous catalog state |
+| **Source-role collapse** (observation → regulatory, model → observed, advisory → warning, etc.) | Restore source role; refuse upcast | Rollback to last release whose source-role anti-collapse tests passed |
+
+### Hazards-specific overlay
+
+- **Operational warning / advisory / watch context** — never act as life-safety. If expired context appears as current, the rollback posture is **immediate disablement of the operational-context layer** followed by a rollback that keeps historical event layers public and demotes the operational layer to a contextual-only state with a visible redirect to the official source.
+- **Disaster declaration layers** — these are administrative records, not life-safety instructions. Rollback follows the standard rights / geometry / temporal postures.
+- **Regulatory layers (e.g., NFHL flood hazard context)** — vintage-bearing; rollback should preserve the rollback target's vintage and explicitly badge it on the UI rather than silently revert to an older regulatory state without context.
+- **Detection layers (NASA FIRMS, NOAA HMS smoke)** — `WildfireDetection` and `SmokeContext` are observations, not warnings; a rollback must not convert a model-as-observed leak into an "observed" rollback target.
+
+[Back to top](#quick-jump)
+
+---
+
+## 9. Hazards-specific variants
+
+The general flow ([§7](#7-the-rollback-flow)) applies uniformly. The variants below highlight where Hazards differs from a generic domain rollback.
+
+### 9.1 Operational warning / advisory / watch context
+
+> [!WARNING]
+> Operational context is **contextual only**. A stale, expired, or mis-rendered operational warning is the most life-safety-adjacent failure mode in Hazards. Treat any stale or expired `WarningContext`, `AdvisoryContext`, or implied "current warning" UI state as a sensitivity-leak-equivalent: immediate disablement of the surface, visible redirect to official sources, rollback underneath.
+
+Required additions to the standard flow:
+
+- Confirm the freshness validator and operational-expiry tests pass on the rollback target.
+- Confirm the rollback target's Evidence Drawer payloads include the non-life-safety disclaimer.
+- The `CorrectionNotice` for an operational-context rollback should explicitly name the official source(s) users were redirected to during disablement.
+
+### 9.2 Regulatory hazard areas (NFHL, KGS, state regulatory polygons)
+
+- Vintage and rights matter more than geometry detail. Preserve the rollback target's source vintage on the UI rather than silently revert.
+- If the trigger was a rights change, the rollback may need to **withdraw the entire layer** rather than revert to a prior rights-bearing release. In that case, the new `ReleaseManifest` pins the layer to a withdrawn state with a tombstone-equivalent record.
+
+### 9.3 Scientific observations and remote-sensing detections
+
+- `HazardObservation`, `WildfireDetection`, `SmokeContext`, `EarthquakeEvent` — these are observation source-role artifacts. The rollback must not promote any of them to a regulatory or warning role.
+- If a model-as-observed leak triggered the rollback, the rollback target itself must be re-checked for the same defect before it is treated as safe.
+
+### 9.4 Exposure and resilience summaries (modeled derivatives)
+
+- These are `modeled_derivative` source-role artifacts and depend on cross-lane inputs (Settlements/Infrastructure, Hydrology, Atmosphere/Air, Roads/Rail).
+- A Hazards rollback that invalidates a cross-lane input MUST trigger a cross-lane review ([§10](#10-cross-lane-fanout)) before the modeled derivative is re-published from the rollback target.
+
+### 9.5 Governed AI answers about Hazards
+
+- An AI answer is a new record; rolling back the underlying release does not retroactively change a previously emitted `AIReceipt`. Instead:
+  1. Invalidate the affected `AIReceipt`s on the published surface (hide from public views).
+  2. Preserve them in audit (no silent deletion).
+  3. Emit new `AIReceipt`s only when a user re-asks against the rolled-back evidence.
+- Focus Mode must ABSTAIN where the rolled-back evidence no longer supports a prior answer and DENY where rights / sensitivity / release state now blocks it.
+
+[Back to top](#quick-jump)
+
+---
+
+## 10. Cross-lane fanout
+
+Hazards has CONFIRMED / PROPOSED cross-lane relations to **Hydrology**, **Atmosphere/Air**, **Settlements/Infrastructure**, and **Roads/Rail**. A Hazards rollback must walk these relations and invalidate or notify the dependent surfaces.
+
+```mermaid
+flowchart LR
+  H["Hazards<br/>(rolled back)"] -->|flood / drought / water context| HY["Hydrology"]
+  H -->|smoke / heat-cold / fire-weather| AT["Atmosphere/Air"]
+  H -->|exposure / lifelines / dependencies| SI["Settlements/<br/>Infrastructure"]
+  H -->|closures / detours / bridge & crossing exposure| RR["Roads/Rail"]
+  HY -. invalidate derivatives .-> H
+  AT -. invalidate derivatives .-> H
+  SI -. invalidate derivatives .-> H
+  RR -. invalidate derivatives .-> H
+```
+
+**Required cross-lane actions on a Hazards rollback:**
+
+| Cross-lane dependency | Action on rollback | Owner |
+|---|---|---|
+| Hydrology — flood / drought event context | Invalidate joined records; notify Hydrology steward; flag for re-publication after Hazards rollback is closed | Hazards + Hydrology stewards |
+| Atmosphere/Air — `SmokeContext`, heat-cold context, AQI joins | Invalidate cross-cited records; notify Atmosphere/Air steward | Hazards + Atmosphere/Air stewards |
+| Settlements/Infrastructure — `ExposureSummary`, lifeline dependencies | Invalidate exposure summaries that referenced the failed release; downstream review required | Hazards + Settlements/Infrastructure stewards |
+| Roads/Rail — closures, detours, bridge/crossing exposure | Invalidate transient `RestrictionEvent` / `StatusEvent` joins; coordinate with Roads/Rail steward | Hazards + Roads/Rail stewards |
+| Story / export / atlas snapshots that included the failed release | Tombstone-equivalent: hide affected snapshots from public; preserve in audit; re-publish from rollback target if appropriate | Story / export steward |
+
+> [!IMPORTANT]
+> Cross-lane invalidation is a **notification + invalidation** action, not a transitive rollback. Each owning lane runs its own rollback procedure for its own published artifacts. The Hazards `RollbackCard.invalidates[]` array enumerates the cross-lane derivatives that must be touched.
+
+[Back to top](#quick-jump)
+
+---
+
+## 11. Stale vs. wrong
+
+CONFIRMED doctrine: **stale ≠ wrong**. A stale claim's evidence, source freshness, dependent data, or context has aged past its declared tolerance; a wrong claim's substance is incorrect. Both states have visible markers and traceable lifecycles, but they trigger different responses.
+
+| Marker | Triggered by | Required action — Hazards |
+|---|---|---|
+| Source freshness expired | `SourceDescriptor` cadence passed without re-admission | Re-admit or supersede; otherwise mark dependent Hazards claims stale and surface the stale-source badge in the Evidence Drawer |
+| Schema version drift | Object schema upgraded past the published claim's version | Migrate, re-validate, re-release — or mark stale until migration completes |
+| Geography version drift | `GeographyVersion` replaced; published claim still bound to prior version | Rebind to current `GeographyVersion`; re-release; or mark stale |
+| Time-scope outside support | Claim's temporal scope outside current data support window | Mark stale; **do not refresh silently** |
+| Model version superseded | `ModelRunReceipt` references an older model | Re-run; supersede; or mark stale |
+| Review aged out | `ReviewRecord` older than the review-cycle tolerance for the sensitive lane | Trigger steward review; potentially downgrade tier |
+| Rights status changed | Rights change in `SourceDescriptor` or rights-holder communication | Re-evaluate tier; potentially downgrade; emit `CorrectionNotice` if necessary |
+| Policy version changed | Policy referenced by `PolicyDecision` was superseded | Re-run gate; potentially supersede release |
+
+**Rule of thumb for this runbook**: *stale* is handled by visible markers and a re-release; *wrong* is handled by rollback. When in doubt — particularly for operational warning context — treat as wrong, not stale.
+
+[Back to top](#quick-jump)
+
+---
+
+## 12. UI and public-surface state during rollback
+
+The trust membrane forbids any public client, normal UI surface, or released AI surface from reaching RAW, WORK, QUARANTINE, canonical/internal stores, graph internals, vector indexes, source APIs, or direct model runtimes. **A rollback in progress does not relax this rule.** The public path remains the governed API; the rollback target becomes the new state that the governed API serves.
+
+| Phase | Recommended UI state |
+|---|---|
+| Trigger detected, awaiting disablement | No UI change yet; reviewers notified |
+| Immediate disablement (sensitive / life-safety conflict) | Affected layer/payload hidden; visible non-life-safety disclaimer and redirect to official sources; trust badge set to *withdrawn* |
+| Rollback target located, target verifying | Hazards layer set to *stale / verifying* on the affected surfaces; Evidence Drawer shows the prior release ID and "rollback in progress" state |
+| `RollbackCard` + `CorrectionNotice` emitted, new `ReleaseManifest` issued | UI begins switching to the rollback target as cache propagation completes; trust badge transitions to *superseded* on the failed release and *current* on the rollback target |
+| Replay verification in progress | UI shows the rollback target as current; an audit-facing badge surfaces "verifying" until verification passes |
+| Verification complete, rollback closed | Stale badges cleared on the rolled-back surfaces; `CorrectionNotice` accessible from the Evidence Drawer |
+| Verification failed | Hold at the rollback target's predecessor or escalate to a manual hold; affected surfaces remain disabled |
+
+**Required UI guarantees** during any rollback phase:
+
+- No public surface reads from RAW / WORK / QUARANTINE / canonical / internal.
+- No direct model traffic to a public client.
+- No uncited authoritative claim is rendered as current state.
+- The non-life-safety disclaimer remains visible on any Hazards operational-context surface that is publicly reachable.
+- The Evidence Drawer can show, for the affected surfaces, the failed release ID, the rollback target ID, and the linked `RollbackCard` and `CorrectionNotice` (audit visibility per policy label).
+
+[Back to top](#quick-jump)
+
+---
+
+## 13. Records emitted by a rollback
+
+Every rollback produces a small, well-known set of records. **None of them is optional.** Missing one means the transition fails closed and the prior public state is preserved.
+
+| Record | Phase | Default home (PROPOSED) | Lifetime |
+|---|---|---|---|
+| `RollbackCard` | Decision | `release/rollback_cards/<rollback_id>.json` | Permanent; never silently deleted |
+| `CorrectionNotice` | Decision | `release/correction_notices/<correction_id>.json` | Permanent |
+| `ReleaseManifest` (superseding) | Decision | `release/manifests/<new_release_id>.json` | Permanent; preserves rollback chain |
+| `ReleaseManifest` (failed; preserved) | Lineage | `release/manifests/<failed_release_id>.json` | Permanent; marked superseded |
+| `PolicyDecision` (re-run against rollback target) | Validation | Linked from `RollbackCard` | Permanent |
+| `ReviewRecord`(s) | Validation | Linked from `RollbackCard.review_ref` | Permanent |
+| `ValidationReport` (replay verification) | Validation | Linked from `RollbackCard` | Permanent |
+| Alias-revert receipts (data plane) | Data plane | `data/rollback/hazards/<alias>/<receipt_id>.json` | Permanent |
+| Cache-invalidation record | Data plane | Cache invalidation log | Permanent |
+| Tombstone records for downstream derivatives | Lineage | Per lane | Permanent |
+
+> [!NOTE]
+> *Permanent* means *append-only* — superseded, withdrawn, and tombstoned records remain queryable for audit and lineage. They are hidden from public views but never deleted. Right-to-be-forgotten obligations for personal data are handled by a distinct erasure procedure with its own log; that procedure is outside the scope of this runbook.
+
+[Back to top](#quick-jump)
+
+---
+
+## 14. Rollback drill and replay verification
+
+A rollback is closed only when **replay verification** passes. Replay verification is a deterministic re-derivation: same evidence + same inputs + same pinned tooling MUST produce the same receipt hashes as the rollback target's original release. The Hazards rollback drill is the routine exercise of this verification.
+
+### Replay verification invariant
+
+```text
+same EvidenceBundle + same pipeline_spec + same pinned tooling
+  -> same TransformReceipt, ValidationReport, and ReleaseManifest digests
+  -> same RollbackCard outcome
+```
+
+### Rollback drill cadence (PROPOSED)
+
+| Cadence | Scope |
+|---|---|
+| Per-release | Every Hazards release MUST have a verifiable rollback target. Replay verification runs as part of the release gate, before PUBLISHED, **not only** when a rollback fires. |
+| Quarterly | Hazards domain steward initiates a full rollback drill against a representative published surface: pick a release, simulate a defect of each class in [§8](#8-defect-class-rollback-postures), execute the rollback flow against a non-production target, and record the outcomes. |
+| Post-incident | After any real rollback, the drill is replayed against a fixture to capture the lessons learned and to update this runbook. |
+
+### Drill fixture requirements (PROPOSED)
+
+- A small, public-safe Hazards fixture: one historical flood / severe weather event, NFHL flood context, and one exposure summary — with warning feeds disabled or contextual-only (this matches the Hazards thin-slice plan).
+- A pinned tool-version manifest.
+- A `pipeline_spec` snapshot that produced the original release.
+- A `replay_check` CI job (PROPOSED name) that emits a pass/fail receipt.
+
+> [!TIP]
+> If replay verification fails, the rollback target is **not** a safe rollback. The most common causes are non-deterministic tooling, drifted external dependencies, and policy bundle changes that change the gate outcome. Investigate, pin, and re-run; do not paper over a verification failure.
+
+[Back to top](#quick-jump)
+
+---
+
+## 15. Failure modes and reason codes
+
+PROPOSED reason codes (consistent with the universal gate-failure catalog). Every rollback that does not close emits one or more of these codes on its `RollbackCard`.
+
+| Reason code (PROPOSED) | Meaning | Recovery path |
+|---|---|---|
+| `ROLLBACK_TARGET_MISSING` | No rollback target named on the failed `ReleaseManifest`, or named target cannot be located | Manually supply a rollback target; escalate to release authority |
+| `ROLLBACK_TARGET_UNVERIFIED` | Rollback target's digests, signatures, or `EvidenceBundle` references do not resolve | Investigate; do not roll back to an unverified target |
+| `RELEASE_MANIFEST_INVALID` | Superseding `ReleaseManifest` fails schema or contract validation | Manifest fix; re-run release |
+| `MISSING_RECEIPT` | Required `TransformReceipt` / `RedactionReceipt` / `AggregationReceipt` for the rollback target cannot be located | Re-emit missing receipt or pick a different target |
+| `MISSING_EVIDENCE` | `EvidenceRef` no longer resolves to an `EvidenceBundle` | Repair evidence resolution; pick a different target if irrecoverable |
+| `MISSING_REVIEW` | Required `ReviewRecord` absent | Convene the required reviewer; record the decision |
+| `REVIEW_REJECTED` | Reviewer denied the rollback | Re-scope; escalate; consider an alternative target or a correction-only path |
+| `ROLE_COLLAPSE` | Source-role collapse risk on the rollback target | Restore source role; refuse upcast; pick a different target |
+| `RIGHTS_UNKNOWN` / `SENSITIVITY_UNRESOLVED` | Rights or sensitivity status unresolved on the rollback target | Steward review; rights resolution; tier reassignment |
+| `SCHEMA_MISMATCH` / `CONTRACT_DRIFT` | Rollback target validates against an older schema/contract that no longer matches the active one | Schema fix and/or ADR; re-run validator |
+| `POLICY_REJECT` | Rollback target fails the **current** policy bundle | Re-run; consider correction-only path; do not bypass the gate |
+| `REPLAY_FAIL` | Replay verification did not reproduce the rollback target's receipts | Investigate non-determinism; pin tooling; re-run |
+| `CORRECTION_DERIVATIVES_UNRESOLVED` | Downstream derivatives could not be invalidated | Walk the invalidation list; engage cross-lane stewards |
+| `CACHE_INVALIDATION_FAILED` | Cache invalidation record could not be emitted or honored | Force-invalidate; if cache cannot be invalidated, hold disablement until cache TTL expires |
+
+[Back to top](#quick-jump)
+
+---
+
+## 16. Anti-patterns
+
+These are explicit non-actions. Reviewers should flag any rollback PR that exhibits them.
+
+> [!WARNING]
+> **Do not** silently mutate a previously released `ReleaseManifest`. The failed release is preserved and superseded; it is never edited in place.
+
+> [!WARNING]
+> **Do not** rebuild a tile / layer / catalog record from raw inputs and call it "the rollback target." A rollback target is a *prior released artifact*, not a re-derivation. (A re-derivation is a forward fix and goes through the release path; it may be a correction, not a rollback.)
+
+> [!WARNING]
+> **Do not** copy files around in the file system to "restore" a prior state. Rollback is a governed state transition through the same release path that produced the original release.
+
+> [!WARNING]
+> **Do not** treat a rollback as a way to bypass the policy gate. The rollback target is re-evaluated against the **current** policy bundle; a target that passed under an old policy may not pass now.
+
+> [!WARNING]
+> **Do not** use a rollback to retroactively change a `AIReceipt`. An AI answer is a new record; retroactive supersession of an `AIReceipt` is forbidden.
+
+> [!WARNING]
+> **Do not** allow a rollback to publish operational warning / advisory / watch context as life-safety. The non-life-safety disclaimer and the official-source redirect remain mandatory on every surface that touches operational context, including the rollback target.
+
+[Back to top](#quick-jump)
+
+---
+
+## 17. Open questions and verification backlog
+
+These are tracked here in addition to `docs/registers/VERIFICATION_BACKLOG.md`. NEEDS VERIFICATION items become PROPOSED until they are settled by mounted-repo or ADR evidence.
+
+| Item | Default posture | Verification step |
+|---|---|---|
+| Path placement: `docs/runbooks/<domain>/<RUNBOOK>.md` (this file) vs. flat `docs/runbooks/<domain>_<TYPE>.md` (per UI / Governed AI plan) | PROPOSED — convention question | Resolve with a docs steward decision or short ADR |
+| Schema home for `RollbackCard`, `CorrectionNotice`, `ReleaseManifest` | NEEDS VERIFICATION — defaults to `schemas/contracts/v1/release/` per ADR-0001 | Inspect mounted repo; confirm or ADR |
+| Policy engine binding for the release-gate policy re-run | NEEDS VERIFICATION — likely OPA / Conftest | Inspect `policy/` and CI workflow |
+| Replay-verification CI job name and fixture path | UNKNOWN | Inspect CI workflows and `fixtures/domains/hazards/` |
+| Cross-lane invalidation tooling (graph, vector index, catalog) | UNKNOWN | Inspect `packages/catalog/`, `packages/evidence-resolver/`, graph projection package |
+| Cache invalidation surface (CDN / edge / proxy) | UNKNOWN | Inspect `infra/` and `apps/governed-api/` |
+| Tombstone schema and visibility rules for Hazards | NEEDS VERIFICATION | Confirm tombstone register and UI visibility tests |
+| Rollback-card signing (cosign / DSSE) for Hazards releases | NEEDS VERIFICATION | Inspect signing pipeline and signing-key handling |
+| Hazards source rights and current terms (NOAA / NWS / FEMA / USGS / NASA / state EM) | NEEDS VERIFICATION | Source-steward review; per-source admissibility records |
+| Whether `data/rollback/hazards/` and `release/rollback_cards/` co-exist with the documented split | NEEDS VERIFICATION | Confirm or merge via ADR per Directory Rules open question |
+
+[Back to top](#quick-jump)
+
+---
+
+## 18. Related docs
+
+> [!NOTE]
+> Links below are repo-relative under the canonical tree defined by `docs/doctrine/directory-rules.md`. Specific file presence is PROPOSED until verified.
+
+- [`docs/runbooks/README.md`](../README.md) — runbook index *(PROPOSED)*
+- [`docs/runbooks/hazards/VALIDATION_RUNBOOK.md`](./VALIDATION_RUNBOOK.md) — Hazards validation runbook *(PROPOSED sibling)*
+- [`docs/runbooks/hazards/LOCAL_DEV_RUNBOOK.md`](./LOCAL_DEV_RUNBOOK.md) — Hazards local dev runbook *(PROPOSED sibling)*
+- [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — lifecycle invariant
+- [`docs/doctrine/trust-membrane.md`](../../doctrine/trust-membrane.md) — trust-membrane rules
+- [`docs/doctrine/truth-posture.md`](../../doctrine/truth-posture.md) — cite-or-abstain
+- [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) — placement law
+- [`docs/domains/hazards/README.md`](../../domains/hazards/README.md) — Hazards domain identity, source families, sensitivity posture
+- [`docs/architecture/governed-api.md`](../../architecture/governed-api.md) — governed API surface
+- [`docs/governance/separation-of-duties.md`](../../governance/separation-of-duties.md) — release authority, correction reviewer *(PROPOSED)*
+- [`docs/registers/VERIFICATION_BACKLOG.md`](../../registers/VERIFICATION_BACKLOG.md) — open verification items
+- [`docs/registers/DRIFT_REGISTER.md`](../../registers/DRIFT_REGISTER.md) — recorded conflicts between docs and repo state
+
+[Back to top](#quick-jump)
+
+---
+
+## Appendix A — RollbackCard fields
+
+Reference for authors of `RollbackCard` records produced by this runbook. CONFIRMED doctrine on purpose; PROPOSED on exact field shape; canonical schema lives in `schemas/contracts/v1/release/RollbackCard.schema.json` *(home PROPOSED per ADR-0001)*.
+
+<details>
+<summary><strong>Expand: PROPOSED field shape</strong></summary>
+
+| Field | Type | Purpose |
+|---|---|---|
+| `release_id` | string (release identifier) | The PUBLISHED release being rolled back |
+| `rollback_to` | string (release identifier) | The prior release the public state is reverting to |
+| `reason` | string + structured `defect_class` enum | Plain-text reason and machine-readable defect class (§8) |
+| `defect_class` | enum | One of: `evidence_gap`, `rights_defect`, `sensitivity_leak`, `geometry_defect`, `temporal_defect`, `policy_defect`, `ai_answer_defect`, `catalog_defect`, `source_role_collapse`, `release_infrastructure`, `other` |
+| `triggered_by` | string + ref | Detection source (validator, reviewer, user correction, monitoring) |
+| `invalidates[]` | array of refs | Catalog records, graph projections, vector index entries, Evidence Drawer payloads, `AIReceipt`s to invalidate |
+| `cross_lane_notifications[]` | array of refs | Cross-lane lanes notified (Hydrology, Atmosphere/Air, Settlements/Infrastructure, Roads/Rail, Story/export) |
+| `review_ref[]` | array of `ReviewRecord` refs | All required reviewers' decisions |
+| `policy_decision_ref` | `PolicyDecision` ref | Re-run against the current policy bundle |
+| `validation_report_ref` | `ValidationReport` ref | Replay verification report |
+| `correction_notice_ref` | `CorrectionNotice` ref | The paired notice |
+| `superseding_release_id` | string | The new `ReleaseManifest` that pins the rollback target |
+| `time` | ISO-8601 timestamp | Decision time |
+| `actor` | identity | Domain steward / release authority who issued the card |
+| `signature` | DSSE / cosign envelope | Signed envelope; verification required before public-state change |
+| `status` | enum | `proposed`, `verifying`, `closed`, `failed`, `held` |
+
+</details>
+
+[Back to top](#quick-jump)
+
+---
+
+## Appendix B — Worked example: stale NWS warning context release
+
+Illustrative only. Identifiers, file paths, and tool names are placeholders. The walk-through is meant to make the flow concrete, not to claim implementation.
+
+<details>
+<summary><strong>Expand: worked example</strong></summary>
+
+**Scenario.** A Hazards release `hazards-rel-2026-05-10-04` published a layer that renders the NWS `WarningContext` from the morning's retrieval. The freshness validator on the afternoon CI run reports that the `WarningContext` polygon for one Kansas county is past its declared expiry but still rendering as current on the affected layer's tile bundle. No life-safety instructions are emitted by KFM, but a stale warning context is visibly current on the public UI.
+
+**Defect class.** `temporal_defect` with a secondary `source_role_collapse_risk` posture (operational context being rendered without the non-life-safety disclaimer adequately surfaced).
+
+**Step-by-step.**
+
+1. **Detect.** Freshness validator emits `STALE_OPERATIONAL_CONTEXT` for the affected polygon.
+2. **Short-circuit disablement.** Operational-context layer is disabled on the affected tile bundle; the UI replaces the layer with the non-life-safety disclaimer plus a redirect to the NWS official URL for the affected county. Trust badge: *withdrawn*.
+3. **Identify failed `release_id`.** `hazards-rel-2026-05-10-04`.
+4. **Locate rollback target.** Walk the `rollback_target` chain on the failed `ReleaseManifest`. Candidate: `hazards-rel-2026-05-10-02`, which preceded the morning operational refresh.
+5. **Verify target.** Digests and signatures on `hazards-rel-2026-05-10-02` artifacts verify. `EvidenceRef → EvidenceBundle` resolves. Source-role anti-collapse tests pass.
+6. **Re-run policy gate.** `PolicyDecision` against the current policy bundle returns ALLOW for the rollback target's content (which contains no operational context for the affected county at that time).
+7. **Reviewers.** Hazards domain steward + release authority + AI surface steward sign `ReviewRecord`s. Sensitivity reviewer not required (no sensitive-content posture).
+8. **Emit `RollbackCard` + `CorrectionNotice`.** `RollbackCard` lists `invalidates[]`: the catalog record for the failed release, the Evidence Drawer payload that referenced the stale `WarningContext`, and one `AIReceipt` that had answered a user question using the stale context.
+9. **Issue superseding `ReleaseManifest`.** `hazards-rel-2026-05-10-05` pins `rollback_to: hazards-rel-2026-05-10-02`.
+10. **Repoint aliases.** Layer URL aliases repointed; alias-revert receipt emitted under `data/rollback/hazards/<alias>/`.
+11. **Invalidate downstream.** Catalog record marked superseded; Evidence Drawer payload hidden from public; `AIReceipt` marked invalidated for public visibility (preserved in audit).
+12. **Cache invalidation.** CDN tile cache invalidated; UI shows *superseded* on the failed release and *current* on the rollback target.
+13. **Replay verification.** Drill fixture re-derives `hazards-rel-2026-05-10-02` receipts; hashes match.
+14. **Close.** Verification report attached to the `RollbackCard`. Status moves from `verifying` to `closed`.
+
+**Records produced.**
+
+```text
+release/manifests/hazards-rel-2026-05-10-05.json     # superseding release pinning rollback target
+release/manifests/hazards-rel-2026-05-10-04.json     # preserved; marked superseded
+release/rollback_cards/hazards-rb-2026-05-10-01.json # RollbackCard
+release/correction_notices/hazards-cn-2026-05-10-01.json
+data/rollback/hazards/operational-context-layer/<receipt_id>.json
+```
+
+</details>
+
+[Back to top](#quick-jump)
+
+---
+
+## Footer
+
+| Field | Value |
+|---|---|
+| **Doc type** | Standard runbook |
+| **Owners** | Docs steward · Hazards domain steward · Release authority |
+| **Last updated** | 2026-05-12 |
+| **Authority** | CONFIRMED doctrine; PROPOSED implementation; PROPOSED specific paths |
+
+**Related docs:** [`docs/runbooks/README.md`](../README.md) · [`docs/domains/hazards/README.md`](../../domains/hazards/README.md) · [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) · [`docs/doctrine/trust-membrane.md`](../../doctrine/trust-membrane.md) · [`docs/architecture/governed-api.md`](../../architecture/governed-api.md)
+
+[Back to top](#quick-jump)

--- a/docs/runbooks/hazards/SOURCE_REFRESH_RUNBOOK.md
+++ b/docs/runbooks/hazards/SOURCE_REFRESH_RUNBOOK.md
@@ -1,3 +1,511 @@
-# hazards :: SOURCE_REFRESH runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-hazards-source-refresh
+title: Hazards Source Refresh Runbook
+type: standard
+version: v0.1
+status: draft
+owners: TODO — Hazards lane steward + Docs steward (NEEDS VERIFICATION)
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/trust-membrane.md
+  - docs/domains/hazards/README.md
+  - docs/sources/SOURCE_DESCRIPTOR_STANDARD.md
+  - docs/runbooks/governed_ai_VALIDATION.md
+  - docs/adr/ADR-0001-schema-home.md
+tags: [kfm, hazards, runbook, source-refresh, lifecycle, governance]
+notes:
+  - Path under docs/runbooks/hazards/ is PROPOSED until verified against mounted-repo convention or an ADR amending Directory Rules.
+  - All path, schema, validator, route, and workflow names are PROPOSED unless tagged otherwise.
+  - Doctrine (lifecycle, trust membrane, not-for-life-safety boundary, stale-state markers, supersession) is CONFIRMED from project corpus.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+<a id="top"></a>
+
+# Hazards Source Refresh Runbook
+
+> Operational procedure for refreshing **Hazards** sources (NOAA, NWS, FEMA, USGS, NASA FIRMS, drought monitors, state emergency management) through the governed `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` lifecycle — without letting operational warning context become a life-safety alerting surface.
+
+![Status: draft](https://img.shields.io/badge/status-draft-lightgrey)
+![Authority: doctrine grounded](https://img.shields.io/badge/authority-doctrine--grounded-blue)
+![Path: PROPOSED](https://img.shields.io/badge/path-PROPOSED-orange)
+![Lifecycle: RAW→PUBLISHED](https://img.shields.io/badge/lifecycle-RAW%E2%86%92PUBLISHED-success)
+![Domain: Hazards](https://img.shields.io/badge/domain-Hazards-red)
+![Life-safety: NOT-A-LIFE-SAFETY-SYSTEM](https://img.shields.io/badge/life--safety-NOT--A--LIFE--SAFETY--SYSTEM-critical)
+
+| Field | Value |
+|---|---|
+| **Status** | Draft |
+| **Owners** | `TODO` — Hazards lane steward + Docs steward (NEEDS VERIFICATION against `CODEOWNERS`) |
+| **Last updated** | 2026-05-12 |
+| **Lifecycle invariant** | RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED — promotion is a **governed state transition, not a file move** |
+| **Trust posture** | Cite-or-abstain; deny-by-default for sensitive / life-safety surfaces |
+| **Domain boundary** | Hazards governs historical, regulatory, modeled, and operational-**context** data; it **MUST NOT** act as a life-safety alerting system |
+
+---
+
+## Contents
+
+1. [Purpose & scope](#1-purpose--scope)
+2. [Doctrinal preflight](#2-doctrinal-preflight)
+3. [Hazards source families & source roles](#3-hazards-source-families--source-roles)
+4. [Refresh flow (RAW → PUBLISHED)](#4-refresh-flow-raw--published)
+5. [Per-stage procedure](#5-per-stage-procedure)
+6. [Stale-state handling](#6-stale-state-handling)
+7. [Quarantine handling](#7-quarantine-handling)
+8. [Receipts, evidence, and audit trail](#8-receipts-evidence-and-audit-trail)
+9. [Validation gates](#9-validation-gates)
+10. [Promotion to PUBLISHED](#10-promotion-to-published)
+11. [Correction & rollback](#11-correction--rollback)
+12. [Failure modes & anti-patterns](#12-failure-modes--anti-patterns)
+13. [Verification backlog](#13-verification-backlog)
+14. [Related docs](#14-related-docs)
+15. [Appendix A — Worked example: NWS alerts refresh](#appendix-a--worked-example-nws-alerts-refresh)
+
+---
+
+## 1. Purpose & scope
+
+This runbook tells a **Hazards lane operator** (steward, on-call engineer, or release reviewer) how to drive a routine or ad-hoc refresh of a Hazards source through the KFM governed lifecycle, what proof to emit at each step, and how to decide between **publish**, **quarantine**, **stale-mark**, **abstain**, or **deny**.
+
+**In scope.**
+
+- Cadence-driven refresh of Hazards `SourceDescriptor`-registered sources.
+- Ad-hoc re-admission after an upstream change (URL, schema, rights, terms, cadence).
+- Stale-state declaration on a Hazards layer or claim when freshness expires.
+- Quarantine intake, disposition, and recovery for Hazards inputs.
+- Triggering correction or rollback when a refresh exposes a published-claim defect.
+
+**Out of scope.**
+
+- Live, operator-facing emergency alerting. KFM is **not** a life-safety system; this runbook **MUST NOT** be used to drive operational warning dispatch.
+- One-time source onboarding (initial admission). That lives in `SOURCE_DESCRIPTOR_STANDARD.md` (PROPOSED) and source-intake doctrine.
+- Schema, contract, or policy authoring. Those live under `contracts/`, `schemas/`, and `policy/` per Directory Rules.
+
+> [!IMPORTANT]
+> **Hazards is not a life-safety alerting system.** Operational warnings, advisories, and watches from NWS or state emergency management enter KFM as **WarningContext** / **AdvisoryContext** with strict issue/expiry handling — never as actionable instructions. The doctrinal boundary is `DOM-HAZ`: *historical, regulatory, modeled, and operational-context hazard information for analysis and resilience, while refusing to act as a life-safety alerting system.* (CONFIRMED doctrine; PROPOSED implementation.)
+
+[⬆ Back to top](#top)
+
+---
+
+## 2. Doctrinal preflight
+
+Run this checklist **before** initiating any Hazards source refresh. Stop and escalate if any item fails.
+
+| # | Check | Where it lives | Status |
+|---|---|---|---|
+| 1 | A current `SourceDescriptor` exists for the source, with role, rights, sensitivity, cadence, and citation. | `data/registry/sources/hazards/` (PROPOSED) | CONFIRMED doctrine |
+| 2 | Source role is recorded as one of: `authority`, `observation`, `context`, `modeled`, `synthetic`, `candidate`. Source role is **fixed at admission** and **never upgraded** by a refresh. | `SourceDescriptor` field `source_role` | CONFIRMED doctrine; PROPOSED field shape |
+| 3 | Rights and terms are current; redistribution class is recorded. Unknown rights **fail closed**. | `SourceDescriptor.rights` + `policy/domains/hazards/` | CONFIRMED doctrine |
+| 4 | Sensitivity tier and any locality / cultural / sovereignty constraints are recorded. | `SourceDescriptor.sensitivity` | CONFIRMED doctrine |
+| 5 | Cadence (`expected_refresh_interval`) is recorded and the current request falls within or beyond it. | `SourceDescriptor.cadence` | CONFIRMED doctrine; field name PROPOSED |
+| 6 | The watcher / connector is **signed** and registered; admin shortcuts are not the normal path. | `connectors/` + control-plane register | CONFIRMED doctrine |
+| 7 | Public clients reach this data only through the **governed API** (`apps/governed-api/`). Browsers, MapLibre, and Focus Mode do **not** read RAW/WORK/QUARANTINE. | Trust membrane (Directory Rules §7.1) | CONFIRMED doctrine |
+
+> [!CAUTION]
+> If any preflight item is **UNKNOWN** or **NEEDS VERIFICATION**, the refresh **MUST NOT** proceed to PROCESSED. Hold in RAW / QUARANTINE, open a `docs/registers/VERIFICATION_BACKLOG.md` entry, and notify the Hazards lane steward.
+
+[⬆ Back to top](#top)
+
+---
+
+## 3. Hazards source families & source roles
+
+CONFIRMED doctrine from the Encyclopedia (§7.10) and Domains Atlas (Hazards Lane, §D): a source's *family* is its provenance origin; its *role* is its evidentiary stance inside KFM. Role determines which assertions a refresh may carry.
+
+| Source family | Typical role(s) | Rights / sensitivity | Freshness profile |
+|---|---|---|---|
+| NOAA Storm Events / NCEI-style records | `observation` (historical) | Public; sensitive joins fail closed | Source-vintage; episodic refresh |
+| NWS API (alerts, warnings, advisories, watches) | `context` only — **not** life-safety authority for KFM | Public; **issue/expiry mandatory** | Operational cadence; expired context **MUST NOT** appear as current |
+| FEMA Disaster Declarations / OpenFEMA | `authority` (legal declaration record) | Public; NEEDS VERIFICATION of redistribution terms | Event-driven |
+| FEMA NFHL / MSC flood hazard | `authority` (regulatory baseline) — **not** observed inundation or forecast | Public; NEEDS VERIFICATION | Localized, event-driven version updates (`VERSION_ID`, `EFFECTIVE_DATE`) |
+| USGS Earthquake Catalog | `observation` / `authority` | Public | Near-real-time to historical |
+| NOAA HMS Fire and Smoke | `observation` / `context` | Public | Daily cadence (PROPOSED) |
+| NASA FIRMS active fire | `observation` | Public; geoprivacy considerations | Sub-daily cadence (PROPOSED) |
+| Drought monitors | `context` / `modeled` | Public | Weekly cadence (PROPOSED) |
+| State / local emergency management & resilience plans | `context` / `authority` (jurisdictional) | NEEDS VERIFICATION per source | Variable |
+
+> [!NOTE]
+> **Source-role anti-collapse rule** (CONFIRMED doctrine, `DOM-HAZ`). A refresh **MUST NOT** silently change a source's role — e.g., a `modeled` source MUST NOT be re-admitted as `observation`, even if the upstream rebrands. Role drift requires a new `SourceDescriptor` with a `superseded_by` link, not an in-place update.
+
+[⬆ Back to top](#top)
+
+---
+
+## 4. Refresh flow (RAW → PUBLISHED)
+
+PROPOSED diagram of the governed refresh path. Concrete tool names, queue topology, and worker boundaries are **NEEDS VERIFICATION** against the mounted repo; doctrine is CONFIRMED.
+
+```mermaid
+flowchart TD
+    A[Cadence trigger or<br/>upstream event] --> B[Watcher / connector<br/>conditional GET ETag/If-None-Match]
+    B -->|304 / no change| C[No-op RunReceipt<br/>spec_hash unchanged]
+    B -->|new payload| D[RAW capture<br/>RawCaptureReceipt + hash]
+    D --> E{Schema / rights /<br/>sensitivity / temporal /<br/>geometry validators}
+    E -->|fail| Q[QUARANTINE<br/>QuarantineRecord +<br/>reason code]
+    E -->|pass| F[WORK<br/>normalize → TransformReceipt]
+    F --> G[PROCESSED<br/>ValidationReport +<br/>EvidenceRef]
+    G --> H[CATALOG / TRIPLET<br/>CatalogRecord +<br/>EvidenceBundle +<br/>release candidate]
+    H --> I{Promotion gate<br/>rights · sensitivity ·<br/>policy · review · proof}
+    I -->|deny / abstain| Q
+    I -->|allow| J[PUBLISHED<br/>ReleaseManifest +<br/>rollback target +<br/>governed API surface]
+    Q -.->|steward review| F
+    J -.->|stale / wrong| K[CorrectionNotice<br/>or RollbackCard]
+    K -.-> H
+
+    classDef gov fill:#0b4d6b,color:#fff,stroke:#062a3a;
+    classDef deny fill:#7a1f1f,color:#fff,stroke:#3a0d0d;
+    classDef pass fill:#1b5e20,color:#fff,stroke:#0d2e10;
+    class B,E,I gov
+    class Q,K deny
+    class C,J pass
+```
+
+> [!NOTE]
+> **PROPOSED diagram.** The branches, gate names, and receipt names reflect CONFIRMED doctrine from `DOM-HAZ`, the Encyclopedia Appendix E feature index, and the Domains Atlas v1.1. Specific queue, worker, validator, and route names remain **NEEDS VERIFICATION** until inspected in a mounted repo.
+
+[⬆ Back to top](#top)
+
+---
+
+## 5. Per-stage procedure
+
+Each subsection states **what the stage does**, **what it emits**, and **what blocks the next stage**. Receipt names are CONFIRMED doctrine; their schema homes are PROPOSED under `schemas/contracts/v1/receipts/` (NEEDS VERIFICATION; see ADR-0001).
+
+### 5.1 Trigger
+
+A refresh starts in one of three ways:
+
+1. **Cadence trigger.** Scheduler fires per the `SourceDescriptor.cadence`.
+2. **Upstream event.** Object-store event, webhook, or feed change advertised by the upstream.
+3. **Operator-initiated.** Hazards lane steward re-runs a refresh manually (e.g., after a rights-status change). All operator-initiated refreshes **MUST** record actor and reason.
+
+### 5.2 Watcher / connector fetch
+
+The watcher performs a **conditional GET** (HTTP `ETag` / `If-None-Match`, or upstream equivalent) and records the response in a `RunReceipt`. On `304 Not Modified`, emit a **no-op `RunReceipt`** and stop — do not create new STAC / catalog entities for unchanged sources.
+
+> [!TIP]
+> The no-op receipt is doctrinally important: it proves the system *looked* and *elected not to act*. Auditors and stale-state detectors rely on it.
+
+### 5.3 RAW capture
+
+Store the source-native payload (or a stable byte-addressed reference) immutably, with:
+
+- `source_id`
+- `source_role` (copied from `SourceDescriptor`; never re-derived here)
+- `content_hash` (e.g., SHA-256 over the byte payload)
+- `retrieval_time`
+- citation pointer
+- `rights` and `sensitivity` snapshots
+
+Emit a **`RawCaptureReceipt`**. **No public client may read RAW.** Egress from `data/raw/hazards/` is denied by trust-membrane policy.
+
+### 5.4 WORK / QUARANTINE — normalize and validate
+
+Run normalization (schema, geometry, time, identity, evidence, rights, policy). Each transform emits a **`TransformReceipt`** with `input_geom_hash`, `output_geom_hash`, parameters, and actor. Failures route to `data/quarantine/hazards/` with a **`QuarantineRecord`** that names the reason code (see §7).
+
+### 5.5 PROCESSED
+
+Emit validated, normalized objects (one of: `HazardEvent`, `HazardObservation`, `WarningContext`, `AdvisoryContext`, `DisasterDeclaration`, `FloodContext`, `WildfireDetection`, `SmokeContext`, `DroughtIndicator`, `EarthquakeEvent`, `HeatColdEvent`, `ExposureSummary`, `ResilienceSummary`, `HazardTimeline`, `ImpactArea`). Each object carries:
+
+- a resolvable **`EvidenceRef`** that points at an **`EvidenceBundle`** (resolution is required before publication);
+- a **`ValidationReport`** with finite outcomes;
+- distinct **temporal fields** for `observed_time`, `valid_time`, `issue_time`, `expiry_time`, `source_time`, `retrieval_time`, `release_time`, and `correction_time` where material.
+
+### 5.6 CATALOG / TRIPLET
+
+Emit a **`CatalogRecord`** with source, schema, validation, policy, and release metadata, plus a graph / triplet projection if applicable. The catalog closure test rejects orphan artifacts (no `EvidenceBundle`, no `ValidationReport`, no `SourceDescriptor`).
+
+### 5.7 PUBLISHED
+
+Promotion is **governed**, not a file move. See §10.
+
+[⬆ Back to top](#top)
+
+---
+
+## 6. Stale-state handling
+
+CONFIRMED doctrine (Domains Atlas v1.1 §24.8.1): KFM separates **stale** from **wrong**. A stale claim is one whose evidence, source freshness, dependent data, or context has aged past its declared tolerance; a wrong claim is incorrect in substance. Both states have visible markers and traceable lifecycles. The stale-state markers below apply to Hazards refreshes.
+
+| Marker | Trigger | UI signal | Required action |
+|---|---|---|---|
+| **Source freshness expired** | Cadence in `SourceDescriptor` passed without a new admission | Stale source badge in Evidence Drawer | Re-admit or supersede; otherwise mark dependent claims stale |
+| **Schema version drift** | Object schema upgraded past the published claim's schema version | Schema-drift badge; show migration ADR | Migrate, re-validate, re-release; or mark stale |
+| **Geography version drift** | `GeographyVersion` replaced; published claim still bound to the prior version | Geography-version banner with prior-version cite | Rebind to current `GeographyVersion`; re-release; or mark stale |
+| **Time-scope outside support** | Claim's temporal scope falls outside current data support window | Time-out-of-support indicator | Mark stale; **do not refresh silently** |
+| **Model version superseded** | `ModelRunReceipt` references an older model than current | Model-version badge with new model identity | Re-run; supersede; or mark stale |
+| **Review aged out** | `ReviewRecord` older than the review-cycle tolerance for the sensitive lane | Review-aged badge | Trigger steward review; potentially downgrade tier |
+| **Rights status changed** | Rights change in `SourceDescriptor` or rights-holder communication | Rights-changed badge | Re-evaluate tier; potentially downgrade; emit `CorrectionNotice` if necessary |
+| **Policy version changed** | Policy referenced by `PolicyDecision` was superseded | Policy-version badge | Re-run gate; potentially supersede release |
+
+> [!WARNING]
+> **Operational-warning expiry is doctrinally absolute.** For Hazards, `WarningContext` and `AdvisoryContext` carry mandatory `issue_time` / `expiry_time` fields. An expired warning **MUST NOT** appear as a current warning state in any released layer, popup, or Evidence Drawer payload. (`DOM-HAZ`, CONFIRMED.)
+
+[⬆ Back to top](#top)
+
+---
+
+## 7. Quarantine handling
+
+CONFIRMED doctrine: **quarantine is not a publishable staging area.** A `QuarantineRecord` holds failed, sensitive, rights-unknown, or malformed inputs until disposition.
+
+Typical Hazards quarantine reasons (PROPOSED reason-code list; align with `policy/domains/hazards/` once mounted):
+
+- `schema_invalid` — payload fails the shape contract.
+- `rights_unknown` — license, redistribution class, or attribution missing.
+- `source_role_ambiguous` — upstream rebranding or unclear evidentiary stance.
+- `sensitive_geometry` — locality, cultural, or sovereignty constraint triggered.
+- `expired_operational_context` — warning/advisory past `expiry_time` at retrieval.
+- `temporal_role_collapse` — observed/issued/valid/retrieved times collapsed in upstream.
+- `geometry_invalid` — topology, CRS, or coordinate-range failure.
+- `evidence_unresolved` — `EvidenceRef` cannot resolve to an `EvidenceBundle`.
+- `policy_deny` — admissibility gate denied the input.
+
+**Recovery path.** A quarantined input may re-enter WORK only after:
+
+1. The blocking condition is documented and resolved (rights letter, schema migration, redaction receipt, etc.).
+2. A steward records a `ReviewRecord` authorizing re-entry.
+3. The original `QuarantineRecord` is retained for audit; a forward link records the disposition.
+
+[⬆ Back to top](#top)
+
+---
+
+## 8. Receipts, evidence, and audit trail
+
+CONFIRMED doctrine: a refresh's audit trail is the union of its receipts. If no receipt exists, the operation did not happen in the governed sense.
+
+<details>
+<summary><strong>Hazards-refresh receipt families (CONFIRMED doctrine; PROPOSED schema home under <code>schemas/contracts/v1/receipts/</code>)</strong></summary>
+
+| Receipt | Purpose | Triggered by |
+|---|---|---|
+| `SourceDescriptor` | Anchors source identity, rights, role, sensitivity, cadence at admission | Source admission (one per source; superseded on change) |
+| `RawCaptureReceipt` | Records the immutable RAW capture (payload reference + hash + time) | Watcher fetch with new payload |
+| `TransformReceipt` | Records a spatial / attribute transform (reprojection, generalization, snap, simplification) | Normalization steps |
+| `ValidationReport` | Records the finite outcome of schema / geometry / temporal / rights / sensitivity / evidence checks | WORK and PROCESSED gates |
+| `RunReceipt` | Records pipeline run, inputs, outputs, `spec_hash`, timestamp, operator, result | Every governed run, including no-op |
+| `RedactionReceipt` | Records a public-safe transformation (mask, fuzz, withhold) for sensitivity or rights | Sensitive-lane publication |
+| `QuarantineRecord` | Records reason and disposition for held inputs | Validator / policy denial |
+| `EvidenceRef` → `EvidenceBundle` | Stable reference from a claim to its evidence; bundle returns sources, excerpts, provenance, policy / review / release state | Every published claim |
+| `PolicyDecision` | ALLOW / DENY / RESTRICT / ABSTAIN / ERROR with rule IDs and reasons | Every gate |
+| `PromotionDecision` | Gate results, materiality, review state, attestations, release / rollback targets | Promotion gate |
+| `ReleaseManifest` | Binds the published artifact set with rollback target and cache-invalidation record | Promotion → PUBLISHED |
+| `CorrectionNotice` | Records a substantive correction to a published claim and lists invalidated derivatives | Wrong-state path |
+| `RollbackCard` | Records a reversal anchor: prior manifest, artifact digests, cache invalidation, replay steps | Pre-publication or post-publication rollback |
+| `ReviewRecord` | Steward / reviewer disposition; required for sensitive lanes | Review queue |
+| `AIReceipt` | Provider, model, context, config, prompt class, evidence refs, output digest, citation report — **never** chain-of-thought | Any AI-assisted summarization over Hazards EvidenceBundles |
+
+</details>
+
+> [!NOTE]
+> **Conditional-GET receipts matter.** Every conditional fetch — including `304 Not Modified` outcomes — **MUST** emit a `RunReceipt`. Silent no-ops break audit chains and confuse stale-state detection.
+
+[⬆ Back to top](#top)
+
+---
+
+## 9. Validation gates
+
+PROPOSED test families derived from `DOM-HAZ` validator list and the Encyclopedia §K. Specific validator names, file paths, and CI job IDs are **NEEDS VERIFICATION** in a mounted repo.
+
+| Gate | What it proves | Default on failure |
+|---|---|---|
+| Schema validation | `SourceDescriptor`, normalized object, `LayerManifest`, `EvidenceBundle`, and receipt families all match `schemas/contracts/v1/...` shapes | DENY before promotion |
+| Source-role anti-collapse | Role at PROCESSED matches role at admission; no upgrade through promotion | DENY |
+| Rights & terms | Current redistribution class and attribution are recorded; unknown rights fail closed | DENY public; allow restricted with `ReviewRecord` |
+| Sensitivity / geoprivacy | Locality, cultural, sovereignty constraints honored; sensitive geometry generalized or denied before public tile production | DENY public; emit `RedactionReceipt` for restricted release |
+| Temporal-role | `observed`, `issued`, `valid`, `source`, `retrieval`, `release`, and `correction` times stay distinct where material | DENY |
+| Operational expiry / freshness | `WarningContext` / `AdvisoryContext` `expiry_time` not passed at release time | DENY public; mark stale |
+| Geometry validity | Topology, CRS, coordinate range pass | Quarantine; emit `GeometryRepairReport` if a repair is attempted |
+| Evidence closure | Every claim's `EvidenceRef` resolves to an `EvidenceBundle` | ABSTAIN on the claim; do not publish |
+| Citation validation | Evidence Drawer payloads carry resolvable citations; Focus Mode answers are cited or abstain | ABSTAIN |
+| Emergency-alert denial | KFM is not invoked as an emergency-alerting authority | DENY |
+| Catalog closure | Published dataset / layer has source, schema, validation, policy, release metadata | DENY promotion |
+| UI no-direct-source | Public clients route through `apps/governed-api/`, never to `data/raw|work|quarantine` or upstream APIs | DENY route at trust-membrane test |
+
+[⬆ Back to top](#top)
+
+---
+
+## 10. Promotion to PUBLISHED
+
+Promotion is a **governed state transition**, not a file move. A Hazards release candidate becomes PUBLISHED only when:
+
+1. **Catalog closure passes.** Every published dataset / layer has its source, schema, validation, policy, and release metadata.
+2. **EvidenceRef → EvidenceBundle resolves** for every claim a public surface might expose.
+3. **Policy gate ALLOWs.** No outstanding DENY or unresolved ABSTAIN on rights, sensitivity, operational expiry, or review state.
+4. **Review state is current.** For sensitive lanes, separation of duties applies: the release authority **MUST** be distinct from the author / promoter.
+5. **`ReleaseManifest` is signed**, carries a **rollback target**, and is bound to a **cache-invalidation record**.
+6. **Trust-membrane tests pass.** No public client can reach RAW, WORK, QUARANTINE, canonical stores, vector indexes, or upstream APIs.
+
+> [!IMPORTANT]
+> **Watcher-as-non-publisher invariant** (CONFIRMED doctrine, Directory Rules §13.5). Workers and connectors emit **receipts and candidate decisions only.** They do **not** write to `data/catalog/` or `data/published/`. The publication boundary is a separate governed step.
+
+[⬆ Back to top](#top)
+
+---
+
+## 11. Correction & rollback
+
+When a refresh exposes a defect in a previously-published Hazards claim:
+
+1. **Decide stale vs wrong.** A *stale* claim is aged-out evidence; a *wrong* claim is substantively incorrect. (Atlas v1.1 §24.8.) Stale-marking is not a correction.
+2. **Emit a `CorrectionNotice`** for wrong claims. The notice **MUST** list invalidated derivatives (tiles, exports, Story Nodes, AI summaries) so downstream caches and `EvidenceBundles` can be re-resolved.
+3. **Emit a `RollbackCard`** if the wrong claim must be withdrawn rather than replaced. The card pins the prior `ReleaseManifest`, artifact digests, cache state, and replay steps.
+4. **Run the rollback drill.** A rollback receipt confirms the prior manifest is restored and caches are invalidated.
+5. **AIReceipts are never superseded retroactively.** An updated answer is a **new** `AIReceipt` with a cross-reference to the old one.
+
+[⬆ Back to top](#top)
+
+---
+
+## 12. Failure modes & anti-patterns
+
+CONFIRMED anti-patterns from Domains Atlas v1.1 §24.9.2 and Directory Rules §13.5, narrowed to Hazards-refresh contexts.
+
+| Anti-pattern | Why it fails | DENY surface |
+|---|---|---|
+| KFM cited as an emergency-alert authority | Out-of-scope use of governed evidence as life-safety guidance | Hazards governed API; Evidence Drawer disclaimer |
+| Expired warning surfaced as current warning state | `expiry_time` ignored; operational-context boundary violated | `WarningContext` validator |
+| Public route reads `data/raw` or `data/quarantine` directly | Trust membrane bypassed; promotion gates skipped | Governed API; layer-manifest resolver |
+| Watcher writes to `data/published/` | Watcher-as-non-publisher invariant violated | Promotion gate |
+| Source role upgraded by refresh (e.g., `modeled` → `observation`) | Source-role anti-collapse rule broken | Source-role validator |
+| Quarantine treated as staging area | Quarantine is not publishable; review must clear it first | Promotion gate |
+| Sensitive geometry hidden only by style filter on the renderer | Renderer is not a governance surface | Tile build; sensitivity validator |
+| Refresh skips a lifecycle phase (e.g., RAW → PUBLISHED directly) | Lifecycle invariant violated | Catalog closure |
+| AI answer published without resolvable citations | Cite-or-abstain rule broken; AI becomes its own truth source | Citation validator; Focus Mode |
+| Promotion auto-approved by the author | Separation of duties violated on a sensitive lane | Promotion gate |
+
+[⬆ Back to top](#top)
+
+---
+
+## 13. Verification backlog
+
+Items to verify against a mounted repo before this runbook can move from `draft` to `published`. Each is **NEEDS VERIFICATION** in this session.
+
+- Path of this runbook (`docs/runbooks/hazards/` subfolder vs flat `docs/runbooks/hazards_SOURCE_REFRESH.md`). Existing PROPOSED examples in the Whole-UI Expansion Report use flat subsystem-prefixed naming (`docs/runbooks/ui_LOCAL_DEV.md`), while Domain Placement Law (Directory Rules §12) supports domain-segmented subfolders inside responsibility roots. **An ADR or a mounted-repo convention should settle this.**
+- Owner names in the meta block and the Status table.
+- Whether `connectors/hazards/` exists and the exact watcher schema fields used.
+- Whether `data/registry/sources/hazards/` is the canonical source-descriptor home (alt: `data/registry/sources/` flat).
+- Whether `schemas/contracts/v1/receipts/` is the canonical receipt-schema home, or whether ADR-S-03 (Atlas v1.1 §24.12) has been accepted to split receipts under `schemas/contracts/v1/<domain>/receipts/`.
+- Concrete validator file names, CI job names, and OPA / policy-engine identifiers for each gate in §9.
+- The release / promotion app or workflow that executes §10 (e.g., `apps/cli/`, `apps/workers/`, GitHub Actions name).
+- Cadence values per source (NOAA Storm Events, NWS API, FEMA, USGS, NASA FIRMS, drought monitors).
+- The rollback-drill schedule for Hazards releases.
+- The mounted-repo `docs/runbooks/` README, if any, governing runbook structure.
+
+> [!TIP]
+> Open backlog items in `docs/registers/VERIFICATION_BACKLOG.md` rather than smoothing them over in this runbook.
+
+[⬆ Back to top](#top)
+
+---
+
+## 14. Related docs
+
+| Doc | Role | Status |
+|---|---|---|
+| `docs/doctrine/directory-rules.md` | Placement law for every file referenced here | CONFIRMED (this session) |
+| `docs/doctrine/lifecycle-law.md` | RAW → PUBLISHED invariant | PROPOSED home; doctrine CONFIRMED |
+| `docs/doctrine/trust-membrane.md` | Public-client boundaries; deny-by-default | PROPOSED home; doctrine CONFIRMED |
+| `docs/domains/hazards/README.md` | Hazards domain README (mission, boundaries, source families) | PROPOSED |
+| `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` | One-time source onboarding and descriptor shape | PROPOSED |
+| `docs/runbooks/governed_ai_VALIDATION.md` | Focus Mode evidence / citation / policy validation runbook | PROPOSED |
+| `docs/runbooks/ui_ROLLBACK.md` | UI rollback, feature flag, schema deprecation | PROPOSED |
+| `docs/adr/ADR-0001-schema-home.md` | Schema-home convention (`schemas/contracts/v1/...`) | PROPOSED home; convention CONFIRMED |
+| `docs/registers/DRIFT_REGISTER.md` | Where to record repo-vs-doctrine conflicts | PROPOSED home |
+| `docs/registers/VERIFICATION_BACKLOG.md` | Where to log items from §13 | PROPOSED home |
+| `control_plane/source_authority_register.yaml` | Machine-readable source authority register | PROPOSED |
+
+[⬆ Back to top](#top)
+
+---
+
+## Appendix A — Worked example: NWS alerts refresh
+
+PROPOSED illustrative example. Treat values as placeholders; real values are NEEDS VERIFICATION against a mounted source registry and connector implementation.
+
+<details>
+<summary><strong>Step-by-step: refreshing an <code>NWS alerts</code> feed into <code>WarningContext</code></strong></summary>
+
+**Source.** `EXT-NWS` — NWS API, official forecast / alert / observation context. Role: `context` (KFM is **not** a forecasting or emergency-alerting authority).
+
+**Cadence.** Sub-hourly (PROPOSED). Operator-initiated refresh is allowed on a documented reason.
+
+**1. Preflight.**
+
+- `SourceDescriptor` for `EXT-NWS` is current, signed, and registered in the source authority register.
+- Source role is `context`. Rights are public (NEEDS VERIFICATION of current terms).
+- Sensitivity tier is the Hazards lane default; locality constraints do not apply.
+
+**2. Watcher fetch.**
+
+```text
+GET /alerts/active?area=KS
+If-None-Match: "<prior_etag>"
+```
+
+- `304 Not Modified` → emit `RunReceipt{spec_hash=unchanged, outcome=no-op}` and stop.
+- `200 OK` → proceed to RAW capture with new payload.
+
+**3. RAW capture.**
+
+```text
+data/raw/hazards/nws/alerts/active/<retrieval_ts>.json   (PROPOSED path)
+RawCaptureReceipt{
+  source_id: "EXT-NWS",
+  source_role: "context",
+  content_hash: "sha256:<...>",
+  retrieval_time: "<iso8601>",
+  rights_snapshot: "<...>",
+  citation: "<...>"
+}
+```
+
+**4. Normalize + validate.**
+
+- Schema-shape the alert envelope to `WarningContext` and `AdvisoryContext` objects.
+- Enforce **issue/expiry**: any alert past `expiry_time` at retrieval routes to QUARANTINE with reason `expired_operational_context`. (CONFIRMED doctrine, `DOM-HAZ`.)
+- Run temporal-role checks: `issued`, `valid_from`, `valid_to`, `source_time`, `retrieval_time` must stay distinct.
+- Run geometry validators.
+- Emit `TransformReceipt` and `ValidationReport`.
+
+**5. PROCESSED.**
+
+Emit one `WarningContext` or `AdvisoryContext` object per active alert with a resolvable `EvidenceRef`, a `ValidationReport`, and a `not-for-life-safety` disclaimer flag set.
+
+**6. CATALOG / TRIPLET.**
+
+Add a `CatalogRecord`; project relevant triples into the graph (e.g., `WarningContext --affects--> County`).
+
+**7. Promotion.**
+
+- Policy gate: ALLOW only if all alerts have non-expired `expiry_time` at release time *or* are explicitly marked historical-context.
+- `ReleaseManifest` is signed and carries the prior manifest as `rollback_target`.
+- Cache invalidation record names the affected layers.
+
+**8. Stale handling at runtime.**
+
+- The Evidence Drawer shows the stale-source badge when the `SourceDescriptor` cadence elapses without a new admission.
+- The not-for-life-safety disclaimer is **never suppressed**, even on a fresh refresh.
+
+</details>
+
+[⬆ Back to top](#top)
+
+---
+
+## Footer
+
+> This runbook is governed by the KFM lifecycle law (`RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`) and the trust-membrane rule (public clients use `apps/governed-api/` only). It is **doctrine-grounded** but **implementation-PROPOSED**. Mounted-repo evidence is required to convert the PROPOSED elements (paths, validator names, schema homes, owners, cadences) into CONFIRMED ones.
+
+**Related docs:** [Directory Rules](../../doctrine/directory-rules.md) · [Lifecycle Law](../../doctrine/lifecycle-law.md) · [Trust Membrane](../../doctrine/trust-membrane.md) · [Hazards domain README](../../domains/hazards/README.md) · [Governed-AI Validation](../governed_ai_VALIDATION.md)
+
+**Last updated:** 2026-05-12 · **Status:** draft · **Owners:** TODO (NEEDS VERIFICATION) · [⬆ Back to top](#top)

--- a/docs/runbooks/hydrology/NO_NETWORK_TEST_RUNBOOK.md
+++ b/docs/runbooks/hydrology/NO_NETWORK_TEST_RUNBOOK.md
@@ -1,3 +1,584 @@
-# hydrology :: NO_NETWORK_TEST runbook
+# 🌊 Hydrology · No-Network Test Runbook
 
-Greenfield placeholder.
+> **Operating procedure for executing KFM's deterministic, offline test pyramid for the Hydrology lane — no live USGS / WBD / NHDPlus / NFHL endpoints, no network egress, fail-closed by design.**
+
+[![Status: draft](https://img.shields.io/badge/status-draft-orange)](#) [![Lane: hydrology](https://img.shields.io/badge/lane-hydrology-1f77b4)](#) [![Posture: no--network](https://img.shields.io/badge/posture-no--network-2ca02c)](#) [![Doctrine: cite--or--abstain](https://img.shields.io/badge/doctrine-cite--or--abstain-555)](#) [![Trust path: governed](https://img.shields.io/badge/trust%20path-governed-7f3fbf)](#) [![CI: TODO](https://img.shields.io/badge/CI-TODO-lightgrey)](#)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` |
+| **Owners** | Hydrology lane steward · QA steward · Docs steward _(placeholder until repo `CODEOWNERS` is verified)_ |
+| **Doc type** | Operations runbook (no-network test execution) |
+| **Last updated** | `YYYY-MM-DD` — set on merge |
+| **Audience** | Lane stewards, QA, validator authors, CI maintainers, reviewers |
+| **Proposed path** | `docs/runbooks/hydrology/NO_NETWORK_TEST_RUNBOOK.md` _(PROPOSED — see §13 for path convention note)_ |
+
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/hydrology/no-network-test
+title: Hydrology · No-Network Test Runbook
+type: standard
+version: v1
+status: draft
+owners: hydrology-lane-steward, qa-steward, docs-steward
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - kfm://doctrine/directory-rules
+  - kfm://doctrine/lifecycle-law
+  - kfm://doctrine/truth-posture
+  - kfm://domain/hydrology
+  - kfm://runbook/ui_validation
+  - kfm://runbook/governed_ai_validation
+  - kfm://adr/ADR-0001-schema-home
+tags: [kfm, hydrology, runbook, testing, no-network, fixtures, proof-lane]
+notes:
+  - "Runbook lives under docs/runbooks/. Subdirectory `hydrology/` is PROPOSED; flat-named alternative `docs/runbooks/hydrology_NO_NETWORK_TEST.md` is also consistent with prior runbook drafts."
+  - "All command paths and CI references are PROPOSED until a mounted repo confirms them."
+[/KFM_META_BLOCK_V2] -->
+
+---
+
+## 🧭 Quick Jump
+
+- [1 · Purpose & Scope](#1--purpose--scope)
+- [2 · Doctrinal Basis](#2--doctrinal-basis)
+- [3 · Test-Surface Overview](#3--test-surface-overview)
+- [4 · Preconditions](#4--preconditions)
+- [5 · Fixture Inventory](#5--fixture-inventory)
+- [6 · The No-Network Test Pyramid](#6--the-no-network-test-pyramid)
+- [7 · Execution Procedure](#7--execution-procedure)
+- [8 · Expected Outcomes & Decision Envelope](#8--expected-outcomes--decision-envelope)
+- [9 · Negative-Test Catalog](#9--negative-test-catalog)
+- [10 · CI Integration](#10--ci-integration)
+- [11 · Failure Handling & Rollback](#11--failure-handling--rollback)
+- [12 · Verification Backlog](#12--verification-backlog)
+- [13 · Related Docs](#13--related-docs)
+- [14 · Appendix · Reference Commands](#14--appendix--reference-commands)
+
+---
+
+## 1 · Purpose & Scope
+
+This runbook governs **how to execute, interpret, and gate KFM's no-network test pyramid for the Hydrology lane**. It exists because Hydrology is the **CONFIRMED early proof lane** for KFM — the first domain where the trust spine (source descriptor → evidence resolution → policy decision → release manifest → rollback target) must run end-to-end without invoking a single live external endpoint.
+
+**In scope**
+
+- Deterministic, offline execution of the hydrology fixture suite.
+- Fixture inventory and outcome expectations for the Kansas HUC12 thin slice.
+- Pyramid ordering (schemas → contracts → validators → policy negative tests → evidence resolution → finite envelopes).
+- Failure handling, ABSTAIN/DENY semantics, and rollback posture.
+- Local-run and CI-run procedure.
+
+**Out of scope**
+
+- Live USGS / WBD / NHDPlus HR / NFHL / 3DEP fetches. _(Those belong to source-activated, opt-in jobs governed by `SourceActivationDecision`.)_
+- Emergency-alert behavior. **Hydrology is not a life-safety surface.** NFHL is regulatory context; it is **never** observed inundation. _CONFIRMED doctrine._
+- UI rendering of layers in `apps/explorer-web` _(see the UI validation runbook)._
+- Governed-AI Focus Mode validation _(see the governed-AI validation runbook)._
+
+> [!IMPORTANT]
+> **No-network means no network.** If a test reaches DNS, an external API, an IP address, an unverified registry, or any non-fixture I/O, the suite has failed its first invariant — regardless of any green check downstream. CI must enforce egress denial; local runs should set `KFM_NO_NETWORK=1` and verify egress is blocked before relying on a passing result.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 2 · Doctrinal Basis
+
+The no-network proof lane is not a stylistic choice. It is a direct consequence of KFM's lifecycle law, truth posture, and trust-membrane doctrine.
+
+| Doctrine | What it requires here | Status |
+|---|---|---|
+| **Lifecycle invariant** — `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` | Fixtures simulate **every** stage offline. Promotion remains a governed state transition, not a file move. | CONFIRMED doctrine / PROPOSED implementation |
+| **Trust membrane** — public clients consume governed APIs and released artifacts only | No test may bind a public surface to `data/raw`, `data/work`, `data/quarantine`, internal stores, or live model clients. | CONFIRMED doctrine |
+| **Cite-or-abstain** | Any test asserting a hydrology answer must either resolve an `EvidenceBundle` or assert `ABSTAIN`. | CONFIRMED doctrine |
+| **Hydrology as early proof lane** | Hydrology is the safest first proof-bearing slice: public-suitable when released, but with non-trivial source-role separation (USGS observations vs NFHL regulatory vs forecasts vs alerts). | CONFIRMED doctrine |
+| **First implementation package is fixture-first and no-network** | HUC/WBD fixture, identity crosswalk fixture, observation normalization fixture, EvidenceBundle closure, catalog/proof closure, public-safe layer output — all offline. | CONFIRMED doctrine / PROPOSED implementation |
+| **Deterministic identity via `spec_hash`** | Bundle and reference IDs derive from canonical JSON (sorted keys, no whitespace variance) hashed with SHA-256. Same evidence ⇒ same `spec_hash` across environments. | PROPOSED (v1 draft per project notes) |
+| **Deny-by-default emergency posture** | KFM never publishes itself as life-safety authority. NFHL is regulatory context only. | CONFIRMED doctrine |
+
+> [!NOTE]
+> Project doctrine ranks Hydrology, Soil + Habitat/Fauna, and MapLibre UI as the typical first three proof phases. This runbook addresses **Phase 1: Hydrology proof lane**. Adjacent runbooks for soil/fauna and the UI shell will follow the same pyramid.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 3 · Test-Surface Overview
+
+The no-network suite walks a controlled record from intake through release-candidate state without touching the publication path. The diagram below shows responsibility boundaries, not file paths.
+
+```mermaid
+flowchart LR
+  subgraph FIX["Fixtures (no network)"]
+    RAWFIX["RAW fixture<br/>SourceDescriptor + payload ref"]
+    WBDFIX["WBD/HUC12 fixture"]
+    NHDFIX["NHDPlus crosswalk fixture"]
+    GAUGEFIX["USGS gauge fixture"]
+    NFHLFIX["NFHL regulatory fixture"]
+  end
+
+  subgraph VAL["Validators"]
+    SCHEMA["Schema validators"]
+    GEOM["Geometry / topology"]
+    ROLE["Source-role separation"]
+    ID["Identity / spec_hash"]
+    EVD["Evidence closure"]
+  end
+
+  subgraph GATE["Policy gates"]
+    RIGHTS["Rights gate"]
+    SENS["Sensitivity gate"]
+    REL["Release gate"]
+  end
+
+  subgraph OUT["Governed envelopes"]
+    ENV["RuntimeResponseEnvelope<br/>ANSWER / ABSTAIN / DENY / ERROR"]
+    REC["RunReceipt / AIReceipt"]
+    RM["ReleaseManifest (dry-run)"]
+    RB["RollbackCard"]
+  end
+
+  FIX --> VAL --> GATE --> OUT
+  classDef forbid fill:#fdd,stroke:#900,color:#900;
+  classDef ok fill:#dfd,stroke:#080,color:#060;
+  class FIX,VAL,GATE,OUT ok
+```
+
+> [!CAUTION]
+> The diagram is a **responsibility map**. It does not assert that these modules, files, or routes exist in the current repo. All path-shaped claims in this runbook are marked **PROPOSED** until verified against a mounted checkout.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 4 · Preconditions
+
+Before running the suite locally or in CI:
+
+1. **Repository checkout** of a known commit / branch. Record the SHA in the run notes.
+2. **Toolchain installed** at pinned versions. Pin set is **PROPOSED** until lockfiles are inspected — see §12.
+3. **No network egress** for the runner. Locally, set `KFM_NO_NETWORK=1` and confirm with the egress probe in §14. In CI, the workflow must run with network disabled or behind a deny-all egress policy.
+4. **No secrets required.** The no-network suite must not require API keys, signing keys, or credentials of any kind. If a test asks for one, it is the wrong layer — promote it to the source-activated suite.
+5. **Fixtures present and read-only.** The suite never mutates fixtures; any test that does so is broken.
+6. **Time deterministic.** Tests requiring timestamps use fixture-provided `observed_time`, `valid_time`, `source_time`, `retrieval_time`, `release_time`, `correction_time` — never `now()`.
+
+> [!TIP]
+> If a developer is unsure whether their change touches network behavior, run with `KFM_NO_NETWORK=1` **first**. A test that depends on live data will fail noisily and clearly — which is the desired outcome.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 5 · Fixture Inventory
+
+The Hydrology lane's thin-slice plan (per `kfm_encyclopedia.pdf` §5 and §7.2) is:
+
+> **Kansas HUC12 + one USGS gauge fixture + one NHDPlus identity crosswalk + NFHL contextual overlay + hydrograph panel + EvidenceBundle closure + ABSTAIN on ambiguous reach identity.** _CONFIRMED doctrine._
+
+The fixture inventory implements that plan. All paths below are **PROPOSED** until verified against a mounted repo.
+
+| Fixture family | Purpose | Variants needed | Proposed home |
+|---|---|---|---|
+| `SourceDescriptor` | Identity, role, rights, sensitivity, cadence per source. | `valid`, `invalid_missing_rights`, `invalid_role_misuse`, `denied_unactivated` | `fixtures/domains/hydrology/source/` |
+| `HUC12 (WBD)` | One Kansas HUC12 polygon with metadata + geometry fingerprint. | `valid`, `invalid_topology`, `stale_snapshot` | `fixtures/domains/hydrology/huc12/` |
+| `NHDPlus identity crosswalk` | One COMID ↔ HUC12 row with `decision_reason` and `alignment_score`. | `valid_official`, `valid_overlay`, `invalid_low_alignment`, `ambiguous_multi_huc` | `fixtures/domains/hydrology/crosswalk/` |
+| `GaugeSite + FlowObservation` | One USGS gauge with one flow record. | `valid_provisional`, `valid_final`, `invalid_unit`, `invalid_qualifier` | `fixtures/domains/hydrology/gauge/` |
+| `NFHL contextual overlay` | One NFHLZone polygon, regulatory-only. | `valid_regulatory`, `denied_as_observed_flood` | `fixtures/domains/hydrology/nfhl/` |
+| `EvidenceBundle` | Closure object resolving the above. | `valid_closed`, `invalid_missing_bundle`, `invalid_hash_mismatch` | `fixtures/domains/hydrology/evidence/` |
+| `PolicyDecision` | Rights / sensitivity / release outcomes. | `allow`, `deny_rights_unknown`, `deny_emergency_misuse`, `hold_pending_review` | `fixtures/domains/hydrology/policy/` |
+| `RuntimeResponseEnvelope` | Finite-outcome wrapper for governed API. | `answer`, `abstain_ambiguous_reach`, `deny_emergency`, `error_malformed` | `fixtures/domains/hydrology/runtime/` |
+| `ReleaseManifest` (dry-run) | Public-safe release candidate. | `valid_dry_run`, `invalid_missing_rollback`, `invalid_missing_correction_path` | `fixtures/domains/hydrology/release/` |
+| `RollbackCard` | Pointer to prior release for revert. | `valid` | `fixtures/domains/hydrology/release/` |
+
+<details>
+<summary><strong>Fixture authoring rules (click to expand)</strong></summary>
+
+The KFM unified manual states: _every major object family should have at least one valid fixture, one invalid fixture, one denied fixture, one abstention fixture, and one rollback or correction fixture._ Apply that rule to each row above; the variants listed are the minimum, not the maximum.
+
+Additional rules:
+
+- **Public-safe only.** No real exact gauge coordinates for sensitive sites; no living-person data; no critical-infrastructure exposure detail. Use Kansas public hydrography where rights are unambiguous.
+- **Canonical JSON.** Sorted keys, UTF-8, compact separators, normalized floats. This is what makes `spec_hash` stable across machines.
+- **Time fields distinct.** `observed_time`, `valid_time`, `source_time`, `retrieval_time`, `release_time`, `correction_time` are never collapsed even when they happen to coincide.
+- **Source-role explicit.** A USGS observation is not an NFHL regulatory record. A regulatory record is not observed inundation. A forecast is not an alert. Each fixture states its role in the `SourceDescriptor`.
+- **No silent reuse.** If two fixtures share a `spec_hash`, they share an identity. Reuse is allowed; silent reuse with diverging meaning is not.
+
+</details>
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 6 · The No-Network Test Pyramid
+
+The KFM testing strategy specifies an explicit ordering: _start with deterministic no-network fixture tests, then schema and contract tests, validator unit tests, policy negative tests, evidence-resolution tests, lifecycle-state tests, receipt/proof tests, release-manifest tests, governed API envelope tests, UI trust-state tests, and only later live-source or runtime tests._ _CONFIRMED doctrine._
+
+| # | Layer | What it proves | Default outcome on failure |
+|---|---|---|---|
+| 1 | **Path / drift scan** | Files live in the responsibility roots Directory Rules requires. | Fail CI; no merge. |
+| 2 | **Schema validators** | Required fields, versions, enums match `schemas/contracts/v1/...`. | Fail; surface field list. |
+| 3 | **Contract tests** | Object _meaning_ matches the vocabulary in `contracts/`. | Fail; surface contract id. |
+| 4 | **Geometry / topology** | Geometry is valid; fingerprints are stable; polygon rings close. | Fail; surface offending feature id. |
+| 5 | **Source-role separation** | NFHL ≠ observed flood; forecast ≠ alert; community-science ≠ regulatory authority. | DENY in policy layer. |
+| 6 | **Identity / `spec_hash`** | Canonical JSON, deterministic hashing, ID derivation parity. | ERROR with `NormalizationError`. |
+| 7 | **Evidence closure** | `EvidenceRef.spec_hash` → catalog lookup → `EvidenceBundle.spec_hash` match → recomputed `bundle_id` equals stored id. | ABSTAIN on miss; DENY on mismatch. |
+| 8 | **Policy negative suite** | Unknown rights, unclear sensitivity, unactivated source, emergency misuse — all DENY with explicit reason codes. | DENY; reason code required. |
+| 9 | **Finite-envelope tests** | `RuntimeResponseEnvelope` returns one of `ANSWER / ABSTAIN / DENY / ERROR` — never silently `null`, never an unstructured 200. | ERROR with diagnostic. |
+| 10 | **Release-manifest dry-run** | Manifest carries proof refs, correction path, rollback target. | HOLD or DENY; never auto-publish. |
+| 11 | **Rollback drill** | RollbackCard resolves to a prior release; revert is reachable from fixtures alone. | Fail; surface unreachable rollback. |
+
+> [!NOTE]
+> Layers 1–11 run **in order**. Earlier layers gate later ones: a schema-broken fixture should never be evaluated by the policy suite — fix the schema first. CI should respect this so failures are localized and readable.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 7 · Execution Procedure
+
+The following procedure assumes a clean checkout and the preconditions in §4. All commands are **PROPOSED** — adapt to the actual tooling once verified against a mounted repo.
+
+### 7.1 Local run
+
+```bash
+# 1. Confirm no-network posture (egress should be blocked or absent).
+export KFM_NO_NETWORK=1
+
+# 2. (PROPOSED) Install pinned toolchain. Replace with verified package manager.
+#    e.g., poetry install --no-interaction
+#         pnpm install --frozen-lockfile
+#         pip install -r requirements.txt
+
+# 3. (PROPOSED) Run the path / drift scan.
+#    e.g., python tools/checks/path_role_scan.py --root .
+
+# 4. (PROPOSED) Run schema + contract suites.
+#    e.g., pytest tests/contracts tests/schemas -k hydrology
+
+# 5. (PROPOSED) Run validators (geometry, role, identity, evidence closure).
+#    e.g., pytest tests/validators -k hydrology
+
+# 6. (PROPOSED) Run policy negative suite.
+#    e.g., conftest test -p policy/domains/hydrology fixtures/domains/hydrology
+
+# 7. (PROPOSED) Run finite-envelope suite.
+#    e.g., pytest tests/runtime_proof -k hydrology
+
+# 8. (PROPOSED) Run release dry-run + rollback drill.
+#    e.g., pytest tests/release -k hydrology
+```
+
+> [!WARNING]
+> The exact command names, package manager, test commands, schema home, and policy engine all remain **UNKNOWN / NEEDS VERIFICATION** until the repo is mounted. The commands above show shape and order, not verified syntax. Adapt before pasting.
+
+### 7.2 Step-by-step interpretation
+
+1. **Path / drift scan.** If a hydrology file lives outside its responsibility root (e.g., a schema under `jsonschema/` instead of `schemas/contracts/v1/`), this layer flags it. Open a drift entry in `docs/registers/DRIFT_REGISTER.md` per Directory Rules §2.5; do not silently move the file.
+2. **Schema + contract.** A failure here usually means a fixture was edited without rebuilding its `spec_hash` or a contract field was renamed without a migration note. Fix the fixture or the contract, not the test.
+3. **Validators.** Geometry topology, source-role separation, and identity (`spec_hash`) faults appear here. Geometry fixes belong to fixture authors; role faults usually mean a `SourceDescriptor` claims an authority it does not have.
+4. **Policy negative suite.** Every DENY must carry a reason code. A passing-when-it-should-deny case is a doctrine violation, not a test bug — treat it as a P0.
+5. **Evidence closure.** Missing bundle → `ABSTAIN`. Hash mismatch → `DENY`. Inconsistent serialization → `ERROR`. These are not interchangeable; the wrong outcome on the wrong condition is itself a failure.
+6. **Finite-envelope tests.** Any envelope that escapes the four-outcome contract is a bug. Silent `null`, unstructured 200, untyped 500 — all forbidden.
+7. **Release dry-run + rollback.** Release-manifest fixtures must reference a `RollbackCard`. If the drill cannot revert from fixtures alone, the lane is not ready for any public-facing slice.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 8 · Expected Outcomes & Decision Envelope
+
+Every governed surface in KFM returns a finite outcome. The hydrology no-network suite asserts the right outcome for the right input. _CONFIRMED doctrine; PROPOSED route surfaces._
+
+| Test input | Expected outcome | Required artifact | Notes |
+|---|---|---|---|
+| Valid Kansas HUC12 + matched NHDPlus + matched gauge + closed EvidenceBundle | `ANSWER` | `EvidenceBundle` resolved; `PolicyDecision = allow`; dry-run `ReleaseManifest` applies. | The happy path. |
+| Ambiguous reach identity (multiple candidate COMIDs / HUC12s) | `ABSTAIN` | `AIReceipt` with reason; no hydrology claim emitted. | Per thin-slice doctrine: _ABSTAIN on ambiguous reach identity._ |
+| Missing `EvidenceBundle` for a referenced `EvidenceRef` | `ABSTAIN` (validator) → `DENY` (policy at publication) | `ResolutionError.missing_bundle`. | Two-stage: validator abstains; policy denies promotion. |
+| `EvidenceRef.spec_hash` ≠ `EvidenceBundle.spec_hash` | `DENY` | `ResolutionError.hash_mismatch`. | Identity drift is never silently reconciled. |
+| Source role misuse: NFHL fixture asserted as **observed inundation** | `DENY` | `PolicyDecision = deny` with role-misuse reason code. | NFHL is regulatory context. Always. |
+| Request for KFM-as-emergency-authority | `DENY` | `PolicyDecision = deny` with `emergency_misuse` reason. | KFM is not a life-safety surface. |
+| Unknown rights status on a SourceDescriptor | `DENY` | `PolicyDecision = deny` with `rights_unknown`. | Deny-by-default. |
+| Stale source snapshot beyond freshness budget | `ABSTAIN` (or `HOLD` if review pending) | Stale-state record; no `ANSWER` on stale-only evidence. | Freshness is a first-class signal. |
+| Malformed query / contract violation | `ERROR` | Diagnostic envelope, no claim leakage. | Errors never fall through to a different lane. |
+
+> [!IMPORTANT]
+> The four outcomes (`ANSWER`, `ABSTAIN`, `DENY`, `ERROR`), plus the validator-class outcomes (`PASS`, `FAIL`) and the promotion-class outcome (`HOLD`), are not stylistic labels — they are governance commitments. Tests that accept a "close enough" envelope are misaligned with KFM doctrine.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 9 · Negative-Test Catalog
+
+A passing positive suite is necessary but not sufficient. The negative suite is where the trust spine is actually proven. Every line below should be a runnable, named test.
+
+| # | Negative case | Layer | Expected outcome |
+|---|---|---|---|
+| N-01 | Invalid HUC12 length (not 12 digits) | Schema | `FAIL_INVALID_HUC12` |
+| N-02 | Duplicate `(comid, huc12)` rows without rationale | Schema / Validator | `FAIL_DUPLICATE_CROSSWALK` |
+| N-03 | Missing provenance / `source_head` on crosswalk | Validator | `FAIL_MISSING_PROVENANCE` |
+| N-04 | `alignment_score < 0.75` with heuristic `decision_reason` | Validator | `FAIL_LOW_ALIGNMENT` |
+| N-05 | Invalid geometry topology (self-intersection, unclosed ring) | Validator | `FAIL_INVALID_GEOMETRY` |
+| N-06 | Missing `spec_hash` on `EvidenceBundle` | Validator | `FAIL_MISSING_SPEC_HASH` |
+| N-07 | `EvidenceRef.spec_hash` ≠ `EvidenceBundle.spec_hash` | Evidence | `DENY` + `ResolutionError.hash_mismatch` |
+| N-08 | Reference resolves to no bundle | Evidence | `ABSTAIN` (validator) → `DENY` (policy at promotion) |
+| N-09 | Non-deterministic serialization (same logical spec, different bytes) | Identity | `ERROR` + `NormalizationError.nondeterministic_serialization` |
+| N-10 | Non-SHA-256 hash algorithm tag | Identity | `DENY` + `HashAlgoUnsupported` |
+| N-11 | NFHL fixture submitted as observed flood evidence | Source-role | `DENY` (role misuse) |
+| N-12 | USGS forecast fixture submitted as alert authority | Source-role | `DENY` (emergency misuse) |
+| N-13 | Unknown rights status on `SourceDescriptor` | Policy | `DENY` (`rights_unknown`) |
+| N-14 | Sensitive infrastructure / private-property hydrology detail | Policy | `DENY` (sensitivity) |
+| N-15 | Direct public bind to `data/raw/`, `data/work/`, or `data/quarantine/` | Trust membrane | `DENY` (forbidden boundary crossing) |
+| N-16 | `ReleaseManifest` missing rollback target | Release | `HOLD` or `DENY`; never auto-publish |
+| N-17 | `ReleaseManifest` missing correction path | Release | `HOLD` or `DENY` |
+| N-18 | Stale source snapshot beyond freshness budget | Freshness | `ABSTAIN` or `HOLD` |
+| N-19 | Empty / null `RuntimeResponseEnvelope` outcome | Finite envelope | `ERROR` (the wrapper itself violates the contract) |
+| N-20 | Network egress attempt during a no-network test | Egress | Suite fails; surface egress probe diagnostic |
+
+> [!WARNING]
+> N-15 and N-20 are **invariant violations**, not ordinary failures. If either passes silently, the suite is providing false assurance — escalate immediately and freeze releases until corrected.
+
+<details>
+<summary><strong>Why this catalog is exhaustive-by-design (click to expand)</strong></summary>
+
+The KFM fixture rule requires _every major object family_ to have at least one valid, one invalid, one denied, one abstention, and one rollback or correction fixture. The negative catalog above pairs each rule (schema, contract, role, identity, evidence, policy, release, freshness, trust membrane, egress) with a representative failure. Adding new fixtures is encouraged; subtracting any of N-01 through N-20 is a doctrine regression and requires an ADR.
+
+</details>
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 10 · CI Integration
+
+The KFM doctrinal CI sequence — no-network by default, path-role checks, schema/fixture, validators, policy, evidence resolution, finite envelopes, promotion dry-run, release-deny, catalog closure, rollback reference — applies here. _CONFIRMED doctrine; UNKNOWN current implementation._
+
+Current CI state for this repo is **UNKNOWN / NEEDS VERIFICATION**. The supplied corpus does not verify workflow files, runners, signing implementation, or branch protections. The integration sketch below is **PROPOSED**.
+
+```yaml
+# PROPOSED — adapt to actual workflow root once verified.
+# .github/workflows/hydrology-no-network.yml
+name: hydrology-no-network
+
+on:
+  pull_request:
+    paths:
+      - "schemas/contracts/v1/domains/hydrology/**"
+      - "contracts/**/hydrology/**"
+      - "policy/domains/hydrology/**"
+      - "tests/domains/hydrology/**"
+      - "fixtures/domains/hydrology/**"
+      - "tools/validators/hydro/**"
+      - "docs/runbooks/hydrology/**"
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  no-network-suite:
+    runs-on: ubuntu-latest
+    env:
+      KFM_NO_NETWORK: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Block egress (illustrative; replace with project pattern)
+        run: |
+          # PROPOSED — actual egress denial mechanism NEEDS VERIFICATION.
+          echo "Egress should be denied in this job. Verify in network policy."
+
+      - name: Path & drift scan
+        run: echo "PROPOSED: python tools/checks/path_role_scan.py --lane hydrology"
+
+      - name: Schema & contract
+        run: echo "PROPOSED: pytest tests/contracts tests/schemas -k hydrology"
+
+      - name: Validators
+        run: echo "PROPOSED: pytest tests/validators -k hydrology"
+
+      - name: Policy negative suite
+        run: echo "PROPOSED: conftest test -p policy/domains/hydrology fixtures/domains/hydrology"
+
+      - name: Finite-envelope suite
+        run: echo "PROPOSED: pytest tests/runtime_proof -k hydrology"
+
+      - name: Release dry-run + rollback drill
+        run: echo "PROPOSED: pytest tests/release -k hydrology"
+```
+
+> [!NOTE]
+> Live-source jobs (USGS / WBD / NHDPlus / NFHL fetches) **MUST** be a **separate, opt-in, source-activated workflow** with its own `SourceActivationDecision`, secrets, and rate-limit posture. They never share a job with the no-network suite.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 11 · Failure Handling & Rollback
+
+### 11.1 When a no-network test fails locally
+
+1. **Read the failure layer first.** A schema failure is not a policy failure; do not "fix" the policy because schema output looked odd.
+2. **Confirm the fixture is the issue, not the validator** — re-run a known-good fixture to isolate.
+3. **If the fixture was correctly edited but `spec_hash` shifted unexpectedly**, the canonical serializer may be drifting. Stop and verify normalization rules before touching anything else.
+4. **Open a draft PR** with the smallest reversible change. Reference the failing test by id and include the failing diagnostic in the PR body.
+5. **Do not loosen a test** to make a failure go away. If a test enforces doctrine, weakening it is a doctrine regression.
+
+### 11.2 When a no-network test fails in CI
+
+| Severity | Trigger | Action |
+|---|---|---|
+| **P0 — invariant break** | N-15 trust-membrane breach; N-20 egress; silent `null` envelope; `DENY` slipped to `ANSWER` | Freeze merges to the hydrology lane. Open an incident. Roll back the most recent merge if needed. |
+| **P1 — gate regression** | A previously-deny case now passes; release-manifest dry-run no longer references rollback | Revert the offending PR; do not patch forward. |
+| **P2 — fixture or schema drift** | Schema or contract change without migration; `spec_hash` rotated unexpectedly | Land a correction PR with an updated fixture or migration note; record in `DRIFT_REGISTER`. |
+| **P3 — flaky or environmental** | Non-determinism, locale issues, ordering instability | Treat as P1 until proven environmental; flaky no-network tests should not exist. |
+
+### 11.3 Rollback posture
+
+- Every release-candidate fixture references a `RollbackCard`. The rollback drill is part of the no-network suite, **not** an external operation.
+- A failing rollback drill blocks all hydrology release activity until resolved.
+- Corrections follow the documented correction path; they never overwrite history.
+
+> [!CAUTION]
+> The point of running rollback drills offline is to prove the path **before** the lane is ever public. A rollback path that has never been exercised is not a rollback path.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 12 · Verification Backlog
+
+Items in this backlog are **UNKNOWN** or **NEEDS VERIFICATION** until inspected against a mounted repo. They are listed so reviewers can resolve them rather than letting them harden into assumed truth.
+
+| Item | Evidence that would settle it | Status |
+|---|---|---|
+| Actual schema home (`schemas/contracts/v1/...` vs other) for hydrology DTOs | Mounted repo + ADR-0001 or equivalent | NEEDS VERIFICATION |
+| Package manager, test runner, and version pins | Lockfiles, `pyproject.toml` / `package.json`, workflow files | UNKNOWN |
+| Policy engine (OPA / Conftest / alternative) and version | Repo + CI workflow | NEEDS VERIFICATION |
+| Validator entrypoints under `tools/validators/hydro/` | Repo source tree | NEEDS VERIFICATION |
+| CI workflow filename and trigger conventions | `.github/workflows/` (or equivalent) | NEEDS VERIFICATION |
+| Whether runbooks use flat names (`hydrology_NO_NETWORK_TEST.md`) or subdirectories (`hydrology/NO_NETWORK_TEST_RUNBOOK.md`) | Existing files under `docs/runbooks/` | PROPOSED (subdirectory used here; flat-name alternative documented) |
+| Fixture root convention (`fixtures/domains/hydrology/` vs `tests/fixtures/domains/hydrology/`) | Repo + `tests/README.md` or `fixtures/README.md` | NEEDS VERIFICATION |
+| Egress-denial mechanism in CI | Workflow file + runner config | NEEDS VERIFICATION |
+| `spec_hash` normalization rule location | `schemas/evidence/spec_normalization.md` or equivalent | NEEDS VERIFICATION |
+| Whether USGS/WBD/NHDPlus/NFHL `SourceActivationDecision` records exist | `data/registry/` or `control_plane/source_authority_register.yaml` | NEEDS VERIFICATION |
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 13 · Related Docs
+
+> Links below are repo-relative and reflect the proposed structure in Directory Rules and the KFM expansion report. Any unverified target is a **TODO** and should be replaced when the corresponding file is created.
+
+- [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) — file placement authority _(canonical home per Directory Rules §6.1; **PROPOSED** until verified)_
+- [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — `RAW → PUBLISHED` invariant _(TODO if not yet present)_
+- [`docs/doctrine/truth-posture.md`](../../doctrine/truth-posture.md) — cite-or-abstain _(TODO)_
+- [`docs/doctrine/trust-membrane.md`](../../doctrine/trust-membrane.md) — governed-API public surface rule _(TODO)_
+- [`docs/domains/hydrology/README.md`](../../domains/hydrology/README.md) — Hydrology lane overview _(TODO)_
+- [`docs/runbooks/ui_VALIDATION.md`](../ui_VALIDATION.md) — UI validation runbook _(PROPOSED, per expansion report)_
+- [`docs/runbooks/governed_ai_VALIDATION.md`](../governed_ai_VALIDATION.md) — Focus Mode validation runbook _(PROPOSED)_
+- [`docs/adr/ADR-0001-schema-home.md`](../../adr/ADR-0001-schema-home.md) — schema home decision _(PROPOSED)_
+- [`docs/registers/DRIFT_REGISTER.md`](../../registers/DRIFT_REGISTER.md) — for placement / convention conflicts _(TODO)_
+- [`docs/registers/VERIFICATION_BACKLOG.md`](../../registers/VERIFICATION_BACKLOG.md) — for unresolved items in §12 _(TODO)_
+
+> [!NOTE]
+> **Path convention.** This runbook is placed under `docs/runbooks/hydrology/` (subdirectory by lane). The Whole-UI + Governed AI Expansion Report uses flat names like `docs/runbooks/ui_VALIDATION.md` for subsystem runbooks. Both shapes are consistent with Directory Rules §6.1, which fixes the canonical root (`docs/runbooks/`) but does not legislate the internal layout. Once a mounted repo establishes a convention, this file should either remain in place (if subdirectories are accepted) or be renamed to `docs/runbooks/hydrology_NO_NETWORK_TEST.md` (if flat naming wins). Record the resolution as an ADR or `DRIFT_REGISTER` entry.
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+## 14 · Appendix · Reference Commands
+
+<details>
+<summary><strong>Egress probe (illustrative; click to expand)</strong></summary>
+
+Use this kind of probe locally to confirm the runner cannot reach the network. The exact form should match the project's preferred tooling once verified. _All commands here are illustrative._
+
+```bash
+# PROPOSED illustrative probe — adapt as needed.
+# Expect connection failure when no-network is enforced.
+( timeout 3 curl -sS https://example.com >/dev/null ) \
+  && echo "EGRESS REACHED — no-network posture is BROKEN" \
+  || echo "EGRESS DENIED — no-network posture OK"
+```
+
+</details>
+
+<details>
+<summary><strong>Canonical JSON + `spec_hash` (illustrative; click to expand)</strong></summary>
+
+Per the KFM v1 identity proposal, `spec_hash` is computed over canonical JSON (sorted keys, UTF-8, compact separators) using SHA-256. This is the algorithm fixtures should use until a published validator supersedes this snippet.
+
+```python
+# PROPOSED illustrative; production implementation lives in the validator package.
+import hashlib
+import json
+
+def spec_hash(obj: dict) -> str:
+    canonical = json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+```
+
+</details>
+
+<details>
+<summary><strong>Minimal validator CLI contract (illustrative; click to expand)</strong></summary>
+
+The hydrology crosswalk validator (PROPOSED) follows a finite-exit-code contract aligned with KFM's runtime envelope outcomes:
+
+| Exit code | Meaning | KFM mapping |
+|---|---|---|
+| `0` | PASS | (validator-class) `PASS` |
+| `1` | FAIL | (validator-class) `FAIL` |
+| `2` | ERROR / runtime | `ERROR` |
+| `3` | ABSTAIN / unresolved | `ABSTAIN` |
+
+```bash
+# PROPOSED CLI shape; final command path NEEDS VERIFICATION.
+python tools/validators/hydro/check_crosswalk.py \
+  --input fixtures/domains/hydrology/crosswalk/valid_official.json \
+  --schema schemas/contracts/v1/domains/hydrology/comid_huc12_crosswalk.schema.json \
+  --fail-on-warning
+```
+
+JSON-mode output (PROPOSED):
+
+```json
+{
+  "outcome": "ANSWER",
+  "valid": true,
+  "errors": [],
+  "warnings": [],
+  "spec_hash": "sha256:…"
+}
+```
+
+</details>
+
+<details>
+<summary><strong>Finite outcome reference (CONFIRMED doctrine; click to expand)</strong></summary>
+
+| Outcome | When | Required artifact |
+|---|---|---|
+| `ANSWER` | Evidence sufficient, policy permits, release state allows, review (if required) recorded. | `EvidenceBundle` resolved; `PolicyDecision = allow`; `ReleaseManifest` applies. |
+| `ABSTAIN` | Evidence insufficient; cannot cite; stale with no released alternative. | `AIReceipt` with reason; no claim. |
+| `DENY` | Policy, rights, sensitivity, or release state forbids. Sensitive lanes default here. | `PolicyDecision = deny` + reason code. |
+| `ERROR` | Cannot evaluate — missing schema, malformed query, contract violation, infra failure. | Error envelope with diagnostic; no claim leakage. |
+| `HOLD` | Promotion / release / correction paused pending review. | `ReviewRecord = pending`; surface remains in prior state. |
+| `PASS` / `FAIL` | Validator-class outcomes only; not directly emitted as a public answer. | `ValidationReport`. |
+
+</details>
+
+[↑ Back to top](#-hydrology--no-network-test-runbook)
+
+---
+
+### Footer
+
+> **Related docs:** [Directory Rules](../../doctrine/directory-rules.md) · [Hydrology Lane](../../domains/hydrology/README.md) _(TODO)_ · [UI Validation Runbook](../ui_VALIDATION.md) _(PROPOSED)_ · [Governed-AI Validation Runbook](../governed_ai_VALIDATION.md) _(PROPOSED)_
+
+**Last updated:** `YYYY-MM-DD` _(set on merge)_ · **Version:** `v1 draft` · **Status:** `draft` · [↑ Back to top](#-hydrology--no-network-test-runbook)

--- a/docs/runbooks/hydrology/PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/hydrology/PROMOTION_RUNBOOK.md
@@ -1,3 +1,490 @@
-# hydrology :: PROMOTION runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-hydrology-promotion
+title: Hydrology Promotion Runbook
+type: standard
+version: v0.1
+status: draft
+owners: Hydrology domain steward, Release authority, Docs steward
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/truth-posture.md
+  - docs/doctrine/trust-membrane.md
+  - docs/domains/hydrology/README.md
+  - docs/runbooks/hydrology/ROLLBACK_RUNBOOK.md
+  - docs/runbooks/hydrology/VALIDATION_RUNBOOK.md
+  - docs/adr/ADR-0001-schema-home.md
+tags: [kfm, runbook, hydrology, promotion, governance]
+notes:
+  - Path is PROPOSED until verified against mounted repo (Directory Rules §0).
+  - Flat vs subdirectory naming for domain runbooks is unresolved; see open questions §11.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Hydrology Promotion Runbook
+
+> Governed state transition from PROCESSED through CATALOG / TRIPLET into PUBLISHED for Kansas Frontier Matrix Hydrology artifacts — evidence-bound, fail-closed, reversible.
+
+<p align="left">
+  <img alt="status: draft" src="https://img.shields.io/badge/status-draft-orange">
+  <img alt="doctrine: CONFIRMED" src="https://img.shields.io/badge/doctrine-CONFIRMED-blue">
+  <img alt="implementation: PROPOSED" src="https://img.shields.io/badge/implementation-PROPOSED-lightgrey">
+  <img alt="lifecycle: RAW%E2%86%92PUBLISHED" src="https://img.shields.io/badge/lifecycle-RAW%E2%86%92PUBLISHED-success">
+  <img alt="trust posture: cite-or-abstain" src="https://img.shields.io/badge/trust%20posture-cite--or--abstain-9cf">
+  <img alt="default: fail-closed" src="https://img.shields.io/badge/default-fail--closed-critical">
+  <img alt="updated: 2026-05-12" src="https://img.shields.io/badge/updated-2026--05--12-informational">
+</p>
+
+| Field | Value |
+|---|---|
+| **Document type** | Operational runbook (standard doc) |
+| **Status** | `draft` |
+| **Owners** | Hydrology domain steward · Release authority · Docs steward |
+| **Last updated** | 2026-05-12 |
+| **Authority** | CONFIRMED for doctrine; PROPOSED for any specific path, route, schema, validator, or CI workflow named below until verified against the mounted repo |
+| **Lifecycle invariant** | `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` (promotion is a governed state transition, **not** a file move) |
+| **Default decision** | **DENY** absent EvidenceBundle, validation, policy, review, release manifest, and rollback target |
+
+---
+
+## Table of contents
+
+1. [Purpose and scope](#1-purpose-and-scope)
+2. [Truth posture and labels used in this runbook](#2-truth-posture-and-labels-used-in-this-runbook)
+3. [Preconditions (must hold before any gate runs)](#3-preconditions-must-hold-before-any-gate-runs)
+4. [Promotion flow at a glance](#4-promotion-flow-at-a-glance)
+5. [Gate matrix A–G](#5-gate-matrix-ag)
+6. [Stage-by-stage procedure](#6-stage-by-stage-procedure)
+7. [Hydrology-specific concerns](#7-hydrology-specific-concerns)
+8. [Receipt and artifact checklist](#8-receipt-and-artifact-checklist)
+9. [Failure handling and quarantine](#9-failure-handling-and-quarantine)
+10. [Rollback and correction (cross-links)](#10-rollback-and-correction-cross-links)
+11. [Open questions and verification backlog](#11-open-questions-and-verification-backlog)
+12. [Related docs](#12-related-docs)
+13. [Appendix](#13-appendix)
+
+---
+
+## 1. Purpose and scope
+
+This runbook is the operational procedure a Hydrology release engineer or domain steward follows to take a Hydrology candidate — a watershed layer, a HUC12 release, a gauge time-series snapshot, an NHDPlus identity crosswalk, an NFHL contextual overlay, a hydrograph artifact — from PROCESSED state into a public-safe PUBLISHED release through the KFM governed-API path.
+
+It is **not**:
+
+- A general system architecture document. See `docs/architecture/` and `docs/domains/hydrology/README.md`.
+- A validation deep dive. See `docs/runbooks/hydrology/VALIDATION_RUNBOOK.md` *(PROPOSED — see §11)*.
+- A rollback drill. See `docs/runbooks/hydrology/ROLLBACK_RUNBOOK.md` *(PROPOSED — see §11)*.
+- A schema or contract reference. See `schemas/contracts/v1/` and `contracts/`.
+
+> [!IMPORTANT]
+> Promotion is a **governed state transition, not a file move.** Copying a file into `data/published/` without a closed gate chain is a trust-membrane violation; see Directory Rules §3 and §13 anti-patterns.
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 2. Truth posture and labels used in this runbook
+
+| Label | Meaning in this document |
+|---|---|
+| **CONFIRMED** | Verified this session from attached KFM doctrine (Directory Rules, Domains Atlas v1.1, Encyclopedia, Unified Manual, Components Pass-10). |
+| **PROPOSED** | Design, path, route, or recommendation not yet verified in implementation against a mounted repo. |
+| **NEEDS VERIFICATION** | Checkable, but not yet checked strongly enough to act as fact. |
+| **UNKNOWN** | Not resolvable without more evidence. |
+
+**Authoritative posture (CONFIRMED doctrine):**
+
+- **Cite-or-abstain.** Released claims resolve to an EvidenceBundle. Missing support returns ABSTAIN; uncited claims are not permitted on public surfaces.
+- **Fail-closed.** Default decision is DENY when any required artifact, signature, evidence resolution, policy decision, or review state is missing.
+- **Trust membrane.** Public clients, the map shell, and Focus Mode reach hydrology data **only** through the governed API; never directly from RAW / WORK / QUARANTINE / canonical stores / graph internals / vector indexes / model runtimes.
+- **AI is interpretive, not the root truth source.** EvidenceBundle outranks any AI-drafted language.
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 3. Preconditions (must hold before any gate runs)
+
+> [!NOTE]
+> Each precondition is doctrinally required (CONFIRMED). Specific paths, schema names, and validator commands below are PROPOSED until verified against the mounted repo.
+
+| # | Precondition | Evidence required | Authority |
+|---|---|---|---|
+| P1 | Source identity and role recorded | `SourceDescriptor` exists per source family (WBD/HUC12, NHDPlus HR, NWIS/Water Data API, FEMA NFHL, 3DEP, water quality, groundwater, historical flood) | Hydrology source families (CONFIRMED), Directory Rules §6.5 |
+| P2 | Rights and sensitivity classification resolved | Rights status set (`public` / `open` / `controlled` / `restricted` / `unknown`); sensitivity class set | NEEDS VERIFICATION on a per-source basis |
+| P3 | Object identity is deterministic | Identity rule: `source_id + object_role + temporal_scope + normalized_digest` | PROPOSED basis (Domains Atlas §E) |
+| P4 | Temporal fields kept distinct | `source_time`, `observed_time`, `valid_time`, `retrieval_time`, `release_time`, `correction_time` not collapsed | CONFIRMED |
+| P5 | Source role not collapsed | NFHL regulatory zones, observed flood events, forecasts, and warnings are **distinct** classes; no upcast | CONFIRMED (Hydrology boundary clause) |
+| P6 | EvidenceRef resolvable | Every claim's `EvidenceRef` resolves to an admissible `EvidenceBundle` | CONFIRMED |
+| P7 | Candidate is in `PROCESSED` state | `ValidationReport` and digest closure exist; emitted from WORK with no quarantine reasons | CONFIRMED (Hydrology pipeline stages) |
+| P8 | Reviewer and release authority distinct from author | Where materiality applies, the release author and the release approver are separate identities | CONFIRMED (separation of duties) |
+
+If any of P1–P8 fails, **stop here.** Open a quarantine reason and route through the validation runbook before re-entering the promotion path.
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 4. Promotion flow at a glance
+
+```mermaid
+flowchart LR
+    subgraph CANDIDATE["Candidate inputs"]
+        P[PROCESSED candidate]
+        VR[ValidationReport]
+        ER[EvidenceRef &rarr; EvidenceBundle]
+        SD[SourceDescriptor]
+    end
+
+    P --> GA["Gate A<br/>Structure &amp; metadata"]
+    VR --> GA
+    GA --> GB["Gate B<br/>Schemas &amp; contracts"]
+    GB --> GC["Gate C<br/>Policy parity (OPA / Conftest)"]
+    ER --> GC
+    GC --> GD["Gate D<br/>Security &amp; sensitivity"]
+    SD --> GD
+    GD --> GE["Gate E<br/>Data quality"]
+    GE --> GF["Gate F<br/>Provenance &amp; lineage<br/>(RunReceipt, DSSE, cosign)"]
+    GF --> GG["Gate G<br/>Reviewability<br/>(two-key approval)"]
+
+    GG --> PD["PromotionDecision"]
+    PD -->|allow| RM["ReleaseManifest emitted<br/>(binds artifacts, validation,<br/>policy, review, rollback target)"]
+    PD -->|deny / abstain / error| Q["QUARANTINE<br/>(record reason, hold prior state)"]
+
+    RM --> CT["CATALOG / TRIPLET<br/>closure"]
+    CT --> PUB["PUBLISHED<br/>via governed API"]
+
+    classDef pass fill:#e6f4ea,stroke:#1e8e3e,color:#1e3a23;
+    classDef fail fill:#fce8e6,stroke:#c5221f,color:#5b0e0c;
+    classDef state fill:#e8f0fe,stroke:#1a73e8,color:#0b2e60;
+    class GA,GB,GC,GD,GE,GF,GG pass
+    class Q fail
+    class P,RM,CT,PUB,PD state
+```
+
+> [!NOTE]
+> The A–G labeling follows the KFM Components Pass-10 gate matrix (CONFIRMED). The specific Hydrology workflow that wires these gates in CI is **PROPOSED** until verified against the mounted repo.
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 5. Gate matrix A–G
+
+CONFIRMED gate intents; PROPOSED implementations (validator filenames, OPA bundle paths, workflow names) until verified.
+
+| Gate | Intent | Required evidence (Hydrology) | Default failure |
+|---|---|---|---|
+| **A — Structure & metadata** | MetaBlock present; lane/zone correctness; file under correct responsibility root per Directory Rules | KFM Meta Block v2 on candidate doc; placement matches `data/processed/hydrology/...` or equivalent | `ERROR / quarantine` |
+| **B — Schemas & contracts** | Machine shape conforms to schema; semantic meaning conforms to contract | `schemas/contracts/v1/domains/hydrology/*.schema.json` validation; `contracts/domains/hydrology/` semantic conformance | `ERROR / quarantine` |
+| **C — Policy parity** | Same OPA bundle (pinned digest) evaluates the same decision in CI (Conftest) as at runtime (PDP) | `PolicyDecision` recorded; bundle digest matches runtime bundle | `DENY` |
+| **D — Security & sensitivity** | Rights status, license posture, sensitivity class, geoprivacy transforms recorded; NFHL role separation enforced | Sensitivity class; SPDX in allowlist; redaction receipts where required; source role intact | `DENY` |
+| **E — Data quality** | Domain DQ checks pass: HUC12 fingerprint, NHDPlus HR identity ambiguity, USGS parameter/unit/qualifier/no-data, NFHL role-separation, EvidenceBundle closure | `ValidationReport` with pass status for each named hydrology validator | `ERROR / abstain` |
+| **F — Provenance & lineage** | RunReceipt exists; DSSE envelope; cosign signature verifies; `spec_hash` recompute matches; OpenLineage event(s) emitted | Signed `RunReceipt`; valid DSSE; `spec_hash` parity; evidence refs resolve | `DENY` |
+| **G — Reviewability (two-key)** | CODEOWNERS-enforced human review **plus** policy approval; release authority distinct from original author when material | `ReviewRecord` (where required); release authority signature distinct from author | `DENY` |
+
+> [!IMPORTANT]
+> **Default-deny is structural, not advisory.** The absence of evidence blocks promotion. Promotion only fires when **all seven** gates pass; any failure holds the candidate at its prior lifecycle state.
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 6. Stage-by-stage procedure
+
+The four governed transitions below run in order. Each transition is closed only when (i) every required artifact exists, (ii) every required artifact **resolves** (`EvidenceRef → EvidenceBundle`, `source_id → SourceDescriptor`, `model_id → ModelRunReceipt`) — not merely references — and (iii) a `PolicyDecision` evaluated and recorded its outcome.
+
+### 6.1 PROCESSED → CATALOG / TRIPLET (catalog closure)
+
+**Goal.** Emit `CatalogRecord`, `EvidenceBundle`, optional graph/triplet projection, and release candidate.
+
+| Step | Action | Required artifact | Status |
+|---|---|---|---|
+| 6.1.1 | Confirm `ValidationReport` is closed and references hydrology validators (HUC12, NHDPlus identity, USGS parameters, NFHL role separation, EvidenceBundle closure) | `ValidationReport` | CONFIRMED required / PROPOSED validators |
+| 6.1.2 | Resolve `EvidenceRef` → `EvidenceBundle` for every claim attached to the candidate | `EvidenceBundle` per claim | CONFIRMED |
+| 6.1.3 | Project to graph/triplet form if applicable; treat triples as **derived**, not sovereign | `Triplet`, `GraphDelta` | PROPOSED |
+| 6.1.4 | Run catalog-closure validation — no orphan artifact, every dataset/layer has source, schema, validation, policy, release metadata | `CatalogRecord`, `CatalogMatrix` | CONFIRMED rule / PROPOSED check |
+| 6.1.5 | Record `PolicyDecision` for catalog admission | `PolicyDecision` | CONFIRMED |
+
+**Failure mode.** Hold at PROCESSED. Open a quarantine reason with a structured FAIL outcome. No public edge.
+
+### 6.2 CATALOG / TRIPLET → PUBLISHED (release closure)
+
+**Goal.** Issue a public-safe `ReleaseManifest` and activate the artifact behind the governed API.
+
+| Step | Action | Required artifact | Status |
+|---|---|---|---|
+| 6.2.1 | Confirm review state where required; release authority is **distinct** from original author when material | `ReviewRecord` | CONFIRMED |
+| 6.2.2 | Build `RunReceipt` pinning artifact digests, `spec_hash`, source heads, tool versions, OIDC builder identity | `RunReceipt` | CONFIRMED doctrine / PROPOSED template |
+| 6.2.3 | Wrap in DSSE envelope; sign with cosign; (recommended) record Rekor UUID back into the manifest | DSSE-signed receipt | PROPOSED |
+| 6.2.4 | Recompute `spec_hash` — must match signed payload (mismatch → `QUARANTINE`) | `spec_hash` parity proof | CONFIRMED rule (Gate F) |
+| 6.2.5 | Emit `ReleaseManifest` binding artifacts, validation, policy, review, checksums, and **rollback target** | `ReleaseManifest`, `RollbackCard` | CONFIRMED |
+| 6.2.6 | Verify governed-API exposure: hydrology resolvers serve only released, evidence-backed payloads with finite outcomes (`ANSWER` / `ABSTAIN` / `DENY` / `ERROR`) | Hydrology `DecisionEnvelope`, `LayerManifest` | PROPOSED routes/DTOs |
+
+> [!WARNING]
+> A `ReleaseManifest` without a **rollback target** is invalid. "Rollback untested is not reliable." A release shall not transition to PUBLISHED until the prior safe release is locatable and its digests verifiable.
+
+### 6.3 PUBLISHED → PUBLISHED' (correction)
+
+**Goal.** Record an error or new evidence and emit a superseding release; never silently mutate.
+
+| Step | Action | Required artifact |
+|---|---|---|
+| 6.3.1 | Identify the defect; classify by class (see §9 table) | Internal triage note |
+| 6.3.2 | Emit `CorrectionNotice` referencing the original `release_id` and listing invalidated derivatives | `CorrectionNotice` |
+| 6.3.3 | Update the affected `EvidenceBundle` and emit a superseding `ReleaseManifest` (do not edit the prior one) | `ReleaseManifest` (new) |
+| 6.3.4 | Surface stale-state announcement on the public claim; never a silent edit | UI stale-state badge / drawer surface |
+
+### 6.4 PUBLISHED → prior release (rollback)
+
+See `docs/runbooks/hydrology/ROLLBACK_RUNBOOK.md` *(PROPOSED — §11)*. In summary: identify affected release, locate prior safe artifact set, verify digests and manifest, disable or withdraw affected public surfaces, preserve audit receipts, mark UI as stale or withdrawn, restore via the same governed release path. Rollback is **not** a hidden file copy.
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 7. Hydrology-specific concerns
+
+These concerns are CONFIRMED doctrine for the Hydrology domain (Domains Atlas v1.1 §4.I; Encyclopedia §7.2). Specific implementation hooks (validator names, fixture paths) are PROPOSED.
+
+### 7.1 Source-role separation
+
+| Source family | Permitted role(s) | Forbidden conflation |
+|---|---|---|
+| USGS WBD / HUC12 | authority, observation, context | Treating WBD polygons as observed flood extents |
+| NHDPlus HR / 3DHP | authority, observation, context, model | Treating modeled flow attributes as direct observation |
+| USGS Water Data / NWIS | observation | Treating provisional observations as final without status field |
+| **FEMA NFHL / MSC** | **regulatory** | **Claiming NFHL zones as observed flood inundation** |
+| 3DEP terrain | authority, context | Treating derived hydro layers as authoritative observation |
+| Water quality / groundwater | observation, context | Cross-source averaging that erases parameter/unit/qualifier |
+| Historical flood evidence | observation, context | Upcast to regulatory or forecast |
+
+> [!CAUTION]
+> **NFHL-as-observed-flood is a denied claim.** Regulatory flood zones, observed inundation, forecasts, and emergency warnings are four distinct truth classes. Gate D enforces this; Gate E provides the NFHL role-separation negative fixture (PROPOSED).
+
+### 7.2 Sensitivity, rights, and publication posture
+
+- **DENY** when rights are unclear, source role is unresolved, evidence is missing, sensitivity is unresolved, or release state is absent.
+- Infrastructure exposure (bridges, dams, utilities) and private-property implications require **review** before public release.
+- Precise sensitive geometry (e.g., individual well coordinates linked to identifiable parties) must be redacted, generalized, staged, or denied. Record transforms and reasons.
+
+### 7.3 Hydrology validators (PROPOSED)
+
+These validators are named in the Domains Atlas v1.1 §4.K backlog. Their canonical home follows Directory Rules: `tools/validators/` and `tests/domains/hydrology/`, with fixtures in `tests/fixtures/` or root `fixtures/domains/hydrology/`.
+
+| Validator | Purpose | Status |
+|---|---|---|
+| HUC12 fingerprint | Verify HUC12 polygon identity stability across snapshots | PROPOSED |
+| NHDPlus HR identity ambiguity | `ABSTAIN` on ambiguous reach identity; preserve permanent IDs and pour-point references | PROPOSED |
+| USGS parameter / unit / qualifier / no-data | Block silent unit collapse and unflagged provisional data | PROPOSED |
+| NFHL role-separation | Negative fixture proving regulatory zones cannot upcast to observed flood | PROPOSED |
+| `EvidenceBundle` closure | Every released claim's `EvidenceRef` resolves; no dangling references | PROPOSED |
+| No-network hydrology proof fixture | Promotion proof runs offline against pinned fixtures | PROPOSED |
+
+### 7.4 Cross-lane care
+
+| Adjacent lane | Hydrology relation | Constraint |
+|---|---|---|
+| Hazards | Flood, drought, warning, declaration, resilience context | Preserve ownership; do not let Hazards consume Hydrology as a synthetic observation feed |
+| Soil | Soil moisture, hydrologic group, infiltration, runoff | Preserve scale and source-role; no false precision in joins |
+| Agriculture | Irrigation, drought stress, crop-water context | Joins must carry uncertainty; `EvidenceBundle` per side |
+| Settlements / Infrastructure | Floodplain, bridges, dams, utilities, exposure context | Sensitivity review required before public exposure |
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 8. Receipt and artifact checklist
+
+CONFIRMED receipt families per phase. A blank cell means the receipt is not normally emitted at that phase; previously emitted receipts remain *referenced* via `EvidenceRef`, not duplicated.
+
+| Receipt | RAW | WORK / QUARANTINE | PROCESSED | CATALOG / TRIPLET | PUBLISHED |
+|---|:---:|:---:|:---:|:---:|:---:|
+| `SourceDescriptor` | • | • | • | • | • |
+| `TransformReceipt` |  | • | • | • |  |
+| `RedactionReceipt` |  | • | • | • | • |
+| `AggregationReceipt` |  | • | • | • | • |
+| `ModelRunReceipt` |  | • | • | • | • |
+| `RepresentationReceipt` |  |  | • | • | • |
+| `AIReceipt` |  |  |  |  | • *(Focus Mode only)* |
+| `ReviewRecord` |  | • | • | • | • |
+| `PolicyDecision` | • | • | • | • | • |
+| `ValidationReport` |  | • | • | • |  |
+| `ReleaseManifest` |  |  |  | • | • |
+| `CorrectionNotice` |  |  |  | • | • |
+| `RollbackCard` |  |  |  | • | • |
+| `RealityBoundaryNote` |  |  | • | • | • |
+
+> [!TIP]
+> When in doubt about whether to emit a new receipt or reference an existing one: **reference, do not duplicate.** Duplication invites drift; references make supersession explicit.
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 9. Failure handling and quarantine
+
+A transition fails closed and preserves the prior state when any required artifact is missing or any required artifact does not resolve. Common failure families and their reason codes:
+
+| Failure family | Reason code (PROPOSED) | Gate(s) where it fires | Recovery path |
+|---|---|---|---|
+| Missing required artifact | `MISSING_RECEIPT`, `MISSING_EVIDENCE`, `MISSING_REVIEW` | B / E / F / G | Re-emit receipt; re-run review; re-validate |
+| Schema / contract mismatch | `SCHEMA_MISMATCH`, `CONTRACT_DRIFT` | B | Schema fix and/or ADR; re-run validator |
+| Rights / sensitivity unresolved | `RIGHTS_UNKNOWN`, `SENSITIVITY_UNRESOLVED` | D | Steward review; rights resolution; tier reassignment |
+| Source-role collapse risk | `ROLE_COLLAPSE`, `ROLE_DOWNCAST_FORBIDDEN` | D / E | Restore source role; refuse upcast (especially NFHL) |
+| Review state inadequate | `REVIEW_NEEDED`, `REVIEW_INSUFFICIENT`, `REVIEW_REJECTED` | G | Run required review; supply `ReviewRecord` |
+| Release infrastructure error | `RELEASE_MANIFEST_INVALID`, `ROLLBACK_TARGET_MISSING` | F | Manifest fix; supply rollback target |
+| Hash / signature drift | `INVALID_SPEC_HASH`, `UNSIGNED_RELEASE_MANIFEST` | F | Recompute `spec_hash`; re-sign; verify cosign chain |
+
+**Defect classification for downstream correction posture** (CONFIRMED):
+
+| Defect class | Correction posture | Rollback posture |
+|---|---|---|
+| Evidence gap | `ABSTAIN` or withdraw unsupported claim | Restore prior evidence-supported release |
+| Source-role error | `CorrectionNotice` + supersede | Restore prior release; preserve audit trail |
+| Rights / sensitivity error | Redact + supersede | Withdraw public surface immediately |
+| Geometry / temporal error | `CorrectionNotice` + supersede | Restore prior release |
+| Policy regression | Fix policy bundle + re-evaluate | Pin prior policy bundle digest |
+| Rendering / UI error | UI fix; no canonical truth change | Disable affected layer; preserve canonical |
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 10. Rollback and correction (cross-links)
+
+This runbook **stops** at promotion. Recovery procedures live in dedicated runbooks:
+
+- **Rollback drill:** `docs/runbooks/hydrology/ROLLBACK_RUNBOOK.md` *(PROPOSED)* — identifies the rollback target, verifies digests, withdraws affected surfaces, restores prior release through the same governed path.
+- **Correction emission:** `docs/runbooks/hydrology/CORRECTION_RUNBOOK.md` *(PROPOSED)* — preserves the original release record, classifies the defect, emits `CorrectionNotice`, supersedes via a new `ReleaseManifest`.
+
+Universal closure rule (CONFIRMED): **the trust membrane forbids any public client, normal UI surface, or released AI surface from reaching RAW, WORK, QUARANTINE, canonical stores, graph internals, vector indexes, source APIs, or direct model runtimes.** The gates above are the only routes by which Hydrology content reaches PUBLISHED.
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 11. Open questions and verification backlog
+
+| # | Question | Status | Where to resolve |
+|---|---|---|---|
+| Q1 | Is this runbook's path `docs/runbooks/hydrology/PROMOTION_RUNBOOK.md` (domain subdirectory) or `docs/runbooks/hydrology_PROMOTION.md` (flat-naming, matching `ui_LOCAL_DEV.md` / `governed_ai_VALIDATION.md`)? | **PROPOSED / OPEN** | Per-root README for `docs/runbooks/`, or short ADR |
+| Q2 | Exact governed-API route names for Hydrology resolvers (feature/detail, layer manifest, Evidence Drawer, Focus Mode) | **UNKNOWN** | `apps/governed-api/` mounted-repo inspection |
+| Q3 | Canonical schema filenames under `schemas/contracts/v1/domains/hydrology/` | **NEEDS VERIFICATION** | ADR-0001 plus repo inspection |
+| Q4 | Existence of the named hydrology validators (HUC12, NHDPlus identity, USGS parameters, NFHL role-separation, EvidenceBundle closure, no-network proof) | **PROPOSED** | `tools/validators/` and `tests/domains/hydrology/` |
+| Q5 | Hydrology promotion CI workflow name (e.g., `hydrology-promotion.yml`) and required-checks branch protection | **UNKNOWN** | `.github/workflows/` inspection |
+| Q6 | OPA / Conftest policy bundle path for hydrology promotion gates | **PROPOSED** | `policy/promotion/` and `policy/domains/hydrology/` (Directory Rules §6.5) |
+| Q7 | SPDX allowlist for hydrology source licenses | **OPEN** | Cross-link to Components Pass-10 C5-02; author allowlist |
+| Q8 | Whether `data/manifests/` or `release/manifests/` is the canonical home for hydrology `ReleaseManifest` | **OPEN** | Directory Rules §18 already flags this |
+
+These questions are healthy. They are the kinds of questions ADRs resolve. They are **not** blockers for the doctrinal procedure above.
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 12. Related docs
+
+- `docs/doctrine/directory-rules.md` — placement law (§4 placement protocol; §6.1 `docs/runbooks/` canonical home)
+- `docs/doctrine/lifecycle-law.md` — RAW → PUBLISHED invariant *(PROPOSED home)*
+- `docs/doctrine/truth-posture.md` — cite-or-abstain *(PROPOSED home)*
+- `docs/doctrine/trust-membrane.md` — governed-API boundary *(PROPOSED home)*
+- `docs/domains/hydrology/README.md` — Hydrology mission, boundary, object families
+- `docs/runbooks/hydrology/VALIDATION_RUNBOOK.md` *(PROPOSED — §11/Q1)*
+- `docs/runbooks/hydrology/ROLLBACK_RUNBOOK.md` *(PROPOSED — §11/Q1)*
+- `docs/adr/ADR-0001-schema-home.md` — schema home convention
+- `contracts/release/` and `contracts/correction/` — meaning of release/correction objects
+- `schemas/contracts/v1/release/` — `ReleaseManifest`, `PromotionDecision`, `RollbackCard` shape *(PROPOSED filenames)*
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+## 13. Appendix
+
+<details>
+<summary><b>A. Hydrology source families and their roles (reference)</b></summary>
+
+| Source family | Role | Rights / sensitivity | Freshness |
+|---|---|---|---|
+| USGS WBD / HUC12 | authority, observation, context | NEEDS VERIFICATION; sensitive joins fail closed | source-vintage / cadence specific |
+| NHDPlus HR / 3DHP-oriented hydrography | authority, observation, context, model | NEEDS VERIFICATION; sensitive joins fail closed | source-vintage / cadence specific |
+| USGS Water Data / NWIS | observation | NEEDS VERIFICATION; sensitive joins fail closed | source-vintage / cadence specific |
+| FEMA NFHL / MSC | regulatory | NEEDS VERIFICATION; sensitive joins fail closed | source-vintage / cadence specific |
+| 3DEP terrain | authority, context, model | NEEDS VERIFICATION; sensitive joins fail closed | source-vintage / cadence specific |
+| Water quality / groundwater | observation, context | NEEDS VERIFICATION; sensitive joins fail closed | source-vintage / cadence specific |
+| Historical observed flood evidence | observation, context | NEEDS VERIFICATION; sensitive joins fail closed | source-vintage / cadence specific |
+
+Source: Domains Atlas v1.1 §4.D (CONFIRMED terms / NEEDS VERIFICATION rights per source).
+
+</details>
+
+<details>
+<summary><b>B. Hydrology object families (reference)</b></summary>
+
+`Watershed`, `HUCUnit`, `HydroFeature`, `ReachIdentity`, `GaugeSite`, `FlowObservation`, `WaterLevelObservation`, `WaterQualityObservation`, `GroundwaterWell`, `AquiferObservation`, `NFHLZone`, `Hydrograph`, `UpstreamTrace`, `WaterUseLink`, `DroughtLink`, `IrrigationLink`.
+
+Common identity rule (PROPOSED): `source_id + object_role + temporal_scope + normalized_digest`.
+Common temporal rule (CONFIRMED): `source_time`, `observed_time`, `valid_time`, `retrieval_time`, `release_time`, `correction_time` remain distinct where material.
+
+Source: Domains Atlas v1.1 §4.E.
+
+</details>
+
+<details>
+<summary><b>C. PROPOSED directory placement of Hydrology promotion artifacts</b></summary>
+
+```text
+docs/runbooks/hydrology/
+├── PROMOTION_RUNBOOK.md          # this file (PROPOSED path)
+├── VALIDATION_RUNBOOK.md         # PROPOSED
+├── ROLLBACK_RUNBOOK.md           # PROPOSED
+└── CORRECTION_RUNBOOK.md         # PROPOSED
+
+schemas/contracts/v1/domains/hydrology/         # PROPOSED schema home
+schemas/contracts/v1/release/                   # ReleaseManifest, PromotionDecision, RollbackCard
+contracts/domains/hydrology/                    # object meaning (Markdown)
+
+policy/promotion/                               # promotion gate policy (OPA bundle)
+policy/domains/hydrology/                       # hydrology-specific policy lanes
+policy/sensitivity/                             # sensitivity classes, redaction rules
+
+tools/validators/                               # repo-wide validators
+tests/domains/hydrology/                        # hydrology test suite
+tests/fixtures/ OR fixtures/domains/hydrology/  # golden / valid / invalid fixtures
+
+data/processed/hydrology/<source_id>/<run_id>/  # PROCESSED candidates
+data/catalog/domain/hydrology/                  # catalog records
+data/published/layers/hydrology/                # published artifacts
+
+release/manifests/                              # ReleaseManifest decisions
+release/rollback_cards/                         # RollbackCard decisions
+release/correction_notices/                     # CorrectionNotice decisions
+
+.github/workflows/hydrology-promotion.yml       # PROPOSED workflow name; UNKNOWN until verified
+```
+
+> All paths above are **PROPOSED** per Directory Rules §0 ("authority of any specific path quoted here is PROPOSED until verified against mounted-repo evidence").
+
+</details>
+
+<details>
+<summary><b>D. Cross-references to KFM doctrine</b></summary>
+
+- Directory Rules — §4 placement protocol; §6.1 `docs/runbooks/`; §6.4 schema home; §6.5 `policy/`; §13 anti-patterns.
+- Domains Atlas v1.1 — §4 Hydrology (A–N), §24.6 universal closure rules.
+- Encyclopedia — §7.2 Hydrology (A–N), capability catalog (release manifest, correction notice, rollback card).
+- Unified Implementation Manual — §3 Directory Rules summary; §5.1 validators and policy gates; correction and rollback model.
+- Components Pass-10 — §6.5 Policy-as-Code and Promotion Gates (Gate Matrix A–G, default-deny doctrine).
+
+</details>
+
+[Back to top ↑](#table-of-contents)
+
+---
+
+**Last updated:** 2026-05-12 · **Status:** `draft` · **Owners:** Hydrology domain steward · Release authority · Docs steward
+
+[↑ Back to top](#hydrology-promotion-runbook)

--- a/docs/runbooks/hydrology/ROLLBACK_RUNBOOK.md
+++ b/docs/runbooks/hydrology/ROLLBACK_RUNBOOK.md
@@ -1,3 +1,452 @@
-# hydrology :: ROLLBACK runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-hydrology-rollback
+title: Hydrology Rollback Runbook
+type: runbook
+version: v0.1
+status: draft
+owners: <TODO: hydrology lane steward + release authority — assign before review>
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/domains/hydrology/README.md
+  - docs/runbooks/ui_ROLLBACK.md
+  - docs/runbooks/governed_ai_ROLLBACK.md
+  - contracts/release/rollback_card.md
+  - release/rollback_cards/
+tags: [kfm, runbook, hydrology, rollback, release, correction]
+notes:
+  - All path-bearing claims are PROPOSED until verified against mounted-repo evidence.
+  - Drill cadence and severity thresholds are PROPOSED defaults; tune in review.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# 🌊 Hydrology Rollback Runbook
+
+> **Governed, reversible withdrawal and supersession of a published Hydrology release — including HUC/WBD layers, gauge observations, reach identities, and NFHL regulatory overlays — through KFM's release path, not around it.**
+
+![status](https://img.shields.io/badge/status-draft-orange?style=flat-square)
+![doctrine](https://img.shields.io/badge/doctrine-CONFIRMED-blue?style=flat-square)
+![implementation](https://img.shields.io/badge/implementation-PROPOSED-lightgrey?style=flat-square)
+![lane](https://img.shields.io/badge/lane-hydrology-blue?style=flat-square)
+![release--policy](https://img.shields.io/badge/release%20policy-cite--or--abstain-informational?style=flat-square)
+![rollback--drill](https://img.shields.io/badge/rollback%20drill-required-yellow?style=flat-square)
+
+| Field | Value |
+|---|---|
+| **Status** | Draft — awaiting hydrology-lane and release-authority review |
+| **Owners** | `<TODO: hydrology lane steward>` · `<TODO: release authority>` |
+| **Last updated** | 2026-05-12 |
+| **Applies to** | Released Hydrology artifacts under `data/published/layers/hydrology/` and any governed-API surface that resolves Hydrology `EvidenceBundle` projections |
+| **Authority** | KFM Directory Rules, lifecycle law, correction-and-rollback model |
+| **Repo evidence** | UNMOUNTED in this session — every quoted path is **PROPOSED** until verified |
+
+---
+
+## Contents
+
+1. [Purpose & scope](#1-purpose--scope)
+2. [Doctrine basis](#2-doctrine-basis)
+3. [When to use this runbook](#3-when-to-use-this-runbook)
+4. [Defect → rollback posture matrix](#4-defect--rollback-posture-matrix)
+5. [Preconditions](#5-preconditions)
+6. [Rollback procedure](#6-rollback-procedure)
+7. [Hydrology-specific considerations](#7-hydrology-specific-considerations)
+8. [Validation & rollback drill](#8-validation--rollback-drill)
+9. [Failure modes & anti-patterns](#9-failure-modes--anti-patterns)
+10. [Related docs & ADRs](#10-related-docs--adrs)
+11. [Verification backlog](#11-verification-backlog)
+12. [Appendix A — RollbackCard field reference](#appendix-a--rollbackcard-field-reference)
+13. [Appendix B — Source-role separation cheat-sheet](#appendix-b--source-role-separation-cheat-sheet)
+
+---
+
+## 1. Purpose & scope
+
+This runbook operationalizes a **governed rollback** of a Hydrology release in the Kansas Frontier Matrix. Hydrology is treated across KFM doctrine as the **preferred early proof lane** — the safest first slice through which the trust spine (`SourceDescriptor → EvidenceBundle → PolicyDecision → ReleaseManifest`) is exercised end-to-end — so the integrity of its rollback path matters disproportionately.
+
+> [!IMPORTANT]
+> **Rollback is a governed state transition, not a file copy.** A rollback that bypasses validators, policy gates, evidence-bundle re-resolution, catalog closure, and release-decision recording is a violation of the lifecycle invariant **regardless of which directory the bytes land in**. (CONFIRMED doctrine.)
+
+**In scope.** Withdrawal or supersession of any published Hydrology artifact: HUC12 / watershed layers, NHDPlus-derived reach / flowline identities, stream networks, gauge observations (USGS NWIS-derived), water-level / flow / water-quality time series, groundwater context, NFHL regulatory overlays, terrain-derived hydrology context, and any Evidence Drawer or Focus Mode answer scoped to released Hydrology evidence.
+
+**Out of scope.** Non-Hydrology domain rollbacks (see sibling runbooks in `docs/runbooks/`); pre-release candidate discard (handled by promotion-gate failure paths under `release/candidates/`); admission-edge `event_envelope` retraction before RAW; secrets / credentials incidents (security IR, not domain rollback).
+
+---
+
+## 2. Doctrine basis
+
+Cited inline so reviewers can trace every step back to KFM doctrine rather than this runbook's prose. Path references are doctrinal targets and remain **PROPOSED** until mounted-repo evidence verifies them.
+
+| Doctrine point | What this runbook inherits | Status |
+|---|---|---|
+| Correction and rollback are publication requirements, not afterthoughts. | A released Hydrology claim, layer, catalog record, or AI answer has no admissible publication state without a visible correction path and rollback target. | **CONFIRMED doctrine** |
+| Rollback flow shape. | Identify affected release → locate prior safe artifact set → verify digests and manifests → disable / withdraw public surfaces → preserve audit receipts → mark stale or withdrawn UI state → restore or republish through the same governed release path. | **PROPOSED** flow / CONFIRMED shape |
+| `ReleaseManifest` + `RollbackCard` + rollback drill are required for every release. | This runbook is one half of that contract; the other half is the **drill** under §8. | **CONFIRMED doctrine** |
+| NFHL must not be collapsed with observed inundation, forecast, or emergency warning. | Rollback that erases NFHL role separation is itself a defect class; see §7. | **CONFIRMED doctrine** |
+| Cite-or-abstain. | When rollback removes the evidence under a public claim, downstream Focus Mode answers must **ABSTAIN**, not silently degrade to plausibility. | **CONFIRMED doctrine** |
+
+> [!NOTE]
+> If the mounted repo eventually shows a rollback flow that disagrees with this runbook, **do not silently conform**. Open a `docs/registers/DRIFT_REGISTER.md` entry, mark the affected paths `PROPOSED / CONFLICTED`, and propose an ADR. (Directory Rules §2.5.)
+
+---
+
+## 3. When to use this runbook
+
+This runbook is invoked when a **released** Hydrology artifact is found defective and a governed correction is required. The triggering signal is usually one of these:
+
+- A reviewer, steward, downstream consumer, or automated check **detects a defect** in a published Hydrology artifact (see §4 for defect classes).
+- A `CitationValidationReport` or `EvidenceRef` resolution failure points back to a Hydrology `EvidenceBundle`.
+- A policy gate decision flips from `ALLOW` to `DENY` after a rights, sensitivity, or freshness change in an upstream `SourceDescriptor`.
+- A scheduled **rollback drill** (governance health indicator: rollback rehearsal rate is required to be non-zero and periodic).
+- An incident in a sibling domain (e.g., Hazards, Settlements/Infrastructure) invalidates a hydrology join used by a public surface.
+
+It is **not** invoked for:
+
+- Pre-publication candidate discard (use `release/candidates/hydrology/` discard flow; no `RollbackCard` is emitted).
+- Cosmetic corrections that do not touch evidence, policy, sensitivity, geometry, time, identity, source role, or release state.
+- Renames / file moves that change *location* without changing *meaning* (Directory Rules placement protocol, not this runbook).
+
+```mermaid
+flowchart LR
+    A["Defect detected<br/>in PUBLISHED hydrology artifact"] --> B{"Defect class?<br/>(see §4)"}
+    B -->|Evidence / source-role / geometry / temporal / policy / catalog / AI| C["Classify · §4<br/>Open ReviewRecord"]
+    C --> D["§6.1 Identify affected release"]
+    D --> E["§6.2 Locate prior safe<br/>release & artifact set"]
+    E --> F["§6.3 Verify digests<br/>& manifests"]
+    F --> G["§6.4 Disable / withdraw<br/>public surfaces"]
+    G --> H["§6.5 Preserve receipts<br/>(do not delete prior meaning)"]
+    H --> I["§6.6 Mark stale /<br/>withdrawn UI state"]
+    I --> J["§6.7 Restore or republish<br/>through governed release path"]
+    J --> K["§6.8 Emit RollbackCard +<br/>CorrectionNotice"]
+    K --> L["Drill receipt & post-rollback<br/>validation · §8"]
+```
+
+> **PROPOSED diagram — NEEDS VERIFICATION** against the rollback-flow contract once `release/rollback_cards/` and the rollback action under §6 are mounted.
+
+---
+
+## 4. Defect → rollback posture matrix
+
+The matrix below is the KFM correction-and-rollback model applied to the Hydrology lane. The first two columns are **CONFIRMED doctrine**; the third column ("Hydrology specifics") is **PROPOSED** and should be tuned during the first hydrology rollback drill.
+
+| Defect class | Correction posture | Rollback posture | Hydrology specifics (PROPOSED) |
+|---|---|---|---|
+| **Evidence gap** | `ABSTAIN` or withdraw the unsupported claim. | Restore the prior evidence-supported release. | Most common path for gauge / NHDPlus identity ambiguity (`ReachIdentity` resolution failure). |
+| **Rights defect** | `DENY` public use; quarantine the source / artifact. | Withdraw affected artifacts. | NFHL or NWIS terms changed; redistribution class no longer supported. |
+| **Sensitivity leak** | Redact / generalize and notify stewards. | **Immediate** public disablement. | Rare for hydrology; consider if joined with archaeology, infrastructure, or private-property surfaces. |
+| **Geometry defect** | Rebuild the derivative layer and evidence payload. | Restore the previous **digest-pinned** artifact. | HUC12 / WBD vintage drift, coastal/braided overlay instability, COMID-HUC12 alignment-score regression. |
+| **Temporal defect** | Correct `valid_time` / `source_time` / `retrieval_time` / `release_time`. | **Mark stale** until rebuilt. | Provisional gauge data treated as final; NFHL `EFFECTIVE_DATE` / `VERSION_ID` mismatch. |
+| **Policy defect** | Re-run the policy gate and `DecisionEnvelope`. | Disable the route or layer if the gate failed. | Source-role collapse (e.g., NFHL surfaced as observed inundation); flood-role misuse. |
+| **AI answer defect** | Invalidate the `AIReceipt` and response envelope. | Remove the answer; **preserve the `EvidenceBundle`**. | Focus Mode summary made a flood claim NFHL does not support. |
+| **Catalog defect** | Re-emit catalog closure after proof repair. | Restore the previous catalog state. | STAC/DCAT/PROV `EvidenceBundle` link broken; `CatalogMatrix` orphan. |
+
+> [!CAUTION]
+> **Never** smooth a defect by upgrading an `ABSTAIN` to an `ANSWER` through prose. If the rollback path removes the evidence under a Hydrology claim, the downstream Focus Mode answer **MUST** flip to `ABSTAIN`. Silent degradation is the worst class of governed-AI failure.
+
+---
+
+## 5. Preconditions
+
+Before executing any step in §6, all of the following must hold. Treat the list as a **fail-closed checklist**: a missing item is a stop, not a workaround.
+
+- [ ] **Release identity is known.** The affected `release_id` is named and pulled from `release/manifests/` (PROPOSED path).
+- [ ] **Prior safe release exists.** A predecessor `ReleaseManifest` is available, with verifiable digests, and was itself emitted through the governed path. If no prior safe release exists, the correct action is **withdrawal**, not rollback.
+- [ ] **Defect class is classified per §4.** Multi-class defects are recorded as the strictest applicable class.
+- [ ] **`ReviewRecord` is opened.** Steward action is auditable. Reviewer identity is distinct from the original release author when materiality applies (separation of duties).
+- [ ] **Kill-switch is honored.** If a global or domain kill-switch is set, no new publication is attempted as part of this rollback until the switch is cleared.
+- [ ] **Public surfaces inventory is current.** The set of governed-API routes, layer registry entries, Evidence Drawer payloads, and Focus Mode answers backed by the affected release is enumerated. Anything missed becomes a stale leak.
+- [ ] **No live secret rotation is mixed in.** Secret incidents follow `SECURITY.md`, not this runbook.
+
+---
+
+## 6. Rollback procedure
+
+This is the **PROPOSED** governed-rollback flow for Hydrology. Each step's *intent* is **CONFIRMED doctrine**; the *commands, file names, route names, and CI targets* are **PROPOSED** until verified against mounted-repo evidence.
+
+> [!TIP]
+> Run every step from a fresh clone with no uncommitted local state. The rollback path **MUST** be reproducible from `main` + the release tag — a half-applied local patch defeats the audit trail.
+
+### 6.1 Identify the affected release
+
+```bash
+# PROPOSED — verify command shape against actual release tooling once repo is mounted.
+kfm release inspect \
+  --domain hydrology \
+  --release-id <release_id> \
+  --show contents,evidence_refs,policy_state,review_state,signatures
+```
+
+Capture, at minimum: `release_id`, contained artifact digests, `EvidenceBundle` refs, declared `rollback_target`, signatures, and review state. If any of these are missing, the release was promoted in violation of the gate matrix and the incident is **larger than this rollback**.
+
+### 6.2 Locate the prior safe artifact set
+
+The prior safe release is the most recent **PUBLISHED** release whose `EvidenceBundle` refs still resolve, whose policy decision still holds, and whose `ReleaseManifest` is digest-verifiable. Walk backward through `release/manifests/` (PROPOSED) until those three predicates hold.
+
+| Check | What to verify | Failure means |
+|---|---|---|
+| Manifest integrity | `ReleaseManifest` digest matches the recorded `release_id`. | Manifest tamper or storage drift; escalate. |
+| Evidence resolution | Every `EvidenceRef` in the manifest resolves to an `EvidenceBundle`. | Choose an earlier release. |
+| Policy currency | The original `PolicyDecision` still holds under current rights / sensitivity / freshness. | Choose an earlier release. |
+| Source-role intent | NFHL is still regulatory context; NWIS is still observation; modeled context is still modeled. | **Stop.** Source-role drift since the prior release is itself a defect class. |
+
+### 6.3 Verify digests and manifests
+
+```bash
+# PROPOSED — adapt to the verifier exposed by the release toolchain.
+kfm release verify \
+  --manifest release/manifests/<prior_release_id>.json \
+  --check digests,signatures,evidence_closure,catalog_closure
+```
+
+A verification failure here is **terminal**: do not proceed by removing checks. Open a `docs/registers/DRIFT_REGISTER.md` entry and escalate.
+
+### 6.4 Disable or withdraw affected public surfaces
+
+The goal is to make sure no public consumer can read the defective artifact via any surface while the rollback is in flight. **Order matters** — start at the outermost surface and work inward.
+
+1. **Layer registry** — remove or mark `stale` the affected `LayerManifest` entries scoped to Hydrology.
+2. **Governed API routes** — flip the affected Hydrology endpoints to return the appropriate finite outcome (`ABSTAIN`, `DENY`, or `ERROR` per §4).
+3. **Tile / PMTiles / GeoParquet** — invalidate caches; emit a cache-invalidation record.
+4. **Evidence Drawer payloads** — fall back to `ABSTAIN` for any feature whose `EvidenceBundle` is being withdrawn.
+5. **Focus Mode answers** — invalidate any `AIReceipt` whose evidence set intersects the withdrawn bundle.
+6. **Search / index** — re-index against the prior release's catalog so search does not surface the defective claim.
+
+### 6.5 Preserve audit receipts
+
+> [!IMPORTANT]
+> **Rollback never deletes prior meaning.** Receipts, prior `ReleaseManifest`, the defective `EvidenceBundle`, `ValidationReport`, `PolicyDecision`, and `ReviewRecord` are retained. The lifecycle invariant requires that the *defect itself* be inspectable after the fact.
+
+What is preserved:
+
+- The defective `ReleaseManifest` (marked superseded, not removed).
+- All `RunReceipt`, `TransformReceipt`, `ValidationReport`, `PolicyDecision`, `AIReceipt`, and `ReviewRecord` artifacts associated with the defective release.
+- The `EvidenceBundle` snapshot at the time of the defective release, retained for inspection.
+- Any `RedactionReceipt` or `AggregationReceipt` emitted along the path.
+
+### 6.6 Mark stale or withdrawn UI state
+
+Public surfaces must visibly reflect that the prior published state is no longer in force.
+
+- Time-aware layers show **stale** badges until republication closes the loop.
+- Evidence Drawer surfaces show the `CorrectionNotice` reference for the affected claims.
+- Focus Mode answers carrying the withdrawn evidence return `ABSTAIN` with a citation to the `CorrectionNotice`.
+
+### 6.7 Restore or republish through the governed release path
+
+The rollback target is restored or republished **through the same gates** that admit any release: source activation → evidence closure → source-role distinction → freshness marking → validation → policy decision → release manifest → correction path → rollback target. A shortcut here is a governance violation, even if the bytes are byte-identical to the prior safe release.
+
+```mermaid
+flowchart LR
+    Q["Rollback target chosen<br/>§6.2"] --> R["Re-validate against<br/>current validators"]
+    R --> P["Re-run PolicyDecision<br/>under current rights/sensitivity"]
+    P --> M["Emit new ReleaseManifest<br/>with rollback_to = defective release_id"]
+    M --> S["Sign · attest · catalog<br/>STAC/DCAT/PROV closure"]
+    S --> U["Publish under governed API<br/>+ refresh trust badges"]
+```
+
+> **PROPOSED diagram — NEEDS VERIFICATION** against the actual promotion gates once mounted.
+
+### 6.8 Emit `RollbackCard` and `CorrectionNotice`
+
+The rollback closes by emitting two governance objects:
+
+- **`RollbackCard`** — `release_id`, `rollback_to`, `reason`, `invalidates[]`, `review_ref`, `time`. Stored under `release/rollback_cards/` (PROPOSED).
+- **`CorrectionNotice`** — `claim_ref`, `prior_release_ref`, `change_summary`, `invalidates[]`, `review_ref`, `time`. Stored under `release/correction_notices/` (PROPOSED). Visible on the public claim until superseded.
+
+Without both, the rollback is not durable; consumers cannot see *that* a correction happened.
+
+---
+
+## 7. Hydrology-specific considerations
+
+Generic rollback doctrine is necessary but not sufficient for Hydrology. The lane has two structural risks that this section names explicitly.
+
+### 7.1 NFHL source-role separation
+
+> [!WARNING]
+> **FEMA NFHL is regulatory baseline, not observed inundation, hydraulic-model output, or forecast.** Any rollback that resurrects an artifact in which NFHL has been published *as* observed flooding, or *as* a forecast, **must** quarantine that artifact rather than restore it. Source-role collapse is its own publication defect, distinct from the geometry, time, or policy defect that triggered the rollback.
+
+Practical implication: when evaluating the **prior safe release** in §6.2, treat source-role intent as a hard predicate. If the prior release predates KFM's NFHL role-separation tests, it is **not** a safe rollback target — withdraw rather than restore, and rebuild from the source descriptor.
+
+### 7.2 Temporal hygiene across hydrology vintages
+
+Hydrology data has several distinct, **non-interchangeable** time fields, all of which must remain distinct across a rollback:
+
+| Time field | Meaning | Common confusion |
+|---|---|---|
+| `observed_time` | When the phenomenon occurred (e.g., gauge reading). | Conflated with publish time, masking lag. |
+| `valid_time` | The window over which a claim is asserted to hold. | Confused with vintage of the source dataset. |
+| `source_time` | When the upstream source last refreshed. | Confused with retrieval. |
+| `retrieval_time` | When KFM fetched / admitted the source. | Confused with release. |
+| `release_time` | When KFM published the derivative. | Confused with the correction time. |
+| `correction_time` | When the present rollback / correction is emitted. | Conflated with `release_time`. |
+
+A rollback that collapses any of these into another is itself a temporal defect (§4). Mark the affected layer **stale** until the time fields are rebuilt cleanly.
+
+### 7.3 Identity ambiguity (COMID ↔ HUC12, NHDPlus vintages)
+
+NHDPlus version drift — silently mixing **NHDPlus v2.1**, **NHDPlus HR**, and **WBD snapshot vintages** — is a recurrent failure mode upstream of release. If the defect being rolled back has an identity ambiguity at its root, the rollback target must carry an explicit `nhdplus_version` and `wbd_snapshot` declaration; otherwise the same defect will re-publish on the next promotion.
+
+### 7.4 Non-CONUS and coastal/braided systems
+
+The official USGS COMID↔HUC12 crosswalk is not universally authoritative outside CONUS, and area-weighted overlays can produce unstable assignments on coastal and braided systems. If the rollback target was emitted with `coverage_scope` that *does not* clear these constraints, prefer withdrawal over republication and route a remediation PR into `data/raw/hydrology/` followed by a re-promotion under §6.7.
+
+### 7.5 Cross-lane consequences
+
+A Hydrology rollback often invalidates downstream joins. The runbook owner is responsible for naming the affected sibling lanes, **even when remediation is owned by those lane stewards**. Typical implicated lanes:
+
+| Sibling lane | Common dependency | Action |
+|---|---|---|
+| Hazards | Flood, drought, warning context that referenced the withdrawn hydrology evidence. | Notify hazard steward; mark joined artifacts stale until reviewed. |
+| Soil | Soil-moisture / hydrologic-group joins. | Re-evaluate joined `LayerManifest` entries. |
+| Agriculture | Irrigation, drought-stress, crop-water context. | Notify agriculture steward. |
+| Settlements / Infrastructure | Floodplain, bridge, dam, utility exposure context. | High-care: implicates infrastructure sensitivity. |
+
+---
+
+## 8. Validation & rollback drill
+
+A rollback runbook with no drill is, per KFM governance health indicators, **not** a rollback. The drill is non-optional.
+
+> [!NOTE]
+> **PROPOSED drill cadence:** at least one rehearsed Hydrology rollback per release window, plus an unplanned drill per quarter. Tune in review.
+
+### 8.1 Drill scope (PROPOSED)
+
+The drill walks the full §6 flow against a **synthetic** Hydrology release whose evidence is a no-network fixture (e.g., one Kansas HUC12 + one USGS gauge fixture + one NHDPlus identity crosswalk + an NFHL contextual overlay), not live data. The drill emits a `RollbackCard` against the synthetic release and verifies that every public surface (layer, API, drawer, Focus Mode) reflects the rolled-back state.
+
+### 8.2 Post-rollback validation checklist
+
+- [ ] Prior `ReleaseManifest` digest re-verifies.
+- [ ] `EvidenceRef` resolution rate on the affected surfaces is ≥ 99.9% on the rolled-back state.
+- [ ] No Focus Mode answer cites the withdrawn `EvidenceBundle` without an `ABSTAIN` + `CorrectionNotice` reference.
+- [ ] Layer registry, governed-API responses, Evidence Drawer payloads, and cache invalidation records all reflect the rolled-back release.
+- [ ] `RollbackCard` and `CorrectionNotice` are emitted, signed, and discoverable from the public claim.
+- [ ] Cross-lane stewards (Hazards, Soil, Agriculture, Settlements / Infrastructure) have been notified where joins were implicated.
+- [ ] The drill receipt is filed under `data/receipts/release/` (PROPOSED).
+
+### 8.3 Governance health indicators touched by this runbook
+
+| Indicator | Healthy posture | This runbook's contribution |
+|---|---|---|
+| Release-with-rollback-target rate | 100% | Enforced by §5 precondition and §6.8 emission. |
+| Correction lead time (median) | Visibly tracked; trend not regressing. | §6.8 timestamps. |
+| Derivative-invalidation coverage | Approaches 100% as coverage matures. | §6.4 + §7.5. |
+| Rollback rehearsal rate | Non-zero; periodic, scheduled. | §8.1 drill cadence. |
+| Supersession lineage gap | Zero. | `RollbackCard.rollback_to` + `CorrectionNotice.prior_release_ref`. |
+
+---
+
+## 9. Failure modes & anti-patterns
+
+> [!CAUTION]
+> Every failure mode below has been observed often enough across KFM doctrine to be named. Treat them as **review stoplights**, not gentle suggestions.
+
+- **Silent file copy.** Restoring artifacts by copying bytes from a prior release path without re-running gates. **Doctrinal violation** — Rollback must not be a hidden file copy.
+- **Receipt deletion.** Deleting the defective `ReleaseManifest`, `EvidenceBundle`, or `ReviewRecord` "to clean up." The defect itself must remain inspectable.
+- **Smoothed degradation.** Quietly downgrading a Focus Mode answer from `ANSWER` to a softer prose `ANSWER` instead of `ABSTAIN` when its evidence was withdrawn.
+- **Source-role collapse on restore.** Republishing an NFHL artifact in a surface that presents it as observed inundation or forecast.
+- **Vintage mix.** Restoring a release whose NHDPlus v2.1 / NHDPlus HR / WBD snapshot vintages were silently mixed.
+- **Cross-lane silence.** Rolling back hydrology without notifying Hazards, Soil, Agriculture, or Settlements/Infrastructure stewards whose joined artifacts depend on the withdrawn evidence.
+- **Drillless rollback.** Treating this runbook as theoretical because no drill has ever been run — see §8.
+- **Kill-switch bypass.** Promoting the rollback target while a kill-switch is set.
+- **Schema-home drift.** Reading rollback-card shape from an out-of-canon location instead of `schemas/contracts/v1/release/` (PROPOSED per ADR-0001).
+
+---
+
+## 10. Related docs & ADRs
+
+> Links below are **PROPOSED** doctrinal targets. Verify each path against mounted-repo evidence before treating any as canonical.
+
+- `docs/doctrine/directory-rules.md` — placement authority for runbooks, release artifacts, and rollback cards.
+- `docs/doctrine/lifecycle-law.md` — the RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED invariant.
+- `docs/doctrine/truth-posture.md` — cite-or-abstain; the basis for §6.4 and §6.6.
+- `docs/domains/hydrology/README.md` — Hydrology lane scope, object families, source-role posture.
+- `docs/runbooks/ui_ROLLBACK.md` *(PROPOSED, sibling)* — UI rollback, feature-flag, and schema-deprecation steps.
+- `docs/runbooks/governed_ai_ROLLBACK.md` *(PROPOSED, sibling)* — AI adapter rollback and kill-switch steps.
+- `contracts/release/rollback_card.md` *(PROPOSED)* — semantic meaning of `RollbackCard`.
+- `schemas/contracts/v1/release/rollback_card.schema.json` *(PROPOSED per ADR-0001)* — machine shape.
+- `policy/release/` *(PROPOSED)* — release-gate policy bundle.
+- `docs/adr/ADR-0001-schema-home.md` *(PROPOSED)* — schema-home rule the rollback card schema follows.
+- `release/rollback_cards/` *(PROPOSED)* — emitted `RollbackCard` artifacts.
+- `data/receipts/release/` *(PROPOSED)* — release receipts including drill receipts.
+
+---
+
+## 11. Verification backlog
+
+Open items this runbook depends on. Each is **UNKNOWN** or **NEEDS VERIFICATION** until mounted-repo evidence resolves it.
+
+| Item | Status | Next action |
+|---|---|---|
+| Exact paths for `release/`, `release/rollback_cards/`, `release/correction_notices/`. | **PROPOSED** | Verify against mounted repo; open `DRIFT_REGISTER.md` entry if mismatched. |
+| Schema home of `RollbackCard` / `CorrectionNotice` (`schemas/contracts/v1/release/` vs. legacy). | **NEEDS VERIFICATION** | Confirm against ADR-0001; migrate any divergent definition. |
+| Concrete `kfm release inspect` / `kfm release verify` command names. | **PROPOSED** | Replace placeholders with the toolchain's actual entrypoints. |
+| Hydrology governed-API route names invalidated on rollback. | **UNKNOWN** | Resolve once the API surface is mounted. |
+| NFHL service freshness handling (localized, event-driven `EFFECTIVE_DATE` / `VERSION_ID`). | **NEEDS VERIFICATION** | Probe service metadata and version-change behavior. |
+| Cross-lane notification mechanism (manual ping vs. automated `CorrectionNotice` fanout). | **PROPOSED** | Decide in review; reflect under §7.5. |
+| Drill cadence numbers (releases / quarter). | **PROPOSED** | Tune after first real drill. |
+| Naming convention: `docs/runbooks/<subsystem>_<TYPE>.md` flat vs. `docs/runbooks/<domain>/<TYPE>_RUNBOOK.md` nested. | **NEEDS VERIFICATION** | Normalize in a small ADR; existing PROPOSED siblings use the flat form. |
+
+---
+
+## Appendix A — `RollbackCard` field reference
+
+Doctrinal field set for the `RollbackCard` object family, applied to Hydrology. The field names below are **CONFIRMED** in KFM doctrine; their JSON shape is **PROPOSED** until `schemas/contracts/v1/release/rollback_card.schema.json` is verified.
+
+<details>
+<summary><strong>Show illustrative <code>RollbackCard</code> payload</strong> (PROPOSED — for orientation, not authority)</summary>
+
+```json
+{
+  "object_type": "RollbackCard",
+  "schema_version": "v1",
+  "release_id": "hydrology/2026-05-08-r1",
+  "rollback_to": "hydrology/2026-04-22-r3",
+  "reason": "Geometry defect: HUC12 boundaries mixed v2.1 / WBD 2024-10-01 snapshot.",
+  "defect_class": "geometry",
+  "invalidates": [
+    "kfm://layer/hydrology/huc12/2026-05-08",
+    "kfm://evidence/hydrology/huc12-comid-crosswalk/2026-05-08",
+    "kfm://focus-answer/hydrology/2026-05-09T14:22Z"
+  ],
+  "preserved_for_audit": [
+    "kfm://manifest/hydrology/2026-05-08-r1",
+    "kfm://review/hydrology/2026-05-09-rr1"
+  ],
+  "review_ref": "kfm://review/hydrology/2026-05-09-rr1",
+  "correction_notice_ref": "kfm://correction/hydrology/2026-05-09-cn1",
+  "kill_switch_state": "cleared",
+  "time": "2026-05-09T18:00:00Z"
+}
+```
+
+This payload is **illustrative**, not normative. Field names follow KFM doctrinal naming; types, required-ness, and namespace shapes resolve against the (PROPOSED) JSON Schema.
+
+</details>
+
+---
+
+## Appendix B — Source-role separation cheat-sheet
+
+Reference card for §7.1. Source role is a **publication defect class** when collapsed, not a labeling preference.
+
+| Source family | Source role | Public surface intent |
+|---|---|---|
+| USGS WBD / HUC12 | Authority / observation | Watershed identity & boundaries; not flood prediction. |
+| NHDPlus HR / 3DHP-oriented hydrography | Authority / observation | Stream network & reach identity; not regulatory flood. |
+| USGS Water Data / NWIS | Observation | Gauge readings; provisional vs. final status preserved. |
+| FEMA NFHL / MSC | Regulatory context | **Regulatory baseline only.** Never observed inundation, never forecast, never emergency warning. |
+| 3DEP terrain | Authority / context | Terrain-derived hydrology context; not hydraulic-model output. |
+| Water-quality / groundwater sources | Observation | Discrete observations; rights and freshness vary. |
+| Historical observed flood evidence | Observation (historical) | Time-bounded; never re-surfaced as current condition. |
+
+---
+
+> **Last updated:** 2026-05-12 · **Status:** draft · **Owners:** `<TODO>` · **Doctrine:** CONFIRMED · **Implementation:** PROPOSED
+>
+> 🔗 Related: [Directory Rules](../../doctrine/directory-rules.md) · [Lifecycle Law](../../doctrine/lifecycle-law.md) · [Hydrology Lane README](../../domains/hydrology/README.md) · [UI Rollback Runbook](../ui_ROLLBACK.md) · [Governed AI Rollback Runbook](../governed_ai_ROLLBACK.md)
+>
+> ⬆ [Back to top](#-hydrology-rollback-runbook)

--- a/docs/runbooks/hydrology/SOURCE_REFRESH_RUNBOOK.md
+++ b/docs/runbooks/hydrology/SOURCE_REFRESH_RUNBOOK.md
@@ -1,3 +1,560 @@
-# hydrology :: SOURCE_REFRESH runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-hydrology-source-refresh-v1
+title: Hydrology — Source Refresh Runbook
+type: standard
+version: v1
+status: draft
+owners: Hydrology domain steward + Source connector owner + Release manager (on-call)
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/truth-posture.md
+  - docs/domains/hydrology/README.md
+  - docs/standards/SMART_SYNC.md
+  - docs/sources/SOURCE_DESCRIPTOR_STANDARD.md
+  - docs/runbooks/hydrology/VALIDATION.md
+  - docs/runbooks/hydrology/ROLLBACK.md
+tags: [kfm, runbook, hydrology, source-refresh, watcher, conditional-get]
+notes:
+  - All path claims are PROPOSED until verified against mounted repo state.
+  - Treat as doctrine-grounded operational guide, not as evidence of installed tooling.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Hydrology — Source Refresh Runbook
+
+> Operational procedure for refreshing Kansas Frontier Matrix hydrology source data through the governed lifecycle `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`, with conditional-GET economy, evidence closure, and a visible correction and rollback path.
+
+<!-- Badges row — placeholders until CI endpoints are verified -->
+![status: draft](https://img.shields.io/badge/status-draft-lightgrey)
+![type: runbook](https://img.shields.io/badge/type-runbook-blue)
+![domain: hydrology](https://img.shields.io/badge/domain-hydrology-0a6abf)
+![policy: public](https://img.shields.io/badge/policy-public-2ea44f)
+![lifecycle: RAW→PUBLISHED](https://img.shields.io/badge/lifecycle-RAW%E2%86%92PUBLISHED-555)
+![cite-or-abstain](https://img.shields.io/badge/posture-cite--or--abstain-orange)
+![last updated: 2026-05-12](https://img.shields.io/badge/last%20updated-2026--05--12-informational)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` |
+| **Owners** | Hydrology domain steward · Source connector owner · Release manager (on-call) |
+| **Last updated** | 2026-05-12 |
+| **Authority of this runbook** | CONFIRMED — operationalizes attached KFM doctrine for Hydrology refresh |
+| **Authority of specific paths/commands quoted here** | PROPOSED until verified against mounted-repo evidence |
+| **Cadence** | Per source family (continuous gauges → frequent; NFHL/3DEP → infrequent). See [§5 Source families and refresh cadence](#5-source-families-and-refresh-cadence). |
+
+---
+
+## Quick jump
+
+- [1. Purpose and scope](#1-purpose-and-scope)
+- [2. When to run this](#2-when-to-run-this)
+- [3. Invariants this runbook must preserve](#3-invariants-this-runbook-must-preserve)
+- [4. The refresh flow at a glance](#4-the-refresh-flow-at-a-glance)
+- [5. Source families and refresh cadence](#5-source-families-and-refresh-cadence)
+- [6. Pre-flight checklist](#6-pre-flight-checklist)
+- [7. Step-by-step procedure](#7-step-by-step-procedure)
+- [8. Lifecycle stage gates](#8-lifecycle-stage-gates)
+- [9. No-change, stale, and drift handling](#9-no-change-stale-and-drift-handling)
+- [10. RunReceipt and evidence closure](#10-runreceipt-and-evidence-closure)
+- [11. Failure modes and triage](#11-failure-modes-and-triage)
+- [12. Rollback pointers](#12-rollback-pointers)
+- [13. Validation and proof](#13-validation-and-proof)
+- [14. PROPOSED lane paths (Directory-Rules basis)](#14-proposed-lane-paths-directory-rules-basis)
+- [15. Related docs](#15-related-docs)
+- [Appendix A — Refresh receipt skeleton](#appendix-a--refresh-receipt-skeleton)
+- [Appendix B — Glossary pointers](#appendix-b--glossary-pointers)
+
+---
+
+## 1. Purpose and scope
+
+**Purpose.** This runbook describes how a hydrology source is refreshed in KFM without bypassing the trust membrane. It applies whenever a connector or watcher pulls fresh content from an upstream hydrology publisher — for example, gauge observations, watershed boundary updates, or regulatory floodplain shifts — and seeks to admit that content into the governed lifecycle.
+
+**In scope.** Conditional fetch, RAW capture, normalization into WORK or QUARANTINE, validation into PROCESSED, evidence and catalog closure into CATALOG / TRIPLET, and the release gate that admits public-safe artifacts into PUBLISHED. Every step emits a receipt; promotion is a governed state transition, not a file move.
+
+**Out of scope.** Source onboarding (handled by the `SourceDescriptor` standard), schema design (handled under `contracts/` and `schemas/`), policy authoring (handled under `policy/`), public client behavior (handled by the governed API), and emergency flood warning. Hydrology is **not** an emergency flood-warning system; NFHL regulatory zones, observed inundation, and forecasts are kept as distinct truth classes.
+
+> [!IMPORTANT]
+> **Cite-or-abstain is the default truth posture.** A refresh that cannot produce or resolve an `EvidenceBundle` for a released claim does not promote. It quarantines, abstains, or denies — and records why.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 2. When to run this
+
+A refresh runs in one of four shapes. The chosen shape is recorded in the `RunReceipt`.
+
+| Trigger | Typical operator | Cadence shape | Notes |
+|---|---|---|---|
+| **Scheduled poll** | Watcher (CI/cron) | Per source family (see [§5](#5-source-families-and-refresh-cadence)) | Default. Conditional-GET first. |
+| **Source-driven event** | Push from publisher (rare for hydrology) | Event | Verify the source descriptor allows push admission. |
+| **Manual refresh** | Domain steward / connector owner | Ad-hoc | Requires an issue or PR reference in `RunReceipt.actor` field. |
+| **Drift recovery** | Domain steward + release manager | Out-of-band | Triggered by a `DRIFT_REGISTER` entry. Treat as a corrective refresh. |
+
+> [!NOTE]
+> An *unconditional* refresh — bypassing ETag / Last-Modified / manifest checksum — is permitted only as a drift-recovery action and MUST be justified inline in the `RunReceipt`.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 3. Invariants this runbook must preserve
+
+The refresh procedure exists to keep these invariants visible at every step. If a step bends one, mark the trade-off explicitly in the `RunReceipt` and route through review.
+
+- **Lifecycle invariant.** `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`. Promotion is a governed state transition, not a file move.
+- **Trust membrane.** Public clients and normal UI surfaces consume governed APIs and released artifacts only. Connectors and watchers write to `data/raw/` or `data/quarantine/`; they do not publish.
+- **Cite-or-abstain.** No release without resolvable `EvidenceRef` → `EvidenceBundle` closure.
+- **Source-role separation.** NFHL regulatory zones, observed flood evidence, hydrology forecasts, and emergency warnings remain distinct truth classes; the refresh MUST NOT merge them.
+- **Deterministic identity where practical.** Hydrology station and series IDs derive from the authoritative provider identifiers (e.g., USGS site ID, NWIS series identifier) so that downstream click-resolution and `promoteId` remain stable.
+- **No-change economy.** Confirmed no-change responses do not emit new STAC / DCAT / PROV entities; they emit a heartbeat receipt only.
+- **Rights and sensitivity first.** If license, rights, or sensitivity is unclear, the artifact quarantines; release fails closed.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 4. The refresh flow at a glance
+
+```mermaid
+flowchart LR
+  SD[SourceDescriptor<br/>rights · cadence · role] --> CG{Conditional GET<br/>HEAD · ETag · If-Modified-Since}
+  CG -- "304 / no-change" --> HB[Heartbeat RunReceipt<br/>no new catalog entity]
+  CG -- "200 / changed" --> RAW[(RAW<br/>data/raw/hydrology/&lt;source_id&gt;/&lt;run_id&gt;/)]
+  RAW --> NRM{Normalize}
+  NRM -- "fail" --> QUA[(QUARANTINE<br/>reason recorded)]
+  NRM -- "pass" --> WRK[(WORK<br/>data/work/hydrology/&lt;run_id&gt;/)]
+  WRK --> VAL{Validate<br/>schema · geometry · identity · time}
+  VAL -- "fail" --> QUA
+  VAL -- "pass" --> PRC[(PROCESSED<br/>EvidenceRef + ValidationReport)]
+  PRC --> CAT[(CATALOG / TRIPLET<br/>EvidenceBundle · STAC · DCAT · PROV)]
+  CAT --> PD{PromotionDecision<br/>policy · review · rollback target}
+  PD -- "deny / abstain" --> QUA
+  PD -- "allow" --> PUB[(PUBLISHED<br/>governed API · released layer)]
+
+  classDef gate fill:#fff3cd,stroke:#856404,color:#333
+  classDef store fill:#e7f3ff,stroke:#0366d6,color:#0b3d91
+  classDef stop fill:#fde2e2,stroke:#a33,color:#7a1f1f
+  class CG,NRM,VAL,PD gate
+  class RAW,WRK,PRC,CAT,PUB store
+  class QUA,HB stop
+```
+
+> [!NOTE]
+> **PROPOSED diagram structure.** The flow reflects KFM hydrology doctrine (intake separates monitoring locations, time series definitions, raw pulls, normalized artifacts, and catalog entries) and the lifecycle law. Exact tool wiring, route names, and queue topology are PROPOSED until verified against mounted-repo evidence.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 5. Source families and refresh cadence
+
+Source families and roles are governed by per-source `SourceDescriptor` entries under `data/registry/sources/hydrology/` (PROPOSED path; see [§14](#14-proposed-lane-paths-directory-rules-basis)). The cadence column below is **shape**, not a contractual SLO — the descriptor is the source of truth.
+
+| Source family | Typical role(s) | Rights / sensitivity | Refresh cadence shape | Status |
+|---|---|---|---|---|
+| **USGS Water Data API** (continuous values, daily values, monitoring locations) | observation / authority | NEEDS VERIFICATION; legacy WaterServices is being phased out (2026/2027), use `api.waterdata.usgs.gov` | High — gauges and time series | CONFIRMED source-family role / PROPOSED endpoint binding |
+| **USGS WBD / HUC12** | authority (watershed identity) | NEEDS VERIFICATION | Low — vintage-tagged | CONFIRMED role |
+| **NHDPlus HR / 3DHP-oriented hydrography** | authority / context | NEEDS VERIFICATION | Low to medium | CONFIRMED role |
+| **FEMA NFHL / MSC** | authority (regulatory) | NEEDS VERIFICATION; **never treat NFHL as observed flood** | Low — episodic | CONFIRMED role |
+| **3DEP terrain** | model / context | NEEDS VERIFICATION | Low | CONFIRMED role |
+| **Water-quality and groundwater programs** (incl. WIZARD, WIMAS/WRIS, WWC5) | observation / context | NEEDS VERIFICATION; some Kansas-program rights are descriptor-specific | Weekly to monthly (e.g., WIMAS/WRIS) | CONFIRMED role |
+| **Historical observed flood evidence** | observation | NEEDS VERIFICATION | Episodic | CONFIRMED role |
+
+> [!CAUTION]
+> **NFHL is regulatory, not observed.** Refreshing NFHL must not collapse regulatory floodplain into observed inundation, forecast, or warning. Source-role separation is enforced before catalog closure; an NFHL-as-observed-flood claim must be denied.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 6. Pre-flight checklist
+
+Run this checklist before any refresh. A failed item halts the refresh; it does not "soft-warn."
+
+- [ ] **SourceDescriptor present and current** for the source being refreshed, with rights, sensitivity, role, cadence, and endpoint pinned.
+- [ ] **Rights and license verified.** Unknown rights ⇒ refresh runs in **quarantine-only** mode; no contentful delta emitted.
+- [ ] **Conditional-GET validators available.** Local ETag / Last-Modified / manifest checksum sidecar exists, or the descriptor flags this source as no-validator (then C3-02 manifest checksum path is used).
+- [ ] **Spec hash recomputable.** `kfm:spec_hash` for the refresh config is derivable from the current config commit.
+- [ ] **Connector identity and credentials** loaded from environment-scoped secret store. No real secrets in `configs/`.
+- [ ] **Lane directories exist** for `data/raw/hydrology/<source_id>/`, `data/work/hydrology/`, `data/quarantine/hydrology/`, `data/receipts/`, `data/proofs/`, `data/catalog/`.
+- [ ] **Rollback target** for the currently published hydrology release is locatable. (See [§12](#12-rollback-pointers).)
+- [ ] **Cite-or-abstain posture acknowledged.** If you cannot resolve evidence at this run, you will abstain and emit a receipt — not silently drop the refresh.
+
+> [!TIP]
+> If any descriptor field is missing or stale, fix the descriptor first. The refresh inherits its trust posture from the descriptor; an incomplete descriptor produces an incomplete `EvidenceBundle`.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 7. Step-by-step procedure
+
+Each step records its own receipt. Receipts accumulate into the run-level `RunReceipt`. None of the commands below are repo-verified; they are PROPOSED entry points consistent with KFM doctrine and the lane-pattern.
+
+### 7.1 Conditional fetch
+
+Send the conditional request first. Strong ETags (no `W/` prefix) are preferred; weak ETags are advisory; fall back to `Last-Modified` with `If-Modified-Since`; fall back again to manifest SHA-256 when neither header is available.
+
+```bash
+# PROPOSED — entry point unverified
+kfm hydrology refresh fetch \
+  --source-id <source_id> \
+  --run-id <run_id> \
+  --use-validators etag,last-modified,manifest-sha256
+```
+
+Outcomes:
+
+| Response | Action | Receipt |
+|---|---|---|
+| `304 Not Modified` | Skip download. Increment heartbeat. | Heartbeat `RunReceipt`; no new STAC / DCAT / PROV entity. |
+| `200 OK` with unchanged content (validator drift) | Compare manifest SHA-256; if unchanged, treat as 304. | Heartbeat with a `validator_drift` note. |
+| `200 OK` with changed content | Proceed to RAW capture. | `RawCaptureReceipt`. |
+| `429 / 5xx` | Backoff per descriptor; record `throttled` or `transient_error`. | Receipt with retry intent. |
+| `4xx` (rights / auth) | Stop. Open an issue against the descriptor. | Receipt with `rights_unknown` or `auth_failed`. |
+
+### 7.2 RAW capture
+
+Persist the raw payload immutably with provenance under the lane pattern.
+
+- Path (PROPOSED): `data/raw/hydrology/<source_id>/<run_id>/`
+- Sidecar (PROPOSED): `data/receipts/ingest/<run_id>.json` carrying source URL, `etag`, `last_modified`, `kfm:spec_hash`, payload digest, license/contact, retrieval time, and operator identity.
+
+### 7.3 Normalize → WORK or QUARANTINE
+
+Normalize schema, geometry, time, and identity. Hydrology intake separates **monitoring locations**, **time series definitions**, **raw pulls**, **normalized artifacts**, and **catalog entries**. Failures route to QUARANTINE with a recorded reason.
+
+- Identity rules — hydrology station and series identifiers derive from the authoritative provider IDs (e.g., USGS site ID, NWIS series identifier). Do not invent local synthetic IDs for click resolution.
+- Temporal rules — keep `source_time`, `observed_time`, `valid_time`, `retrieval_time`, `release_time`, and `correction_time` distinct. Mark provisional vs. final per parameter.
+
+### 7.4 Validate → PROCESSED
+
+Validation must produce a `ValidationReport`, resolve an `EvidenceRef`, and pass digest closure before emitting to PROCESSED.
+
+| Check | Failing here means… |
+|---|---|
+| Schema (per source family) | Refresh fails fast; do not promote to WORK. |
+| Geometry validity and CRS | Refresh quarantines until repaired or descriptor amended. |
+| Identity ambiguity (NHDPlus HR, HUC12 fingerprint) | Quarantine; raise a domain-steward review. |
+| Parameter / unit / qualifier / no-data (USGS) | Quarantine on missing or unknown units. |
+| NFHL role-separation | Hard deny if an NFHL record claims observed-flood role. |
+| EvidenceBundle closure | Refresh stays in PROCESSED until closure resolves; no catalog emission. |
+
+### 7.5 Catalog and triplet emission
+
+On validation pass, emit STAC, DCAT, and PROV records, the `EvidenceBundle`, and any graph/triplet projection candidates. A refresh that did not change content does **not** emit new catalog entities.
+
+### 7.6 PromotionDecision
+
+The release manager (or a governed automated gate, where available) issues a `PromotionDecision` linking the candidate to:
+
+- The proof pack (validation report, citation validation report, run receipts).
+- The policy decision (rights, sensitivity, public/restricted tier).
+- The rollback target (prior release manifest, prior artifact digests, cache keys).
+- The review state, where the source family or sensitivity tier requires separation of duties.
+
+A passing decision promotes the candidate; a failing decision abstains or denies, with reasons attached.
+
+### 7.7 Publish and confirm
+
+Published artifacts are served via the governed API. Confirm:
+
+- The map shell can resolve `EvidenceBundle` for clicked features.
+- The released LayerManifest references the refreshed `TileArtifactManifest` and source digests.
+- Cache invalidation receipts were emitted where applicable.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 8. Lifecycle stage gates
+
+The lifecycle is governance, not storage organization. A stage is **entered** only when the prior gate passes; a stage is **exited** only by a recorded state transition.
+
+| Stage | Handling | Gate (must pass before exit) | Status |
+|---|---|---|---|
+| **RAW** | Capture immutable source payload or reference with source role, rights, sensitivity, citation, time, and hash. | `SourceDescriptor` exists and is current. | CONFIRMED doctrine / PROPOSED implementation |
+| **WORK / QUARANTINE** | Normalize schema, geometry, time, identity, evidence, rights, and policy; hold failures. | Validation and policy gate pass, or quarantine reason is recorded. | CONFIRMED doctrine / PROPOSED implementation |
+| **PROCESSED** | Emit validated normalized objects, receipts, and public-safe candidates. | `EvidenceRef`, `ValidationReport`, and digest closure exist. | CONFIRMED doctrine / PROPOSED implementation |
+| **CATALOG / TRIPLET** | Emit catalog records, `EvidenceBundle`s, graph/triplet projections, and release candidates. | Catalog and proof closure pass. | CONFIRMED doctrine / PROPOSED implementation |
+| **PUBLISHED** | Serve released public-safe artifacts through governed APIs and manifests. | `ReleaseManifest`, correction path, rollback target, and review/policy state exist. | CONFIRMED doctrine / PROPOSED implementation |
+
+> [!WARNING]
+> A lifecycle skip — for example, writing directly to `data/published/layers/hydrology/` from a connector — is a Directory Rules anti-pattern (§13). Watcher-as-non-publisher applies: connectors and watchers emit receipts and candidate decisions only.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 9. No-change, stale, and drift handling
+
+Hydrology refreshes can run frequently. Cheap, correct no-change handling protects downstream churn and cache health.
+
+| Condition | What the refresh does | What the UI shows |
+|---|---|---|
+| **304 No-change** | Heartbeat `RunReceipt`. No new STAC / DCAT / PROV entity. No tile rebuild. No cache invalidation. | Released state unchanged; `last_seen` advances on the source ledger entry. |
+| **Validator drift, content unchanged** (manifest SHA-256 confirms) | Heartbeat with `validator_drift` note. | Same as 304. |
+| **Cadence missed** (expected interval exceeded) | Refresh marks the source `stale`. | Stale badge surfaces; map remains released-state correct. |
+| **Drift exceeds severity threshold** | Refresh routes to domain-steward review; may block release. | Stale + warning; or `abstain` for derived layers. |
+| **Rights / license becomes unclear mid-refresh** | Refresh quarantines and emits a deny receipt. | Affected layers fall back per `PolicyDecision`; never silently published. |
+
+> [!NOTE]
+> Stale state is **not** the same as denied release. UI must show stale or degraded source state separately from policy denial.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 10. RunReceipt and evidence closure
+
+Every refresh produces at least one `RunReceipt`. Every released artifact carries a chain of receipts that an auditor can replay.
+
+A hydrology refresh `RunReceipt` is expected to record (PROPOSED field set — verify against `schemas/contracts/v1/proofs/run_receipt.schema.json` when mounted):
+
+- `run_id`, `source_id`, `source_url`, retrieval time, operator identity.
+- HTTP validators: `etag`, `last_modified`, manifest SHA-256.
+- `kfm:spec_hash` of the refresh config.
+- Tool versions used at each stage.
+- Outputs: RAW path digest, normalized artifact digest, validation report digest, catalog item ids.
+- Decision outcomes per stage: ANSWER / ABSTAIN / DENY / ERROR, with reasons.
+- Signatures (where signing is wired) and attestation references.
+
+Receipts emitted alongside a hydrology refresh:
+
+| Receipt | When emitted | Home (PROPOSED) |
+|---|---|---|
+| `RawCaptureReceipt` | After successful RAW write | `data/receipts/ingest/` |
+| `ValidationReport` | After schema/identity/geometry checks | `data/receipts/validation/` |
+| `RunReceipt` (run-level) | At end of refresh, success or fail | `data/receipts/pipeline/` |
+| `EvidenceBundle` | At CATALOG closure for each released claim | `data/proofs/evidence_bundle/` |
+| `CitationValidationReport` | Before any exported or AI-surfaced answer cites this refresh | `data/proofs/citation_validation/` |
+| `PromotionDecision` | At release gate | `release/decisions/` |
+| `RollbackTarget` reference | Captured at release gate, pointed at prior manifest | `release/rollback/` |
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 11. Failure modes and triage
+
+The table below is operational guidance. Each row maps to an expected receipt outcome and a defect class for the correction model.
+
+| Failure | Receipt outcome | Defect class | Triage |
+|---|---|---|---|
+| Upstream `429` or 5xx | `transient_error` | Source availability | Backoff per descriptor; retry; surface as stale if persistent. |
+| Validator drift with unchanged content | `validator_drift` + heartbeat | Source operational | Log; no promotion; consider descriptor note. |
+| Schema fail at normalize | `quarantine` with `schema_fail` | Schema | Open issue against `schemas/contracts/v1/domains/hydrology/`. |
+| Identity ambiguity (NHDPlus HR / HUC12) | `quarantine` with `identity_ambiguous` | Identity | Steward review; possibly amend `SourceDescriptor`. |
+| USGS parameter / unit / qualifier unknown | `quarantine` with `unit_unknown` | Unit / parameter | Update parameter dictionary; do not guess units. |
+| NFHL record claims observed-flood role | `deny` with `role_collapse` | Source role | Hard deny; correction notice; never published. |
+| Rights or license unclear | `deny` with `rights_unknown` | Rights | Refresh runs in quarantine-only; clear rights before re-attempt. |
+| Sensitivity tier raised mid-refresh | `deny` with `sensitivity_raised` | Sensitivity | Apply transform/generalization per `PolicyDecision`. |
+| Citation does not resolve `EvidenceBundle` | `abstain` with `evidence_gap` | Evidence | Hold release; fix evidence chain. |
+| Cache invalidation receipt missing | `deny` at publish | Release operational | Re-run release step with cache step wired. |
+
+> [!CAUTION]
+> Do not "soft-promote" a hydrology refresh after a failure to avoid the receipt. A silent skip is worse than a recorded abstain; a recorded abstain preserves auditability and the correction path.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 12. Rollback pointers
+
+This runbook does not perform rollback; the [Hydrology Rollback Runbook](../hydrology/ROLLBACK.md) (PROPOSED) is the operational source. Two notes apply here:
+
+1. **Every promotion captures a rollback target.** A refresh that publishes without a verifiable rollback target violates the publication contract and must be reverted.
+2. **Rollback shifts pointers, not bytes.** Prior artifact digests, manifests, and cache keys remain available; rollback restores them through the same governed release path.
+
+Defect-class postures (from the correction and rollback model):
+
+| Defect class | Correction posture | Rollback posture |
+|---|---|---|
+| Evidence gap | ABSTAIN or withdraw unsupported claim | Restore prior evidence-supported release |
+| Source-role | Issue correction notice; deny re-publication | Restore prior release that preserved role separation |
+| Rights / sensitivity | Quarantine; re-tier | Restore prior public-safe release |
+| Geometry / identity | Repair receipt; supersede | Restore prior identity-stable release |
+| Temporal | Issue correction notice with corrected time fields | Restore prior temporally accurate release |
+| Validation / policy | Re-run gates; supersede | Restore prior passing release |
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 13. Validation and proof
+
+The refresh is "done" only when the proof chain closes. The validation expectations below are doctrinal; specific test names are PROPOSED until verified.
+
+- **Schema validation** for `SourceDescriptor`, `LayerManifest`, `TileArtifactManifest`, `MapReleaseManifest`, `RunReceipt`, `EvidenceDrawerPayload`, and any hydrology-specific descriptor.
+- **HUC12 fingerprint validation** — confirms HUC identity stability across refreshes.
+- **NHDPlus HR identity ambiguity tests** — guards against silent reach-identity drift.
+- **USGS parameter / unit / qualifier / no-data tests** — ensures provisional vs. final and unit handling.
+- **NFHL role-separation tests** — denies role collapse.
+- **EvidenceBundle closure tests** — released claims resolve evidence.
+- **No-network hydrology proof fixture** — deterministic offline replay of a refresh + promotion.
+- **304 / no-change regression** — confirms heartbeat-only behavior; no catalog churn.
+- **Station/series schema tests and stale/late telemetry cases** — confirms time-series intake rules.
+- **Stale-source fixture** — proves stale badge / abstain behavior.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 14. PROPOSED lane paths (Directory-Rules basis)
+
+These paths follow the Domain Placement Law (domain-as-segment inside a responsibility root). All paths are **PROPOSED** and require mounted-repo verification. They do not assert that anything exists today.
+
+```text
+docs/runbooks/hydrology/
+├── SOURCE_REFRESH_RUNBOOK.md       ← this file
+├── VALIDATION.md                   ← PROPOSED sibling
+└── ROLLBACK.md                     ← PROPOSED sibling
+
+docs/domains/hydrology/             ← domain doctrine (CONFIRMED placement rule)
+contracts/domains/hydrology/        ← object meaning
+schemas/contracts/v1/domains/hydrology/   ← machine shape (per ADR-0001)
+policy/domains/hydrology/           ← admissibility decisions
+tests/domains/hydrology/            ← enforceability proofs
+fixtures/domains/hydrology/         ← golden / invalid samples
+connectors/usgs/                    ← USGS Water Data API connector home
+connectors/fema/                    ← FEMA NFHL connector home
+pipelines/domains/hydrology/        ← executable refresh + normalize + catalog
+pipeline_specs/hydrology/           ← declarative refresh configs
+data/raw/hydrology/<source_id>/<run_id>/
+data/work/hydrology/<run_id>/
+data/quarantine/hydrology/<reason>/<run_id>/
+data/processed/hydrology/<dataset_id>/<version>/
+data/catalog/domain/hydrology/
+data/published/layers/hydrology/
+data/registry/sources/hydrology/
+data/receipts/ingest/  validation/  pipeline/
+data/proofs/evidence_bundle/  validation_report/  citation_validation/
+release/candidates/hydrology/
+release/decisions/                  ← PromotionDecision home
+release/rollback/                   ← rollback target home
+```
+
+> [!NOTE]
+> **Directory Rules basis.** Hydrology must not appear as a root folder. The lane pattern keeps the repo root stable while the domain grows. Any deviation from this pattern requires an ADR (Directory Rules §2.4).
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## 15. Related docs
+
+- [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) — placement law and lifecycle invariant.
+- [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — promotion is a governed state transition.
+- [`docs/doctrine/truth-posture.md`](../../doctrine/truth-posture.md) — cite-or-abstain default.
+- [`docs/domains/hydrology/README.md`](../../domains/hydrology/README.md) — domain identity, source families, object families.
+- [`docs/sources/SOURCE_DESCRIPTOR_STANDARD.md`](../../sources/SOURCE_DESCRIPTOR_STANDARD.md) — required descriptor fields.
+- [`docs/standards/SMART_SYNC.md`](../../standards/SMART_SYNC.md) — conditional-GET + manifest-checksum playbook (PROPOSED).
+- [`docs/runbooks/hydrology/VALIDATION.md`](./VALIDATION.md) — hydrology validation runbook (PROPOSED).
+- [`docs/runbooks/hydrology/ROLLBACK.md`](./ROLLBACK.md) — hydrology rollback runbook (PROPOSED).
+- [`docs/registers/DRIFT_REGISTER.md`](../../registers/DRIFT_REGISTER.md) — drift entries that may trigger corrective refreshes.
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## Appendix A — Refresh receipt skeleton
+
+PROPOSED skeleton; field names are illustrative and must match `schemas/contracts/v1/proofs/run_receipt.schema.json` when mounted.
+
+<details>
+<summary><strong>Example <code>RunReceipt</code> (hydrology refresh — no-change heartbeat)</strong></summary>
+
+```json
+{
+  "object_type": "RunReceipt",
+  "run_id": "run-2026-05-12T14:03:11Z-usgs-water-001",
+  "domain": "hydrology",
+  "source_id": "usgs-water-continuous",
+  "source_url": "https://api.waterdata.usgs.gov/...",
+  "kfm:spec_hash": "<sha256>",
+  "validators": {
+    "etag": "\"abc123\"",
+    "last_modified": "Mon, 12 May 2026 13:55:00 GMT",
+    "manifest_sha256": null
+  },
+  "outcome": "no-change",
+  "heartbeat": true,
+  "stac_emitted": false,
+  "actor": "watcher@kfm-ci",
+  "tool_versions": { "kfm.cli": "PROPOSED", "kfm.connector.usgs": "PROPOSED" },
+  "timestamps": {
+    "retrieval_time": "2026-05-12T14:03:11Z",
+    "release_time": null
+  },
+  "signature": "PROPOSED"
+}
+```
+
+</details>
+
+<details>
+<summary><strong>Example <code>RunReceipt</code> (hydrology refresh — promotion to PUBLISHED)</strong></summary>
+
+```json
+{
+  "object_type": "RunReceipt",
+  "run_id": "run-2026-05-12T14:09:42Z-usgs-water-002",
+  "domain": "hydrology",
+  "source_id": "usgs-water-continuous",
+  "kfm:spec_hash": "<sha256>",
+  "validators": {
+    "etag": "\"def456\"",
+    "last_modified": "Mon, 12 May 2026 14:07:00 GMT"
+  },
+  "stages": {
+    "raw": { "digest": "<sha256>", "path": "data/raw/hydrology/usgs-water-continuous/<run_id>/" },
+    "work": { "digest": "<sha256>", "validation_report": "<ref>" },
+    "processed": { "dataset_id": "<id>", "version": "<v>", "evidence_ref": "<ref>" },
+    "catalog": { "stac_item": "<id>", "evidence_bundle": "<ref>" },
+    "release": {
+      "promotion_decision": "<ref>",
+      "release_manifest": "<ref>",
+      "rollback_target": "<ref>"
+    }
+  },
+  "policy_decision": { "outcome": "allow", "reasons": [] },
+  "outcome": "promoted",
+  "actor": "release-manager@kfm",
+  "signature": "PROPOSED"
+}
+```
+
+</details>
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+## Appendix B — Glossary pointers
+
+Hydrology preserves KFM-specific terminology. Pointers, not definitions; canonical meanings live under `contracts/` and `docs/domains/hydrology/`.
+
+| Term | Notes |
+|---|---|
+| `EvidenceRef` / `EvidenceBundle` | Reference resolves to admissible evidence; bundle outranks UI projection. |
+| `SourceDescriptor` | Per-source identity, rights, sensitivity, role, cadence, endpoints. |
+| `RunReceipt` | Process memory: inputs, outputs, validators, hashes, actor, time. |
+| `PromotionDecision` | Governed state transition into release. |
+| `LayerManifest` / `TileArtifactManifest` / `MapReleaseManifest` | Released layer, tile artifact, and release bundle metadata. |
+| `EvidenceDrawerPayload` | UI projection of `EvidenceBundle`, citations, policy/review/release state. |
+| `RollbackTarget` | Pointer to a prior safe release, used to revert without byte moves. |
+| `Stale-source fixture` | Negative fixture proving stale headers trigger badge / abstain / deny. |
+| `Sensitive-geometry deny fixture` | Negative fixture proving exact sensitive geometry cannot publish. |
+
+[Back to top](#hydrology--source-refresh-runbook)
+
+---
+
+**Related docs:** see [§15](#15-related-docs).
+**Last updated:** 2026-05-12.
+[Back to top](#hydrology--source-refresh-runbook)

--- a/docs/runbooks/people-dna-land/NO_NETWORK_TEST_RUNBOOK.md
+++ b/docs/runbooks/people-dna-land/NO_NETWORK_TEST_RUNBOOK.md
@@ -1,3 +1,479 @@
-# people-dna-land :: NO_NETWORK_TEST runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-people-dna-land-no-network-test
+title: People/DNA/Land — No-Network Test Runbook
+type: standard
+version: v0.1-draft
+status: draft
+owners: Docs steward; People/DNA/Land domain steward; QA owner (PLACEHOLDER — verify against governance register)
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: internal-doc
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/domains/people-dna-land/README.md            # PROPOSED
+  - docs/runbooks/governed_ai_VALIDATION.md           # PROPOSED
+  - docs/runbooks/ui_VALIDATION.md                    # PROPOSED
+  - tests/fixtures/domains/people-dna-land/README.md  # PROPOSED
+  - policy/domains/people-dna-land/README.md          # PROPOSED
+  - policy/sensitivity/people-dna-land/               # PROPOSED
+  - policy/consent/people-dna-land/                   # PROPOSED
+  - docs/registers/VERIFICATION_BACKLOG.md            # PROPOSED
+tags: [kfm, runbook, people-dna-land, testing, no-network, deterministic, fixtures, governance, sensitivity]
+notes:
+  - Path is PROPOSED per Domain Placement Law (Directory Rules §12) and pending repo-mounted verification.
+  - All tool identities and command lines are PROPOSED until repo evidence confirms package manager, framework, and runners.
+  - This runbook prescribes procedure; it does not claim any of the prescribed tests, validators, or fixtures currently exist in the repository.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# People/DNA/Land — No-Network Test Runbook
+
+> A deterministic, fixture-driven proof routine for the People, Genealogy, DNA, and Land domain — exercising the KFM trust spine end-to-end without crossing any live source, model runtime, network endpoint, or canonical store boundary.
+
+[![Status: draft](https://img.shields.io/badge/status-draft-orange?style=flat-square)](#)
+[![Lane: people-dna-land](https://img.shields.io/badge/lane-people--dna--land-blue?style=flat-square)](#)
+[![Posture: deny-default](https://img.shields.io/badge/posture-deny--default-critical?style=flat-square)](#)
+[![Network: none](https://img.shields.io/badge/network-none-lightgrey?style=flat-square)](#)
+[![Evidence: fixture-only](https://img.shields.io/badge/evidence-fixture--only-yellow?style=flat-square)](#)
+[![Path: PROPOSED](https://img.shields.io/badge/path-PROPOSED-informational?style=flat-square)](#)
+
+**Status:** draft &nbsp;·&nbsp; **Owners:** Docs steward · People/DNA/Land domain steward · QA owner *(placeholders — verify against governance register)* &nbsp;·&nbsp; **Last updated:** 2026-05-12
+
+---
+
+## Contents
+
+- [1. Purpose and scope](#1-purpose-and-scope)
+- [2. Doctrinal anchors](#2-doctrinal-anchors)
+- [3. What "no-network" means here](#3-what-no-network-means-here)
+- [4. Test pyramid for People/DNA/Land](#4-test-pyramid-for-peopledna-land)
+- [5. Required fixtures and mock markers](#5-required-fixtures-and-mock-markers)
+- [6. Execution flow](#6-execution-flow)
+- [7. Command families (PROPOSED)](#7-command-families-proposed)
+- [8. Pass criteria and finite outcomes](#8-pass-criteria-and-finite-outcomes)
+- [9. Sensitivity guardrails specific to this domain](#9-sensitivity-guardrails-specific-to-this-domain)
+- [10. Failure modes and triage](#10-failure-modes-and-triage)
+- [11. Reversibility and rollback posture](#11-reversibility-and-rollback-posture)
+- [12. Verification backlog](#12-verification-backlog)
+- [13. Directory Rules basis for this path](#13-directory-rules-basis-for-this-path)
+- [14. Related docs](#14-related-docs)
+- [Appendix A — Object-family fixture matrix](#appendix-a--object-family-fixture-matrix)
+- [Appendix B — Doctrine citations](#appendix-b--doctrine-citations)
+
+---
+
+## 1. Purpose and scope
+
+This runbook prescribes a **deterministic, no-network test pass** for the People, Genealogy, DNA, and Land domain (lane: `people-dna-land`). It is the first proof layer that any change touching domain schemas, contracts, validators, policies, fixtures, evidence-resolution code, governed API surfaces, or UI trust-state rendering for this lane MUST satisfy before any live-source or runtime-bound test is even considered. **CONFIRMED doctrine:** the first KFM implementation package is "no-network and fixture-driven" and the test pyramid begins with deterministic no-network fixture tests, schema/contract tests, validator units, policy negatives, evidence-resolution, lifecycle, receipt/proof, release-manifest, governed-API envelope, and UI trust-state tests — *only later* live-source or runtime tests.
+
+**In scope.** The fixture-only proof that the trust spine — source admission → lifecycle state → validation → evidence resolution → policy decision → catalog/proof closure → release decision → governed API / UI payload → correction → rollback — operates for People/DNA/Land objects without crossing any forbidden boundary.
+
+**Out of scope.** Live source connectors (GEDCOM ingest, DNA vendor APIs, county recorder fetchers); live model providers (Ollama, hosted LLMs); production release; production auth/SSO; database, graph, or vector-index migrations; cross-domain joins to Settlements, Roads/Rail, Archaeology, Agriculture. Each of these is covered by a separate runbook or is intentionally deferred.
+
+> [!NOTE]
+> This runbook **prescribes** procedure. It does **not** claim that any of the listed tests, validators, fixtures, or CI jobs currently exist in the repository. Implementation status is **UNKNOWN** until verified against a mounted repo.
+
+[Back to top](#contents)
+
+---
+
+## 2. Doctrinal anchors
+
+The behaviors below are non-negotiable for this runbook. They predate this file and are inherited from KFM core doctrine.
+
+| Anchor | What it forces | Truth |
+|---|---|---|
+| **Cite-or-abstain** | Every claim that depends on evidence resolves to an `EvidenceBundle`; missing evidence → `ABSTAIN`, not invention. | CONFIRMED doctrine |
+| **Lifecycle invariant** | `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`. Promotion is a **governed state transition, not a file move.** | CONFIRMED doctrine |
+| **Trust membrane** | Public clients and normal UI surfaces consume governed APIs and released payloads only; they never read `RAW`, `WORK`, `QUARANTINE`, canonical stores, model runtimes, vector indexes, or internal handles directly. | CONFIRMED doctrine |
+| **Finite outcomes** | Governed-API and AI surfaces return `ANSWER` / `ABSTAIN` / `DENY` / `ERROR` — never freeform text outside that envelope. | CONFIRMED doctrine |
+| **Fail-closed sensitivity** | For People/DNA/Land: living-person output and DNA-derived output are **denied or restricted by default**; raw kit/vendor IDs and DNA segments are not public; assessor/tax records are not title truth; parcel geometry is not title-boundary proof. | CONFIRMED doctrine |
+| **Fixture rule** | Every major object family has *at least one* valid, one invalid, one denied, one abstention, and one rollback or correction fixture. Sensitive lanes use public-safe transformed fixtures — never real living-person data, real DNA material, or real restricted geometry. | CONFIRMED doctrine |
+| **Watcher-as-non-publisher** | Workers, watchers, and connectors emit receipts and candidate decisions; they MUST NOT publish or rewrite catalog. | CONFIRMED doctrine |
+| **AI is interpretive** | `MockAdapter` is the default in this runbook; the AI surface MUST NOT answer without admissible evidence, MUST cite, and MUST abstain on missing evidence. | CONFIRMED doctrine |
+
+[Back to top](#contents)
+
+---
+
+## 3. What "no-network" means here
+
+"No-network" in this runbook is **stronger than "offline."** It is a posture, enforced by fixtures, harnesses, and boundary tests.
+
+**A no-network test pass MUST hold all of these simultaneously:**
+
+1. **No outbound HTTP, gRPC, DNS, or socket traffic** from any test process, validator, evidence resolver, policy engine, governed-API adapter, or UI test runner. Outbound traffic is a runner-level failure regardless of test assertions.
+2. **No live model providers.** Only the `MockAdapter` (per the governed-AI doctrine) is engaged. The MockAdapter answers only over fixture-resident `EvidenceBundle` projections and emits an `AIReceipt` for every call.
+3. **No live source fetches.** Connector code is exercised through pre-recorded fixture payloads under `data/raw/people-dna-land/<source_id>/<run_id>/` *(PROPOSED layout per Directory Rules §9.1)* with explicit fixture markers — never against live GEDCOM, DNA vendor, county recorder, assessor, or PLSS endpoints.
+4. **No canonical-store reads from the public path.** Any code path that simulates the `apps/explorer-web/` surface reads only released, public-safe payloads — never `data/raw|work|quarantine|processed`.
+5. **No real living-person, DNA, or restricted-geometry content.** Fixtures use synthetic identities, synthetic kit tokens, generalized geometry, and obvious mock markers.
+6. **Deterministic.** Same fixtures + same code → byte-identical receipts, envelope payloads, and policy decisions. Non-determinism (random IDs, wall-clock timestamps not pinned, unseeded RNG) is a runbook failure.
+
+> [!WARNING]
+> **No real DNA material, no real living-person records, no real-precision parcel geometry, no real kit/vendor IDs may enter fixtures under any circumstance.** This rule has no exceptions — not for "convenience," not for "more realism," not for "just this one steward review." Real material moves through the governed intake path (`data/raw/` → quarantine → review), not through the test corpus.
+
+[Back to top](#contents)
+
+---
+
+## 4. Test pyramid for People/DNA/Land
+
+The pyramid runs **bottom-up**: a layer is meaningful only if every layer below it is green. A red layer halts the run; later layers are not attempted.
+
+```mermaid
+flowchart TD
+    F1["1 · Schema & contract fixture tests<br/>valid · invalid · denied · abstain · rollback"]
+    F2["2 · Validator unit tests<br/>schema · evidence · rights · sensitivity · temporal · geometry"]
+    F3["3 · Policy negative tests<br/>living-person · DNA · assessor-as-title · raw-kit-id · parcel-as-title"]
+    F4["4 · Evidence-resolution tests<br/>EvidenceRef → EvidenceBundle · finite outcomes"]
+    F5["5 · Lifecycle-state tests<br/>RAW → WORK/QUARANTINE → PROCESSED → CATALOG/TRIPLET → PUBLISHED"]
+    F6["6 · Receipt & proof tests<br/>RunReceipt · AIReceipt · ProofPack · RedactionReceipt"]
+    F7["7 · Release-manifest tests<br/>ReleaseManifest · RollbackCard · CorrectionNotice"]
+    F8["8 · Governed-API envelope tests<br/>RuntimeResponseEnvelope · ANSWER / ABSTAIN / DENY / ERROR"]
+    F9["9 · UI trust-state tests<br/>Evidence Drawer · Focus Mode · badges · restricted-view"]
+
+    F1 --> F2 --> F3 --> F4 --> F5 --> F6 --> F7 --> F8 --> F9
+
+    classDef base fill:#eef,stroke:#557,stroke-width:1px;
+    classDef mid  fill:#efe,stroke:#575,stroke-width:1px;
+    classDef top  fill:#fee,stroke:#755,stroke-width:1px;
+    class F1,F2 base
+    class F3,F4,F5,F6 mid
+    class F7,F8,F9 top
+```
+
+> [!NOTE]
+> The pyramid above reflects KFM-wide CONFIRMED doctrine on test ordering, **specialized** for the People/DNA/Land lane in the policy-negatives layer (F3) and the receipt layer (F6, where `RedactionReceipt` is critical for this domain). The exact runner names, file layout, and module identities remain PROPOSED until verified.
+
+[Back to top](#contents)
+
+---
+
+## 5. Required fixtures and mock markers
+
+Each People/DNA/Land object family requires the standard five-fixture set. Synthetic, mock-marked, public-safe.
+
+| Object family | valid | invalid | denied | abstain | rollback / correction |
+|---|---|---|---|---|---|
+| `PersonAssertion` | ✅ | ✅ | living-person → deny | missing evidence → abstain | correction notice on identity merge |
+| `PersonCanonical` | ✅ | ✅ | living-person → deny | unresolved identity → abstain | rollback on bad merge |
+| `NameAssertion` | ✅ | ✅ | n/a | conflicting names → abstain | correction notice |
+| `RelationshipAssertion` | ✅ | ✅ | living-relationship inference → deny | unresolved → abstain | hypothesis revoked |
+| `GenealogyRelationship` | ✅ | ✅ | living-link → deny | unresolved → abstain | rollback on bad link |
+| `FamilyGroup` | ✅ | ✅ | living-member → deny | partial → abstain | correction notice |
+| `LifeEvent` | ✅ | ✅ | living-person → deny | unsourced → abstain | correction notice |
+| `ResidenceEvent` | ✅ | ✅ | living-residence → deny | unsourced → abstain | correction notice |
+| `MigrationEvent` | ✅ | ✅ | living-trajectory → deny | unresolved → abstain | correction notice |
+| `DNAMatchEvidence` | ✅ | ✅ | **default deny (restricted)** | missing consent → abstain | revocation receipt |
+| `DNASegment` | ✅ | ✅ | **default deny (restricted)** | missing consent → abstain | revocation receipt |
+| `DNAKitToken` | ✅ | ✅ | raw kit/vendor ID exposure → deny | missing consent → abstain | revocation receipt |
+| `ConsentGrant` | ✅ | ✅ | expired/revoked → deny | unresolved scope → abstain | revocation cascade |
+| `RevocationReceipt` | ✅ | ✅ | n/a | n/a | revocation closure |
+| `LandInstrument` (patent, deed, mortgage, lien, easement, lease, mineral, water, access, probate) | ✅ | ✅ | unclear rights → deny | gap in chain → abstain | correction notice |
+| `DeedInstrument` / `TitleInstrument` | ✅ | ✅ | assessor-as-title → deny | gap → abstain | correction notice |
+| `LegalDescription` | ✅ | ✅ | ambiguous metes → deny | gap → abstain | correction notice |
+| `LandOwnershipAssertion` / `OwnershipInterval` | ✅ | ✅ | assessor-as-title → deny | gap → abstain | correction notice |
+| `ParcelVersion` / `LandParcel` | ✅ | ✅ | parcel-as-title-boundary → deny | unsourced geometry → abstain | rollback on geometry error |
+| `AssessorRecord` / `TaxRecord` | ✅ | ✅ | used as title → deny | partial → abstain | correction notice |
+
+**Mock-marker rules.** Every fixture file MUST include an obvious mock marker in a top-level field (e.g., `"$mock": true`, `"$kfm_fixture": "people-dna-land/<family>/<scenario>"`) so that no fixture can be confused with released evidence even if it leaks out of the test tree. Fixtures are **not** publication artifacts and MUST NOT carry signatures, release manifests, or release IDs that match production form.
+
+> [!IMPORTANT]
+> Sensitive-lane fixtures use **public-safe transformations** in place of real material: synthetic personal identifiers, synthetic kit tokens, generalized or fabricated geometry, fabricated centimorgan profiles, and fabricated source-document references. The fixture authoring discipline mirrors the Archaeology and Fauna sensitivity posture and inherits the same redaction/transform receipts.
+
+[Back to top](#contents)
+
+---
+
+## 6. Execution flow
+
+The pass is conceptually one pipeline, even if implemented as several test commands. A passing run produces a deterministic set of receipts and a green rollup.
+
+```mermaid
+flowchart LR
+    A([Start: clean working tree]) --> B[Pin clock & RNG seed]
+    B --> C[Load fixtures<br/>fixtures/domains/people-dna-land/]
+    C --> D[Schema & contract validation]
+    D --> E[Validator units<br/>rights · sensitivity · temporal · geometry]
+    E --> F[Policy negatives<br/>living-person · DNA · assessor · raw kit ID]
+    F --> G[EvidenceRef → EvidenceBundle<br/>finite outcomes]
+    G --> H[Lifecycle promotion dry-run<br/>no public write]
+    H --> I[Receipts & proofs<br/>RunReceipt · AIReceipt · RedactionReceipt]
+    I --> J[Release dry-run<br/>ReleaseManifest + RollbackCard]
+    J --> K[Governed-API envelope tests<br/>MockAdapter only]
+    K --> L[UI trust-state tests<br/>Evidence Drawer · Focus Mode]
+    L --> M[Boundary scan<br/>no forbidden imports / no outbound calls]
+    M --> N([End: green rollup or first-failing layer])
+
+    style A fill:#eef
+    style N fill:#eef
+    style M fill:#fee,stroke:#a44
+```
+
+**Pre-flight, every run:**
+
+1. Clean working tree; record `git rev-parse HEAD` in the run receipt header. *(PROPOSED — depends on repo presence.)*
+2. Pin wall-clock and any RNG seed. Determinism is mandatory.
+3. Assert network isolation. Outbound traffic is a runner-level abort.
+4. Engage `MockAdapter` only. No provider adapter (Ollama, hosted LLM) is permitted in this pass.
+
+**Post-run, every run:**
+
+1. Emit `RunReceipt` per fixture set with `spec_hash` matching the canonical JCS digest of the input.
+2. Emit a rollup summarizing per-layer pass/fail counts.
+3. Emit a boundary-scan report: no forbidden imports, no canonical-store reads, no outbound calls observed.
+4. Diff receipts against the previous green baseline; any non-determinism is a failure.
+
+[Back to top](#contents)
+
+---
+
+## 7. Command families (PROPOSED)
+
+> [!NOTE]
+> **Every command line below is PROPOSED.** The actual tool identities (package manager, schema validator, policy engine, test runner) are **UNKNOWN** at the time of writing because the repository is not mounted in this session. The intent is that the runbook *prescribes* the family of operations; the exact invocation lands as a follow-up once repo evidence resolves the toolchain (see §12 Verification backlog).
+
+| # | Layer | Command family (PROPOSED) | Expected result | Status |
+|---|---|---|---|---|
+| 1 | Schema & contract fixtures | `<schema-validator> validate schemas/contracts/v1/domains/people-dna-land/**/*.schema.json fixtures/domains/people-dna-land/**/*.json` | All `valid/` fixtures pass; all `invalid/` fail with the documented error class. | PROPOSED |
+| 2 | Validator units | `<test-runner> run tests/domains/people-dna-land/validators/` | Every rights / sensitivity / temporal / geometry validator passes its positive and negative cases. | PROPOSED |
+| 3 | Policy negatives | `<policy-engine> test policy/domains/people-dna-land/ -d fixtures/domains/people-dna-land/` | Deny on living-person, DNA-exposure, assessor-as-title, parcel-as-title-boundary, missing-consent, revoked-consent. | PROPOSED |
+| 4 | Evidence resolution | `<test-runner> run tests/domains/people-dna-land/evidence/` | `EvidenceRef` resolves to `EvidenceBundle`; missing → `ABSTAIN`; restricted → `DENY`. | PROPOSED |
+| 5 | Lifecycle state | `<test-runner> run tests/domains/people-dna-land/lifecycle/` | Promotion is a state transition, not a file move; no public write occurs in dry-run. | PROPOSED |
+| 6 | Receipts & proofs | `<test-runner> run tests/domains/people-dna-land/receipts/` | `RunReceipt`, `AIReceipt`, `RedactionReceipt` schemas valid; `spec_hash` matches input JCS digest. | PROPOSED |
+| 7 | Release manifest | `<test-runner> run tests/domains/people-dna-land/release/` | `ReleaseManifest` closes proof; `RollbackCard` is reachable; `CorrectionNotice` is reachable. | PROPOSED |
+| 8 | Governed-API envelope | `<test-runner> run tests/domains/people-dna-land/api/` | All responses are `RuntimeResponseEnvelope`s with finite outcome; `MockAdapter` is the only adapter loaded. | PROPOSED |
+| 9 | UI trust state | `<test-runner> run tests/domains/people-dna-land/ui/` | Evidence Drawer renders source role, rights, sensitivity, review state, freshness, release state; restricted view never leaks raw kit IDs / segments / exact geometry. | PROPOSED |
+| 10 | Boundary scan | `<static-grep-or-import-boundary-tool> scan` | No browser-side raw store, vector DB, object store, model runtime, or internal DB call; no outbound network call during test run. | PROPOSED |
+
+**Convention for documenting the actual runner.** When the toolchain is verified against a mounted repo, the runner team updates this table in a single ADR-noted PR rather than editing values piecemeal. The PR description references the relevant ADR (e.g., `ADR-people-dna-land-runner-toolchain.md`, PROPOSED).
+
+[Back to top](#contents)
+
+---
+
+## 8. Pass criteria and finite outcomes
+
+A run is **green** only when every condition below holds simultaneously. A single failure halts the pyramid and the rollup reports the first failing layer.
+
+| Criterion | Requirement |
+|---|---|
+| Determinism | Two consecutive clean runs over identical fixtures produce byte-identical receipts and identical rollups. |
+| Network isolation | Zero outbound network calls observed by the runner sandbox. |
+| Provider isolation | Only `MockAdapter` is loaded; no provider adapter is reachable. |
+| Schema closure | Every fixture validates against `schemas/contracts/v1/domains/people-dna-land/` *(PROPOSED home per ADR-0001)*; every `invalid/` fixture fails for its documented reason. |
+| Validator parity | Each validator passes its positive AND negative cases; coverage of rights / sensitivity / temporal / geometry / consent is complete. |
+| Policy negatives | Every documented deny case in §9 produces a `DENY` decision with a recorded reason. |
+| Evidence finite outcomes | Every `EvidenceRef` lookup returns one of: resolved bundle, abstain (missing), deny (restricted), error (malformed). No silent fallback. |
+| Lifecycle integrity | No public write originates from `RAW` / `WORK` / `QUARANTINE`. Promotion is recorded as a state transition with receipt. |
+| Receipt closure | `RunReceipt`, `AIReceipt`, `RedactionReceipt` are present where required; `spec_hash` matches input JCS canonical digest. |
+| Release closure | `ReleaseManifest` references `EvidenceBundle`, `ValidationReport`, `RollbackCard`, and a correction path. |
+| Envelope discipline | Every governed-API response is `ANSWER` / `ABSTAIN` / `DENY` / `ERROR`. No free-form fallback. |
+| UI trust state | Evidence Drawer renders the trust badges; restricted-view fixtures show redacted state, not raw values. |
+| Mock markers | Every fixture file carries an obvious mock marker; no fixture file impersonates a released artifact. |
+
+**Finite-outcome legend.**
+
+| Outcome | Meaning in this runbook |
+|---|---|
+| `ANSWER` | The requested object is releasable and supported by an `EvidenceBundle`. |
+| `ABSTAIN` | Evidence is missing, partial, stale, or under review. AI MUST NOT compensate. |
+| `DENY` | Policy refused the request (living-person, DNA exposure, raw kit ID, assessor-as-title, parcel-as-title, missing/revoked consent, sovereignty, unresolved rights). |
+| `ERROR` | Schema, validator, or runner failure. Operator action required. |
+
+[Back to top](#contents)
+
+---
+
+## 9. Sensitivity guardrails specific to this domain
+
+People/DNA/Land carries the strongest default-deny posture in KFM after Archaeology sovereignty. Each guardrail below MUST be exercised by at least one negative fixture and one policy test.
+
+| Concern | Rule | Fixture treatment | Negative test class |
+|---|---|---|---|
+| **Living persons** | Denied or restricted by default; living-flag must be set; public release requires explicit authorization recorded in `ReviewRecord`. | All "living" fixtures use synthetic identities with the living-flag set; `ConsentGrant` references are synthetic. | `policy/domains/people-dna-land/living_person.rego` *(PROPOSED)* |
+| **DNA match / segment data** | Default deny; raw kit IDs and segment data never public; aggregate or context-only derivatives may release under explicit consent + sensitivity policy. | Synthetic centimorgan profiles; synthetic kit tokens; no real vendor identifiers. | `policy/domains/people-dna-land/dna_restriction.rego` *(PROPOSED)* |
+| **Raw kit / vendor ID exposure** | Deny in any payload that would reach a non-steward surface. | Fixture kit tokens are obviously synthetic (e.g., `KIT-MOCK-…`). | `dna_raw_id_no_log.rego` *(PROPOSED)* |
+| **Consent / revocation** | Revocation cascades through all derived projections; a revoked match MUST disappear from drawers, focus answers, graphs, and tile layers. | `RevocationReceipt` fixtures exercise the cascade; pre/post-revocation snapshots compared. | `consent_revocation_cleanup.rego` *(PROPOSED)* |
+| **Assessor / tax records as title** | Deny equating assessor or tax records with title truth. | Mixed fixtures where assessor and title disagree force the deny path. | `assessor_as_title_deny.rego` *(PROPOSED)* |
+| **Parcel geometry as title-boundary** | Deny parcel geometry standing as title-boundary proof without supporting `LandInstrument` + source role. | Geometry-only fixtures must `ABSTAIN` or `DENY`, never `ANSWER`. | `parcel_geometry_not_title.rego` *(PROPOSED)* |
+| **Chain-of-title gaps** | Gaps must be visible; AI must not "smooth" a gap by inferring continuity. | Fixtures with documented gaps; pass requires `ABSTAIN` on the gap span. | `chain_of_title_gap.rego` *(PROPOSED)* |
+| **Graph projections leaking sensitive joins** | Sensitive joins (DNA × living-person, kit × vendor, parcel × living-owner) MUST NOT appear in published graph projections. | Fixtures attempt the join; pass requires policy deny. | `graph_projection_safety.rego` *(PROPOSED)* |
+| **AI hypothesizing identity / relationship** | AI may compare evidence and explain limitations; it MUST NOT manufacture identity or relationship claims without admissible bundles. | Fixture asks for an unsupported merge; pass requires `ABSTAIN`. | `ai_no_identity_invention.rego` *(PROPOSED)* |
+
+> [!CAUTION]
+> A **single missing negative test** in this section is grounds to mark the affected component PROPOSED and block public release of the lane, even if every positive case passes. The asymmetry is deliberate: in this domain, harm from a false `ANSWER` outweighs benefit from one more positive surface.
+
+[Back to top](#contents)
+
+---
+
+## 10. Failure modes and triage
+
+| Symptom | Likely cause | First triage step |
+|---|---|---|
+| Outbound network call detected | Test or validator unintentionally calls a live source/model. | Identify the call site; replace with fixture or `MockAdapter`; add a boundary-scan rule to prevent recurrence. |
+| Non-deterministic receipt | Unpinned clock, unseeded RNG, or unordered iteration. | Pin clock and seed; sort keys via JCS canonicalization; rerun. |
+| `ANSWER` returned on a deny case | Policy bundle drift, fixture mislabel, or validator regression. | Diff policy bundle against last green; verify fixture mock marker and scenario tag; run the policy negative in isolation. |
+| `ABSTAIN` on a case that should `ANSWER` | Missing `EvidenceRef` → `EvidenceBundle` link; new schema field not yet wired. | Inspect the resolver output; check schema version and `spec_hash`; verify catalog closure. |
+| Schema valid but contract test fails | Object passes shape but violates meaning (e.g., assessor used as title). | Re-read the contract Markdown for the object family; tighten the validator or policy. |
+| Revocation cascade incomplete | A derived projection (graph, drawer payload, layer) retained a reference past revocation. | Trace the projection path; add a revocation-cascade test for that projection. |
+| `RedactionReceipt` missing on a transformed fixture | Transform applied without recording the transform. | Require redaction receipt emission at every public-safe transform site. |
+| Mock fixture appears outside the test tree | Fixture path or build copied a fixture into a release surface. | Treat as a near-miss release incident; remove, audit, document in `docs/registers/DRIFT_REGISTER.md` *(PROPOSED)*. |
+
+[Back to top](#contents)
+
+---
+
+## 11. Reversibility and rollback posture
+
+This runbook is **fixture-only and test-only**. It writes no public artifacts. Its rollback posture is correspondingly small but explicit.
+
+- **Test artifacts.** Receipts, rollups, and boundary-scan reports for this runbook live under an ephemeral test-output path *(PROPOSED: `data/receipts/test/people-dna-land/<run_id>/` or repo-equivalent ephemeral location — verify against Directory Rules §9.1 once mounted)*. They are not promotion candidates and MUST NOT be referenced by a `ReleaseManifest`.
+- **Fixture changes.** A fixture change is a content change. It rides on a PR with a CODEOWNERS review by the People/DNA/Land steward and a docs note. Reverting the PR is the rollback.
+- **Schema changes touched by this runbook.** A schema change is governed by ADR-0001 (`schemas/contracts/v1/...`); rollback is the schema-version revert plus old-fixture parity tests, per Directory Rules §14.3.
+- **Policy changes touched by this runbook.** A policy change reverts the policy bundle and **fails closed** while ambiguous, per the broader policy-rollback posture.
+- **Documentation.** This file's revisions are tracked in git; revisions that materially change procedure SHOULD reference the relevant ADR or `DRIFT_REGISTER` entry.
+
+> [!NOTE]
+> The runbook **never** writes to `data/published/`, `release/`, or any catalog surface. If a run appears to have done so, treat it as a near-miss release incident, not a test failure.
+
+[Back to top](#contents)
+
+---
+
+## 12. Verification backlog
+
+Items below are open. Each one is `NEEDS VERIFICATION` until checked against a mounted repository. None of them should be claimed as fact in a downstream doc until resolved.
+
+| # | Item | What would settle it | Status |
+|---|---|---|---|
+| V1 | Repository mount and current branch state | `git status --short`; `git branch --show-current`; repo tree scan | NEEDS VERIFICATION |
+| V2 | Schema validator identity and version | Repo lockfile; `tools/validators/` README; CI workflow | NEEDS VERIFICATION |
+| V3 | Policy engine identity and version (OPA / Conftest / Rego version) | `policy/README.md`; CI workflow; tool lockfile | NEEDS VERIFICATION |
+| V4 | Test runner identity (pytest / vitest / jest / etc.) and package manager | `package.json` / `pyproject.toml` / `Cargo.toml` / repo equivalent | NEEDS VERIFICATION |
+| V5 | Existence and shape of `schemas/contracts/v1/domains/people-dna-land/` | Repo file inspection | NEEDS VERIFICATION |
+| V6 | Existence and shape of `policy/domains/people-dna-land/` and `policy/sensitivity/people-dna-land/` and `policy/consent/people-dna-land/` | Repo file inspection | NEEDS VERIFICATION |
+| V7 | Existence and shape of `tests/domains/people-dna-land/` and `fixtures/domains/people-dna-land/` (or `tests/fixtures/...` per local convention) | Repo file inspection; fixture-home rule in `tests/README.md` | NEEDS VERIFICATION |
+| V8 | MockAdapter location (`runtime/mock/` per Directory Rules §10.1 vs. `apps/governed-api/src/ai/MockAdapter.ts` per prior plan) | Repo inspection; ADR-focus-model-adapter-boundary | NEEDS VERIFICATION |
+| V9 | Living-person policy enforcement | Mounted repo: schemas, policies, tests, fixtures, receipts | NEEDS VERIFICATION |
+| V10 | DNA consent / revocation enforcement | Mounted repo: schemas, policies, tests, fixtures, receipts | NEEDS VERIFICATION |
+| V11 | Land instrument chain logic | Mounted repo: schemas, policies, tests, fixtures, receipts | NEEDS VERIFICATION |
+| V12 | Geometry-role boundary logic (parcel ≠ title boundary) | Mounted repo: schemas, policies, tests, fixtures, receipts | NEEDS VERIFICATION |
+| V13 | UI / API restricted-field no-leak behavior | Mounted repo: governed-API tests, UI snapshot or e2e tests | NEEDS VERIFICATION |
+| V14 | Receipt home for ephemeral test runs | Directory Rules §9.1 cross-check; `data/receipts/README.md` | NEEDS VERIFICATION |
+| V15 | Boundary-scan tool identity (static grep, import-boundary linter, sandbox network deny) | CI workflow inspection | NEEDS VERIFICATION |
+
+[Back to top](#contents)
+
+---
+
+## 13. Directory Rules basis for this path
+
+The path `docs/runbooks/people-dna-land/NO_NETWORK_TEST_RUNBOOK.md` is **PROPOSED**. Its basis in Directory Rules:
+
+- **Responsibility root: `docs/`.** A runbook *explains a procedure to humans*; under Directory Rules §5 and §6.1, that responsibility belongs to `docs/`. Specifically, `docs/runbooks/` is listed as the canonical home for "ops procedures, rollback drills, validation runs."
+- **Domain segment, not domain root.** Per Domain Placement Law (§12), the domain `people-dna-land` MUST appear as a **segment** inside a responsibility root, never as a root folder. `docs/runbooks/people-dna-land/` follows the lane pattern that is uniformly applied across hydrology, soil, fauna, flora, habitat, geology, atmosphere, roads-rail-trade, settlements-infrastructure, archaeology, hazards, agriculture, and people-dna-land.
+- **Lane name consistency.** `people-dna-land` is the lane segment used by `policy/domains/people-dna-land/` (Directory Rules §6.5) and by the v1.1 Atlas crosswalk (row 16). This runbook uses the same segment to keep authority-surface discovery consistent across docs, policy, schemas, tests, and fixtures.
+- **Filename convention.** A flat `docs/runbooks/people-dna-land_NO_NETWORK_TEST.md` would also be defensible and matches the prior naming style of `ui_LOCAL_DEV.md`, `governed_ai_VALIDATION.md`. The lane-segmented form is preferred here for two reasons: (1) Domain Placement Law favors a lane segment over a topic-flat name when the lane has more than one runbook expected; (2) it keeps the per-lane runbook set co-locatable in a single folder as the lane grows (validation, rollback, intake, sensitivity drill, revocation drill). If the project commits to flat naming by ADR, this file moves to `docs/runbooks/people-dna-land_NO_NETWORK_TEST.md` under a routine §14.1 migration with `git mv`.
+
+> [!NOTE]
+> No new canonical root, compatibility root, or sibling under `data/` is created by this file. No ADR is required for this placement.
+
+[Back to top](#contents)
+
+---
+
+## 14. Related docs
+
+The list below is partly placeholder. Each entry is marked CONFIRMED if it is present in the project knowledge consulted for this runbook, or PROPOSED if it is a doctrinally expected sibling that has not been verified against a mounted repo.
+
+| Doc | Role | Status |
+|---|---|---|
+| `docs/doctrine/directory-rules.md` | Placement and lifecycle doctrine; cited throughout this runbook. | CONFIRMED |
+| `docs/domains/people-dna-land/README.md` | Domain README, ubiquitous language, scope, non-ownership. | PROPOSED |
+| `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` | Source descriptor and rights/sensitivity intake. | PROPOSED |
+| `docs/runbooks/governed_ai_LOCAL_DEV.md` | MockAdapter and provider-adapter local dev. | PROPOSED |
+| `docs/runbooks/governed_ai_VALIDATION.md` | Focus Mode evidence / citation / policy validation. | PROPOSED |
+| `docs/runbooks/governed_ai_ROLLBACK.md` | AI adapter rollback and kill switch. | PROPOSED |
+| `docs/runbooks/ui_VALIDATION.md` | UI validation, accessibility, contract, e2e smoke. | PROPOSED |
+| `docs/runbooks/ui_ROLLBACK.md` | UI rollback, feature flag, schema deprecation. | PROPOSED |
+| `docs/adr/ADR-0001-schema-home.md` | Schema-home convention (`schemas/contracts/v1/...`). | PROPOSED |
+| `policy/domains/people-dna-land/README.md` | Domain policy bundle index. | PROPOSED |
+| `tests/fixtures/domains/people-dna-land/README.md` (or `fixtures/domains/...`) | Fixture rules and mock markers for this lane. | PROPOSED |
+| `docs/registers/VERIFICATION_BACKLOG.md` | Tracks the items in §12. | PROPOSED |
+| `docs/registers/DRIFT_REGISTER.md` | Tracks any near-miss release or fixture-leak incidents. | PROPOSED |
+
+[Back to top](#contents)
+
+---
+
+## Appendix A — Object-family fixture matrix
+
+<details>
+<summary>Expand: per-object-family fixture filenames (PROPOSED layout)</summary>
+
+The structure below is a **proposed** layout that follows Domain Placement Law. The actual fixture-home convention (root `fixtures/` vs. `tests/fixtures/`) MUST be verified against the local `tests/README.md` per Directory Rules §6.6 before any of these paths are created.
+
+```text
+fixtures/domains/people-dna-land/
+├── README.md                               # mock-marker rule; sensitivity rule; index
+├── person_assertion/
+│   ├── valid/                              # synthetic identity, fully sourced
+│   ├── invalid/                            # schema-violating
+│   ├── denied/                             # living-person trigger
+│   ├── abstain/                            # missing evidence
+│   └── rollback/                           # identity-merge undo
+├── person_canonical/
+├── name_assertion/
+├── relationship_assertion/
+├── genealogy_relationship/
+├── family_group/
+├── life_event/
+├── residence_event/
+├── migration_event/
+├── dna_match_evidence/                     # default-deny scenarios dominate
+├── dna_segment/
+├── dna_kit_token/                          # synthetic tokens only
+├── consent_grant/
+├── revocation_receipt/
+├── land_instrument/                        # patent, deed, mortgage, lien, etc.
+├── deed_instrument/
+├── title_instrument/
+├── legal_description/
+├── land_ownership_assertion/
+├── ownership_interval/
+├── parcel_version/
+├── land_parcel/
+├── assessor_record/
+├── tax_record/
+└── _cross/                                 # cross-object scenarios (chain-of-title, revocation cascade, graph projection)
+```
+
+Every leaf folder contains the five-fixture standard set (valid, invalid, denied, abstain, rollback/correction) per the rule recorded in §5 and CONFIRMED by the project knowledge consulted.
+
+</details>
+
+## Appendix B — Doctrine citations
+
+<details>
+<summary>Expand: short-name citations grounding this runbook</summary>
+
+| Short name | Document | Use in this runbook |
+|---|---|---|
+| `[DIRRULES]` | Directory Rules (`docs/doctrine/directory-rules.md`) | Path placement, Domain Placement Law, lifecycle invariant |
+| `[DOM-PEOPLE]` | People / DNA / Land domain dossier | Object families, sensitivity posture, ubiquitous language |
+| `[ENCY]` | KFM Domain and Capability Encyclopedia | Domain mission, source families, pipeline shape |
+| `[UNIFIED]` | KFM Unified Implementation Architecture Build Manual | Test pyramid; first-package no-network rule; test classes |
+| `[UIAI]` | Whole-UI + Governed AI Expansion Report | MockAdapter posture; runbook target paths; fixture/CI plan |
+| `[MAP-MASTER]` | Master MapLibre Components / Functions / Features | No-network watcher dry-run receipts; spec_hash and JCS |
+| `[GAI]` | Governed AI dossier | AI interpretive role; ANSWER/ABSTAIN/DENY/ERROR envelope |
+
+</details>
+
+---
+
+**Related:** [Directory Rules](../../doctrine/directory-rules.md) · [People/DNA/Land domain README](../../domains/people-dna-land/README.md) *(PROPOSED)* · [Governed AI validation runbook](../governed_ai_VALIDATION.md) *(PROPOSED)* · [UI validation runbook](../ui_VALIDATION.md) *(PROPOSED)*
+
+**Last updated:** 2026-05-12 &nbsp;·&nbsp; **Status:** draft &nbsp;·&nbsp; **Truth posture:** procedure is prescriptive; implementation status is `NEEDS VERIFICATION`
+
+[Back to top](#contents)

--- a/docs/runbooks/people-dna-land/PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/people-dna-land/PROMOTION_RUNBOOK.md
@@ -1,3 +1,600 @@
-# people-dna-land :: PROMOTION runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/people-dna-land/promotion
+title: People, Genealogy, DNA, and Land Ownership — Promotion Runbook
+type: standard
+version: v0.1
+status: draft
+owners: <docs steward + people-dna-land subsystem owner>
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/trust-membrane.md
+  - docs/domains/people-dna-land/README.md
+  - docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md
+  - docs/runbooks/people-dna-land/VALIDATION_RUNBOOK.md
+  - docs/adr/ADR-0001-schema-home.md
+tags: [kfm, runbook, people-dna-land, promotion, governance, sensitivity, dna, living-person]
+notes:
+  - Status is draft until owners, ADR references, and paths are verified against mounted-repo evidence.
+  - All paths quoted in this runbook are PROPOSED per Directory Rules §0 unless explicitly marked CONFIRMED.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# People, Genealogy, DNA, and Land Ownership — Promotion Runbook
+
+Operational procedure for promoting `people-dna-land` objects through `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`, with living-person, DNA, and title/parcel safeguards built into every gate.
+
+![status: draft](https://img.shields.io/badge/status-draft-blue)
+![doctrine: CONFIRMED](https://img.shields.io/badge/doctrine-CONFIRMED-2ea44f)
+![implementation: PROPOSED](https://img.shields.io/badge/implementation-PROPOSED-yellow)
+![sensitivity: T4-default](https://img.shields.io/badge/sensitivity-T4--default-critical)
+![review: two-key](https://img.shields.io/badge/review-two--key-purple)
+![last updated](https://img.shields.io/badge/updated-2026--05--12-lightgrey)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` |
+| **Owners** | `<docs steward + people-dna-land subsystem owner>` *(placeholder — verify against `CODEOWNERS`)* |
+| **Last updated** | 2026-05-12 |
+| **Doctrine class** | CONFIRMED for lifecycle invariant, gates, tier scheme, separation-of-duties; PROPOSED for paths, schemas, CI wiring, exact reason codes |
+| **Promotion authority** | Domain steward + sensitivity reviewer + release authority + rights-holder representative (where applicable) |
+| **Trust posture** | Deny-by-default for living-person, DNA, and private person-parcel joins |
+
+> [!IMPORTANT]
+> **Promotion is a governed state transition, not a file move.** A path-level move that bypasses validators, policy gates, evidence-bundle creation, catalog closure, and release-decision recording is a violation of the lifecycle invariant regardless of where the bytes land. *(CONFIRMED — `directory-rules.md` §9.1; [ENCY] [DIRRULES])*
+
+---
+
+## Contents
+
+- [1. Scope](#1-scope)
+- [2. Repo fit](#2-repo-fit)
+- [3. Inputs accepted](#3-inputs-accepted)
+- [4. Exclusions — what this runbook does not cover](#4-exclusions--what-this-runbook-does-not-cover)
+- [5. The lifecycle, at a glance](#5-the-lifecycle-at-a-glance)
+- [6. Domain non-negotiables before any promotion](#6-domain-non-negotiables-before-any-promotion)
+- [7. Lifecycle gates — required artifacts and outcomes](#7-lifecycle-gates--required-artifacts-and-outcomes)
+- [8. Promotion Gates A–G — checklist](#8-promotion-gates-ag--checklist)
+- [9. Sensitivity tier matrix for People/DNA/Land](#9-sensitivity-tier-matrix-for-peopledn aland)
+- [10. Source-role discipline — title vs. assessor vs. parcel-geometry](#10-source-role-discipline--title-vs-assessor-vs-parcel-geometry)
+- [11. Separation of duties](#11-separation-of-duties)
+- [12. Receipts emitted at each stage](#12-receipts-emitted-at-each-stage)
+- [13. Failure-closed reason codes (this domain)](#13-failure-closed-reason-codes-this-domain)
+- [14. Correction and rollback paths](#14-correction-and-rollback-paths)
+- [15. Cross-lane considerations](#15-cross-lane-considerations)
+- [16. Verification backlog](#16-verification-backlog)
+- [17. Related docs](#17-related-docs)
+- [Appendix A — Worked promotion examples](#appendix-a--worked-promotion-examples)
+- [Appendix B — Glossary (placement-relevant)](#appendix-b--glossary-placement-relevant)
+
+---
+
+## 1. Scope
+
+This runbook governs the **promotion procedure** for objects owned by the People, Genealogy, DNA, and Land Ownership domain (hereafter `people-dna-land`). It names the gates, the required artifacts at each gate, the reviewer separation, and the fail-closed outcome when a gate cannot close.
+
+The domain owns *(CONFIRMED doctrine / PROPOSED implementation; [DOM-PEOPLE] [ENCY])*:
+
+`PersonAssertion`, `PersonIdentityCandidate`, `GenealogyRelationship`, `FamilyGroup`, `LifeEvent`, `ResidenceEvent`, `MigrationEvent`, `LandOwnershipAssertion`, `DeedInstrument`, `TitleInstrument`, `AssessorRecord`, `TaxRecord`, `ParcelVersion`, `OwnershipInterval`, `DNAMatchEvidence`, `RelationshipHypothesis`, `ReviewRecord`.
+
+The domain **does not own** settlements, roads/rail, archaeology, hydrology, agriculture, hazards, or spatial foundation. Those lanes provide context but **do not weaken living-person, DNA, title, or parcel-boundary controls** *(CONFIRMED — [DOM-PEOPLE] [ENCY])*.
+
+[Back to top](#contents)
+
+---
+
+## 2. Repo fit
+
+| Surface | PROPOSED path | Class |
+|---|---|---|
+| This runbook | `docs/runbooks/people-dna-land/PROMOTION_RUNBOOK.md` | Operational doctrine |
+| Domain README (upstream) | `docs/domains/people-dna-land/README.md` | Domain doctrine |
+| Validation runbook (sibling) | `docs/runbooks/people-dna-land/VALIDATION_RUNBOOK.md` | Operational doctrine |
+| Rollback runbook (sibling) | `docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md` | Operational doctrine |
+| Contracts (downstream) | `contracts/domains/people-dna-land/` *(PROPOSED)* | Object meaning |
+| Schemas (downstream) | `schemas/contracts/v1/domains/people-dna-land/` *(PROPOSED — per ADR-0001)* | Object shape |
+| Policy (downstream) | `policy/domains/people-dna-land/` *(PROPOSED)* | Admissibility / release |
+| Tests (downstream) | `tests/domains/people-dna-land/` *(PROPOSED)* | Enforcement proof |
+| Fixtures (downstream) | `fixtures/domains/people-dna-land/` or `tests/fixtures/people-dna-land/` *(PROPOSED — pick one home)* | Golden / negative inputs |
+| Pipelines (downstream) | `pipelines/domains/people-dna-land/` *(PROPOSED)* | Execution |
+
+> [!NOTE]
+> The existing `docs/runbooks/` examples in prior expansion reports use a **flat** convention (`ui_LOCAL_DEV.md`, `governed_ai_ROLLBACK.md`). This runbook adopts a **per-domain subdirectory** (`docs/runbooks/people-dna-land/`). Both are consistent with **Directory Rules §11** (*domain appears as a segment inside the responsibility root, never as a root itself*). The choice between conventions **NEEDS VERIFICATION** against a mounted repo and should be settled by short ADR if both shapes co-exist.
+
+[Back to top](#contents)
+
+---
+
+## 3. Inputs accepted
+
+Material this runbook governs the promotion of:
+
+- Public historical records (census, vital records where public/legal), directory and probate records, court files.
+- GEDCOM / GEDZip / tree overlays as **hypotheses**, not authoritative claims.
+- Land patents, deeds, mortgages, liens, easements, leases, mineral/water/access instruments, probate instruments.
+- Assessor and tax-roll records (treated as **observation**, not title truth).
+- Plat / survey / metes-and-bounds / PLSS / subdivision / derived parcel geometry (treated as **geometry version**, not title-boundary proof).
+- DNA vendor match CSV / segment / triangulation data — **restricted intake only**, default T4.
+
+*(CONFIRMED scope / PROPOSED field realization; [DOM-PEOPLE] [ENCY])*
+
+[Back to top](#contents)
+
+---
+
+## 4. Exclusions — what this runbook does not cover
+
+This runbook **does not** cover:
+
+- Settlement, road/rail, archaeology, hydrology, agriculture, hazards, or spatial-foundation promotions — those have their own per-domain runbooks.
+- Source admission policy authorship — see `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` *(PROPOSED)*.
+- Schema-home decisions — see `docs/adr/ADR-0001-schema-home.md`.
+- Reviewer enrollment and identity provisioning — see `docs/governance/` *(PROPOSED)*.
+- Atlas / supplement publication — see `docs/doctrine/` and the docs-steward runbook *(PROPOSED)*.
+- Erasure vs. tombstone policy under right-to-be-forgotten obligations — **NEEDS VERIFICATION**; this is a deliberate open question deferred to `docs/runbooks/revocation.md` *(PROPOSED)*.
+
+[Back to top](#contents)
+
+---
+
+## 5. The lifecycle, at a glance
+
+The KFM lifecycle invariant applies to this domain without exception *(CONFIRMED — [DIRRULES] [DOM-PEOPLE] [ENCY])*:
+
+```mermaid
+flowchart LR
+    SRC([Source<br/>candidate]) -->|SourceDescriptor| RAW[RAW]
+    RAW -->|TransformReceipt<br/>ValidationReport<br/>PolicyDecision| WORK[WORK]
+    RAW -->|defect detected| QUAR[QUARANTINE]
+    WORK -->|ValidationReport pass<br/>+ RedactionReceipt / AggregationReceipt<br/>where sensitivity applies| PROC[PROCESSED]
+    QUAR -.->|remediation| WORK
+    PROC -->|CatalogMatrix entry<br/>EvidenceBundle close<br/>graph / triplet projections| CAT[CATALOG / TRIPLET]
+    CAT -->|ReleaseManifest<br/>+ ReviewRecord<br/>+ rollback target<br/>+ correction path| PUB((PUBLISHED))
+    PUB -.->|CorrectionNotice<br/>+ ReviewRecord| PUB
+    PUB -.->|RollbackCard| CAT
+
+    classDef public fill:#103a1f,stroke:#2ea44f,color:#fff
+    classDef internal fill:#1f2230,stroke:#999,color:#fff
+    classDef hold fill:#3a2310,stroke:#cc7a00,color:#fff
+    class PUB public
+    class RAW,WORK,PROC,CAT internal
+    class QUAR hold
+```
+
+> [!CAUTION]
+> **PUBLISHED is the only state from which the governed API may emit an `ANSWER`.** Public clients, the normal UI, and Focus Mode **must not** reach `RAW`, `WORK`, `QUARANTINE`, canonical/internal stores, graph internals, vector indexes, source APIs, or direct model runtimes. *(CONFIRMED — [ENCY] §24.6.2; [GAI]; [MAP-MASTER])*
+
+[Back to top](#contents)
+
+---
+
+## 6. Domain non-negotiables before any promotion
+
+These hold at **every** gate. A `ValidationReport`, `PolicyDecision`, or `ReviewRecord` that fails to enforce any of these must fail closed.
+
+| # | Rule | Source |
+|---|---|---|
+| 1 | **Living-person fields are denied or restricted by default.** Aggregation by tract or county with an `AggregationReceipt` may release to T1; per-record exact exposure remains T4. | CONFIRMED — [DOM-PEOPLE]; [ENCY] §24.5.2 |
+| 2 | **Raw DNA segment data is T4 default.** No transform releases it to a public tier. T3 only under explicit named consent / research agreement, with `PolicyDecision + ReviewRecord` and rights-holder rep on file. | CONFIRMED — [DOM-PEOPLE]; [ENCY] §24.5.2 |
+| 3 | **Relationship hypotheses remain hypotheses.** Genealogy relations are assertions with evidence and confidence; promotion must not silently upgrade a hypothesis to a sourced finding. | CONFIRMED — [DOM-PEOPLE] §D |
+| 4 | **Assessor / tax records are not title truth.** Treat as `AssessorRecord` / `TaxRecord` with source role `observation`; never collapse into `TitleInstrument`. | CONFIRMED — [DOM-PEOPLE] §A; [ENCY] |
+| 5 | **Parcel geometry is not title-boundary proof.** `ParcelVersion` is a geometry version; legal title is carried by `DeedInstrument` / `TitleInstrument` evidence, not by `ParcelVersion` shape. | CONFIRMED — [DOM-PEOPLE] §A; [ENCY] |
+| 6 | **Private person-parcel joins default T4.** Generalized parcel + de-identified person may release to T2 only, with `RedactionReceipt + ReviewRecord`. | CONFIRMED — [DOM-PEOPLE]; [ENCY] §24.5.2 |
+| 7 | **Source-role downcast is forbidden.** A `model`-origin claim must not be promoted by relabeling it `authority`. Reason code: `ROLE_DOWNCAST_FORBIDDEN`. | CONFIRMED — [ENCY] §24.6.3 |
+| 8 | **EvidenceRef must resolve to an EvidenceBundle** before catalog closure. Unresolved references fail closed; AI emits `ABSTAIN`. | CONFIRMED — [ENCY] §24.6.2; [GAI] |
+
+[Back to top](#contents)
+
+---
+
+## 7. Lifecycle gates — required artifacts and outcomes
+
+Each row reflects the master lifecycle gate reference *(CONFIRMED — [ENCY] §24.6.1; [DIRRULES])* applied to this domain. The **status** of artifact homes is PROPOSED until mounted-repo evidence verifies the schema/policy/test paths.
+
+| Transition | Pre-condition | Required artifacts (minimum) | Domain additions for `people-dna-land` | Failure-closed outcome |
+|---|---|---|---|---|
+| **— → RAW** *(Admission)* | Source identity, rights, role intent established at discovery. | `SourceDescriptor` (role, authority, rights, sensitivity, cadence); payload hash or reference. | DNA/vendor sources: explicit consent / research-agreement reference; living-person source-class flag. | Source not admitted; logged as candidate awaiting steward. |
+| **RAW → WORK / QUARANTINE** *(Normalization)* | Schema, geometry, time, identity, evidence, rights, and policy rules runnable. | `TransformReceipt`; `ValidationReport` (working set); `PolicyDecision`; **QUARANTINE** for failures. | Living-person screening; DNA restriction enforcement; title vs. assessor vs. geometry role tagging; temporal-validity range check. | Quarantine with reason — never silently promotes. |
+| **WORK → PROCESSED** *(Validation)* | Deterministic validators tied to fixtures; required receipts present. | `ValidationReport` pass; `RedactionReceipt` if sensitivity applies; `AggregationReceipt` if applies. | Person-fields redaction; parcel-geometry generalization where rights/sensitivity require; chain-of-title temporal-overlap check. | Stay in `WORK`; structured `FAIL` outcome. |
+| **PROCESSED → CATALOG / TRIPLET** *(Catalog closure)* | `EvidenceRef`s resolve; catalog matrix and digests close. | `CatalogMatrix` entry; `EvidenceBundle`; graph / triplet projections if applicable. | Graph-projection safety test for living-person / DNA leakage; relationship-hypothesis confidence carried explicitly. | `HOLD` at `PROCESSED`; no public edge. |
+| **CATALOG / TRIPLET → PUBLISHED** *(Release)* | Review state recorded where required; release authority distinct from original author when materiality applies. | `ReleaseManifest`; rollback target; correction path; `ReviewRecord` (where required). | **Always required for sensitive lanes:** sensitivity reviewer + release authority + rights-holder rep (where applicable). | `HOLD` at `CATALOG`; no public surface change. |
+| **PUBLISHED → PUBLISHED′** *(Correction)* | Detected error or new evidence; downstream derivatives identified. | `CorrectionNotice`; `ReviewRecord`; invalidation list; `ReleaseManifest` update or supersession. | Cascading derivative invalidation across cross-lane consumers (Settlements, Frontier Matrix, Agriculture). | Stale-state announcement; no silent edit. |
+| **PUBLISHED → prior release** *(Rollback)* | Failed release or post-publication failure; targeted prior release identified. | `RollbackCard`; `CorrectionNotice`; `ReleaseManifest` reverts to prior release; downstream derivative invalidation. | UI stale/withdrawn-state propagation; AI surface re-validation against prior `EvidenceBundle`. | Held at current state until rollback validated. |
+
+> [!NOTE]
+> A transition is closed **only when** (i) every required artifact above exists, (ii) every required artifact *resolves* — not just references — the artifacts it depends on (`EvidenceRef → EvidenceBundle`, `source_id → SourceDescriptor`, `model_id → ModelRunReceipt`), and (iii) the policy gate has evaluated and recorded its decision. Missing any of these → **fail closed**, prior state preserved. *(CONFIRMED — [ENCY] §24.6.2)*
+
+[Back to top](#contents)
+
+---
+
+## 8. Promotion Gates A–G — checklist
+
+The canonical seven gates *(CONFIRMED — [KFM Pass 10 C5-01]; consolidated as `PromotionReceipt` enumerable per Build Manual §32)* mapped to operational steps for this domain. The CI workflow path is **PROPOSED**; verify against mounted repo before binding required-checks.
+
+### Gate A — Structure and Metadata
+
+- [ ] Object carries a valid `MetaBlock` (header zone present and well-formed).
+- [ ] Domain segment `people-dna-land` resolves to a known lane in `docs/domains/`, `schemas/contracts/v1/domains/`, `policy/domains/`, and `tests/domains/`. *(PROPOSED paths)*
+- [ ] No root-folder violation (the domain MUST NOT appear as a repo-root folder — Directory Rules §12).
+
+**Machine check (PROPOSED):** `check_structure` — MetaBlock presence and zone correctness.
+**Required evidence:** structured metadata pass record attached to the candidate.
+
+### Gate B — Schemas and Contracts
+
+- [ ] Each object validates against `schemas/contracts/v1/domains/people-dna-land/<object>.schema.json`. *(PROPOSED paths)*
+- [ ] Source-role enum value is one of the canonical vocabulary entries; no silent introduction of new roles. *(NEEDS VERIFICATION — ADR-S-04)*
+- [ ] DTO contracts in `contracts/domains/people-dna-land/` declare the object family and field meaning. *(PROPOSED)*
+
+**Machine check (PROPOSED):** schema and OpenAPI validation in CI.
+**Required evidence:** `ValidationReport` with passing schema rows.
+
+### Gate C — Policy Parity (CI = runtime)
+
+- [ ] Policy bundle pinned by digest in `policy/domains/people-dna-land/` runs identically in CI (Conftest) and at runtime (PDP). *(PROPOSED)*
+- [ ] Negative-path fixtures cover: `missing_rights`, `unresolved_source`, `living_person_exact_exposure`, `dna_raw_public_request`, `private_parcel_join_exact`, `assessor_as_title`.
+- [ ] Outcome is one of `ANSWER` / `ABSTAIN` / `DENY` / `ERROR` / `HOLD`; never silent allow.
+
+**Machine check (CONFIRMED behavior, PROPOSED home):** Conftest/OPA decision with finite-outcome envelope.
+**Required evidence:** `PolicyDecision` with `decision_id`, `policy_id`, `result`.
+
+### Gate D — Security and Sensitivity
+
+- [ ] Sensitivity tier resolved per §9 below; tier persisted on the candidate.
+- [ ] Living-person screening pass: no exact-record exposure proposed for T0 / T1 without `AggregationReceipt`.
+- [ ] DNA segment data confirmed T4 unless `T4 → T3` artifacts (`PolicyDecision + ReviewRecord + agreement`) are present.
+- [ ] License / rights scan pass on every source file underlying the EvidenceBundle.
+
+**Machine check (PROPOSED):** sensitivity-policy and license scans.
+**Required evidence:** `RedactionReceipt` or `AggregationReceipt` for any tier downgrade; `PolicyDecision` for restricted tiers.
+
+### Gate E — Data Quality
+
+- [ ] Temporal-validity ranges close (`valid_from < valid_to`; no overlap conflicts on a single `OwnershipInterval`).
+- [ ] Chain-of-title joins resolve without breaking ownership intervals for cited deeds/titles.
+- [ ] Parcel-version reference is dated, not a generic "current parcel" pointer.
+- [ ] Relationship-hypothesis confidence is recorded; no upgrade to "fact" without source-supported `LifeEvent` / `ResidenceEvent` evidence.
+
+**Machine check (PROPOSED):** DQ profilers / assertions with thresholds.
+**Required evidence:** `ValidationReport` with DQ rows in status `pass`.
+
+### Gate F — Provenance and Lineage
+
+- [ ] Every `EvidenceRef` resolves to an `EvidenceBundle` that itself resolves source descriptors.
+- [ ] `spec_hash` is recomputable (canonical JSON, JCS, SHA-256) and matches the recorded hash.
+- [ ] `RunReceipt` chain covers every transform from RAW; cosign signature is verifiable; OpenLineage events recorded where present. *(NEEDS VERIFICATION — signing baseline / phase M10)*
+
+**Machine check (PROPOSED):** receipt and lineage validation; spec-hash recomputation.
+**Required evidence:** signed `RunReceipt`; `EvidenceBundle` digest closure.
+
+### Gate G — Reviewability (two-key approval)
+
+- [ ] **Author ≠ release authority** for any PUBLISHED transition where materiality applies.
+- [ ] Sensitive-lane release also requires sensitivity reviewer **and** rights-holder representative (where applicable). See §11.
+- [ ] `ReviewRecord` is attached, with reviewer id, decision, reason, and timestamp.
+- [ ] Auto-merge fires only when **all** of A–G pass.
+
+**Machine check (PROPOSED):** CODEOWNERS-enforced human plus policy approval.
+**Required evidence:** `ReviewRecord` and `PromotionReceipt` enumerating gates A–G outcomes.
+
+> [!TIP]
+> When in doubt at Gate G, prefer `HOLD`. Promotion that proceeds without the right reviewers is harder to unwind than promotion that waits.
+
+[Back to top](#contents)
+
+---
+
+## 9. Sensitivity tier matrix for People/DNA/Land
+
+The tier scheme is **CONFIRMED doctrine** *(scheme: [ENCY] §24.5.1; per-domain rows: [ENCY] §24.5.2; [DOM-PEOPLE])*. Default tiers and allowed transforms below apply specifically to this domain.
+
+| Object class | Default tier | Allowed transforms | Required gates |
+|---|---|---|---|
+| Living-person fields (any exact identifier or living individual) | **T4** | Aggregation by tract or county + `AggregationReceipt` → T1. | Consent or aggregation gate + `ReviewRecord`. |
+| Raw DNA segment / match / triangulation data | **T4** | **No transform releases this to a public tier.** T3 only under explicit named research agreement. | Named consent + `ReviewRecord` + `PolicyDecision`. |
+| Private person-parcel join (exact) | **T4** | Generalized parcel + de-identified person → **T2 only**. | `RedactionReceipt` + `ReviewRecord`. |
+| `PersonAssertion` / `NameAssertion` for **deceased** historical persons | T1 / T2; aggregate may be T0 | Public-safe family/history surfaces; redaction where descendants are still living. | `ReviewRecord` for sensitive descent lines. |
+| `LandParcel` / `ParcelVersion` (aggregate, historical) | **T0 aggregate**; T2 / T4 for private joins | Aggregate historic parcel rendering; ownership-interval views from `DeedInstrument` evidence. | Standard release gates. |
+| `DeedInstrument` / `TitleInstrument` (public record, historical) | **T0** | Public document rendering with citation; exact private-citizen identifiers redacted where required. | Standard release gates. |
+| `AssessorRecord` / `TaxRecord` | T0 / T1 depending on jurisdiction and freshness | Rendered as **observation**, never collapsed into title. | Standard release gates + source-role guard. |
+
+### Allowed tier motion (CONFIRMED doctrine)
+
+| From → To | Required artifact | Required reviewer | Reversibility |
+|---|---|---|---|
+| T4 → T3 | `PolicyDecision` + `ReviewRecord` + agreement | Steward + rights-holder where applicable | Reversible — agreement revocation returns to T4 with `CorrectionNotice`. |
+| T4 → T2 | `PolicyDecision` + `ReviewRecord` | Steward | Reversible — review revocation returns to T4. |
+| T4 → T1 | `RedactionReceipt` + `ReviewRecord` | Steward | Reversible — redaction may be re-evaluated; correction may demote a published T1 to T4. |
+| T3 → T2 | `PolicyDecision` + `ReviewRecord` | Steward | Reversible. |
+| T2 → T1 | `RedactionReceipt` + `ReviewRecord` | Steward | Reversible. |
+| T1 → T0 | `ReleaseManifest` + `ReviewRecord` | Steward + release authority | Reversible — rollback supported via `RollbackCard`. |
+| **Any tier → T4** (downgrade) | `CorrectionNotice` + `ReviewRecord` | Steward + rights-holder where applicable | Always permitted; precedes derivative invalidation. |
+
+> [!IMPORTANT]
+> **Tier upgrade** (toward more public) always needs both a transform receipt and a review record. **Tier downgrade** (toward less public) never needs both — `CorrectionNotice` alone is sufficient to remove or restrict. *(CONFIRMED — [ENCY] §24.5.3)*
+
+[Back to top](#contents)
+
+---
+
+## 10. Source-role discipline — title vs. assessor vs. parcel-geometry
+
+This is the most common source-role-collapse failure mode in the domain. Reason code on collapse: `ROLE_COLLAPSE` or `ROLE_DOWNCAST_FORBIDDEN`.
+
+```mermaid
+flowchart TB
+    subgraph "Ownership claim"
+        DEED[DeedInstrument / TitleInstrument<br/>role: authority<br/>carries: legal title]
+    end
+    subgraph "Observation"
+        ASSR[AssessorRecord / TaxRecord<br/>role: observation<br/>carries: declared use & valuation]
+    end
+    subgraph "Geometry version"
+        PARCEL[ParcelVersion<br/>role: geometry<br/>carries: shape at time T]
+    end
+    DEED -- "cites" --> PARCEL
+    ASSR -- "observes" --> PARCEL
+    ASSR -. "does not establish" .-> DEED
+    PARCEL -. "does not establish" .-> DEED
+
+    classDef authority fill:#103a1f,stroke:#2ea44f,color:#fff
+    classDef observation fill:#1f2230,stroke:#888,color:#fff
+    classDef geometry fill:#23232f,stroke:#666,color:#fff
+    class DEED authority
+    class ASSR observation
+    class PARCEL geometry
+```
+
+| Source-role pitfall | What it looks like | Correct posture |
+|---|---|---|
+| Assessor → Title collapse | Treating an `AssessorRecord` as proof of who owns the parcel. | Assessor is **observation**; title is carried by `DeedInstrument` / `TitleInstrument` evidence. Reject the candidate at Gate B / Gate E. |
+| Parcel geometry → Title boundary | Treating a `ParcelVersion` shape as a legal boundary. | `ParcelVersion` is a geometry version at a moment in time; legal boundaries flow from instrument evidence + survey, not from rendered shape. |
+| Tree overlay → Authoritative relation | Promoting a GEDCOM hypothesis to a `RelationshipHypothesis` with confidence `high` absent supporting `LifeEvent` evidence. | Tree overlays are **hypotheses**. Promote only when supported by named source-role evidence. |
+
+[Back to top](#contents)
+
+---
+
+## 11. Separation of duties
+
+CONFIRMED separation-of-duties matrix *(- [ENCY] §24.7.2; [DIRRULES])* applied to this domain:
+
+| Action | May the author also approve? | Required separation |
+|---|---|---|
+| Source admission (— → RAW) | Routine yes; **no** when source has unresolved rights / sovereignty / consent. | Source steward + rights-holder rep where applicable. |
+| Normalization receipts (RAW → WORK) | Routine yes; **no** when transforms are sensitivity-relevant (any living-person / DNA / private-join data). | Domain steward + sensitivity reviewer. |
+| Validator authorship & run | Yes (validators are deterministic). | Domain steward; periodic audit by docs steward. |
+| Promotion to PROCESSED / CATALOG | Routine yes for non-sensitive; **no** for sensitive lanes (living-person, DNA, private person-parcel). | Domain steward + sensitivity reviewer. |
+| Release to PUBLISHED | **No** when materiality applies. | Author ≠ release authority; rights-holder rep where applicable. |
+| **Sensitive-lane release** | **No.** | Author + sensitivity reviewer + release authority + rights-holder rep. |
+| Correction / rollback | **No** when correction is steward-significant. | Author / detector + correction reviewer + release authority. |
+
+> [!NOTE]
+> Separation-of-duties enforcement is maturity-dependent. Early-stage authoring may have a single actor when materiality is low. As the public trust surface expands, **enforcement must move from custom to tooling.** This runbook does not assert that the tooling exists yet — that is **NEEDS VERIFICATION** until CI / `CODEOWNERS` / branch protection are inspected in a mounted repo. *(CONFIRMED — [DIRRULES] §2; [ENCY] §24.7.2)*
+
+[Back to top](#contents)
+
+---
+
+## 12. Receipts emitted at each stage
+
+Receipt ↔ lifecycle phase mapping for this domain *(CONFIRMED doctrine — [ENCY] §24.2.2; PROPOSED schema homes)*:
+
+| Receipt | RAW | WORK / QUARANTINE | PROCESSED | CATALOG / TRIPLET | PUBLISHED |
+|---|:-:|:-:|:-:|:-:|:-:|
+| `SourceDescriptor` | • | • | • | • | • |
+| `TransformReceipt` |   | • | • | • |   |
+| `RedactionReceipt` |   | • | • | • |   |
+| `AggregationReceipt` |   | • | • | • |   |
+| `ModelRunReceipt` *(rare — relationship-scoring models only)* |   | • | • | • |   |
+| `RepresentationReceipt` |   |   | • | • |   |
+| `AIReceipt` *(Focus Mode summaries only)* |   |   |   | • | • |
+| `ReviewRecord` |   | • | • | • | • |
+| `PolicyDecision` | • | • | • | • | • |
+| `ValidationReport` |   | • | • | • |   |
+| `ReleaseManifest` |   |   |   | • | • |
+| `CorrectionNotice` |   |   |   |   | • |
+| `RollbackCard` |   |   |   |   | • |
+| `RealityBoundaryNote` *(if synthetic genealogy reconstructions appear)* |   |   | • | • | • |
+| `PromotionReceipt` |   | • | • | • | • |
+
+> [!NOTE]
+> A dot means the receipt is **normally emitted, amended, or referenced** at that phase. Receipts created earlier are **referenced** (not duplicated) at later phases via `EvidenceRef`. *(CONFIRMED — [ENCY] §24.2.2)*
+
+[Back to top](#contents)
+
+---
+
+## 13. Failure-closed reason codes (this domain)
+
+A non-exhaustive PROPOSED catalog scoped to People/DNA/Land *(family taxonomy CONFIRMED — [ENCY] §24.6.3; codes PROPOSED unless otherwise noted)*.
+
+| Failure family | Reason code | Gate(s) | Recovery |
+|---|---|---|---|
+| Missing required artifact | `MISSING_RECEIPT`, `MISSING_EVIDENCE`, `MISSING_REVIEW` | Normalization / Validation / Catalog / Release | Re-emit missing receipt; re-run review; re-validate. |
+| Schema / contract mismatch | `SCHEMA_MISMATCH`, `CONTRACT_DRIFT` | Normalization / Validation | Schema fix and/or ADR; re-run validator. |
+| Rights / sensitivity unresolved | `RIGHTS_UNKNOWN`, `SENSITIVITY_UNRESOLVED` | Admission / Validation / Catalog / Release | Steward review; rights resolution; tier reassignment. |
+| Source-role collapse | `ROLE_COLLAPSE`, `ROLE_DOWNCAST_FORBIDDEN` | Validation / Catalog / Release | Restore source role; refuse upcast; quarantine where appropriate. |
+| **Living-person exact exposure** *(PROPOSED domain code)* | `LIVING_PERSON_EXACT_DENIED` | Validation / Catalog / Release | Aggregate by tract or county; re-run with `AggregationReceipt`. |
+| **DNA raw public path** *(PROPOSED domain code)* | `DNA_PUBLIC_PATH_DENIED` | Admission / Validation / Catalog / Release | Hold at restricted store; require agreement for T3; otherwise T4. |
+| **Private parcel join** *(PROPOSED domain code)* | `PRIVATE_PARCEL_JOIN_DENIED` | Validation / Catalog / Release | Generalize parcel; de-identify person; release to T2 only with `RedactionReceipt`. |
+| Review state inadequate | `REVIEW_NEEDED`, `REVIEW_INSUFFICIENT`, `REVIEW_REJECTED` | Catalog / Release | Run required review; supply `ReviewRecord`. |
+| Release infrastructure error | `RELEASE_MANIFEST_INVALID`, `ROLLBACK_TARGET_MISSING` | Release | Manifest fix; supply rollback target. |
+| Correction lineage broken | `CORRECTION_DERIVATIVES_UNRESOLVED`, `CORRECTION_PRIOR_RELEASE_MISSING` | Correction | Resolve derivatives; supersession entry. |
+
+[Back to top](#contents)
+
+---
+
+## 14. Correction and rollback paths
+
+Both are **publication requirements**, not afterthoughts *(CONFIRMED — Build Manual correction/rollback model)*.
+
+### 14.1 Correction (`PUBLISHED → PUBLISHED′`)
+
+1. Identify the defect class: evidence gap, source-role collapse, rights / consent change, sensitivity reclassification, geometry error, temporal error, policy change, validation regression, rendering bug, API/contract change, or AI-output error.
+2. Locate the original `ReleaseManifest` and its `EvidenceBundle`.
+3. Emit `CorrectionNotice` describing the defect, the corrected claim, and the **list of invalidated downstream derivatives** (cross-lane consumers: Settlements, Frontier Matrix, Agriculture; AI summaries; story exports).
+4. Update the `EvidenceBundle`; emit a **superseding** `ReleaseManifest` rather than mutating the old one.
+5. Announce stale-state visibly in the UI Evidence Drawer; do not silently edit.
+
+> [!TIP]
+> A correction that downgrades tier (e.g., T1 → T4) requires only `CorrectionNotice + ReviewRecord`. A correction that re-publishes a corrected claim at the **same** tier requires the full release cycle for the corrected artifact.
+
+### 14.2 Rollback (`PUBLISHED → prior release`)
+
+See the sibling `docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md` *(PROPOSED)*. Summary of preconditions:
+
+- `RollbackCard` identifies the prior safe release.
+- Digests and manifests on the prior release verify.
+- Public surfaces and AI surfaces are disabled or withdrawn while the rollback runs.
+- Stale-state markers propagate to UI and Focus Mode.
+- The rollback target is republished through the **same governed release path**, not as a hidden file copy.
+
+[Back to top](#contents)
+
+---
+
+## 15. Cross-lane considerations
+
+Edges this domain owns *(CONFIRMED — [ENCY] §24.4.14)*. Each edge **must preserve ownership, source role, sensitivity, and EvidenceBundle support** before promotion can close.
+
+| Consumes from owner | Relation | Promotion implication |
+|---|---|---|
+| **Settlements** | Residence events anchor settlement membership. | Living-person fields fail closed regardless of the consuming lane's tier. Settlement publication does not "wash" sensitivity. |
+| **Frontier Matrix** | Aggregated population observations feed matrix cells. | Per-record exposure is denied; only aggregates promoted. Matrix cell receipts carry the aggregation lineage. |
+| **Archaeology / Cultural Heritage** | Indigenous community context. | Steward-reviewed and rights-bounded; sovereignty review applies before any release motion. |
+| **Agriculture** | `LandParcel` context may bound field-candidate joins. | **Private person-parcel joins denied by default.** Only generalized aggregates may cross the lane boundary. |
+| **Roads / Rail** | Migration paths, access. | Public-safe migration routes only; precision suppressed where descendants still living. |
+
+[Back to top](#contents)
+
+---
+
+## 16. Verification backlog
+
+These items remain `NEEDS VERIFICATION` until inspected against a mounted repo, schemas, tests, workflows, dashboards, or emitted artifacts *(carried forward from [DOM-PEOPLE] §N and Build Manual §People/DNA/Land)*.
+
+- [ ] Living-person policy enforcement (CI + runtime parity, negative fixtures).
+- [ ] DNA consent / revocation enforcement (named-agreement lifecycle).
+- [ ] Land instrument chain logic (deed → title → parcel-version overlap rules).
+- [ ] Geometry-role boundary logic (`ParcelVersion` vs. `TitleInstrument` separation in storage and API).
+- [ ] UI / API restricted-field no-leak behavior.
+- [ ] Whether subdirectory (`docs/runbooks/people-dna-land/`) or flat-prefix (`people_dna_land_PROMOTION.md`) is the chosen runbook convention.
+- [ ] `CODEOWNERS` entries for sensitive-lane review.
+- [ ] Signing baseline / `PromotionReceipt` emission (Build Manual phase M10 / 16).
+- [ ] Rollback drill: targeted prior release verified end-to-end.
+- [ ] Erasure vs. tombstone boundary for personal data (right-to-be-forgotten obligations).
+
+[Back to top](#contents)
+
+---
+
+## 17. Related docs
+
+- `docs/doctrine/directory-rules.md` — placement law (CONFIRMED authority surface).
+- `docs/doctrine/lifecycle-law.md` — RAW → PUBLISHED invariant *(PROPOSED home)*.
+- `docs/doctrine/trust-membrane.md` — public surfaces consume governed APIs only *(PROPOSED home)*.
+- `docs/domains/people-dna-land/README.md` — domain identity, scope, ubiquitous language *(PROPOSED home)*.
+- `docs/runbooks/people-dna-land/VALIDATION_RUNBOOK.md` — validator inventory, fixtures, deterministic runs *(PROPOSED)*.
+- `docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md` — rollback drill and stale-state propagation *(PROPOSED)*.
+- `docs/adr/ADR-0001-schema-home.md` — schema-home convention.
+- `docs/adr/ADR-S-04-source-role-vocabulary.md` — source-role enum *(PROPOSED ADR)*.
+- `docs/adr/ADR-S-05-sensitivity-tier-scheme.md` — tier scheme adoption *(PROPOSED ADR)*.
+
+[Back to top](#contents)
+
+---
+
+## Appendix A — Worked promotion examples
+
+<details>
+<summary><strong>A.1 — Historical deceased-person family/land story slice (T0 / T1)</strong></summary>
+
+**Goal:** publish a public-safe family/history story map for a deceased historical person, with cited residence and land-ownership assertions.
+
+| Stage | Required artifacts | Notes |
+|---|---|---|
+| RAW | `SourceDescriptor` for census, vital records, deeds, land patents. | All sources public-record class; rights resolved at admission. |
+| WORK | `TransformReceipt` (normalization); `ValidationReport` (schema, temporal); `PolicyDecision` (T0 / T1 acceptable). | Living-descendant screening still applies even when subject is deceased. |
+| PROCESSED | `ValidationReport` pass; `RedactionReceipt` where a living descendant identifier appears in source text. | Relationship hypotheses carry confidence; not upgraded silently. |
+| CATALOG / TRIPLET | `EvidenceBundle` resolves all `EvidenceRef`s; graph projection passes leakage test. | Cross-lane edges to Settlements, Frontier Matrix recorded. |
+| PUBLISHED | `ReleaseManifest`; `ReviewRecord` from domain steward + release authority; rollback target set. | Story snapshot may emit `StorySnapshot` receipt. |
+
+**Outcome:** `ANSWER` via governed API; Evidence Drawer cites every assertion; correction path active.
+
+</details>
+
+<details>
+<summary><strong>A.2 — DNA match data submitted by researcher (T4 → T3 motion)</strong></summary>
+
+**Goal:** admit DNA match CSV under named research agreement.
+
+| Stage | Required artifacts | Notes |
+|---|---|---|
+| Admission | `SourceDescriptor` includes named consent / research agreement reference; rights-holder rep on file. | If agreement reference is absent: `RIGHTS_UNKNOWN` → quarantine. |
+| RAW → WORK | `TransformReceipt`; `PolicyDecision` confirms restricted store; no public-path emission permitted. | Default outcome `DENY` for any public-surface query. |
+| WORK → PROCESSED | `ValidationReport`; `RedactionReceipt` for any incidentally captured living-person fields. | DNA segment data remains at T4 unless explicitly motioned to T3. |
+| T4 → T3 motion | `PolicyDecision` + `ReviewRecord` + named agreement. | Reviewer: steward + rights-holder rep. |
+| Release | Restricted-only release manifest; **no T0 / T1 motion permitted** without separate aggregation pipeline + `AggregationReceipt`. | UI surfaces named-party only. |
+
+**Outcome:** `ANSWER` only for named parties; `DENY` for the public surface; `ABSTAIN` from AI in absence of `EvidenceBundle`.
+
+</details>
+
+<details>
+<summary><strong>A.3 — Failure case: assessor record promoted as title (rejected)</strong></summary>
+
+**Goal:** demonstrate the source-role collapse failure mode.
+
+```text
+Candidate: LandOwnershipAssertion
+  source_ref:  AssessorRecord/JEFFERSON-1898-001
+  source_role: authority           ← INCORRECT (assessor is observation)
+  asserts:     ownership-by:       "J. Smith, 1898–1902"
+
+Gate B  (Schemas/Contracts):     PASS — schema valid
+Gate E  (Data Quality):          PASS — temporal range closes
+Gate F  (Provenance/Lineage):    FAIL — ROLE_COLLAPSE
+                                 reason: AssessorRecord source-role is
+                                 observation, not authority. Title evidence
+                                 (DeedInstrument / TitleInstrument) absent.
+
+Decision: DENY
+Action:   Hold at WORK; require DeedInstrument or TitleInstrument evidence
+          to substantiate ownership-by claim; AssessorRecord may remain as
+          observation in EvidenceBundle.
+```
+
+**Outcome:** structured `FAIL` outcome; candidate stays in WORK; correction is to supply title evidence, not to relabel the role.
+
+</details>
+
+[Back to top](#contents)
+
+---
+
+## Appendix B — Glossary (placement-relevant)
+
+| Term | Short definition |
+|---|---|
+| **Promotion** | A governed state transition between lifecycle phases. **Not** a file move. *(CONFIRMED — Directory Rules §19)* |
+| **PromotionReceipt** | Governed state-transition record enumerating Promotion Gates A–G as auditable promotion memory. *(CONFIRMED — Build Manual §32.1)* |
+| **Trust membrane** | Boundary ensuring public/UI/AI surfaces consume governed APIs and released artifacts, not raw or internal stores. *(CONFIRMED)* |
+| **EvidenceBundle** | Resolved support package for a claim; lives in `data/proofs/`. References resolve via `packages/evidence-resolver/`. *(PROPOSED paths)* |
+| **ReleaseManifest** | The release decision artifact; lives in `release/manifests/`. *(PROPOSED path)* |
+| **CorrectionNotice** | Public notice of a corrected claim; lives in `release/correction_notices/`. *(PROPOSED path)* |
+| **RollbackCard** | Rollback decision artifact; lives in `release/rollback_cards/`. *(PROPOSED path)* |
+| **Tier (T0–T4)** | Sensitivity scheme. T0 open; T1 generalized public; T2 reviewer-only; T3 restricted under named agreement; T4 denied. *(CONFIRMED — [ENCY] §24.5.1)* |
+| **Source role** | `authority` / `observation` / `context` / `model`. Downcast forbidden; collapse prohibited. *(CONFIRMED)* |
+
+[Back to top](#contents)
+
+---
+
+> Last updated: **2026-05-12**.
+> Related: `docs/doctrine/directory-rules.md` · `docs/domains/people-dna-land/README.md` · `docs/runbooks/people-dna-land/VALIDATION_RUNBOOK.md` · `docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md`
+> [Back to top](#contents)

--- a/docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md
+++ b/docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md
@@ -1,3 +1,648 @@
-# people-dna-land :: ROLLBACK runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-people-dna-land-rollback
+title: People · DNA · Land — Rollback Runbook
+type: standard
+version: v1
+status: draft
+owners: TODO — release authority + sensitivity reviewer + rights-holder representative + domain steward (People/DNA/Land)
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: internal-operational
+related:
+  - kfm://doctrine/lifecycle-law
+  - kfm://doctrine/trust-membrane
+  - kfm://doctrine/truth-posture
+  - kfm://domain/people-dna-land
+  - TODO docs/runbooks/people-dna-land/CORRECTION_RUNBOOK.md
+  - TODO docs/runbooks/people-dna-land/PROMOTION_RUNBOOK.md
+  - TODO docs/runbooks/governed_ai_ROLLBACK.md
+  - TODO docs/adr/ADR-people-dna-land-rollback-targets.md
+tags: [kfm, runbook, rollback, people, dna, land, governance, sensitive-lane]
+notes:
+  - PROPOSED placement; path conforms to Directory Rules §12 (domain as lane segment).
+  - Prior dossiers list runbooks with flat naming (e.g. ui_ROLLBACK.md); a docs steward + subsystem owner sign-off is required if reconciling.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# People · DNA · Land — Rollback Runbook
+
+> Governed reversal of a People/DNA/Land **PUBLISHED** release to a prior safe target, with audit preservation, derivative invalidation, and visible stale/withdrawn UI state. **Rollback is a governed state transition, not a file copy.**
+
+<!-- Badges -->
+
+![status: draft](https://img.shields.io/badge/status-draft-yellow)
+![authority: governed--api only](https://img.shields.io/badge/authority-governed--api%20only-blue)
+![sensitivity: deny--by--default](https://img.shields.io/badge/sensitivity-deny--by--default-critical)
+![lifecycle: PUBLISHED → prior release](https://img.shields.io/badge/lifecycle-PUBLISHED%20%E2%86%92%20prior%20release-informational)
+![evidence: cite--or--abstain](https://img.shields.io/badge/evidence-cite--or--abstain-success)
+![review: separation of duties](https://img.shields.io/badge/review-separation%20of%20duties-orange)
+![last reviewed: 2026-05-12](https://img.shields.io/badge/last%20reviewed-2026--05--12-lightgrey)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` (PROPOSED — content reflects KFM doctrine; runtime implementation is UNKNOWN) |
+| **Owners** | TODO — release authority **+** sensitivity reviewer **+** rights-holder representative **+** People/DNA/Land domain steward |
+| **Last reviewed** | 2026-05-12 |
+| **Authority root** | `docs/` (human-facing control plane) — Directory Rules §6.1 |
+| **Domain segment** | `people-dna-land/` — Directory Rules §12 (Domain Placement Law) |
+| **Truth posture** | CONFIRMED doctrine / PROPOSED implementation |
+
+> [!IMPORTANT]
+> This runbook governs the **most sensitive domain** in KFM. Living-person fields, DNA-derived outputs, sovereignty-touched material, and title/parcel claims have **deny-by-default** publication posture. Any rollback that touches those classes **must** retain the sensitivity reviewer and (where applicable) the rights-holder representative as co-signers. See §6 and §10.
+
+---
+
+## Quick jump
+
+- [1. Scope](#1-scope)
+- [2. When to trigger this runbook](#2-when-to-trigger-this-runbook)
+- [3. Roles and separation of duties](#3-roles-and-separation-of-duties)
+- [4. Inputs and exclusions](#4-inputs-and-exclusions)
+- [5. Rollback flow at a glance](#5-rollback-flow-at-a-glance)
+- [6. Defect classification matrix (People/DNA/Land)](#6-defect-classification-matrix-peopledna land)
+- [7. Step-by-step procedure](#7-step-by-step-procedure)
+- [8. The `RollbackCard` — required fields and shape](#8-the-rollbackcard--required-fields-and-shape)
+- [9. Reason codes and recovery paths](#9-reason-codes-and-recovery-paths)
+- [10. Sensitive-lane specifics: living-person, DNA, sovereignty, land](#10-sensitive-lane-specifics-living-person-dna-sovereignty-land)
+- [11. Derivative invalidation](#11-derivative-invalidation)
+- [12. Verification, smoke tests, and closure](#12-verification-smoke-tests-and-closure)
+- [13. Stale-state, supersession, and UI signals](#13-stale-state-supersession-and-ui-signals)
+- [14. Rollback drill (rehearsal procedure)](#14-rollback-drill-rehearsal-procedure)
+- [15. Common pitfalls and anti-patterns](#15-common-pitfalls-and-anti-patterns)
+- [16. Open questions and NEEDS VERIFICATION](#16-open-questions-and-needs-verification)
+- [17. Related docs](#17-related-docs)
+- [Appendix A — Object families touched by this runbook](#appendix-a--object-families-touched-by-this-runbook)
+- [Appendix B — Example `RollbackCard` skeleton](#appendix-b--example-rollbackcard-skeleton)
+
+---
+
+## 1. Scope
+
+**CONFIRMED doctrine / PROPOSED implementation.** This runbook covers operational rollback of any **PUBLISHED** People/DNA/Land artifact, layer, catalog record, governed-API payload, Evidence Drawer payload, or Focus Mode answer back to a previously released safe state. It applies whenever a defect in a released People/DNA/Land surface meets the trigger criteria in §2 and the affected surface cannot be safely corrected in place.
+
+This runbook **belongs to** the operational governance plane (`docs/runbooks/`). It is paired with — but does not duplicate — the People/DNA/Land **Correction Runbook** (forward fix without state reversal), the **Promotion Runbook** (forward governed state transitions), and the cross-cutting **Governed AI Rollback Runbook** (AI surface kill switches).
+
+> [!NOTE]
+> **Rollback ≠ deletion.** Rollback restores a *prior safe release* through the same governed path that produced the original release. The withdrawn release record, its receipts, its `EvidenceBundle`, its `ReviewRecord`, and any signed attestations are **preserved for audit** and surfaced as withdrawn/stale via UI signals. Hard-deleting a release without a `RollbackCard` violates the lifecycle invariant.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 2. When to trigger this runbook
+
+Trigger **immediately** when any of the following applies to a PUBLISHED People/DNA/Land surface:
+
+| Trigger | Severity | Time to first action (PROPOSED) |
+|---|---|---|
+| Living-person data leaked to a public surface | CRITICAL | Minutes — disable surface first, file `RollbackCard` second |
+| DNA-segment, raw kit ID, vendor ID, or genomic inference exposed | CRITICAL | Minutes — disable surface first |
+| Sovereignty / rights-holder objection to a published claim | CRITICAL | Hours — coordinate with rights-holder rep before action |
+| Sensitivity policy mis-evaluation (DENY should have fired and did not) | HIGH | Hours |
+| Released assessor / tax / parcel record presented as title proof | HIGH | Hours |
+| Geometry defect that conflates parcel boundary with title boundary | HIGH | Hours |
+| Released claim whose `EvidenceRef` no longer resolves to an `EvidenceBundle` | HIGH | Hours |
+| Source-role collapse (e.g. observation upcast to authority without evidence) | HIGH | Hours |
+| Schema / contract drift detected post-release (validator now fails) | MEDIUM | Day |
+| Stale-source threshold passed with no refresh and the released claim is still served | MEDIUM | Day |
+| AI surface emitted an unsupported People/DNA/Land claim with an AIReceipt | MEDIUM | Day — also trigger Governed AI rollback |
+
+> [!WARNING]
+> For the first **three** triggers (living-person leak, DNA/genomic exposure, rights-holder objection), the **disablement step (§7, Phase B) happens first**; the `RollbackCard` follows. The trust membrane explicitly forbids leaving sensitive content visible while paperwork is drafted.
+
+If unsure whether the situation qualifies, **default to disablement** and escalate to the release authority and sensitivity reviewer. Over-rollback is reversible; an extra hour of sensitive exposure is not.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 3. Roles and separation of duties
+
+CONFIRMED doctrine: separation of duties applies to People/DNA/Land rollback because release materiality is high. The author/detector of the defect **MUST NOT** also be the sole approver of the rollback.
+
+| Role | Required signature on `RollbackCard`? | Notes |
+|---|:---:|---|
+| **Domain steward (People/DNA/Land)** | ✅ | Owns contracts, validators, and object-family semantics for this lane. |
+| **Release authority** | ✅ | Issues the rollback decision; MUST be distinct from the original release author when materiality applies. |
+| **Sensitivity reviewer** | ✅ for living-person / DNA / sovereignty / cultural triggers | Reviews redaction, generalization, withholding, and tier decisions. |
+| **Rights-holder representative** | ✅ when sovereignty, consent, or cultural-heritage matters touch the release | Confirms sovereignty, cultural-heritage, or consent-based reversal. |
+| **Correction reviewer** | ✅ | Reviews `RollbackCard` against doctrine before it amends the PUBLISHED claim. |
+| **Source steward** | ✅ where the defect is source-rooted (rights, role, cadence) | Owns admission lifecycle for the affected source family. |
+| **Docs steward** | ✅ (post-action) | Confirms doc updates, drift register, and any ADR linkage. |
+| **AI surface steward** | ✅ if the defect involves a Focus Mode answer or `AIReceipt` | Coordinates with the Governed AI Rollback Runbook. |
+| **Detector** | sign-off as detector only | MAY NOT also approve as release authority for the same rollback. |
+
+> [!CAUTION]
+> Author-only approval of a sensitive-lane rollback is a **doctrine violation**. The required separation is enforced socially today and SHOULD migrate to tool-enforcement as KFM matures. Until tool-enforcement exists, the `RollbackCard` MUST list distinct human signers in `signed_by[]`.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 4. Inputs and exclusions
+
+**What this runbook needs as input** (all PROPOSED until repo evidence verifies their canonical homes):
+
+- The `release_id` of the affected release (from `ReleaseManifest`).
+- The candidate **rollback target** `release_id` (a prior PUBLISHED release that is currently considered safe).
+- The detection record: receipt, AIReceipt, validator report, sensitivity audit hit, user-submitted correction, rights-holder objection, or steward observation.
+- The downstream **derivative inventory**: catalog records, layer manifests, graph projections, Evidence Drawer payloads, Focus Mode templates, and any external integrations that referenced the affected release.
+
+**What this runbook explicitly does NOT cover:**
+
+- **Forward correction without state reversal.** Use the **Correction Runbook** when a defect can be safely fixed by a *superseding* release rather than by reverting to a prior one.
+- **Source admission failures or quarantine intake.** Those are handled by source admission and quarantine runbooks (pre-PUBLISHED).
+- **Hard deletion of personal data (right-to-erasure).** Tombstoning preserves explainability but does not satisfy erasure. Erasure obligations are handled by a separate, ADR-governed erasure procedure; this runbook does not substitute for it.
+- **Schema or contract evolution.** Schema-home and contract changes are ADR-class per Directory Rules §2.4.
+- **Adapter-internal AI rollback** (e.g. switching model adapters, killing a provider). That is the **Governed AI Rollback Runbook**.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 5. Rollback flow at a glance
+
+```mermaid
+flowchart TD
+    A[Defect detected on PUBLISHED<br/>People/DNA/Land surface] --> B{Sensitive-lane trigger?<br/>living-person, DNA,<br/>sovereignty, rights}
+    B -->|Yes| C[Phase B FIRST:<br/>Disable affected public surface<br/>via governed API kill switch]
+    B -->|No| D[Phase A:<br/>Identify affected release<br/>and prior safe target]
+    C --> D
+    D --> E[Phase C:<br/>Verify prior release digests,<br/>manifest, EvidenceBundle]
+    E --> F[Phase D:<br/>Draft RollbackCard<br/>+ CorrectionNotice]
+    F --> G[Phase E:<br/>Separation-of-duties<br/>review and signatures]
+    G --> H[Phase F:<br/>Republish prior release<br/>through governed release path]
+    H --> I[Phase G:<br/>Invalidate downstream<br/>derivatives]
+    I --> J[Phase H:<br/>Mark stale or withdrawn<br/>UI state; surface signals]
+    J --> K[Phase I:<br/>Verify rollback closure<br/>and run smoke tests]
+    K --> L[(PUBLISHED<br/>prior release restored)]
+    G -. fail .-> M[HOLD at current state;<br/>do not publish rollback]
+    E -. digest mismatch .-> M
+    K -. smoke failure .-> M
+
+    classDef sensitive fill:#fde2e2,stroke:#c0392b,color:#000;
+    classDef hold fill:#fff4d6,stroke:#a67c00,color:#000;
+    class C sensitive;
+    class M hold;
+```
+
+> [!NOTE]
+> The diagram is **doctrinal**, not runtime. `NEEDS VERIFICATION` against any specific deployed orchestration: routes, queue names, kill-switch wiring, and dashboard hooks are UNKNOWN at this session's evidence level.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 6. Defect classification matrix (People/DNA/Land)
+
+Classify the defect **before** picking a posture. The classification determines whether correction or rollback is the right tool, and whether immediate public disablement is required.
+
+| Defect class | Typical People/DNA/Land triggers | Correction posture (PROPOSED) | Rollback posture (PROPOSED) | Disable surface first? |
+|---|---|---|---|:---:|
+| **Evidence gap** | `EvidenceRef` no longer resolves; `EvidenceBundle` revoked | ABSTAIN or withdraw unsupported claim | Restore prior evidence-supported release | No (unless sensitive) |
+| **Rights defect** | Source rights revoked; license expired; consent withdrawn | DENY public use; quarantine source/artifact | Withdraw affected artifacts | **Yes** |
+| **Sensitivity leak** | Living-person identifier exposed; DNA segment leaked; raw kit ID logged | Redact/generalize; notify stewards | Immediate public disablement, then prior release | **Yes (minutes)** |
+| **Sovereignty / cultural** | Rights-holder objection; cultural-heritage rule breach | Hold pending rights-holder review | Withdraw until rights-holder approves restoration | **Yes** |
+| **Geometry defect** | Parcel boundary presented as title boundary; bad CRS; bad legal description | Rebuild derivative layer and `EvidenceBundle` | Restore previous digest-pinned artifact | No |
+| **Temporal defect** | Wrong valid time on residence; deed instrument dated wrong | Correct valid/source/retrieval/release time | Mark stale until rebuilt | No |
+| **Source-role collapse** | Assessor record upcast to "title authority"; tree assertion treated as authority | Restore source role; refuse upcast | Restore prior release with correct role | No |
+| **Policy defect** | Sensitive-lane DENY did not fire when it should have | Re-run policy and `DecisionEnvelope` | Disable route/layer if gate failed | **Yes** |
+| **AI answer defect** | Focus Mode answered with uncited or unsupported People/DNA/Land claim | Invalidate `AIReceipt` and response envelope | Remove answer; preserve `EvidenceBundle`; coordinate with Governed AI rollback | **Yes** for unsupported claim |
+| **Catalog defect** | `EvidenceRef` → `EvidenceBundle` chain breaks; orphan catalog entry | Re-emit catalog closure after proof repair | Restore previous catalog state | No |
+| **Release infrastructure** | `ReleaseManifest` invalid; rollback target missing; signatures broken | Manifest fix and re-issue | Restore manifest from prior release | No |
+
+> [!TIP]
+> A single defect often has **multiple classes** (e.g. a DNA-segment leak is both *sensitivity leak* and *rights defect*). When in doubt, take the union of all required postures, including all "Disable surface first?" instances marked Yes.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 7. Step-by-step procedure
+
+### Phase A — Identify affected release and rollback target
+
+1. Resolve `release_id` of the affected release from the public surface back through `ReleaseManifest`. The chain is: public surface → `LayerManifest` / governed-API payload → `EvidenceRef` → `EvidenceBundle` → `ReleaseManifest`.
+2. Enumerate every PUBLISHED artifact in that release's `contents[]`: layer manifests, tile sets, GeoParquet, COG, catalog records, graph projections, Evidence Drawer payloads, and any AI templates that cite the release.
+3. Identify the **rollback target**: the most recent prior PUBLISHED release that is currently considered safe under today's rights, sensitivity, evidence, and policy posture. The candidate is named in the affected release's `rollback_target` field, but it MUST be **re-verified** — a prior release may itself have aged out, lost rights, or been superseded since publication.
+4. If no safe prior release exists, do **not** publish a rollback. Hold the surface in disabled/withdrawn state and escalate to release authority + sensitivity reviewer for a forward-correction or quarantine decision.
+
+### Phase B — Disable affected public surface (sensitive-lane first action)
+
+> [!CAUTION]
+> If §2 lists the trigger as CRITICAL or as "sensitive-lane," **execute this phase first** — before any drafting, signature collection, or downstream coordination. The trust membrane forbids leaving sensitive content visible while paperwork is in flight.
+
+Disablement applies, where applicable, to:
+
+- The governed-API route that returns the affected `LayerManifest`, feature, Evidence Drawer payload, or Focus Mode answer.
+- The MapLibre layer descriptor for any tile or vector layer in the affected release.
+- The graph/triplet projection that exposes affected `PersonAssertion`, `GenealogyRelationship`, `LandOwnershipAssertion`, `OwnershipInterval`, or `DNAMatchEvidence` records.
+- Any cached Evidence Drawer payloads keyed to the affected `EvidenceBundle`.
+- Any AI Focus Mode template bound to the affected release; coordinate with the **Governed AI Rollback Runbook**.
+
+The disablement mechanism MUST emit a receipt (PROPOSED: `SurfaceDisableReceipt` or equivalent) recording who, when, why, and which surfaces were disabled. Hidden file copies, silent route 404s, or unaudited config flips are doctrine violations.
+
+### Phase C — Verify the rollback target
+
+Before the rollback is published, the prior release must be re-verified:
+
+- **Digests.** Every artifact digest in the target `ReleaseManifest.contents[]` resolves and matches.
+- **`EvidenceRef` resolution.** Every `EvidenceRef` in the target release resolves to a current `EvidenceBundle`. If an evidence bundle has been retracted since the target was first published, the target is no longer safe.
+- **Rights & sensitivity.** The target release's source rights and sensitivity posture remain valid under today's policy. A previously-fine release can become unfit if rights were revoked or sensitivity rules tightened.
+- **`ReviewRecord`.** The target's review state remains adequate. If the original reviewers' authority has been withdrawn, escalate.
+- **Schema & contract.** The target's payload still validates against the **current** governed-API schema, or a documented compatibility shim exists. Schema-home changes are ADR-class per Directory Rules §2.4.
+
+If any of the above fails, **do not roll back to that target.** Either select an earlier safe release, or hold disabled and pursue a forward correction.
+
+### Phase D — Draft `RollbackCard` and `CorrectionNotice`
+
+The `RollbackCard` is the rollback **decision** artifact. The `CorrectionNotice` is the public-facing record that a previously published claim has been corrected, withdrawn, or superseded. Both are emitted **together** — neither alone is sufficient.
+
+See [§8](#8-the-rollbackcard--required-fields-and-shape) for the `RollbackCard` shape and [Appendix B](#appendix-b--example-rollbackcard-skeleton) for an illustrative skeleton.
+
+### Phase E — Separation-of-duties review and signatures
+
+Collect signatures per [§3](#3-roles-and-separation-of-duties). The detector MAY NOT sign as release authority. For sensitive-lane triggers, the sensitivity reviewer AND (where applicable) the rights-holder representative MUST sign.
+
+### Phase F — Republish prior release through the governed release path
+
+The rollback target is **republished** as the current PUBLISHED release. Republication MUST flow through the same release path as a normal promotion:
+
+- A new `ReleaseManifest` is issued that pins the rollback-target contents, digests, evidence refs, and a *new* `rollback_target` (typically the release prior to the one being rolled back from).
+- The new manifest carries a forward link to the `RollbackCard` and the matching `CorrectionNotice`.
+- The withdrawn release record is **preserved** with a forward link to its supersession. Hard-deleting it is forbidden.
+
+### Phase G — Invalidate downstream derivatives
+
+See [§11](#11-derivative-invalidation). A rollback that does not invalidate caches, search indexes, graph projections, story snapshots, AI templates, and external integrations is incomplete.
+
+### Phase H — Mark stale or withdrawn UI state
+
+See [§13](#13-stale-state-supersession-and-ui-signals). The Evidence Drawer, trust badges, and any visible release-state surface MUST announce the withdrawal/supersession. Silent UI restoration is a doctrine violation.
+
+### Phase I — Verify rollback closure
+
+Run the smoke tests in [§12](#12-verification-smoke-tests-and-closure). The rollback is **closed** only when every required artifact exists, every `EvidenceRef` resolves, the policy gate has recorded its decision, and the smoke battery passes.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 8. The `RollbackCard` — required fields and shape
+
+CONFIRMED doctrine (object-family definition): `RollbackCard` records a rollback decision and the targeted prior release. PROPOSED implementation: schema home is `schemas/contracts/v1/release/` per Directory Rules §6 and ADR-0001 (schema home); exact path is NEEDS VERIFICATION against current repo evidence.
+
+| Field | Required | Description |
+|---|:---:|---|
+| `release_id` | ✅ | The `release_id` of the **affected** release being rolled back from. |
+| `rollback_to` | ✅ | The `release_id` of the prior safe release being restored. |
+| `reason` | ✅ | One of the reason codes in [§9](#9-reason-codes-and-recovery-paths), plus a short prose description. |
+| `defect_class` | ✅ | One or more of the classes in [§6](#6-defect-classification-matrix-peopledna-land). |
+| `invalidates[]` | ✅ | List of downstream derivatives invalidated by this rollback (see [§11](#11-derivative-invalidation)). |
+| `review_ref` | ✅ | Reference to the `ReviewRecord` that approved the rollback. |
+| `correction_notice_ref` | ✅ | Reference to the paired `CorrectionNotice`. |
+| `signed_by[]` | ✅ | Distinct human signers per [§3](#3-roles-and-separation-of-duties); detector MAY NOT also sign as release authority. |
+| `surface_disable_refs[]` | conditional | Receipts emitted by Phase B disablement, required when the trigger is sensitive-lane. |
+| `evidence_state` | ✅ | Statement that every `EvidenceRef` in the rollback target was re-verified at rollback time. |
+| `time` | ✅ | ISO-8601 timestamp of the rollback decision. |
+| `prior_release_ref` | ✅ | Forward link from the withdrawn release to this card. |
+
+> [!NOTE]
+> Field names above are PROPOSED and align with the encyclopedia / Atlas summary of `RollbackCard` (`release_id`, `rollback_to`, `reason`, `invalidates[]`, `review_ref`, `time`). Any divergence from a future canonical schema must be resolved via ADR; do not invent parallel fields.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 9. Reason codes and recovery paths
+
+PROPOSED reason-code catalog. Codes are drawn from the Atlas master gate-failure catalog and the Build Manual's defect-class table; the catalog is intentionally finite so dashboards can aggregate without free-text drift.
+
+| Reason code | Typical defect class | Recovery path |
+|---|---|---|
+| `RIGHTS_UNKNOWN` | Rights defect | Steward review; rights resolution; tier reassignment. |
+| `RIGHTS_REVOKED` | Rights defect | Withdraw affected artifacts; quarantine source/artifact. |
+| `SENSITIVITY_UNRESOLVED` | Sensitivity leak | Sensitivity reviewer disposition; redaction / generalization. |
+| `LIVING_PERSON_LEAK` | Sensitivity leak | Immediate disablement; redact; notify stewards. |
+| `DNA_EXPOSURE` | Sensitivity leak | Immediate disablement; restricted-store reassessment. |
+| `SOVEREIGNTY_OBJECTION` | Sovereignty / cultural | Hold pending rights-holder rep; restoration only with explicit approval. |
+| `MISSING_EVIDENCE` | Evidence gap | Re-emit / restore `EvidenceBundle` chain; ABSTAIN until resolved. |
+| `MISSING_REVIEW` | Review state inadequate | Run required review; supply `ReviewRecord`. |
+| `ROLE_COLLAPSE` | Source-role collapse | Restore source role; refuse upcast. |
+| `ROLE_DOWNCAST_FORBIDDEN` | Source-role collapse | Re-validate source role; correct downstream consumers. |
+| `SCHEMA_MISMATCH` | Release infrastructure | Schema fix and/or ADR; re-run validator. |
+| `CONTRACT_DRIFT` | Release infrastructure | Contract change ADR; re-validate prior release against current contract. |
+| `RELEASE_MANIFEST_INVALID` | Release infrastructure | Manifest fix; re-issue from rollback target. |
+| `ROLLBACK_TARGET_MISSING` | Release infrastructure | Select earlier safe target; if none, hold disabled and escalate. |
+| `CORRECTION_PRIOR_RELEASE_MISSING` | Correction lineage broken | Recover prior release record; resolve supersession lineage. |
+| `CORRECTION_DERIVATIVES_UNRESOLVED` | Correction lineage broken | Resolve derivative inventory; emit supersession entries. |
+| `AI_ANSWER_UNSUPPORTED` | AI answer defect | Invalidate `AIReceipt`; coordinate Governed AI rollback. |
+| `STALE_PAST_TOLERANCE` | Temporal defect | Mark stale; refresh source or supersede. |
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 10. Sensitive-lane specifics: living-person, DNA, sovereignty, land
+
+### 10.1 Living-person data
+
+CONFIRMED doctrine: **living-person fields fail closed.** A PUBLISHED claim that names, geolocates, or otherwise identifies a living person is presumed unfit for public surfaces unless legal basis, consent/review, and release state are explicitly proven.
+
+A rollback caused by a living-person leak MUST:
+
+- Disable every public surface (governed API, MapLibre layer, Evidence Drawer, Focus Mode template) referencing the affected `PersonAssertion`, `PersonCanonical`, `NameAssertion`, or `ResidenceEvent` *first*, before drafting any record.
+- Quarantine the source artifact's path through the lifecycle (RAW/WORK/QUARANTINE/PROCESSED) for re-review. Do not silently re-promote.
+- Co-sign by sensitivity reviewer and release authority. Author-only approval is forbidden.
+- Record a side-channel audit hit if the leak surfaced via legend, popup, Evidence Drawer label, or AI-rendered prose — those are the historically-failure-prone surfaces and MUST be hardened in follow-up.
+
+### 10.2 DNA and genomic data
+
+CONFIRMED doctrine: **DNA matches, genomic inferences, and living-person relatives derived from DNA are DENY by default.** Raw kit IDs, vendor IDs, and DNA segments are not public artifacts. The restricted store is the only authorized location for these objects, and AI must not perform public inference over them.
+
+A rollback caused by `DNA_EXPOSURE` MUST:
+
+- Disable any public surface that exposed `DNAMatchEvidence`, `DNASegment`, `RelationshipHypothesis`, or any derivative carrying segment-level or kit-level identity.
+- Audit the restricted-store boundary: a leak to a public surface indicates a boundary failure that requires a security review, not just a rollback.
+- Treat consent-revocation triggers as a **revocation cleanup** path, not just a rollback. Revocation cleanup tests are part of the PROPOSED test surface for this domain.
+- Co-sign by sensitivity reviewer, release authority, and (where consent is the trigger) the consent-holder representative.
+
+### 10.3 Sovereignty and cultural sensitivity
+
+CONFIRMED doctrine: cultural affiliations cited within People/DNA/Land carry rights, sovereignty, and steward-review obligations from the Archaeology / Cultural Heritage domain. A rights-holder objection trumps a release record.
+
+A rollback caused by `SOVEREIGNTY_OBJECTION` MUST:
+
+- Pause action until the rights-holder representative is on the call.
+- Treat restoration as **not automatic** — the prior release is not safer just because it is older. Restoration requires explicit rights-holder approval, recorded in the `RollbackCard`'s `signed_by[]`.
+- Carry the supersession lineage forward so future reviewers can see what happened and why.
+
+### 10.4 Land, parcel, title
+
+CONFIRMED doctrine: **assessor/tax records are not title truth; parcel geometry is not title-boundary proof.** The most common land-side defect is conflation of these — a UI that presents an assessor record as if it answered a title question, or a parcel polygon used as if it were a surveyed boundary.
+
+A rollback caused by such a defect MUST:
+
+- Distinguish the **geometry defect** (the polygon is wrong) from the **source-role collapse** (the polygon is fine, but the surface labeled it as title proof). The remediation differs.
+- Replace, do not patch, any layer or `LayerManifest` that lost the source-role distinction. A patched layer with a corrected label still carries the cached confusion in any client that hit it.
+- Surface the corrected source role in legend, Evidence Drawer, and any AI Focus Mode template that touched the layer.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 11. Derivative invalidation
+
+CONFIRMED doctrine: a correction or rollback that does not name its downstream derivatives is **incomplete**. The `RollbackCard.invalidates[]` field is not optional, and "covers approximately 100%" is the healthy posture for derivative-invalidation coverage.
+
+Downstream derivatives that may need invalidation when a People/DNA/Land release is rolled back:
+
+- **Catalog records** keyed to the affected `release_id` — both `CatalogMatrix` entries and per-domain catalog entries under `data/catalog/domain/people-dna-land/` (PROPOSED path).
+- **Graph projections / triplets** that referenced `PersonAssertion`, `GenealogyRelationship`, `LandOwnershipAssertion`, `DeedInstrument`, `TitleInstrument`, `AssessorRecord`, `ParcelVersion`, `OwnershipInterval`, `LifeEvent`, `ResidenceEvent`, `MigrationEvent`, `FamilyGroup`, `DNAMatchEvidence`, `RelationshipHypothesis`, `DNASegment`, or `PersonCanonical`.
+- **Layer manifests** and their published artifacts (PMTiles, GeoParquet, COG, GeoJSON) under `data/published/layers/people-dna-land/` (PROPOSED path).
+- **Story snapshots** and any export receipts that captured the affected release.
+- **AI Focus Mode templates** bound to the affected `EvidenceBundle`; any cached `AIReceipt` referencing the withdrawn release MUST be invalidated.
+- **Search indexes** that included the released catalog/evidence/feature summaries.
+- **External integrations** or downstream consumers if KFM has notified them of the release.
+
+> [!TIP]
+> Derivative invalidation reads as bureaucratic in calm times and as exactly-right in incident times. The healthy posture is a **machine-generated derivative inventory** for each release, so rollback day is a tick-through, not a hunt. PROPOSED follow-up: a derivative-inventory generator that the `RollbackCard` can cite by reference rather than enumerate by hand.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 12. Verification, smoke tests, and closure
+
+A rollback is **closed** only when all of the following hold. Until then, the affected surfaces remain disabled.
+
+### 12.1 Doctrinal closure checks (CONFIRMED doctrine)
+
+- [ ] Every required artifact in [§8](#8-the-rollbackcard--required-fields-and-shape) exists.
+- [ ] Every required `EvidenceRef` resolves to an `EvidenceBundle`.
+- [ ] The policy gate has evaluated and recorded its decision (ALLOW / RESTRICT / DENY / ABSTAIN / ERROR).
+- [ ] The new `ReleaseManifest` names a valid `rollback_target`.
+- [ ] The withdrawn release record is preserved with a forward link to the `CorrectionNotice` and `RollbackCard`.
+- [ ] Separation of duties is satisfied per [§3](#3-roles-and-separation-of-duties).
+
+### 12.2 Smoke tests (PROPOSED battery for this domain)
+
+PROPOSED test homes live under `tests/domains/people-dna-land/` (NEEDS VERIFICATION against mounted repo). Suggested tests:
+
+- Person assertion **evidence test**: every public-surfaced `PersonAssertion` resolves to a current `EvidenceBundle`.
+- GEDCOM import **rights / living-flag test**: living-flagged records remain DENY on public surfaces.
+- DNA **consent and raw-ID no-log test**: no DNA segment, raw kit ID, or vendor ID appears in any log emitted on the rollback path.
+- **Revocation cleanup test**: a previously-revoked record stays revoked after rollback; rollback does not re-expose retracted content.
+- **Legal-description and chain-of-title gap test**: gaps remain visible and ABSTAIN-flagged after rollback; rollback does not paper over uncertainty.
+- **Assessor-as-title denial test**: assessor and tax records remain labeled as such; rollback does not restore a source-role collapse.
+- **Graph projection safety test**: the rollback-target graph projection contains no living-person or DNA-derived edges that today's policy would forbid.
+
+### 12.3 Side-channel audit (CONFIRMED healthy posture)
+
+The healthy posture is periodic automated checks for label / popup / AI-text leaks. After rollback, run those checks once before re-enabling public surfaces. A sensitive-content leak via legend or AI prose is harder to detect than a primary-payload leak and has historically been the most common failure surface for sensitive lanes.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 13. Stale-state, supersession, and UI signals
+
+CONFIRMED doctrine: KFM separates **stale** from **wrong**. Both states have visible markers and traceable lifecycles. A rollback typically produces both — the withdrawn release becomes *withdrawn/superseded*, while any derivative that has not yet rebuilt becomes *stale*.
+
+| Marker | When triggered | UI signal | Required action |
+|---|---|---|---|
+| **Withdrawn** | Release rolled back; `CorrectionNotice` issued | Withdrawn badge in Evidence Drawer; visible "Superseded by …" link | Surface the rollback record; do not silently restore prior content |
+| **Superseded** | A later release replaces an earlier one (forward) | Superseded badge with forward link | Forward link MUST exist; gap is a defect (`Supersession lineage gap` = 0 is the healthy posture) |
+| **Stale** | A derivative has not yet rebuilt to match the new PUBLISHED release | Stale badge with last-rebuilt timestamp | Schedule derivative rebuild; do not hide the badge |
+| **Quarantined** | The source / artifact was returned to QUARANTINE during rollback | Withholding notice in Evidence Drawer | Steward disposition before any re-promotion |
+
+> [!IMPORTANT]
+> Silent restoration — where a rolled-back surface comes back online without a withdrawn/superseded badge — defeats the durable-public-claim property of KFM. Users who relied on the withdrawn release have **no way to learn** their reference is stale without the badge.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 14. Rollback drill (rehearsal procedure)
+
+CONFIRMED doctrine: *rollback untested is not reliable.* The healthy posture is a **non-zero, periodic, scheduled rollback rehearsal rate** per release window.
+
+The drill is run against a non-production fixture release (PROPOSED home: `fixtures/domains/people-dna-land/rollback_drill/`) and exercises the full procedure end-to-end without affecting any production public surface.
+
+**Suggested drill cadence (PROPOSED):**
+
+- After every materially significant change to the People/DNA/Land release path.
+- Quarterly minimum for the sensitive-lane scenarios (living-person leak, DNA exposure, sovereignty objection).
+- Whenever a new role (sensitivity reviewer, rights-holder rep, release authority) onboards.
+
+**What the drill exercises:**
+
+1. The detector path: a synthetic defect is "found" via the same channel as a real defect (validator hit, audit fire, steward observation).
+2. Phase B disablement: the kill switch fires on a fixture surface; the receipt is emitted.
+3. Phase C target verification: digests, evidence, rights, sensitivity, review, schema all re-verified against today's policy.
+4. Phase E signature collection: distinct human signers exercise their roles.
+5. Phase F republication: a new `ReleaseManifest` is issued through the same governed path.
+6. Phase G derivative invalidation: catalog, graph, layers, AI templates all named in `invalidates[]`.
+7. Phase H UI signals: withdrawn / superseded / stale badges appear correctly in a fixture client.
+8. Phase I smoke tests: the §12 battery passes.
+
+A drill that exits without exercising all of the above has trained the team in a shortcut. PROPOSED: each drill emits a `DrillReceipt` that captures coverage, gaps, and rehearsal time.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 15. Common pitfalls and anti-patterns
+
+<details>
+<summary>📋 Click to expand — anti-patterns observed or anticipated for this domain</summary>
+
+> [!WARNING]
+> The items below describe **patterns to avoid**. They are doctrine-grounded (CONFIRMED) even where the specific failure has not yet been observed in this repo (PROPOSED / NEEDS VERIFICATION).
+
+- **Hidden file copy.** Treating rollback as "swap the published file." Rollback MUST flow through the governed release path; the file change is a *consequence* of the state transition, not the transition itself.
+- **Author-only approval.** The author or detector also signing as release authority. Forbidden for sensitive-lane releases and for any release with materiality.
+- **Paperwork-before-disablement on a sensitive trigger.** Drafting a `RollbackCard` while a living-person identifier or DNA segment is still on a public surface. Phase B (disablement) happens first.
+- **Stale derivatives left enabled.** Rolling back the primary release but leaving a graph projection, search index, or AI template still serving the withdrawn content.
+- **Silent re-promotion.** Restoring a previously-rolled-back release without a fresh `ReviewRecord` because "we already approved it once." Rights, sensitivity, and evidence posture may have changed.
+- **Title / parcel re-conflation.** Patching a labeling defect on a layer that conflated assessor records with title proof, instead of replacing the layer. Cached clients keep the old confusion.
+- **Selecting a prior release as rollback target without re-verifying its evidence chain.** Yesterday-safe is not today-safe; the target MUST be re-verified against current rights, sensitivity, and evidence posture.
+- **Tombstone treated as erasure.** Tombstoning preserves explainability for revocation but does not satisfy right-to-erasure obligations. Erasure is a separate, ADR-governed procedure.
+- **AI surface left bound to the withdrawn release.** A Focus Mode template citing the withdrawn `EvidenceBundle` will continue to generate uncited or stale prose unless the template's binding is updated and the `AIReceipt` cache invalidated.
+- **No drill, no readiness.** Treating §14 as optional. A team that has not rehearsed a sensitive-lane rollback should assume it cannot perform one safely under pressure.
+
+</details>
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 16. Open questions and NEEDS VERIFICATION
+
+The items below cannot be settled by attached doctrine alone. They are tracked here so reviewers can route them to the right register (`docs/registers/VERIFICATION_BACKLOG.md`) or ADR.
+
+| Item | Evidence that would settle it | Status |
+|---|---|---|
+| Canonical schema home for `RollbackCard` (default: `schemas/contracts/v1/release/`) | Mounted repo + ADR-0001 ratification | NEEDS VERIFICATION |
+| Exact governed-API kill-switch route for disabling a People/DNA/Land layer | Mounted repo, `apps/governed-api/`, route table | UNKNOWN |
+| Whether `release/rollback_cards/` is the canonical home for `RollbackCard` artifacts (Directory Rules §18 lists this as OPEN) | ADR resolving `data/rollback/` vs. `release/rollback_cards/` | NEEDS VERIFICATION |
+| Whether tombstone-based revocation satisfies KFM's correction-vs-erasure boundary for personal data | ADR aligning tombstone scope with GDPR / applicable Tribal data policies | NEEDS VERIFICATION |
+| Living-person policy enforcement in current code paths | Mounted repo files, schemas, registry entries, tests, logs, emitted artifacts, review records, or release manifests | NEEDS VERIFICATION |
+| DNA consent and revocation enforcement in current code paths | Same evidence basis as above | NEEDS VERIFICATION |
+| Land instrument chain logic in current code paths | Same evidence basis as above | NEEDS VERIFICATION |
+| Geometry-role boundary logic (parcel ≠ title boundary) in current code paths | Same evidence basis as above | NEEDS VERIFICATION |
+| UI / API restricted-field no-leak behavior in current code paths | Same evidence basis as above | NEEDS VERIFICATION |
+| Whether the runbook tree uses `docs/runbooks/<domain>/<TOPIC>_RUNBOOK.md` (this doc's pattern, conforms to Directory Rules §12) or `docs/runbooks/<subsystem>_<TOPIC>.md` (flat naming used in prior UI/AI report) | Repo convention + docs steward sign-off | PROPOSED |
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## 17. Related docs
+
+> Links are PROPOSED until each target exists. Where the target is not yet authored, the entry is marked `TODO`.
+
+- TODO — `docs/runbooks/people-dna-land/CORRECTION_RUNBOOK.md` — forward correction without state reversal.
+- TODO — `docs/runbooks/people-dna-land/PROMOTION_RUNBOOK.md` — governed promotion through the lifecycle.
+- TODO — `docs/runbooks/people-dna-land/REVOCATION_CLEANUP_RUNBOOK.md` — DNA / consent-driven cleanup paths.
+- TODO — `docs/runbooks/governed_ai_ROLLBACK.md` — AI surface kill switches and adapter rollback (cross-cutting).
+- TODO — `docs/runbooks/release/RELEASE_AUTHORITY.md` — release authority responsibilities.
+- TODO — `docs/domains/people-dna-land/README.md` — domain identity, scope, and source families.
+- TODO — `docs/doctrine/lifecycle-law.md` — RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED.
+- TODO — `docs/doctrine/trust-membrane.md` — public-client boundary.
+- TODO — `docs/doctrine/truth-posture.md` — cite-or-abstain.
+- `docs/doctrine/directory-rules.md` — placement authority (CONFIRMED rules / PROPOSED presence).
+- TODO — `docs/adr/ADR-people-dna-land-rollback-targets.md` — open ADR placeholder for any decisions this runbook surfaces.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## Appendix A — Object families touched by this runbook
+
+> CONFIRMED doctrine: these object families are owned by People/DNA/Land per the Encyclopedia and the Domains Culmination Atlas. Inclusion here means a rollback **may** invalidate instances of the family; not every rollback touches every family.
+
+- `PersonAssertion`
+- `PersonCanonical`
+- `NameAssertion`
+- `PersonIdentityCandidate`
+- `GenealogyRelationship`
+- `FamilyGroup`
+- `LifeEvent`
+- `ResidenceEvent`
+- `MigrationEvent`
+- `LandOwnershipAssertion`
+- `DeedInstrument`
+- `TitleInstrument`
+- `AssessorRecord`
+- `TaxRecord`
+- `ParcelVersion`
+- `OwnershipInterval`
+- `DNAMatchEvidence`
+- `DNASegment`
+- `RelationshipHypothesis`
+- `ReviewRecord`
+- `LegalDescription`
+- `LandInstrument`
+
+Cross-cutting object families also touched: `SourceDescriptor`, `EvidenceRef`, `EvidenceBundle`, `ValidationReport`, `PolicyDecision`, `DecisionEnvelope`, `LayerManifest`, `ReleaseManifest`, `CorrectionNotice`, `RollbackCard`, `AIReceipt`, `RuntimeResponseEnvelope`.
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## Appendix B — Example `RollbackCard` skeleton
+
+<details>
+<summary>📄 Click to expand — illustrative skeleton (PROPOSED shape; not a schema)</summary>
+
+> [!NOTE]
+> The block below is **illustrative**. Field names align with the encyclopedia / Atlas summary of `RollbackCard`. Any canonical schema lives in `schemas/contracts/v1/release/` (PROPOSED, per ADR-0001) and supersedes this skeleton on any divergence. Do not use this skeleton as a substitute for a validated schema.
+
+```json
+{
+  "object_type": "RollbackCard",
+  "schema_version": "v1",
+  "card_id": "kfm://rollback/people-dna-land/2026-05-12-0001",
+  "release_id": "kfm://release/people-dna-land/2026-05-09-0007",
+  "rollback_to": "kfm://release/people-dna-land/2026-05-02-0006",
+  "reason": "LIVING_PERSON_LEAK",
+  "reason_detail": "Public Evidence Drawer payload exposed a NameAssertion for a flagged living-person record via a graph projection edge that should have been redacted.",
+  "defect_class": ["sensitivity_leak", "policy_defect"],
+  "invalidates": [
+    "kfm://catalog/people-dna-land/2026-05-09-0007",
+    "kfm://layer/people-dna-land/residences/v3",
+    "kfm://graph/people-dna-land/projection/2026-05-09",
+    "kfm://ai/focus-template/people-dna-land/residence-summary",
+    "kfm://search-index/people-dna-land/2026-05-09"
+  ],
+  "surface_disable_refs": [
+    "kfm://receipt/surface-disable/2026-05-12-0001"
+  ],
+  "correction_notice_ref": "kfm://correction/people-dna-land/2026-05-12-0001",
+  "review_ref": "kfm://review/release-correction/2026-05-12-0001",
+  "evidence_state": "All EvidenceRefs in the rollback target re-verified at 2026-05-12T14:03:00Z. No bundle retractions since target release.",
+  "prior_release_ref": "kfm://release/people-dna-land/2026-05-09-0007",
+  "signed_by": [
+    { "role": "domain_steward",         "actor": "TODO" },
+    { "role": "release_authority",      "actor": "TODO (distinct from detector)" },
+    { "role": "sensitivity_reviewer",   "actor": "TODO" },
+    { "role": "rights_holder_rep",      "actor": "n/a — not a sovereignty trigger" },
+    { "role": "correction_reviewer",    "actor": "TODO" }
+  ],
+  "time": "2026-05-12T14:05:00Z"
+}
+```
+
+</details>
+
+[Back to top ↑](#quick-jump)
+
+---
+
+## Footer
+
+**Related docs:** see [§17](#17-related-docs).
+**Open questions:** see [§16](#16-open-questions-and-needs-verification).
+**Last reviewed:** 2026-05-12 — `draft`; PROPOSED placement under `docs/runbooks/people-dna-land/` per Directory Rules §12. Reconciliation with prior flat-naming convention (`docs/runbooks/<subsystem>_ROLLBACK.md`) requires docs steward + subsystem owner sign-off and SHOULD be recorded against `docs/registers/DRIFT_REGISTER.md` if the project keeps both styles.
+
+[Back to top ↑](#quick-jump)

--- a/docs/runbooks/people-dna-land/SOURCE_REFRESH_RUNBOOK.md
+++ b/docs/runbooks/people-dna-land/SOURCE_REFRESH_RUNBOOK.md
@@ -1,3 +1,545 @@
-# people-dna-land :: SOURCE_REFRESH runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/people-dna-land/source-refresh
+title: People · Genealogy · DNA · Land — Source Refresh Runbook
+type: standard
+version: v0.1
+status: draft
+owners: People/DNA/Land domain steward · Source intake steward · Privacy/sensitivity reviewer
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public (procedure) · restricted-aware (operates on restricted sources)
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/trust-membrane.md
+  - docs/domains/people-dna-land/README.md
+  - docs/sources/SOURCE_DESCRIPTOR_STANDARD.md
+  - docs/standards/SMART_SYNC.md
+  - docs/runbooks/people-dna-land/VALIDATION_RUNBOOK.md
+  - docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md
+  - data/registry/sources/people-dna-land/
+  - policy/domains/people-dna-land/
+tags: [kfm, runbook, people-dna-land, source-refresh, intake, governance]
+notes:
+  - Operates on the most sensitivity-laden KFM domain; default-deny applies to living-person and DNA-derived material.
+  - Specific paths quoted herein are PROPOSED until verified against mounted-repo evidence.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# People · Genealogy · DNA · Land — Source Refresh Runbook
+
+Governed procedure for refreshing People / Genealogy / DNA / Land source material from upstream publishers, detecting material delta, holding sensitive content closed by default, and emitting auditable receipts before any catalog or publication change.
+
+![Status](https://img.shields.io/badge/status-draft-yellow)
+![Domain](https://img.shields.io/badge/domain-people--dna--land-blue)
+![Lifecycle](https://img.shields.io/badge/lifecycle-governed-informational)
+![Sensitivity](https://img.shields.io/badge/sensitivity-fail--closed-critical)
+![Authority](https://img.shields.io/badge/authority-runbook-lightgrey)
+![Repo Evidence](https://img.shields.io/badge/repo--evidence-NEEDS%20VERIFICATION-orange)
+
+**Status:** draft &middot; **Owners:** People/DNA/Land steward · Source intake steward · Privacy reviewer &middot; **Last updated:** 2026-05-12
+
+> [!IMPORTANT]
+> This runbook governs intake refresh for the most sensitivity-laden domain in KFM. **Living-person data and DNA-derived material are denied or restricted by default.** Assessor records are **not** title truth. Parcel geometry is **not** title-boundary proof. Refresh procedures that do not preserve these distinctions fail closed at the policy gate.
+
+---
+
+## Quick Links
+
+- [1. Purpose & Scope](#1-purpose--scope)
+- [2. Inputs & Outputs](#2-inputs--outputs)
+- [3. Source Families in Scope](#3-source-families-in-scope)
+- [4. Refresh Flow](#4-refresh-flow)
+- [5. Step-by-Step Procedure](#5-step-by-step-procedure)
+- [6. Sensitivity & Source-Role Boundaries](#6-sensitivity--source-role-boundaries)
+- [7. Receipts, Manifests, and Lifecycle Gates](#7-receipts-manifests-and-lifecycle-gates)
+- [8. Failure Modes and Fail-Closed Behavior](#8-failure-modes-and-fail-closed-behavior)
+- [9. Dry-Run / No-Network CI](#9-dry-run--no-network-ci)
+- [10. Rollback & Correction Path](#10-rollback--correction-path)
+- [11. Operator Checklist](#11-operator-checklist)
+- [12. Open Verification Items](#12-open-verification-items)
+- [13. Related Docs](#13-related-docs)
+- [14. Appendix](#14-appendix)
+
+---
+
+## 1. Purpose & Scope
+
+**Scope.** This runbook covers periodic and event-driven refresh of source material owned by the **People, Genealogy, DNA, and Land Ownership** domain. It addresses how to:
+
+- Probe upstream publishers using HTTP validators and / or manifest checksums.
+- Canonicalize source descriptors and compute a stable `spec_hash`.
+- Detect material change without re-downloading unchanged bytes.
+- Hold sensitive deltas in `data/quarantine/` until steward review.
+- Emit a `RunReceipt` that records the refresh decision, validators, and digests.
+- Open a watcher pull request that **proposes** — but does not publish — a catalog change.
+
+**Out of scope.** This runbook does **not** decide release. Release is governed by `ReleaseManifest`, review state, and the publication gate in `release/`. It does not decide rights, sensitivity tiers, or correction logic; those decisions live in `policy/`, `data/registry/`, and a separate correction runbook.
+
+**Truth posture of this document.**
+
+| Layer | Status |
+|---|---|
+| Doctrine (lifecycle invariant, default-deny for living-person and DNA, source-role anti-collapse) | CONFIRMED |
+| Procedure shape (HEAD probe · canonical hash · receipt · policy gate · draft PR) | CONFIRMED at the doctrinal level |
+| Specific repo paths, tool names, command flags, schema homes, fixture trees | PROPOSED until verified against mounted-repo evidence |
+| Current presence or enforcement state of the cited validators, watchers, and policies in the live repo | NEEDS VERIFICATION |
+
+[Back to top](#quick-links)
+
+---
+
+## 2. Inputs & Outputs
+
+**Inputs.**
+
+- A `SourceDescriptor` under `data/registry/sources/people-dna-land/<source_id>/` (PROPOSED path).
+- A watcher trigger (cron schedule, dispatch event, or manual run).
+- The upstream publisher endpoint (HTTP, S3, OAI-PMH, file drop, or API).
+- The previous `RunReceipt` for delta comparison, if any.
+- Source rights and sensitivity tier from `data/registry/rights/` and `policy/sensitivity/` (PROPOSED).
+
+**Outputs.**
+
+- A canonicalized `source_descriptor.json` and recomputed `spec_hash`.
+- A `RunReceipt` recording URL, fetched-at time, ETag / Last-Modified, `spec_hash`, artifact digests, provider, and the linked `PolicyDecision`.
+- New artifacts placed under either `data/raw/people-dna-land/<source_id>/<run_id>/` or `data/quarantine/people-dna-land/<reason>/<run_id>/`, depending on policy outcome.
+- A **draft** pull request (the watcher PR) that proposes catalog / provenance updates *after* validation and policy gates pass — never a direct commit to a canonical branch.
+
+[Back to top](#quick-links)
+
+---
+
+## 3. Source Families in Scope
+
+Each family carries a source-role intent (authority / observation / context / model) that **must** be preserved through refresh. Rights and sensitivity vary; sensitive joins fail closed.
+
+| Family | Role posture | Sensitivity floor | Refresh signal | Status |
+|---|---|---|---|---|
+| Vital records · census · cemetery · obituary · church · school · military · court · probate | authority / observation | public when source permits; **living-person fields fail closed** | publisher cadence; manifest | CONFIRMED doctrine / PROPOSED implementation |
+| GEDCOM / GEDZip / tree overlays | observation / context (hypotheses) | restricted while living individuals present | user submission or batch refresh | CONFIRMED doctrine / PROPOSED implementation |
+| DNA vendor match CSV / segment / triangulation | restricted observation | **DNA-derived — denied unless consent record present** | manual; consent-bound | CONFIRMED doctrine / PROPOSED implementation |
+| Patent · deed · mortgage · lien · easement · lease · mineral · water · access · probate instruments | authority | public per source terms | publisher cadence | CONFIRMED doctrine / PROPOSED implementation |
+| Assessor and tax roll records | observation (**not title**) | public per jurisdiction | publisher cadence | CONFIRMED doctrine / PROPOSED implementation |
+| Plat · survey · metes & bounds · PLSS · subdivision · derived geometry | observation / context (**not title boundary**) | public per source terms | publisher cadence | CONFIRMED doctrine / PROPOSED implementation |
+
+> [!CAUTION]
+> Assessor records and tax rolls record **what the assessor believes**, not who legally holds title. PLSS, plat, and survey geometry record **survey assertions and parcel polygons**, not legal title boundaries. Refresh runs must preserve these source-role distinctions, or fail closed.
+
+[Back to top](#quick-links)
+
+---
+
+## 4. Refresh Flow
+
+```mermaid
+flowchart LR
+    A[Scheduler / Dispatch] --> B[Resolve SourceDescriptor]
+    B --> C[HEAD probe<br/>ETag · Last-Modified · Length]
+    C --> D{Changed?}
+    D -- No --> Z1[Emit no-change<br/>RunReceipt · exit]
+    D -- Yes --> E[Conditional GET]
+    E --> F[Canonicalize descriptor<br/>compute spec_hash]
+    F --> G[Verify manifest<br/>SHA-256 if available]
+    G --> H{Policy gate<br/>rights · sensitivity · role}
+    H -- Deny --> Q[data/quarantine/<br/>record reason]
+    H -- Restrict --> R[data/raw/<br/>restricted partition]
+    H -- Allow --> S[data/raw/<br/>standard partition]
+    Q --> T[Emit RunReceipt]
+    R --> T
+    S --> T
+    T --> U[Open draft watcher PR<br/>propose · do not publish]
+    U --> V[CI: validators · policy · receipts]
+    V --> W{Gates pass?}
+    W -- No --> X[Block merge; comment failures]
+    W -- Yes --> Y[Steward review for promotion<br/>handled by a separate runbook]
+```
+
+The diagram reflects the conditional-fetch + canonical-hash + receipt + policy-gate pattern that the wider KFM source-refresh doctrine recommends. The **shape** of these steps is CONFIRMED at the doctrinal level; the **specific component names and paths** remain PROPOSED until verified against mounted-repo evidence.
+
+[Back to top](#quick-links)
+
+---
+
+## 5. Step-by-Step Procedure
+
+> [!NOTE]
+> The commands below are **illustrative**. Tool names and flags labelled `PROPOSED` must be replaced with the actual verified tooling in the mounted repo before operational use. Treat the structure as authoritative; treat the literals as placeholders.
+
+### 5.1 Resolve the `SourceDescriptor`
+
+```bash
+# PROPOSED tool name — verify against repo
+kfm-source resolve \
+  --domain people-dna-land \
+  --source-id "$SOURCE_ID" \
+  --out source_descriptor.json
+```
+
+What this captures: source identity, source role (authority / observation / context / model), rights status, sensitivity tier, publisher endpoint, expected cadence, and prior `spec_hash`.
+
+### 5.2 HEAD probe for validators
+
+```bash
+SRC_URL="$(jq -r '.endpoint.url' source_descriptor.json)"
+
+curl -sI \
+  -H "If-None-Match: $(jq -r '.last_etag // empty' source_descriptor.json)" \
+  "$SRC_URL" \
+  > head_response.txt
+```
+
+Capture `ETag`, `Last-Modified`, and `Content-Length`. A `304 Not Modified` response short-circuits to a no-change `RunReceipt`.
+
+> [!NOTE]
+> Some publishers strip or weakly version ETags. Treat weak ETags (`W/...`) as advisory and fall through to manifest verification before promotion.
+
+### 5.3 Conditional fetch (only on change)
+
+```bash
+curl -sS -L \
+  --etag-compare etag.cache \
+  --etag-save etag.cache.new \
+  -o "raw_payload.bin" \
+  "$SRC_URL"
+```
+
+Skip this step entirely on `304`. On `200`, place the payload under `data/raw/people-dna-land/<source_id>/<run_id>/` (PROPOSED path).
+
+### 5.4 Canonicalize and hash
+
+```bash
+# Canonical JSON (JCS / RFC 8785) → stable digest for the descriptor
+jq -cS '.' source_descriptor.json \
+  | sha256sum | cut -d' ' -f1 \
+  > spec_hash.txt
+```
+
+`spec_hash` is the source descriptor's deterministic fingerprint. Equal evidence → equal hash; any field drift produces a new hash and is therefore an auditable delta.
+
+### 5.5 Verify the upstream manifest (if available)
+
+If the publisher exposes a checksums manifest (for example `SHA256SUMS`, or a `manifest.json` with per-file digests), fetch it and run:
+
+```bash
+sha256sum -c upstream_checksums.txt
+```
+
+Fail closed on any mismatch. Record `manifest_verified: true|false` in the `RunReceipt`.
+
+### 5.6 Policy gate — rights, sensitivity, source role
+
+Run the policy bundle. The decision must be one of `allow`, `restrict`, `quarantine`, or `deny`.
+
+```bash
+# PROPOSED policy entrypoint — verify against repo
+conftest test \
+  --policy policy/domains/people-dna-land/ \
+  --data data/registry/rights/people-dna-land.yaml \
+  source_descriptor.json
+```
+
+The gate **must** check, at minimum:
+
+- Rights status of the source family for this candidate refresh.
+- Sensitivity tier — living-person presence, DNA-derived material, restricted joins.
+- Source-role intent vs. how the data is described downstream (assessor ≠ title; parcel geometry ≠ title boundary).
+- Required temporal validity fields (source time, observed time, retrieval time).
+- Whether a steward consent record is required — **mandatory for DNA-derived material**.
+
+### 5.7 Emit the `RunReceipt`
+
+```bash
+# PROPOSED tool — verify against repo
+kfm-attest make-run-receipt \
+  --spec source_descriptor.json \
+  --decision policy_decision.json \
+  --target-zone RAW \
+  --source-url "$SRC_URL" \
+  --source-etag        "$(awk '/^ETag:/{print $2}' head_response.txt)" \
+  --source-last-modified "$(awk '/^Last-Modified:/{$1=""; print $0}' head_response.txt)" \
+  --source-content-length "$(awk '/^Content-Length:/{print $2}' head_response.txt)" \
+  --out data/receipts/ingest/people-dna-land/run-receipt.json
+```
+
+The receipt must carry: source URL, fetched-at, ETag, Last-Modified, `spec_hash`, artifact digests, provider / runner identity, the linked `PolicyDecision`, and an outcome from the finite envelope (`ANSWER`, `ABSTAIN`, `DENY`, `ERROR`).
+
+### 5.8 Open a draft watcher PR (propose, do not publish)
+
+The watcher **MUST NOT** commit to canonical catalog branches directly. It opens a **draft pull request** that includes the `RunReceipt`, the new or updated `SourceDescriptor`, and any candidate catalog / provenance updates. CI runs validators, policy parity checks, and receipt verification. Merge requires steward approval — and for any change that touches living-person or DNA-derived material, an additional privacy / sensitivity reviewer.
+
+[Back to top](#quick-links)
+
+---
+
+## 6. Sensitivity & Source-Role Boundaries
+
+> [!WARNING]
+> **The default-deny rules for this domain are doctrinal, not optional.** A refresh that surfaces living-person or DNA-derived material to a public catalog path without an explicit, recorded consent and review trail is a publication-discipline failure regardless of intent.
+
+| Boundary | Default posture | What a refresh must do |
+|---|---|---|
+| Living-person fields | DENY public exposure | Hold record in `data/quarantine/people-dna-land/living_person/<run_id>/`; require steward review before any non-restricted placement. |
+| DNA / genomic material | RESTRICT or DENY | Place in restricted partition only; refuse public catalog emission; require a referenced consent record. |
+| Genealogy relationships involving living individuals | RESTRICT | Mark hypothesis status; never publish as confirmed fact. |
+| Assessor / tax records described as title | DENY (the description, not necessarily the record) | The record family is `observation`, never `authority for title`. Refuse the title framing. |
+| Parcel geometry described as legal boundary | DENY (the description, not necessarily the record) | Record family is `observation`; geometry version ≠ legal boundary. Refuse the boundary framing. |
+| Source rights unclear or stale | QUARANTINE | Hold pending source-rights review and steward decision. |
+
+When in doubt, the safe state is **quarantine, deny, or restrict** until source rights, source role, access conditions, cadence, and release class are recorded.
+
+[Back to top](#quick-links)
+
+---
+
+## 7. Receipts, Manifests, and Lifecycle Gates
+
+A refresh participates in the lifecycle invariant. It does **not** transit lifecycle states by itself; promotion is a separate governed decision.
+
+```text
+RAW  →  WORK / QUARANTINE  →  PROCESSED  →  CATALOG / TRIPLET  →  PUBLISHED
+ ▲           ▲
+ │           │
+ this runbook ends here (RAW or QUARANTINE placement);
+ promotion is governed by a separate validation + release path.
+```
+
+### 7.1 Required receipts at refresh time
+
+| Receipt | When emitted in this runbook | Required fields (PROPOSED minimum) |
+|---|---|---|
+| `SourceDescriptor` (updated) | On any descriptor field change | source id, role, rights, sensitivity, cadence, payload reference, hash |
+| `RunReceipt` | Every refresh run — change or no-change | URL, fetched-at, ETag, Last-Modified, `spec_hash`, artifact digests, provider, policy decision id, outcome |
+| `PolicyDecision` | Whenever the policy gate runs | decision (`allow` / `restrict` / `quarantine` / `deny`), reason codes, evidence refs |
+| `TransformReceipt` | Only if normalization runs in WORK as part of the refresh PR | inputs, outputs, transforms applied, validator outcomes |
+| `RedactionReceipt` | Only if generalization / redaction runs (uncommon at refresh) | scope, method, evidence refs |
+
+Receipts created earlier in the lifecycle remain referenced (not duplicated) at later phases through `EvidenceRef`.
+
+### 7.2 Gate posture at refresh
+
+| Gate | This runbook's responsibility | Fail-closed behavior |
+|---|---|---|
+| Admission ( → RAW) | Yes | Reject if `SourceDescriptor` or `RunReceipt` cannot close. |
+| Normalization (RAW → WORK / QUARANTINE) | Partial — only if a delta requires an immediate transform | Quarantine with recorded reason. |
+| Validation (WORK → PROCESSED) | No — runs in a separate validation runbook | Hold at WORK. |
+| Catalog closure (PROCESSED → CATALOG / TRIPLET) | No | Hold at PROCESSED. |
+| Release (CATALOG / TRIPLET → PUBLISHED) | No — runs via the release pipeline | Hold at CATALOG. |
+
+[Back to top](#quick-links)
+
+---
+
+## 8. Failure Modes and Fail-Closed Behavior
+
+| Symptom | Cause | Action |
+|---|---|---|
+| `spec_hash` cannot be computed | Descriptor missing required fields, or canonicalization tool unavailable | Halt; treat run as `ERROR`; emit `RunReceipt` with `outcome: ERROR` and **no** payload placement. |
+| HEAD probe returns no validator and no manifest | Publisher exposes neither ETag, Last-Modified, nor a checksums file | Fall back to full `GET` + content digest; record `validator_strength: weak` in receipt. Promotion gates may require additional support. |
+| Manifest checksum mismatch | Bytes do not match publisher claims | Fail closed; do not place in RAW; record `manifest_verified: false` and quarantine the candidate. |
+| Source rights stale / unknown | Rights record older than cadence, or marked `NEEDS VERIFICATION` | Quarantine; open a `data/registry/rights/` review entry. |
+| Living-person field detected on a route claiming public scope | Policy gate caught it; or a downstream describer mismatched the source role | `DENY`; quarantine; alert privacy reviewer. |
+| DNA-derived field present without a consent record | Policy gate caught it | `DENY`; quarantine; alert privacy reviewer. |
+| Assessor record described as title | Source-role anti-collapse violation | `DENY` the **description**; the record itself may still be admitted as `observation`. |
+| Parcel geometry described as legal boundary | Source-role anti-collapse violation | `DENY` the **description**; the geometry may still be admitted as `observation`. |
+| Watcher attempts to commit to a canonical branch | Watcher-as-publisher anti-pattern | CI rejects; the watcher must use the draft-PR pattern instead. |
+| Compromised runner or credential rotation | Token / key leak or rotation event | Mark affected `RunReceipt` set as untrusted; reissue under new identity. |
+
+[Back to top](#quick-links)
+
+---
+
+## 9. Dry-Run / No-Network CI
+
+The first run of any new refresher or source family **should** be a no-network, deterministic fixture run that emits receipts and validates structure without contacting the publisher. This protects the trust membrane during onboarding and catches schema and policy drift before live traffic hits the gate.
+
+Suggested fixtures (PROPOSED paths):
+
+```text
+fixtures/domains/people-dna-land/source-refresh/
+├── descriptor.valid.json
+├── descriptor.invalid.missing_rights.json
+├── descriptor.invalid.dna_no_consent.json
+├── descriptor.invalid.assessor_as_title.json
+├── head_response.changed.txt
+├── head_response.unchanged_304.txt
+├── manifest.matching.txt
+├── manifest.mismatch.txt
+└── expected/
+    ├── run_receipt.no_change.json
+    ├── run_receipt.changed.json
+    ├── policy_decision.deny.dna_no_consent.json
+    └── policy_decision.deny.assessor_as_title.json
+```
+
+CI invocation:
+
+```bash
+# PROPOSED entrypoint — verify against repo
+kfm-refresh dry-run \
+  --domain people-dna-land \
+  --fixture-dir fixtures/domains/people-dna-land/source-refresh \
+  --expected-dir fixtures/domains/people-dna-land/source-refresh/expected
+```
+
+> [!TIP]
+> A no-network fixture suite is also the most reliable surface for catching schema or policy drift, because it exercises the deny and quarantine paths in addition to the happy path. Negative fixtures matter at least as much as positive ones for this domain.
+
+[Back to top](#quick-links)
+
+---
+
+## 10. Rollback & Correction Path
+
+Refresh itself is **reversible by construction** because it stops at RAW or QUARANTINE — no public surface changes during refresh. Rollback at this layer is therefore narrow but specific.
+
+| Defect class | Correction posture | Rollback posture |
+|---|---|---|
+| Wrong source description (rights, role) | Update `SourceDescriptor`; reissue refresh; emit `CorrectionNotice` if downstream is already PUBLISHED. | Restore prior `SourceDescriptor`; reissue affected `RunReceipt`. |
+| Wrong policy decision (false `allow`) | Re-run policy; quarantine affected records; emit `CorrectionNotice`. | Restore prior `PolicyDecision`; move records to the quarantine partition; consult privacy reviewer. |
+| Wrong manifest verification (false pass) | Re-fetch; recompute digests; quarantine. | Move RAW placement to QUARANTINE with reason. |
+| Compromised credentials or runner identity | Rotate; re-run with the new identity. | Mark affected `RunReceipt` set as untrusted; reissue. |
+| Living-person or DNA leakage to a non-restricted path | Quarantine immediately; emit `CorrectionNotice`; alert privacy reviewer. | Disable affected route; restore prior release manifest via the rollback runbook; preserve audit receipts. |
+
+If downstream lifecycle phases have already consumed the bad refresh, follow `docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md` (PROPOSED) for the broader correction-and-rollback procedure, which preserves the original release record and publishes a superseding release rather than silently mutating the old one.
+
+[Back to top](#quick-links)
+
+---
+
+## 11. Operator Checklist
+
+Use this checklist before merging a watcher PR generated by this runbook.
+
+- [ ] `SourceDescriptor` is current and includes source role, rights, sensitivity, and cadence.
+- [ ] HEAD probe captured ETag and / or Last-Modified; or a manifest checksum was captured.
+- [ ] `spec_hash` recomputes deterministically from the canonicalized descriptor.
+- [ ] No-change runs short-circuit and emit a `RunReceipt` without re-downloading bytes.
+- [ ] Changed runs verified the upstream manifest where one is available.
+- [ ] The policy gate ran and produced an `allow` / `restrict` / `quarantine` / `deny` decision with reasons.
+- [ ] Living-person, DNA-derived, and restricted-join checks fired and recorded outcomes.
+- [ ] Assessor and parcel-geometry records carry `observation` role; no record is described as title or title boundary.
+- [ ] `RunReceipt` is present, signed (or attested per repo policy), and references the `PolicyDecision`.
+- [ ] No commit to a canonical catalog branch from the watcher; only a draft PR.
+- [ ] No public surface changed as a result of refresh alone.
+- [ ] Verification-backlog entries (§12) were updated if new gaps surfaced.
+
+[Back to top](#quick-links)
+
+---
+
+## 12. Open Verification Items
+
+These items remain `NEEDS VERIFICATION` against mounted-repo evidence. Each should be settled by inspecting actual files, schemas, registry entries, tests, logs, emitted artifacts, review records, or release manifests.
+
+| Item | What would settle it | Status |
+|---|---|---|
+| Living-person policy enforcement in `policy/domains/people-dna-land/` | Mounted policy bundle + negative tests | NEEDS VERIFICATION |
+| DNA consent / revocation enforcement and schema | Consent record schema; revocation receipt; deny fixtures | NEEDS VERIFICATION |
+| Land instrument chain logic (deed → title) | Chain-of-title contract; transition tests | NEEDS VERIFICATION |
+| Geometry-role boundary enforcement (PLSS / plat / parcel) | Schema role enums; fixtures rejecting a `title_boundary` framing | NEEDS VERIFICATION |
+| UI / API restricted-field no-leak behavior | API integration tests; redaction receipts; sensitive field masking | NEEDS VERIFICATION |
+| Canonical watcher tool name and path | Mounted `tools/ingest/watchers/` or equivalent | NEEDS VERIFICATION |
+| Canonical attestation tool (`kfm-attest`, `cosign`, or other) | Mounted toolchain + tool-versions pin | NEEDS VERIFICATION |
+| Canonical receipt-schema home (`schemas/contracts/v1/receipts/` vs. domain-scoped) | ADR + present-day repo evidence | NEEDS VERIFICATION |
+| Sensitivity tier scheme (T0–T4) adoption status | Mounted `policy/sensitivity/`; ADR | NEEDS VERIFICATION |
+| Runbook naming convention (flat `people_dna_land_*.md` vs. per-domain subdir) | Per-root README in `docs/runbooks/`; ADR; mounted convention | NEEDS VERIFICATION |
+| Drift register entry format for refresh-related conflicts | Mounted `docs/registers/DRIFT_REGISTER.md` | NEEDS VERIFICATION |
+
+[Back to top](#quick-links)
+
+---
+
+## 13. Related Docs
+
+- [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) — placement authority for this file and the artifacts it touches.
+- [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — the RAW → PUBLISHED invariant.
+- [`docs/doctrine/trust-membrane.md`](../../doctrine/trust-membrane.md) — why watchers propose rather than publish.
+- [`docs/domains/people-dna-land/README.md`](../../domains/people-dna-land/README.md) — domain charter and boundaries (PROPOSED neighbor).
+- [`docs/sources/SOURCE_DESCRIPTOR_STANDARD.md`](../../sources/SOURCE_DESCRIPTOR_STANDARD.md) — source descriptor field standard (PROPOSED).
+- [`docs/standards/SMART_SYNC.md`](../../standards/SMART_SYNC.md) — HTTP-validator + manifest pattern (PROPOSED).
+- [`docs/runbooks/people-dna-land/VALIDATION_RUNBOOK.md`](./VALIDATION_RUNBOOK.md) — validation runbook (PROPOSED neighbor).
+- [`docs/runbooks/people-dna-land/ROLLBACK_RUNBOOK.md`](./ROLLBACK_RUNBOOK.md) — rollback runbook (PROPOSED neighbor).
+- [`docs/registers/VERIFICATION_BACKLOG.md`](../../registers/VERIFICATION_BACKLOG.md) — where §12 items file.
+
+[Back to top](#quick-links)
+
+---
+
+## 14. Appendix
+
+<details>
+<summary><strong>A. Reference — fields a refresh <code>RunReceipt</code> should carry</strong></summary>
+
+```json
+{
+  "schema_version": "v1",
+  "object_type": "RunReceipt",
+  "domain": "people-dna-land",
+  "source_id": "<source_id>",
+  "source_url": "<endpoint>",
+  "fetched_at": "2026-05-12T00:00:00Z",
+  "validators": {
+    "etag": "<strong-or-weak-etag-or-null>",
+    "last_modified": "<rfc1123-or-null>",
+    "content_length": 0,
+    "manifest_verified": true
+  },
+  "spec_hash": "sha256:...",
+  "artifacts": [
+    {
+      "uri": "data/raw/people-dna-land/<source_id>/<run_id>/payload.ext",
+      "sha256": "..."
+    }
+  ],
+  "provider": {
+    "runner": "<runner-id>",
+    "tool_versions_ref": "<digest>"
+  },
+  "policy_decision_ref": "<uri-or-id>",
+  "outcome": "ANSWER | ABSTAIN | DENY | ERROR",
+  "evidence_refs": [],
+  "previous_run_receipt_ref": "<uri-or-null>"
+}
+```
+
+</details>
+
+<details>
+<summary><strong>B. Reference — example denial reasons specific to this domain</strong></summary>
+
+| Reason code (PROPOSED) | Trigger |
+|---|---|
+| `living_person_field_in_public_route` | A field whose presence implies a living individual reached a public-targeted refresh path. |
+| `dna_material_without_consent_record` | DNA / genomic data encountered without a referenced, valid consent record. |
+| `assessor_described_as_title` | A descriptor or downstream label declared assessor data as legal title. |
+| `parcel_geometry_described_as_title_boundary` | A descriptor or downstream label declared parcel polygons as legal boundaries. |
+| `rights_stale_or_unknown` | The rights record for this source is older than its cadence, or is marked `NEEDS VERIFICATION`. |
+| `manifest_checksum_mismatch` | Upstream manifest digest did not match observed bytes. |
+| `weak_validators_only` | Publisher exposed only weak ETag and no manifest; promotion gates may require additional support. |
+
+</details>
+
+<details>
+<summary><strong>C. Why "assessor ≠ title" and "parcel geometry ≠ title boundary" are doctrine, not pedantry</strong></summary>
+
+Assessor and tax-roll data record the taxing authority's working belief about ownership at a moment in time, for taxation purposes. Title is a legal status established by recorded instruments (patent, deed, mortgage discharge, court order) interpreted by examiners and courts. The two correlate but are not the same surface; treating them as equivalent has practical consequences for people whose records were mis-entered, contested, or never updated after a transfer.
+
+Parcel polygons, similarly, are survey assertions and administrative shapes — useful, but not legal boundaries. The legal boundary is a description in an instrument; the polygon is one observation of that description.
+
+These distinctions are first-class to this domain. A refresh that loses them — even briefly, even in a label — is a publication-discipline failure waiting to happen.
+
+</details>
+
+<details>
+<summary><strong>D. Directory Rules basis for this file's path</strong></summary>
+
+- **Responsibility root:** `docs/` (human-facing control plane). Runbooks are explicitly enumerated as docs/runbooks/ content.
+- **Domain segment:** `people-dna-land/` appears as a segment inside `docs/runbooks/`, not as a root folder. This follows Directory Rules §4 Step 3 — a domain MUST NOT become a root folder, but it MAY appear as a segment under a responsibility root.
+- **File name:** `SOURCE_REFRESH_RUNBOOK.md` describes the operation, not the topic alone, consistent with the runbook naming patterns seen in prior reports (e.g., `*_LOCAL_DEV.md`, `*_VALIDATION.md`, `*_ROLLBACK.md`).
+- **Convention caveat:** Prior reports show **flat** runbook names directly under `docs/runbooks/` (for example `ui_VALIDATION.md`). This file uses a **per-domain subdirectory**. Both forms are PROPOSED; an ADR or `docs/runbooks/README.md` should freeze the convention. Until then, this placement is marked NEEDS VERIFICATION for convention-fit.
+
+</details>
+
+---
+
+**Related docs:** see §13 &middot; **Last updated:** 2026-05-12 &middot; [Back to top](#quick-links)

--- a/docs/runbooks/roads-rail-trade/NO_NETWORK_TEST_RUNBOOK.md
+++ b/docs/runbooks/roads-rail-trade/NO_NETWORK_TEST_RUNBOOK.md
@@ -1,3 +1,411 @@
-# roads-rail-trade :: NO_NETWORK_TEST runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/roads-rail-trade/no-network-test
+title: Roads, Rail, and Trade Routes — No-Network Test Runbook
+type: standard
+version: v0.1
+status: draft
+owners: Roads/Rail/Trade Routes domain steward + QA + Docs steward
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/runbooks/README.md (PROPOSED)
+  - docs/domains/roads-rail-trade/README.md (PROPOSED)
+  - docs/architecture/testing-strategy.md (PROPOSED)
+  - docs/adr/ADR-runbook-domain-placement.md (PROPOSED)
+  - tests/domains/roads-rail-trade/ (PROPOSED)
+  - fixtures/domains/roads-rail-trade/ (PROPOSED)
+  - schemas/contracts/v1/domains/roads-rail-trade/ (PROPOSED)
+  - policy/domains/roads-rail-trade/ (PROPOSED)
+tags: [kfm, runbook, roads-rail-trade, no-network, fixtures, tests, governance]
+notes:
+  - Path placement is PROPOSED; see §12 (Directory Rules basis) for rationale.
+  - All command shapes are PROPOSED until verified against a mounted repo.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Roads, Rail, and Trade Routes — No-Network Test Runbook
+
+> **Run the Roads/Rail/Trade domain's trust-spine fixture suite — schema, contract, evidence, policy, release, correction, and rollback — entirely offline, with zero live sources and zero public side effects.**
+
+![status](https://img.shields.io/badge/status-draft-orange)
+![doctrine](https://img.shields.io/badge/doctrine-CONFIRMED-blue)
+![implementation](https://img.shields.io/badge/implementation-PROPOSED-lightgrey)
+![network](https://img.shields.io/badge/network-deny--by--default-critical)
+![lifecycle](https://img.shields.io/badge/lifecycle-RAW→PUBLISHED-informational)
+![last%20updated](https://img.shields.io/badge/last%20updated-2026--05--12-lightgrey)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` — first iteration, not yet exercised against a mounted repo |
+| **Owners** | Roads/Rail/Trade Routes domain steward + QA + Docs steward |
+| **Last updated** | 2026-05-12 |
+| **Applies to** | PR-00 no-network fixture wave, scoped to Roads, Rail, and Trade Routes |
+| **Pipeline scope** | RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED |
+| **Network posture** | Deny-by-default; no egress allowed during this runbook |
+
+---
+
+## Quick jump
+
+- [1 · Purpose](#1--purpose)
+- [2 · Scope and non-scope](#2--scope-and-non-scope)
+- [3 · Preconditions](#3--preconditions)
+- [4 · Domain object families under test](#4--domain-object-families-under-test)
+- [5 · Pipeline gates the suite must exercise](#5--pipeline-gates-the-suite-must-exercise)
+- [6 · Fixture catalogue (per object family)](#6--fixture-catalogue-per-object-family)
+- [7 · Sensitivity, rights, and public-safe fixture rules](#7--sensitivity-rights-and-public-safe-fixture-rules)
+- [8 · Procedure](#8--procedure)
+- [9 · Finite outcomes and exit criteria](#9--finite-outcomes-and-exit-criteria)
+- [10 · Failure modes and triage](#10--failure-modes-and-triage)
+- [11 · Rollback](#11--rollback)
+- [12 · Directory Rules basis](#12--directory-rules-basis)
+- [13 · Verification backlog](#13--verification-backlog)
+- [Related docs](#related-docs)
+
+---
+
+## 1 · Purpose
+
+This runbook governs the **no-network deterministic test pass** for the Roads, Rail, and Trade Routes domain. It is the operational form of **PR-00 no-network fixture** as applied to this lane: a fully offline rehearsal that proves the trust spine — source admission, lifecycle handling, schema, evidence, policy, release, correction, rollback — runs end-to-end against synthetic, public-safe fixtures before any live source or public surface is wired.
+
+> [!IMPORTANT]
+> **The point of this runbook is not "tests pass." The point is that the system fails closed in the right places.** A green run that never produced an `ABSTAIN`, never produced a `DENY`, and never exercised a rollback fixture has not validated the trust spine — it has only validated the happy path.
+
+The doctrine is project-wide; this file localizes it to **Roads/Rail/Trade Routes** so the lane can ship its first reversible PR without crossing a forbidden boundary.
+
+---
+
+## 2 · Scope and non-scope
+
+### In scope
+
+- The deterministic, no-network fixture suite for Roads/Rail/Trade Routes objects, schemas, validators, policy gates, evidence resolution, release manifests, correction notices, and rollback cards.
+- Synthetic and public-safe fixtures only (no real exact sensitive geometry, no live source pulls).
+- Schema, contract, source-role, evidence, policy, lifecycle, release, UI-trust (payload-shape only), and AI-boundary (MockAdapter) test classes.
+- Producing per-run receipts and per-fixture validation reports as local artifacts.
+
+### Explicitly out of scope
+
+- Live KDOT / FHWA / FRA / WZDx / OSM / GNIS / KanDrive / KanPlan source fetches. Source rights are `NEEDS VERIFICATION` and live retrieval is forbidden in this run.
+- Publication to any public path. `data/published/` MUST NOT be written during this runbook.
+- Live AI provider adapters (Ollama, OpenAI, hosted). Only the **MockAdapter** is permitted.
+- Production auth, deployment topology, or real tile signing infrastructure.
+- Domains adjacent to but **not owned** by Roads/Rail/Trade Routes (Settlements/Infrastructure, Hydrology, Archaeology, Hazards). Cross-lane relations are exercised only via reference, not by mutating those domains' canon.
+
+---
+
+## 3 · Preconditions
+
+> [!NOTE]
+> Every precondition below is **PROPOSED** until verified against a mounted repo. Do not treat the path strings as proof a file exists.
+
+| Precondition | Where it lives (PROPOSED) | Truth label |
+|---|---|---|
+| Domain dossier present | `docs/domains/roads-rail-trade/README.md` | PROPOSED |
+| Schemas reachable | `schemas/contracts/v1/domains/roads-rail-trade/` | PROPOSED |
+| Contracts reachable | `contracts/domains/roads-rail-trade/` | PROPOSED |
+| Policy bundle reachable | `policy/domains/roads-rail-trade/` | PROPOSED |
+| Fixtures reachable | `fixtures/domains/roads-rail-trade/` (or `tests/fixtures/domains/roads-rail-trade/`) | PROPOSED |
+| Validator entry point | `tools/validators/` (repo-wide) | PROPOSED |
+| Test harness | `tests/domains/roads-rail-trade/` | PROPOSED |
+| MockAdapter available | `runtime/mock/` | PROPOSED |
+| Receipt writer | `tools/` or `packages/` (exact home `NEEDS VERIFICATION`) | PROPOSED |
+| **Network egress disabled at runner level** | `infra/` egress policy / CI runner config | PROPOSED · **MUST** be true |
+| No real secrets present | `configs/dev/`, `configs/test/`, `configs/local/` | CONFIRMED rule (Directory Rules §10.3) |
+
+> [!CAUTION]
+> If network egress cannot be proven disabled at the runner level, **do not start this run**. A no-network suite that ran with egress available has not validated the no-network invariant — it has merely happened to not call out. Treat this as a missed gate, not a passed run.
+
+---
+
+## 4 · Domain object families under test
+
+Roads/Rail/Trade Routes owns the following canonical object families. Each MUST have at least the five fixture roles in §6.
+
+| Object family | Owned by this domain | Cross-lane note |
+|---|---|---|
+| `RoadSegment` | ✓ | Anchors crossings/facilities in Settlements (settlement-owned identity) |
+| `RailSegment` | ✓ | Same constraint as RoadSegment |
+| `HistoricRoute` / `Historic RouteClaim` | ✓ | Indigenous corridors default to generalized public geometry |
+| `CorridorRoute` / `TradeRouteCorridor` | ✓ | Distinguish surveyed alignment from narrative claim |
+| `Depot`, `Siding`, `Yard` | ✓ | Facility identity is settlement-owned for cross-references |
+| `Crossing`, `Bridge`, `Ferry`, `RiverCrossing` | ✓ | Hydrology owns the water evidence |
+| `FreightCorridor`, `NetworkEdge`, `Network Node` | ✓ | Derived graph projections are not root truth |
+| `RouteEvent`, `OperatorStatus` / `StatusEvent` | ✓ | Temporal fields stay distinct (observed/valid/release/correction) |
+| `AccessRestriction` / `RestrictionEvent` | ✓ | Hazards owns closure/detour/exposure context |
+| `RouteMembership`, `OperatorAssignment` | ✓ | Designation vs membership must remain separable |
+| `TransportFacility` | ✓ | Public detail subject to sensitivity review |
+| `MovementStoryNode` | ✓ | Narrative carrier; never sovereign over surveyed alignment |
+| `GeneralizationReceipt` | ✓ | Records redaction/generalization transforms and reasons |
+
+Source: domain identity, scope, and object families per the KFM Domains Atlas chapter on Roads, Rail, and Trade Routes (CONFIRMED doctrine / PROPOSED implementation).
+
+---
+
+## 5 · Pipeline gates the suite must exercise
+
+The no-network suite walks the lifecycle **without** writing to any public surface. Each gate has a finite outcome and a fixture that proves it.
+
+```mermaid
+flowchart LR
+  RAW["RAW<br/>SourceDescriptor exists"]:::raw
+  WORK["WORK / QUARANTINE<br/>schema·geometry·time·rights·policy"]:::work
+  PROC["PROCESSED<br/>EvidenceRef + ValidationReport"]:::proc
+  CATL["CATALOG / TRIPLET<br/>EvidenceBundle + closure"]:::catl
+  PUB["PUBLISHED<br/>ReleaseManifest + rollback target"]:::pub
+  ROLL["Rollback drill<br/>RollbackCard + receipt"]:::roll
+
+  RAW --> WORK --> PROC --> CATL --> PUB
+  PUB -.-> ROLL
+  WORK -. quarantine reason .-> WORK
+
+  classDef raw fill:#f4f4f5,stroke:#71717a,color:#18181b
+  classDef work fill:#fef3c7,stroke:#a16207,color:#451a03
+  classDef proc fill:#dbeafe,stroke:#1d4ed8,color:#0c1d4d
+  classDef catl fill:#dcfce7,stroke:#15803d,color:#052e16
+  classDef pub fill:#ede9fe,stroke:#6d28d9,color:#1e1338
+  classDef roll fill:#fee2e2,stroke:#b91c1c,color:#3f0708
+```
+
+> [!NOTE]
+> **Diagram status:** the lifecycle invariant is **CONFIRMED doctrine**; per-stage gate labels are **PROPOSED implementation** until a mounted repo confirms the validator outputs. Re-render once `tests/domains/roads-rail-trade/` exists.
+
+---
+
+## 6 · Fixture catalogue (per object family)
+
+Every major Roads/Rail/Trade object family **SHOULD** carry at least the five fixture roles below. Sensitive lanes (Indigenous corridors, critical facilities) **MUST** substitute public-safe transformed geometry for the `valid` role; never real exact coordinates.
+
+| Fixture role | Purpose | Expected outcome | Example for this domain (illustrative) |
+|---|---|---|---|
+| **valid** | Schema-conformant, releasable shape | `ANSWER` at resolver; `ALLOW` at policy | A synthetic `RoadSegment` with normalized time, rights, evidence ref |
+| **invalid** | Violates schema or contract | Validator fails closed; receipt records `NormalizationError` | A `RailSegment` missing temporal fields |
+| **denied** | Schema-valid but policy-blocked | `DENY` with reason (rights/sensitivity/review/release) | A `Historic RouteClaim` over an Indigenous corridor without steward review |
+| **abstention** | Evidence unresolved | `ABSTAIN` with `ResolutionError.missing_bundle` | A `MovementStoryNode` whose `EvidenceRef` points to a missing bundle |
+| **rollback / correction** | Drives the reversal path | Rollback receipt emitted; correction notice linked | A withdrawn `ReleaseManifest` for a generalized `TradeRouteCorridor` |
+
+> [!TIP]
+> The five-role fixture rule is project-wide doctrine. Treat any object family with fewer than five fixture roles as "not yet ready for PR-00 closure" — even if its happy path passes.
+
+<details>
+<summary><strong>Domain-specific negative tests this suite MUST contain</strong> (click to expand)</summary>
+
+The following negative tests are called out specifically for Roads, Rail, and Trade Routes (status: **PROPOSED**):
+
+- **Route membership vs designation separation** — a `RouteMembership` change MUST NOT silently rewrite a `CorridorRoute` designation; the fixture forces both to be present and distinguishable.
+- **Operator / status temporal tests** — `OperatorAssignment` and `StatusEvent` keep `source`, `observed`, `valid`, `retrieval`, `release`, and `correction` times distinct; collapse fails closed.
+- **OSM / GNIS legal-status denial** — community-sourced or place-name attributes MUST NOT be used to assert legal-status authority. Fixture forces `DENY` when source role is `context` but the claim requires `authority`.
+- **Historic overprecision denial** — a `Historic RouteClaim` carrying surveyor-precision geometry from a narrative source fails closed; fixture asserts `DENY` and points at the `GeneralizationReceipt` requirement.
+- **Public generalization receipt tests** — every public-safe geometry for a sensitive corridor MUST resolve to a `GeneralizationReceipt` describing the transform and reason; missing receipt → `DENY`.
+- **Transport graph projection rollback** — a derived `NetworkEdge` projection MUST be reversible. Rollback fixture exercises the full revert and emits an attestation.
+
+These map to the validator/test entries listed in the Roads/Rail/Trade Routes domain chapter (status: PROPOSED).
+
+</details>
+
+---
+
+## 7 · Sensitivity, rights, and public-safe fixture rules
+
+> [!WARNING]
+> Even **synthetic** fixtures can leak real sensitive geometry if built from sketched real corridors. Build fixtures from clearly invented place names, generic coordinate ranges, and explicit `mock:true` markers. Never paste real Indigenous corridor coordinates, real rare-species crossings, real critical-infrastructure precision, or real archaeological alignments into a fixture, even "for realism."
+
+| Sensitivity class | Public-safe rule for fixtures | Default outcome on violation |
+|---|---|---|
+| Indigenous trade and mobility corridors | Generalized geometry + steward-review marker required | `DENY` |
+| Treaty / cultural / oral-history evidence | Steward review + provenance citation required | `DENY` or `ABSTAIN` |
+| Critical transport facilities (precision) | Default to generalized public view | `DENY` |
+| Living-person operator data | Public-safe redaction; no PII payload | `DENY` |
+| OSM / GNIS / community attributes used outside their role | Source-role mismatch must surface | `DENY` |
+
+All fixtures **MUST** include an obvious mock marker, **MUST** be schema-valid, and **MUST NOT** be confused with released evidence. Fixtures are not publication artifacts. (CONFIRMED doctrine.)
+
+---
+
+## 8 · Procedure
+
+> [!IMPORTANT]
+> Every command shape below is **PROPOSED**. The actual command names depend on the repo's chosen toolchain (`npm` / `pnpm` / `yarn` / `pytest` / `make` / Dagster / equivalent). Substitute the repo's verified equivalent before running. Do not invent commands without verifying.
+
+### 8.1 Confirm network egress is denied
+
+```bash
+# PROPOSED — substitute the repo's verified network-deny check.
+# Examples (each NEEDS VERIFICATION before use):
+#   make assert-no-egress
+#   ./tools/assert-no-egress.sh
+#   curl --max-time 2 -sS https://example.invalid && echo "FAIL: egress reached" || echo "OK"
+```
+
+Expected: any outbound DNS or HTTP call fails or is denied at the runner level. If not, **stop**.
+
+### 8.2 Validate schemas and fixtures
+
+```bash
+# PROPOSED — repo-wide validator over the domain's schemas and fixtures.
+# Substitute the repo's actual command (ajv, jsonschema, or in-tree validator).
+#
+#   <repo-validator> \
+#     --schemas schemas/contracts/v1/domains/roads-rail-trade \
+#     --fixtures fixtures/domains/roads-rail-trade \
+#     --report tests/reports/roads-rail-trade/schema.json
+```
+
+Expected: every `valid` fixture passes; every `invalid` fixture fails with a precise error. A `valid` failure or a silent `invalid` pass is a release-blocker.
+
+### 8.3 Run the domain test suite
+
+```bash
+# PROPOSED — domain test runner; substitute the verified entry point.
+#
+#   <repo-test-runner> tests/domains/roads-rail-trade --no-network --deterministic
+```
+
+Expected: every test class in the table below produces a finite outcome and a receipt.
+
+| Test class | What it asserts | Expected outcome |
+|---|---|---|
+| Schema test | Required fields and versions present | pass / fail-closed |
+| Contract test | Object meaning matches vocabulary and lifecycle role | pass / fail-closed |
+| Source-role test | A source is not used outside its authority | `DENY` on misuse |
+| Evidence test | `EvidenceRef` resolves or answer abstains | `ANSWER` / `ABSTAIN` |
+| Policy test | Unknown rights or sensitivity deny release | `DENY` |
+| Release test | Manifest has proof, correction, rollback | pass / fail-closed |
+| UI trust test (payload shape) | Drawer payload renders required trust state | pass / fail-closed |
+| AI boundary test | `MockAdapter` cannot answer without admissible evidence | `ABSTAIN` / `DENY` |
+
+(Default status for every class: **PROPOSED**, per the unified testing strategy.)
+
+### 8.4 Walk the lifecycle without publishing
+
+```bash
+# PROPOSED — promotion dry-run; MUST NOT write to data/published/.
+#
+#   <repo-promote> --dry-run \
+#     --candidate release/candidates/roads-rail-trade \
+#     --emit-receipt
+```
+
+Expected: a `PromotionReceipt` or equivalent receipt is emitted to a local artifact path. No file is written under `data/published/`. A `no-public-write` assertion confirms this.
+
+### 8.5 Run the rollback drill
+
+```bash
+# PROPOSED — rollback against the dry-run release candidate.
+#
+#   <repo-rollback> --drill \
+#     --release release/candidates/roads-rail-trade \
+#     --emit-rollback-card
+```
+
+Expected: a `RollbackCard` is produced; the prior release manifest is restored in-fixture; an attestation lands in the receipts area. The drill must be re-runnable from a clean state.
+
+### 8.6 Collect receipts
+
+All receipts from §§8.2–8.5 land in the repo-local receipts area (PROPOSED home: `data/receipts/` per Directory Rules §6). The run is **incomplete** until those receipts exist and are themselves schema-valid.
+
+---
+
+## 9 · Finite outcomes and exit criteria
+
+This run produces only **finite outcomes**, never silent success. Every fixture path resolves to one of:
+
+| Outcome | Meaning | Suite implication |
+|---|---|---|
+| `ANSWER` | Schema-valid, evidence resolved, policy allows | Counted toward happy-path coverage |
+| `ABSTAIN` | Evidence unresolved or insufficient | **Required** for abstention fixtures; failing to abstain is a release-blocker |
+| `DENY` | Policy / rights / sensitivity / review state blocks | **Required** for denied fixtures; failing to deny is a release-blocker |
+| `ERROR` | Validator / runtime fault before a decision | Triage; never accept as a passing state |
+
+### Exit criteria for PR-00 closure (Roads/Rail/Trade lane)
+
+The lane's no-network slice may merge only when **all** of the following hold:
+
+- [ ] Network egress is verifiably denied for the entire run.
+- [ ] Every object family in §4 has the five fixture roles in §6.
+- [ ] Every domain-specific negative test in §6 (collapsible) is present and passes (i.e., correctly **denies**).
+- [ ] Every test class in §8.3 produces a finite outcome.
+- [ ] The promotion dry-run produces a receipt **and** writes no file under `data/published/`.
+- [ ] The rollback drill produces a `RollbackCard` and a restoration receipt.
+- [ ] All receipts are themselves schema-valid.
+- [ ] The `VERIFICATION_BACKLOG` (§13) is updated, not silently closed.
+
+---
+
+## 10 · Failure modes and triage
+
+| Symptom | Likely cause | Triage step |
+|---|---|---|
+| `valid` fixture fails schema | Schema drift, or fixture authored against an older version | Pin schema version; record in `DRIFT_REGISTER`; do not patch fixture into compliance silently |
+| `invalid` fixture silently passes | Validator regression or rule weakened | Treat as release-blocker; revert validator change; add a negative-test gate |
+| `EvidenceRef` resolves when it should abstain | Resolver pulling from a non-released store | Audit resolver scope; confirm it reads only released / review-authorized layers |
+| Network call attempted | A connector, watcher, or analytics call slipped in | Identify caller; gate behind `--no-network`; file an ADR if the call is unavoidable |
+| Sensitive corridor geometry exact-match | Fixture built from real data | Replace with synthetic geometry; record in correction log; rotate the fixture id |
+| Rollback drill leaves residue | Restoration path incomplete | Treat as a rollback-bug; do not paper over with manual cleanup; fix the drill |
+| Receipt is missing or unsigned | Receipt writer not wired into this lane | Block PR-00 closure for the lane until the receipt step is present |
+
+> [!CAUTION]
+> A failure to abstain or deny is a **more serious** finding than a `valid` fixture failing schema. The latter is loud; the former is silent and degrades the trust spine. Triage abstain/deny regressions first.
+
+---
+
+## 11 · Rollback
+
+Per PR-00 doctrine, the no-network fixture PR is itself reversible:
+
+- **Forward step:** revert the PR. No public artifact has been published, so revert is sufficient.
+- **Fixtures retained as lineage:** if the PR is superseded rather than withdrawn, keep the fixture set under a `lineage/` or `superseded/` marker rather than deleting it; the work has documentary value.
+- **Receipts retained:** receipts from the dry-run remain valid as evidence of the run; they should not be deleted on revert.
+- **Drift register:** if the revert reveals doctrine drift, open a `DRIFT_REGISTER` entry instead of just rolling back.
+
+---
+
+## 12 · Directory Rules basis
+
+This document's placement, and the paths it references, follow these Directory Rules conventions:
+
+- **Responsibility root for this file:** `docs/` (explains something to humans).
+- **Domain segment for this file:** `roads-rail-trade` as a sub-folder under `docs/runbooks/`, applying Domain Placement Law (§12) by analogy. **Status: PROPOSED.** The Directory Rules confirm `docs/runbooks/` exists as a runbook home but show flat naming examples (e.g., `ui_LOCAL_DEV.md`). The sub-folder pattern is consistent with how `docs/domains/<domain>/`, `tests/domains/<domain>/`, etc. are structured, but is **not yet ADR-resolved** for runbooks specifically.
+- **Alternatives considered** (each PROPOSED):
+  - `docs/runbooks/roads_rail_trade_NO_NETWORK_TEST.md` — flat, matches the visible runbook naming in source docs.
+  - `docs/domains/roads-rail-trade/runbooks/NO_NETWORK_TEST.md` — keeps all roads-rail-trade artifacts under one domain umbrella inside `docs/`.
+- **Recommendation:** open a short ADR (`docs/adr/ADR-runbook-domain-placement.md`, PROPOSED) to freeze one of the three forms. Until then, treat this file's location as `PROPOSED / CONFLICTED` and link it from `docs/runbooks/README.md` (PROPOSED) regardless of which form wins.
+- **Lifecycle / responsibility roots referenced:** `data/raw/`, `data/work/`, `data/quarantine/`, `data/processed/`, `data/catalog/`, `data/published/`, `data/receipts/`, `release/`, `schemas/contracts/v1/domains/roads-rail-trade/`, `policy/domains/roads-rail-trade/`, `tests/domains/roads-rail-trade/`, `fixtures/domains/roads-rail-trade/`. All are PROPOSED until verified against a mounted repo.
+
+---
+
+## 13 · Verification backlog
+
+These items roll up to `docs/registers/VERIFICATION_BACKLOG.md` (PROPOSED). Do not silently close any of them — each requires a citable piece of repo evidence to retire.
+
+| Item | Evidence that would settle it | Status |
+|---|---|---|
+| Runbook placement form (flat vs `roads-rail-trade/` vs `docs/domains/...`) | Accepted ADR | NEEDS VERIFICATION |
+| `tools/validators/` actual command and flag surface | Mounted repo file presence and CI invocation | NEEDS VERIFICATION |
+| Domain schema home actually present | `schemas/contracts/v1/domains/roads-rail-trade/*.schema.json` in repo | NEEDS VERIFICATION |
+| Policy bundle actually present | `policy/domains/roads-rail-trade/` in repo with conftest / OPA tests | NEEDS VERIFICATION |
+| Fixture home convention (root `fixtures/` vs `tests/fixtures/`) | Per-root README declaration | NEEDS VERIFICATION |
+| Receipt writer wired for this lane | Local receipt artifacts emitted by a sample run | NEEDS VERIFICATION |
+| `MockAdapter` boundary holds for roads/rail Focus | Test asserting MockAdapter cannot answer without an admissible EvidenceBundle | NEEDS VERIFICATION |
+| KDOT / FHWA / FRA / WZDx / OSM / GNIS rights and terms | Source descriptors with verified rights state | NEEDS VERIFICATION |
+| Indigenous / cultural corridor policy concrete form | Reviewed `policy/domains/roads-rail-trade/sensitivity/...` rule set | NEEDS VERIFICATION |
+| Transport graph projection rollback drill | Replayable rollback fixture + restoration receipt | NEEDS VERIFICATION |
+| MapLibre layer manifest read path for this domain | Verified `apps/explorer-web/` → `apps/governed-api/` route | NEEDS VERIFICATION |
+
+---
+
+## Related docs
+
+- `docs/runbooks/README.md` — runbook index (PROPOSED).
+- `docs/domains/roads-rail-trade/README.md` — domain dossier (PROPOSED).
+- `docs/architecture/testing-strategy.md` — overall no-network test pyramid (PROPOSED).
+- `docs/runbooks/ui_LOCAL_DEV.md`, `ui_VALIDATION.md`, `ui_ROLLBACK.md` — UI lane runbooks (PROPOSED).
+- `docs/runbooks/governed_ai_LOCAL_DEV.md`, `governed_ai_VALIDATION.md`, `governed_ai_ROLLBACK.md` — Governed AI lane runbooks (PROPOSED).
+- `docs/adr/ADR-runbook-domain-placement.md` — to be opened (PROPOSED).
+- `docs/registers/DRIFT_REGISTER.md`, `docs/registers/VERIFICATION_BACKLOG.md` — registers (PROPOSED).
+
+---
+
+_Last updated: **2026-05-12** · Status: **draft (v0.1)** · Authority: this runbook is **CONFIRMED** as project doctrine localized to the Roads/Rail/Trade lane; implementation-level claims are **PROPOSED** until a mounted repo verifies them._
+
+[↑ Back to top](#roads-rail-and-trade-routes--no-network-test-runbook)

--- a/docs/runbooks/roads-rail-trade/PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/roads-rail-trade/PROMOTION_RUNBOOK.md
@@ -1,3 +1,598 @@
-# roads-rail-trade :: PROMOTION runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-roads-rail-trade-promotion
+title: Roads / Rail / Trade Routes — Promotion Runbook
+type: standard
+version: v1
+status: draft
+owners: <docs-steward>, <roads-rail-trade-domain-steward>
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/truth-posture.md
+  - docs/doctrine/trust-membrane.md
+  - docs/domains/roads-rail-trade/README.md
+  - docs/architecture/promotion-gates.md
+  - policy/domains/roads-rail-trade/
+  - schemas/contracts/v1/receipts/promotion_receipt.schema.json
+  - release/candidates/roads-rail-trade/
+tags: [kfm, runbook, promotion, roads-rail-trade, governance]
+notes:
+  - Runbook is doctrine-grounded; specific paths PROPOSED until mounted-repo verification.
+  - Path placement follows Directory Rules §12; runbook lives under a domain segment.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+<a id="top"></a>
+
+# Roads / Rail / Trade Routes — Promotion Runbook
+
+> Operator-facing procedure for promoting roads, rail, historic routes, trade corridors, facilities, and graph projections across `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` under KFM's seven-gate matrix.
+
+<p align="center">
+  <img alt="Lifecycle" src="https://img.shields.io/badge/lifecycle-governed-blue">
+  <img alt="Domain" src="https://img.shields.io/badge/domain-roads--rail--trade-2c7">
+  <img alt="Gates" src="https://img.shields.io/badge/gates-A%E2%80%93G-orange">
+  <img alt="Policy" src="https://img.shields.io/badge/policy-fail--closed-red">
+  <img alt="AI" src="https://img.shields.io/badge/AI-advisory--only-lightgrey">
+  <img alt="Status" src="https://img.shields.io/badge/status-draft-lightgrey">
+</p>
+
+| Status | Owner(s) | Authority | Last reviewed |
+|---|---|---|---|
+| `draft` | `<docs-steward>` · `<roads-rail-trade-domain-steward>` | CONFIRMED doctrine · **PROPOSED** implementation | 2026-05-12 |
+
+> [!IMPORTANT]
+> **Promotion is a governed state transition, not a file move.** No artifact reaches `PUBLISHED` without (1) resolved `EvidenceRef → EvidenceBundle`, (2) policy decision, (3) all seven gates A–G passing, (4) a signed `PromotionReceipt`, (5) a `ReleaseManifest` with rollback and correction targets. Missing any one element → fail-closed → `DENY` / `QUARANTINE`.
+
+---
+
+## Quick links
+
+- [Purpose](#purpose)
+- [Scope and repo fit](#scope-and-repo-fit)
+- [What this runbook governs](#what-this-runbook-governs)
+- [Lifecycle map for Roads / Rail / Trade Routes](#lifecycle-map-for-roads--rail--trade-routes)
+- [Domain snapshot](#domain-snapshot)
+- [Promotion Gates A–G applied to Roads / Rail / Trade Routes](#promotion-gates-ag-applied-to-roads--rail--trade-routes)
+- [Operator procedure](#operator-procedure)
+- [Sensitivity, generalization, and fail-closed defaults](#sensitivity-generalization-and-fail-closed-defaults)
+- [Failure modes and quarantine handling](#failure-modes-and-quarantine-handling)
+- [Negative-path fixtures](#negative-path-fixtures)
+- [Receipts and artifacts emitted](#receipts-and-artifacts-emitted)
+- [Rollback and correction](#rollback-and-correction)
+- [Governed AI posture for this domain](#governed-ai-posture-for-this-domain)
+- [Verification backlog and open questions](#verification-backlog-and-open-questions)
+- [Related docs](#related-docs)
+- [Appendix — receipt sketches](#appendix--receipt-sketches)
+
+---
+
+## Purpose
+
+This runbook tells a domain steward, release officer, and pipeline operator **how to move a Roads / Rail / Trade Routes artifact through KFM's governed lifecycle** without bypassing the trust membrane. It binds three things together for this domain:
+
+1. The **canonical KFM lifecycle** — `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` (CONFIRMED doctrine).
+2. The **seven-gate promotion matrix** (Gates **A** Structure and Metadata, **B** Schemas and Contracts, **C** Policy Parity, **D** Security and Sensitivity, **E** Data Quality, **F** Provenance and Lineage, **G** Reviewability with two-key approval) — CONFIRMED gate names and meaning; per-domain wiring PROPOSED until mounted-repo verification.
+3. The **Roads / Rail / Trade Routes domain doctrine** — modern roads, rail corridors, historic routes (wagon, military, emigrant, stage, cattle, trade), depots, sidings, yards, crossings, bridges, ferries, river crossings, freight corridors, network graph projections, and the explicit sensitivity rules that gate Indigenous corridors, culturally sensitive routes, and critical transport facilities.
+
+It does **not** decide truth, replace `EvidenceBundle` resolution, or substitute for steward review. AI summarization is advisory only.
+
+[Back to top](#top)
+
+---
+
+## Scope and repo fit
+
+> [!NOTE]
+> All paths in this section are PROPOSED until verified against mounted-repo evidence. Placement follows Directory Rules §3 (responsibility roots), §4 (placement protocol), and §12 (Domain Placement Law). A domain MUST appear as a *segment* inside a responsibility root, never as a root itself.
+
+This runbook lives under `docs/` because its primary responsibility is **explaining a governed procedure to humans**. It lives under the `roads-rail-trade` domain segment because every step here applies specifically to that domain's objects, sources, and sensitivity posture.
+
+```text
+docs/
+└── runbooks/
+    └── roads-rail-trade/
+        └── PROMOTION_RUNBOOK.md    ← this file
+```
+
+**Upstream of this runbook** (inputs it depends on):
+
+| Upstream artifact | PROPOSED home | Why this runbook needs it |
+|---|---|---|
+| Roads / Rail / Trade Routes domain README | `docs/domains/roads-rail-trade/README.md` | Scope, ubiquitous language, object families. |
+| Lifecycle law | `docs/doctrine/lifecycle-law.md` | `RAW → PUBLISHED` invariants. |
+| Directory Rules | `docs/doctrine/directory-rules.md` | Where every artifact emitted by promotion belongs. |
+| Authority ladder | `docs/doctrine/authority-ladder.md` | Conflict resolution between sources, ADRs, and convention. |
+| Promotion-gate spec (A–G) | `docs/architecture/promotion-gates.md` | Canonical gate definitions; this runbook applies them to one domain. |
+| `SourceDescriptor` standard | `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` | Intake field requirements. |
+| Domain object map | `contracts/domains/roads-rail-trade/OBJECT_MAP.md` | Object meaning. |
+| Domain schemas | `schemas/contracts/v1/domains/roads-rail-trade/*.schema.json` | Object shape. |
+| Domain policy | `policy/domains/roads-rail-trade/*.rego` | Allow / deny / restrict / abstain. |
+
+**Downstream of this runbook** (artifacts produced by following it):
+
+| Downstream artifact | PROPOSED home |
+|---|---|
+| `RunReceipt` for each pipeline run | `data/receipts/roads-rail-trade/` |
+| `PromotionReceipt` covering Gates A–G | `data/receipts/roads-rail-trade/promotion/` |
+| `EvidenceBundle` for released claims | `data/catalog/domain/roads-rail-trade/` |
+| `ReleaseManifest` for a release set | `release/candidates/roads-rail-trade/` then `release/published/roads-rail-trade/` |
+| `RollbackCard` paired with every release | `release/rollback/roads-rail-trade/` |
+| `CorrectionNotice` for any superseded release | `release/corrections/roads-rail-trade/` |
+| `GeneralizationReceipt` / `RedactionReceipt` | `data/receipts/roads-rail-trade/transforms/` |
+
+[Back to top](#top)
+
+---
+
+## What this runbook governs
+
+| In scope | Out of scope (and where to look instead) |
+|---|---|
+| Roads, rail, historic route, depot, siding, yard, crossing, bridge, ferry, river-crossing, freight-corridor, route-event, operator-status, access-restriction, network-edge, movement-story-node promotion. | Settlement / infrastructure canonical claims → **Settlements / Infrastructure** runbook. |
+| Generalization, suppression, and uncertainty handling for Indigenous corridors, culturally sensitive routes, uncertain historic alignments, and critical transport facilities. | Hydrologic evidence for fords, gauges, channels → **Hydrology** runbook. |
+| Cross-lane consumption of crossings, river fords, facility identity, hazard closures, and historic-corridor context. | Hazard event / advisory / warning publication → **Hazards** runbook. |
+| Graph / triplet projection of the transport network and rollback of derived graphs. | Archaeological site coordinates → **Archaeology** runbook (denied / generalized by default). |
+| `RunReceipt`, `PromotionReceipt`, `ReleaseManifest`, `RollbackCard`, and `CorrectionNotice` for this domain. | Generic governed-API runtime semantics → `docs/architecture/governed-ai/` and governed-API runbooks. |
+
+[Back to top](#top)
+
+---
+
+## Lifecycle map for Roads / Rail / Trade Routes
+
+The lifecycle below is CONFIRMED KFM doctrine; the per-domain handler labels are PROPOSED — exact validator, policy, and pipeline names will be set when the responsibility-root files are landed.
+
+```mermaid
+flowchart LR
+  RAW["RAW
+  immutable source intake
+  (KDOT / FHWA / WZDx / TIGER / GNIS / OSM / archival)"]
+  WORK["WORK
+  normalize schema · geometry · time · identity
+  derive route membership · uncertainty profile"]
+  Q["QUARANTINE
+  unclear rights · unresolved source role
+  cultural-corridor flag · over-precise historic geom
+  legal-status from OSM/GNIS · failed validator"]
+  PROC["PROCESSED
+  EvidenceRef · ValidationReport
+  GeneralizationReceipt · digest closure"]
+  CAT["CATALOG / TRIPLET
+  EvidenceBundle · graph projection
+  release candidate"]
+  PUB["PUBLISHED
+  ReleaseManifest · RollbackCard
+  governed API only"]
+
+  RAW --> WORK
+  WORK --> PROC
+  WORK -- "fail-closed" --> Q
+  Q -. "steward decision" .-> WORK
+  Q -. "no resolution" .-> RAW
+  PROC --> CAT
+  CAT -- "Gates A–G PASS" --> PUB
+  CAT -- "any gate FAIL" --> Q
+  PUB -- "correction / rollback" --> CAT
+```
+
+> [!NOTE]
+> The "fail-closed" arrows are non-decorative: **unclear rights, unresolved source role, missing evidence, unresolved sensitivity, or absent release state MUST block public promotion** (CONFIRMED doctrine). Resolution is a steward action, not an operator override.
+
+[Back to top](#top)
+
+---
+
+## Domain snapshot
+
+CONFIRMED domain scope; PROPOSED field-level realization until schemas land.
+
+### Object families this runbook moves
+
+| Object family | Identity rule (PROPOSED) | Temporal handling (CONFIRMED) |
+|---|---|---|
+| `RoadSegment` | `source_id + object_role + temporal_scope + normalized_digest` | `source / observed / valid / retrieval / release / correction` times distinct where material. |
+| `RailSegment` | same shape as RoadSegment | same |
+| `HistoricRouteClaim` | same shape; uncertainty class required | same; alignment versions explicit |
+| `TradeRouteCorridor` | same shape; corridor envelope, not surveyed alignment | same |
+| `CorridorRoute` · `RouteMembership` | same | same |
+| `Crossing` · `Bridge` · `Ferry` · `RiverCrossing` | point identity + temporal scope | same |
+| `Depot` · `Siding` · `Yard` · `TransportFacility` | facility identity is **Settlements/Infrastructure-owned**; this runbook carries the *transport* relation. | same |
+| `RouteEvent` · `OperatorStatus` · `AccessRestriction` · `RestrictionEvent` | event identity + temporal scope | same |
+| `NetworkNode` · `NetworkEdge` | derived graph identity; rollback-distinct from canonical | derived; never replaces canonical |
+| `MovementStoryNode` | narrative identity bound to released evidence | linked to source/observed times |
+| `GeneralizationReceipt` | transform identity + input/output digests | always paired with public-safe geometry |
+
+### Key source families (CONFIRMED)
+
+| Source family | Role | Rights / sensitivity | Freshness |
+|---|---|---|---|
+| Census TIGER/Line roads | authority / observation / context / model | terms NEEDS VERIFICATION; sensitive joins fail-closed | source-vintage |
+| FHWA HPMS | authority / observation | terms NEEDS VERIFICATION | cadence-specific |
+| FHWA National Highway Freight Network | authority / context | terms NEEDS VERIFICATION | cadence-specific |
+| WZDx feeds | observation | terms NEEDS VERIFICATION | near-real-time; treat as observation, not authority |
+| KDOT / KanPlan / KanDrive / Kansas GIS | authority / observation | terms NEEDS VERIFICATION | cadence-specific |
+| County / state bridge and restriction data | authority / observation | terms NEEDS VERIFICATION | cadence-specific |
+| GNIS names | authority / context | terms NEEDS VERIFICATION | versioned |
+| OpenStreetMap | context / observation | **MUST NOT** be used as legal-status authority | crowd-cadence |
+| Historic maps · county atlases · military/emigrant trail sources | context | sensitive cultural-corridor flag possible | source-vintage |
+| Steward sources for sensitive cultural corridors | authority (restricted) | steward-only; **never** public-default | as steward defines |
+
+### Cross-lane relations (CONFIRMED doctrine)
+
+| This domain → related lane | Relation type | Constraint |
+|---|---|---|
+| Roads/Rail → Settlements / Infrastructure | depots · crossings · facilities · dependencies | preserve facility ownership; settlement-owned identity. |
+| Roads/Rail → Hydrology | bridge · ferry · ford · river-crossing | preserve hydrologic evidence ownership. |
+| Roads/Rail → Hazards | closure · detour · flood / fire / smoke exposure | KFM is **never** an alert authority. |
+| Roads/Rail → Archaeology / Cultural Heritage | historic routes · Indigenous corridors · forts · missions | exact archaeological coordinates **denied**; corridor reconstructions cited as context only. |
+
+[Back to top](#top)
+
+---
+
+## Promotion Gates A–G applied to Roads / Rail / Trade Routes
+
+The seven gates are CONFIRMED canonical (KFM Promotion Gate Matrix A–G). The mapping below shows what each gate checks **for this domain**. Per-gate validator names, Rego packages, and CI job names remain PROPOSED until mounted-repo verification.
+
+| Gate | Canonical intent (CONFIRMED) | Roads / Rail / Trade Routes specifics (PROPOSED) | Pass evidence | Default on failure |
+|---|---|---|---|---|
+| **A · Structure and Metadata** | MetaBlock present; zone correctness; placement matches Directory Rules. | KFM Meta Block present on doc artifacts; emitted records placed under `data/<phase>/roads-rail-trade/` and `release/candidates/roads-rail-trade/`; no path drift into a root domain folder. | `check_structure` PASS; placement audit clean. | `ERROR` → quarantine. |
+| **B · Schemas and Contracts** | Schema and OpenAPI validation against canonical homes. | `RoadSegment`, `RailSegment`, `HistoricRouteClaim`, `TradeRouteCorridor`, `Crossing`, `Bridge`, `Ferry`, `RouteEvent`, `OperatorStatus`, `AccessRestriction`, `NetworkEdge`, `GeneralizationReceipt` validate against `schemas/contracts/v1/domains/roads-rail-trade/*.schema.json`; layer manifests validate against the canonical `LayerManifest` schema. | Validator PASS with version pinned; spec_hash recorded. | `ERROR` → quarantine. |
+| **C · Policy Parity** | Same Rego bundle in CI (Conftest) and runtime. | `policy/domains/roads-rail-trade/*.rego` runs identically in CI and PDP; pinned by digest. | Conftest PASS; PDP digest matches CI digest. | `DENY` → fail-closed. |
+| **D · Security and Sensitivity** | Sensitivity, rights, license scans; living-person and culturally sensitive content checks. | **Indigenous trade / mobility corridors, oral history, treaty, cultural, and interpretive evidence default to steward review and generalized public geometry**; critical transport facilities require review; OSM / GNIS **may not** publish a legal-status determination; over-precise historic alignments without uncertainty profile are denied. | `RedactionReceipt` / `GeneralizationReceipt` present where required; license SPDX in allowlist; steward sensitivity review recorded. | `DENY` → quarantine; steward review required. |
+| **E · Data Quality** | DQ profilers / assertions with thresholds. | Route membership and designation are separable (no conflation); operator / status timelines temporally coherent; uncertainty class set for every `HistoricRouteClaim`; crossing / bridge / ferry references resolve to facility identity in Settlements / Infrastructure. | DQ assertions PASS at threshold; failed assertions emit a structured report. | `ERROR` → quarantine; remediation required. |
+| **F · Provenance and Lineage** | Receipt and lineage validation; PROV-O round-trip. | Every claim resolves `EvidenceRef → EvidenceBundle`; `RunReceipt` present for the producing pipeline; PROV-O / STAC / DCAT fragments emitted; graph / triplet projection labeled as **derived**, not canonical. | `EvidenceBundle` content-addressed; `RunReceipt` cosign-verified; lineage walk returns no orphans. | `ABSTAIN` (missing evidence) or `ERROR` (missing receipt). |
+| **G · Reviewability** | CODEOWNERS-enforced human approval plus policy approval (two-key). | Domain steward **and** release officer both approve; sensitivity steward additionally approves any cultural-corridor or critical-facility release; `PromotionReceipt` records both approval identities and timestamps. | `PromotionReceipt` carries two distinct, valid approval signatures bound to CODEOWNERS roles. | `DENY` until both approvals present and policy-significant duties separated. |
+
+> [!IMPORTANT]
+> **Auto-merge / auto-publish fires only when all seven gates pass.** Any gate failure blocks the transition. The matrix is the *complete* set; partial passage is not a partial release.
+
+[Back to top](#top)
+
+---
+
+## Operator procedure
+
+The procedure is grouped by lifecycle phase. Each step lists the **action**, the **evidence emitted**, and the **failure rule**. Commands shown are illustrative; exact tool names and flags are PROPOSED until repo verification.
+
+### Phase 0 — Pre-flight checks
+
+- [ ] You hold the domain-steward or release-officer role for `roads-rail-trade` (CODEOWNERS check).
+- [ ] The release officer is **a different person** than the producing operator when the release is policy-significant (cultural corridor, critical facility, schema-versioned change). Separation of duties is required at Gate G.
+- [ ] `SourceDescriptor` exists for every source you intend to admit; `source_role`, `rights`, `sensitivity`, `cadence`, and citation are present.
+- [ ] You have read the active sensitivity callouts in `docs/domains/roads-rail-trade/README.md` for cultural corridors and critical facilities.
+- [ ] No active `CorrectionNotice` or open rollback drill blocks the affected layer.
+
+### Phase 1 — RAW intake (admission, not promotion)
+
+> [!NOTE]
+> `RAW` is **not** a public surface. Admission to `RAW` does not imply promotion. Connectors emit to `data/raw/roads-rail-trade/` and quarantine — never to `data/processed/` or `data/published/`.
+
+1. Run the source connector or watcher. The connector emits a `RunReceipt` covering fetch metadata (ETag, Last-Modified, content length, source URL, fetch timestamp).
+2. Persist the immutable source payload (or governed reference) plus the `SourceDescriptor`.
+3. If `source_role`, `rights`, `sensitivity`, citation, or hash are missing → **route to `QUARANTINE`** with a structured reason. Do not proceed.
+4. Watchers MUST open a PR or candidate record — **never publish directly** (watcher-as-non-publisher invariant).
+
+**Emitted:** `RunReceipt` · `SourceDescriptor` (or update).
+
+### Phase 2 — WORK / QUARANTINE normalization
+
+1. Normalize schema, geometry, time, identity, evidence references, rights, and policy posture.
+2. For `HistoricRouteClaim` and `TradeRouteCorridor`, attach an uncertainty profile and explicit alignment-version. Over-precise historic geometry without uncertainty profile → quarantine (per the Roads/Rail validator set).
+3. For cross-lane references (crossings → settlements, bridges/fords → hydrology, closures → hazards, historic corridors → archaeology), resolve to the **owning lane's** canonical identity; do not invent identity here.
+4. For OSM / GNIS-derived legal-status claims → strip the claim; persist the geometry / name evidence but **do not** carry an OSM legal-status determination into `PROCESSED`.
+5. Failures hold in `QUARANTINE`; a quarantine reason record is required. Quarantine is not "later"; it is a governed holding state with its own review queue.
+
+**Emitted:** `RunReceipt` for the normalization run · quarantine reason record where applicable.
+
+### Phase 3 — PROCESSED (validated, but not yet public)
+
+1. Resolve `EvidenceRef → EvidenceBundle` for every claim. Unresolved evidence → `ABSTAIN` (Gate F).
+2. Emit `ValidationReport` covering shape (Gate B), meaning (contract conformance), and domain-specific assertions (Gate E).
+3. Apply public-safe transforms where sensitivity policy requires generalization (cultural corridors, critical facilities, precise historic alignments). Each transform emits a `GeneralizationReceipt` or `RedactionReceipt` with input / output geometry digests and reasoning.
+4. Compute a canonical `spec_hash` from the JCS-canonicalized record. Same evidence → same hash, deterministically.
+
+**Emitted:** `ValidationReport` · `EvidenceRef` chain · `GeneralizationReceipt` / `RedactionReceipt` as needed · `RunReceipt`.
+
+### Phase 4 — CATALOG / TRIPLET (release candidate)
+
+1. Emit the `EvidenceBundle` (JSON-LD, content-addressed by `spec_hash`).
+2. Emit catalog records and the graph / triplet projection, **labeled derived**. The graph never replaces canonical records.
+3. Emit a release candidate under `release/candidates/roads-rail-trade/<release-id>/`.
+4. Run the **full** Gate A–G evaluation against the candidate. Joined decision records carry a shared `decision_id`.
+
+**Emitted:** `EvidenceBundle` · catalog records · graph projection (derived) · candidate `ReleaseManifest` · gate decision records.
+
+### Phase 5 — PUBLISHED (governed release)
+
+1. If all seven gates PASS → produce the signed `PromotionReceipt` enumerating Gates A–G.
+2. Bind the release to a `ReleaseManifest` that records: artifact digests, policy posture, review state, correction path, and rollback target.
+3. Sign with DSSE; record cosign verification; (optionally) anchor via Rekor.
+4. Promote to `release/published/roads-rail-trade/<release-id>/`. The governed API is the **only** route public clients use; no direct reads of canonical stores.
+5. Open the paired `RollbackCard` in `release/rollback/roads-rail-trade/<release-id>/`. Every release MUST have a rollback target, even if the rollback is "forward fix only" with stated reason.
+
+**Emitted:** `PromotionReceipt` (Gates A–G) · `ReleaseManifest` · DSSE signature · `RollbackCard`.
+
+> [!TIP]
+> If a partial set of gates passes and one fails, the right action is **always** quarantine plus a structured reason — never "publish the safe parts now and fix the rest later." Lifecycle skip is an anti-pattern (Directory Rules §13.5).
+
+[Back to top](#top)
+
+---
+
+## Sensitivity, generalization, and fail-closed defaults
+
+This domain has explicit, CONFIRMED sensitivity posture. The defaults below apply unless a steward decision documented in the `PromotionReceipt` overrides them with stated reason.
+
+| Class | Default posture | Required transform | Required reviewer |
+|---|---|---|---|
+| Indigenous trade and mobility corridors | **Steward review** required; geometry **generalized** for public release. | Corridor envelope, not surveyed alignment; precision generalization to reviewer-stated tolerance. | Cultural / sensitivity steward + domain steward. |
+| Oral history, treaty, or interpretive route evidence | Steward review; public release **default-off**. | `RedactionReceipt`; cited as context, not as authoritative alignment. | Cultural / sensitivity steward. |
+| Uncertain historic alignments (wagon, military, emigrant, stage, cattle) | Uncertainty profile **required**; over-precise geometry denied. | `GeneralizationReceipt` with stated tolerance and uncertainty class. | Domain steward. |
+| Critical transport facilities (bridges, ferries, designated freight nodes flagged as critical) | Review required before public detail. | Sensitivity-aware projection; precision suppression where harmful. | Sensitivity steward + domain steward. |
+| OSM- or GNIS-derived legal status | **Never** published as legal authority. | Strip status; retain geometry / name only. | Validator; no steward override at Gate C. |
+| Cross-domain join with archaeology (historic corridor near a site) | Exact archaeological coordinates **denied** by default. | Archaeology lane controls site geometry; this lane carries only the corridor. | Archaeology steward. |
+
+> [!WARNING]
+> Unclear rights, unresolved source role, missing evidence, unresolved sensitivity, or absent release state **MUST** block public promotion (CONFIRMED doctrine, Directory Rules §3, Lifecycle Law). The default is `DENY`, not "publish and revisit."
+
+[Back to top](#top)
+
+---
+
+## Failure modes and quarantine handling
+
+| Failure | Detected at | Outcome | Remediation |
+|---|---|---|---|
+| Missing `SourceDescriptor` field (role / rights / sensitivity / citation / hash). | Phase 1 RAW intake. | `QUARANTINE`. | Source steward populates descriptor; re-admit. |
+| Geometry / time / identity normalization fails. | Phase 2. | `QUARANTINE`. | Pipeline operator + domain steward repair; re-run. |
+| OSM / GNIS attempts to set legal status. | Phase 2 / Gate C. | `DENY`. | Strip claim; retain underlying observation only. |
+| Over-precise historic alignment, no uncertainty profile. | Phase 2 / Gate E. | `QUARANTINE`. | Attach uncertainty profile; apply `GeneralizationReceipt`. |
+| `EvidenceRef` does not resolve to `EvidenceBundle`. | Phase 3 / Gate F. | `ABSTAIN`. | Re-resolve; if unresolvable, drop the claim. |
+| Cultural corridor flagged but no sensitivity review recorded. | Gate D. | `DENY`. | Sensitivity steward review; record decision in `PromotionReceipt`. |
+| Single-approver attempt on policy-significant release. | Gate G. | `DENY`. | Second approver required; release officer ≠ producer. |
+| Spec hash mismatch (recomputation differs from recorded). | Gate B / Gate F. | `ERROR` → quarantine. | Re-canonicalize; investigate non-determinism. |
+| Cosign signature invalid or absent. | Phase 5. | `DENY`. | Re-sign; verify key chain; abort release if unresolved. |
+| Rollback target missing or stale. | Phase 5 / Gate G. | `DENY`. | Pair release with `RollbackCard` covering the prior root hash / manifest reference. |
+
+[Back to top](#top)
+
+---
+
+## Negative-path fixtures
+
+Negative-path coverage is mandatory; fail-closed gates are only meaningful when proven by failing inputs. The fixture list below is PROPOSED in shape and home; exact filenames are NEEDS VERIFICATION until landed.
+
+```text
+tests/domains/roads-rail-trade/negative/
+fixtures/domains/roads-rail-trade/invalid/
+```
+
+| Fixture | Asserted outcome | Gate exercised |
+|---|---|---|
+| `missing_source_role.json` | `DENY` | Gate D · source-role check |
+| `osm_legal_status_claim.json` | `DENY` (claim stripped) | Gate C · policy parity |
+| `historic_route_no_uncertainty.json` | `QUARANTINE` | Gate E · data quality |
+| `cultural_corridor_no_review.json` | `DENY` | Gate D · sensitivity review |
+| `evidence_ref_unresolvable.json` | `ABSTAIN` | Gate F · provenance |
+| `spec_hash_mismatch.json` | `ERROR` | Gate B · schemas / Gate F · receipts |
+| `single_approver_policy_significant.json` | `DENY` | Gate G · two-key approval |
+| `release_manifest_no_rollback.json` | `DENY` | Gate G · review / rollback target |
+| `graph_projection_published_as_canonical.json` | `DENY` | Gate F · derived-vs-canonical labeling |
+
+[Back to top](#top)
+
+---
+
+## Receipts and artifacts emitted
+
+CONFIRMED doctrine: receipts are not optional when an operation is consequential. If no receipt exists, the operation did not happen in the governed sense.
+
+| Artifact | Emitted at | PROPOSED schema home | Lifetime |
+|---|---|---|---|
+| `SourceDescriptor` | RAW intake | `schemas/contracts/v1/sources/source_descriptor.schema.json` | Immutable; supersession via new descriptor + lineage. |
+| `RunReceipt` | Every pipeline run | `schemas/contracts/v1/receipts/run_receipt.schema.json` | Permanent; signed. |
+| `GeneralizationReceipt` / `RedactionReceipt` | Public-safe transform | `schemas/contracts/v1/receipts/transform_receipt.schema.json` | Permanent; bound to release. |
+| `ValidationReport` | Phase 3 | `schemas/contracts/v1/validation/validation_report.schema.json` | Permanent. |
+| `EvidenceBundle` | Phase 4 | `schemas/contracts/v1/evidence/evidence_bundle.schema.json` | Content-addressed; immutable. |
+| `PromotionReceipt` (Gates A–G) | Phase 5 | `schemas/contracts/v1/receipts/promotion_receipt.schema.json` | Permanent; signed. |
+| `ReleaseManifest` | Phase 5 | `schemas/contracts/v1/release/release_manifest.schema.json` | Permanent. |
+| `RollbackCard` | Phase 5 | `schemas/contracts/v1/release/rollback_card.schema.json` | Paired with release; survives release retirement. |
+| `CorrectionNotice` | On correction | `schemas/contracts/v1/release/correction_notice.schema.json` | Permanent; carries supersession link. |
+| `ReviewRecord` | At Gate G | `schemas/contracts/v1/review/review_record.schema.json` | Permanent; carries reviewer identities. |
+| `DecisionEnvelope` (per gate) | Each gate | `schemas/contracts/v1/decisions/decision_envelope.schema.json` | Permanent; joined by `decision_id`. |
+
+[Back to top](#top)
+
+---
+
+## Rollback and correction
+
+Rollback is a **governance event**, not an emergency hack.
+
+### Rollback procedure (PROPOSED operational shape)
+
+1. Identify the affected release via `release/published/roads-rail-trade/<release-id>/`.
+2. Locate the paired `RollbackCard` in `release/rollback/roads-rail-trade/<release-id>/`. It names the prior root hash, manifest reference, and tile / artifact checksum set.
+3. Two-key approval: domain steward + release officer (Gate G mirror).
+4. Promote the prior `ReleaseManifest` back to active via the same governed transition — **never** a manual file move.
+5. Emit a fresh `PromotionReceipt` for the rollback transition. Gates A–G evaluate over the rollback, not the original release.
+6. Open a `CorrectionNotice` linked to the superseded release. Citations to the prior release MUST be updated through the governed API.
+
+### Correction procedure
+
+1. File a `CorrectionNotice` referencing the affected `EvidenceBundle` `spec_hash` and the specific claim.
+2. Re-run the lifecycle from the lowest phase the correction touches (usually Phase 2 or Phase 3).
+3. The new release supersedes — never silently overwrites — the prior release. Both remain inspectable.
+
+> [!CAUTION]
+> A rollback that has no paired `RollbackCard`, or a correction that does not preserve the superseded artifact for audit, is an invariant violation. Halt and escalate to the docs steward.
+
+[Back to top](#top)
+
+---
+
+## Governed AI posture for this domain
+
+AI may **summarize** released Roads / Rail / Trade Routes `EvidenceBundle`s, **compare** evidence across sources, **explain** uncertainty, and **draft** steward-review notes. AI must `ABSTAIN` when evidence is insufficient and `DENY` where policy, rights, sensitivity, or release state blocks the request. AI must `ERROR` cleanly on internal failure.
+
+| AI may | AI must not |
+|---|---|
+| Summarize a released route's evidence and limitations. | Establish truth about a route, alignment, or restriction. |
+| Compare two source claims for the same corridor. | Bypass steward review on cultural corridors or critical facilities. |
+| Draft a steward-review note explaining a sensitivity concern. | Publish an unsigned claim or substitute generated language for an `EvidenceBundle`. |
+| Surface a `RunReceipt` for inspection. | Override a `DENY` policy decision under any framing. |
+| Project a public-safe popup or Evidence Drawer payload. | Read `RAW`, `WORK`, `QUARANTINE`, or unpublished candidates directly from a public client. |
+
+[Back to top](#top)
+
+---
+
+## Verification backlog and open questions
+
+NEEDS VERIFICATION until a mounted repo or accepted ADR settles each.
+
+| Item | Evidence that would settle it | Status |
+|---|---|---|
+| Live KDOT / FHWA / FRA / WZDx source terms and rights. | `data/registry/sources/roads-rail-trade/` entries + license SPDX in allowlist. | NEEDS VERIFICATION |
+| Indigenous / cultural corridor policy text and reviewer assignments. | `policy/domains/roads-rail-trade/sensitivity_cultural_corridor.rego` + steward CODEOWNERS. | NEEDS VERIFICATION |
+| `RouteUncertaintyProfile` shape and validator. | Schema landed under `schemas/contracts/v1/domains/roads-rail-trade/`. | NEEDS VERIFICATION |
+| Transport graph projection and MapLibre integration boundary. | ADR (renderer-as-non-truth) + accompanying tests. | NEEDS VERIFICATION |
+| Two-key approval enforcement (Gate G) on policy-significant releases. | CODEOWNERS + branch protection + Conftest rule. | NEEDS VERIFICATION |
+| Path convention for domain runbooks: `docs/runbooks/<domain>/` vs `docs/runbooks/<domain>_PROMOTION.md`. | An accepted ADR or per-root README directive in `docs/runbooks/`. | NEEDS VERIFICATION |
+| Existence of canonical `docs/architecture/promotion-gates.md` (gate definitions referenced by this runbook). | File presence + cross-linking. | NEEDS VERIFICATION |
+| CI workflow name(s) that implement Gates A–G for this domain. | `.github/workflows/*` and required-checks branch protection. | NEEDS VERIFICATION |
+
+[Back to top](#top)
+
+---
+
+## Related docs
+
+PROPOSED links; targets exist as doctrine references and may not all be landed.
+
+- `docs/doctrine/directory-rules.md` — placement authority for every artifact this runbook emits.
+- `docs/doctrine/lifecycle-law.md` — `RAW → PUBLISHED` invariant.
+- `docs/doctrine/truth-posture.md` — cite-or-abstain default.
+- `docs/doctrine/trust-membrane.md` — public clients consume governed APIs only.
+- `docs/architecture/promotion-gates.md` — canonical Gate A–G specification.
+- `docs/domains/roads-rail-trade/README.md` — domain scope, ubiquitous language, object families.
+- `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` — `SourceDescriptor` intake standard.
+- `docs/adr/ADR-0001-schema-home.md` — schemas live under `schemas/contracts/v1/`.
+- `policy/domains/roads-rail-trade/` — gate logic and sensitivity policy.
+- `release/candidates/roads-rail-trade/` and `release/published/roads-rail-trade/` — release homes.
+- TODO: cross-link the Settlements / Infrastructure, Hydrology, Hazards, and Archaeology promotion runbooks once they exist.
+
+[Back to top](#top)
+
+---
+
+## Appendix — receipt sketches
+
+The shapes below are PROPOSED illustrative skeletons. They show the joins this runbook depends on (`decision_id`, `spec_hash`, gate identifiers). Authoritative shape lives in `schemas/contracts/v1/`.
+
+<details>
+<summary><b>Illustrative <code>RunReceipt</code> (PROPOSED shape)</b></summary>
+
+```json
+{
+  "object_type": "RunReceipt",
+  "schema_version": "v1",
+  "decision_id": "<uuid>",
+  "domain": "roads-rail-trade",
+  "phase": "PROCESSED",
+  "pipeline": "roads-rail-trade/normalize",
+  "spec_hash": "sha256:<jcs-canonicalized-hash>",
+  "inputs": [
+    { "source_descriptor_ref": "kfm://source/<id>", "fetch_etag": "<etag>" }
+  ],
+  "outputs": [
+    { "object_type": "RoadSegment", "digest": "sha256:<...>" }
+  ],
+  "tool_versions": { "normalizer": "<pin>", "validator": "<pin>" },
+  "policy_decision_ref": "kfm://decision/<decision_id>",
+  "evidence_refs": [ "kfm://evidence/<bundle-id>" ],
+  "actor": "<runner-identity>",
+  "timestamp": "2026-05-12T00:00:00Z"
+}
+```
+
+</details>
+
+<details>
+<summary><b>Illustrative <code>PromotionReceipt</code> with Gates A–G (PROPOSED shape)</b></summary>
+
+```json
+{
+  "object_type": "PromotionReceipt",
+  "schema_version": "v1",
+  "decision_id": "<uuid>",
+  "domain": "roads-rail-trade",
+  "release_id": "<release-id>",
+  "release_manifest_ref": "kfm://release/roads-rail-trade/<release-id>",
+  "spec_hash": "sha256:<...>",
+  "gates": {
+    "A_structure_metadata": { "outcome": "ANSWER", "evidence_refs": ["..."] },
+    "B_schemas_contracts": { "outcome": "ANSWER", "evidence_refs": ["..."] },
+    "C_policy_parity":     { "outcome": "ANSWER", "evidence_refs": ["..."] },
+    "D_security_sensitivity": {
+      "outcome": "ANSWER",
+      "evidence_refs": ["..."],
+      "review_record_ref": "kfm://review/<id>"
+    },
+    "E_data_quality":      { "outcome": "ANSWER", "evidence_refs": ["..."] },
+    "F_provenance_lineage": {
+      "outcome": "ANSWER",
+      "evidence_bundle_ref": "kfm://evidence/<bundle-id>"
+    },
+    "G_reviewability": {
+      "outcome": "ANSWER",
+      "approvals": [
+        { "role": "domain-steward", "actor": "<id>", "timestamp": "..." },
+        { "role": "release-officer", "actor": "<id>", "timestamp": "..." }
+      ]
+    }
+  },
+  "outcome": "ANSWER",
+  "rollback_card_ref": "kfm://rollback/<release-id>",
+  "signature": { "type": "DSSE", "key_id": "<cosign-key>", "rekor_ref": "<optional>" },
+  "timestamp": "2026-05-12T00:00:00Z"
+}
+```
+
+</details>
+
+<details>
+<summary><b>Illustrative <code>RollbackCard</code> (PROPOSED shape)</b></summary>
+
+```json
+{
+  "object_type": "RollbackCard",
+  "schema_version": "v1",
+  "domain": "roads-rail-trade",
+  "release_id": "<release-id>",
+  "prior_release_manifest_ref": "kfm://release/roads-rail-trade/<prior-id>",
+  "prior_root_hash": "<hash>",
+  "rollback_target_state": "release/published/roads-rail-trade/<prior-id>/",
+  "rehearsal_status": "REHEARSED | NEEDS_REHEARSAL | FORWARD_FIX_ONLY",
+  "forward_fix_reason": "<required iff rehearsal_status = FORWARD_FIX_ONLY>",
+  "approvers": [
+    { "role": "domain-steward", "actor": "<id>" },
+    { "role": "release-officer", "actor": "<id>" }
+  ],
+  "timestamp": "2026-05-12T00:00:00Z"
+}
+```
+
+</details>
+
+[Back to top](#top)
+
+---
+
+**Related docs:** [Directory Rules](../../doctrine/directory-rules.md) · [Lifecycle Law](../../doctrine/lifecycle-law.md) · [Promotion Gates A–G](../../architecture/promotion-gates.md) · [Roads / Rail / Trade Routes domain README](../../domains/roads-rail-trade/README.md)
+
+**Last updated:** 2026-05-12 · **Status:** `draft` · **[Back to top](#top)**

--- a/docs/runbooks/roads-rail-trade/ROLLBACK_RUNBOOK.md
+++ b/docs/runbooks/roads-rail-trade/ROLLBACK_RUNBOOK.md
@@ -1,3 +1,530 @@
-# roads-rail-trade :: ROLLBACK runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/roads-rail-trade/rollback
+title: Roads / Rail / Trade Routes — Rollback Runbook
+type: standard
+version: v1
+status: draft
+owners: [Docs steward, Roads/Rail/Trade lane owner, Release authority]
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/architecture/correction-and-rollback.md
+  - docs/domains/roads-rail-trade/README.md
+  - docs/runbooks/governed_ai_ROLLBACK.md
+  - docs/adr/ADR-0001-schema-home.md
+  - release/candidates/roads-rail-trade/
+  - data/receipts/README.md
+  - data/proofs/README.md
+  - schemas/contracts/v1/domains/roads-rail-trade/
+tags: [kfm, runbook, rollback, roads-rail-trade, governance, release]
+notes:
+  - Doctrine is CONFIRMED from attached KFM corpus.
+  - All path-shaped claims about *this repo* are PROPOSED until verified against mounted-repo evidence.
+  - Placement follows Directory Rules §12 (Domain Placement Law) and the existing docs/runbooks/* convention.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+<a id="top"></a>
+
+# Roads / Rail / Trade Routes — Rollback Runbook
+
+> **Reversible withdrawal and restoration of public-safe Roads, Rail, and Trade-Routes releases through the governed release path — pointer-shift, not file delete; audit-preserving, not memory-holing.**
+
+![Status: draft](https://img.shields.io/badge/status-draft-yellow)
+![Type: runbook](https://img.shields.io/badge/type-runbook-blue)
+![Domain: roads--rail--trade](https://img.shields.io/badge/domain-roads--rail--trade-1f6feb)
+![Lifecycle: PUBLISHED → rollback target](https://img.shields.io/badge/lifecycle-PUBLISHED%20%E2%86%92%20rollback%20target-7e57c2)
+![Policy: public](https://img.shields.io/badge/policy-public-green)
+<!-- TODO badges to verify: CI workflow badge for release/rollback drill; coverage of rollback fixtures. -->
+
+| Field | Value |
+|---|---|
+| **Status** | draft |
+| **Owners** | Docs steward · Roads/Rail/Trade lane owner · Release authority |
+| **Reviewers required** | Release authority + lane owner; additional steward sign-off for Indigenous / cultural corridors |
+| **Last updated** | 2026-05-12 |
+| **Doctrine basis** | CONFIRMED — KFM domain atlas, encyclopedia, unified build manual, MapLibre master, Directory Rules |
+| **Implementation basis** | PROPOSED — exact route names, schema homes, CI wiring, and deployed behavior remain `NEEDS VERIFICATION` |
+
+---
+
+## Table of contents
+
+1. [Scope and non-scope](#1-scope-and-non-scope)
+2. [Doctrine basis and truth labels](#2-doctrine-basis-and-truth-labels)
+3. [When to run this runbook](#3-when-to-run-this-runbook)
+4. [Preconditions](#4-preconditions)
+5. [Roles and separation of duties](#5-roles-and-separation-of-duties)
+6. [Rollback flow at a glance](#6-rollback-flow-at-a-glance)
+7. [Procedure](#7-procedure)
+8. [Roads / Rail / Trade-specific concerns](#8-roads--rail--trade-specific-concerns)
+9. [Verification checklist](#9-verification-checklist)
+10. [Failure modes and anti-patterns](#10-failure-modes-and-anti-patterns)
+11. [Artifacts touched](#11-artifacts-touched)
+12. [Appendix — receipt and manifest sketches](#12-appendix--receipt-and-manifest-sketches)
+13. [Verification backlog](#13-verification-backlog)
+14. [Related docs](#14-related-docs)
+
+---
+
+## 1. Scope and non-scope
+
+This runbook governs **rollback of a published Roads / Rail / Trade-Routes release** — i.e., reversing a release that already cleared the publication gate and is now in `PUBLISHED` state.
+
+**In scope.** Released road segments, rail segments, historic routes, trade-route corridors, depots, sidings, yards, crossings, bridges, ferries, river crossings, freight corridors, route events, operator-status records, access restrictions, network-edge / graph projections, `MovementStoryNode` exposures, and any released `LayerManifest`, `TileArtifactManifest`, `StyleManifest`, or `EvidenceDrawerPayload` whose source-of-truth lives in the Roads / Rail / Trade lane.
+
+**Out of scope.**
+
+- **Pre-publication retraction.** A defect found before `PUBLISHED` is a promotion gate failure handled by validation and review, not by this runbook. Send it back to `WORK / QUARANTINE`.
+- **Settlements / Infrastructure canonical claims.** Settlement, depot identity, and infrastructure-ownership records are owned by Settlements/Infrastructure; rolling those back follows that lane's runbook.
+- **Hydrology, Archaeology/Cultural Heritage, Hazards.** Crossings of river or sensitive cultural geometry that originate in those lanes follow their lane runbooks; this runbook only rolls back the *transport-side* derivative.
+- **Emergency alerting.** KFM is never an alert authority. WZDx or live restriction feeds are governed evidence, not life-safety guidance. Redirect users to the official source.
+- **Governed AI answers and Focus Mode.** `AIReceipt`-level retraction is handled by `docs/runbooks/governed_ai_ROLLBACK.md`. This runbook only rolls back the underlying domain release that an AI answer may have cited.
+
+> [!NOTE]
+> A rollback is a **governed state transition**, not a file move and not a delete. The rollback target is a *pointer to a prior `ReleaseManifest`, `root_hash`, and tile-checksum set*; the prior artifacts and the retracted artifacts both remain inspectable.
+
+---
+
+## 2. Doctrine basis and truth labels
+
+| Claim | Label | Source |
+|---|---|---|
+| Lifecycle invariant `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` with promotion as a governed state transition | CONFIRMED | Directory Rules §0; Unified Build Manual §7; Encyclopedia |
+| Released claims, layers, catalog records, artifacts, and AI answers MUST carry a visible correction path **and** rollback target before they are safely publishable | CONFIRMED | Unified Build Manual — Correction and rollback model |
+| Rollback flow: identify affected release → locate prior safe artifact set → verify digests/manifests → disable or withdraw affected public surfaces → preserve audit receipts → mark stale or withdrawn UI state → restore or republish via the same governed release path | CONFIRMED doctrine | Unified Build Manual — Correction and rollback model |
+| `ReleaseManifest` rollback target is **pointer-based** — tile variants are kept and lineage/catalog references shift back to a prior `tile_id` / `root_hash` set | CONFIRMED doctrine | Master MapLibre — ML-057-047, ML-058-031, ML-058-043, ML-058-044, ML-058-045 |
+| Revocation is **not** deletion — a signed tombstone receipt is appended to the audit ledger; UI/API hide tombstoned items while lineage remains explorable | CONFIRMED doctrine | KFM Components — C5-09, C1-06, C6-08 |
+| Roads / Rail / Trade rollback gate includes route-membership/designation separation, operator-status temporality, OSM/GNIS legal-status denial, historic-overprecision denial, public-generalization receipt, and transport-graph projection rollback | CONFIRMED doctrine | Domain Atlas — Roads, Rail, and Trade Routes §K |
+| Indigenous trade and mobility corridors, oral history, treaty, cultural, and interpretive evidence default to steward review and generalized public geometry; critical transport facilities require review | CONFIRMED doctrine | Domain Atlas §I; Encyclopedia §7.11 |
+| Cache invalidation (CDN/client) must accompany rollback or stale tiles can leak retracted content | CONFIRMED doctrine | Master MapLibre — Cache invalidation record; KFM Components C6-08 |
+| Exact route names, schema homes, CI workflow names, governed API routes, and deployed behavior for this lane | UNKNOWN / NEEDS VERIFICATION | Domain Atlas §J, §N; Unified Build Manual §6.8 |
+
+Memory is not evidence. Every implementation specific in this runbook (path, schema name, command, owner identity) is **PROPOSED** until verified against mounted-repo evidence.
+
+---
+
+## 3. When to run this runbook
+
+A rollback is the correct response to a **defect class** discovered after publication. Other responses (forward-fix correction, supersession by next release, ABSTAIN) may apply in parallel; rollback is the path when **continued public exposure is the worse outcome**.
+
+| Defect class | Rollback posture | Forward correction available? | Notes |
+|---|---|---|---|
+| **Evidence gap** — released claim no longer supported by an `EvidenceBundle` (source retracted, evidence invalidated, citation broken) | Restore prior evidence-supported release | Yes, if superseding evidence is admissible | `EvidenceBundle` outranks generated language; do not patch by paraphrase |
+| **Source-role error** — OSM / GNIS / WZDx / KDOT row promoted to `authority` when it was `observation` or `context`; cattle-trail narrative promoted to surveyed alignment | Restore prior release; reclassify source-role at admission, not at promotion | No — role is fixed at admission | See Domain Atlas §K *route membership and designation separation* |
+| **Rights / license defect** — feed license unknown, attribution missing, terms changed, ETag / `Last-Modified` provenance broken | Restore prior release; quarantine the offending source pending re-admission | Only after rights re-verified | WZDx and other transport feeds explicitly require license-from-feed proof |
+| **Sensitivity / sovereignty defect** — Indigenous trade or mobility corridor exposed at precision, treaty / oral-history corridor exposed without steward review, sensitive cultural-route geometry leaked | **Roll back immediately**; notify cultural steward; generalize or suppress before any re-release | Only after steward review records `ALLOW` or `RESTRICT` with conditions | Default is **steward review + generalized public geometry** |
+| **Geometry / precision defect** — historic alignment published at modern-survey precision; route narrative collapsed onto surveyed centerline; uncertainty class lost | Restore prior release with `GeneralizationReceipt`; fix uncertainty labeling | Yes, when uncertainty class can be re-stated | Historic overprecision is a named denial gate |
+| **Temporal defect** — operator-status or route-event published with wrong valid-time / observed-time / retrieval-time; restriction-event valid window incorrect | Restore prior release; recompute temporal scope | Yes, if `valid_time` is the only field affected | Keep source / observed / valid / retrieval / release / correction times **distinct** |
+| **Policy defect** — `policy_label = unknown`, `rights_status = unknown`, `sensitivity ≠ public`, missing `evidence_refs`, missing artifacts, or `rollback_supported = false` slipped through | Restore prior release; treat the missed gate as an incident | Forward-fix only after policy fixtures pass | Public runtime rule for `ReleaseManifest` is fail-closed |
+| **Validation defect** — `ValidationReport` claimed pass under stale inputs; schema validation drifted; spec_hash mismatch | Restore prior release; re-run validators on deterministic inputs | Yes, if validators newly pass | Spec_hash and digest closure must hold |
+| **Rendering defect** — tile root hash mismatch, `VerifyReceipt` failed digest / bounds / schema, `RuntimeProbeResult` exceeded budget after release | Shift tile lineage pointer to prior root_hash; invalidate caches | Yes, after rebuild | Tile variants are kept; pointers move |
+| **API defect** — `RoadsRailDecisionEnvelope` returns wrong outcome class (e.g., `ANSWER` where doctrine requires `ABSTAIN`); layer manifest resolver returns non-public artifact | Withdraw the affected route surface; restore prior contract | Yes, after contract test passes | Finite outcomes must remain finite |
+| **AI-output defect** — Focus Mode answer cites retracted Roads/Rail/Trade evidence | Roll back the **domain release first**; then follow `governed_ai_ROLLBACK.md` to retract the `AIReceipt` | Both | AI never root truth |
+
+> [!IMPORTANT]
+> If a defect involves **rights, sovereignty, cultural sensitivity, living-person data, archaeology, infrastructure precision, or rare / sensitive location exposure** — prefer **quarantine, redaction, generalization, staged access, delayed publication, or denial** over forward-fix. Roll back first; debate scope after the public surface is safe.
+
+---
+
+## 4. Preconditions
+
+A rollback MUST NOT begin until each of the following is true. Use this as a checklist in the incident channel before the first state-changing command.
+
+- [ ] **Affected release is identified.** A specific `release_id` (or set of `release_id`s) is named, with its `ReleaseManifest` digest and its `rollback_target`.
+- [ ] **Rollback target exists and is valid.** The prior `ReleaseManifest` is fetchable, its artifact digests verify, its policy posture is `release_state = PUBLISHED`, `policy_label != unknown`, `rights_status != unknown`, `sensitivity == public`, and its `evidence_refs` and artifact hashes are present.
+- [ ] **Defect class is named.** One or more rows from the table in §3 is selected; defect is recorded in the incident ledger.
+- [ ] **Receipts are loadable.** `RunReceipt`, `ValidationReport`, `PolicyDecision`, `VerifyReceipt`, and the relevant `EvidenceBundle`s for both the affected release and the rollback target are accessible.
+- [ ] **Audit ledger is writable.** A new tombstone / rollback record can be appended; the ledger is append-only and not in degraded mode.
+- [ ] **Cache invalidation surfaces are reachable.** The CDN / tile-server / client cache invalidation hooks bound to the affected `LayerManifest` are responsive.
+- [ ] **Separation of duties is satisfied.** The author of the affected release is **not** the sole approver of the rollback. Sensitive lanes require a cultural / rights steward in addition to the release authority.
+- [ ] **Communication plan is staged.** Steward, downstream consumer, and public-surface notice messages are drafted (not yet sent).
+
+> [!WARNING]
+> If any precondition is missing — especially a valid rollback target — **do not roll back blind.** Withdraw the affected public surface with `ABSTAIN` / withdrawn-state UI markers, open a `CorrectionNotice` candidate, and escalate to release authority for a *new* governed release rather than a rollback.
+
+---
+
+## 5. Roles and separation of duties
+
+Rollback is a release-class action. The roles below MUST be distinct people (or at minimum, distinct approval seats); a single actor MUST NOT both author and approve a rollback on a sensitive lane.
+
+| Role | Responsibility |
+|---|---|
+| **Incident initiator** | Files the defect, names the defect class, opens the incident ticket. May be anyone with read access to the lane. |
+| **Lane owner (Roads / Rail / Trade)** | Confirms defect class fits the lane, identifies the affected release, names the rollback target candidate. |
+| **Release authority** | Approves the rollback, signs the new `ReleaseManifest` (rollback target re-asserted), authorizes cache invalidation. MUST be distinct from the release's original author for sensitive lanes. |
+| **Cultural / rights steward** | Required when the defect touches Indigenous trade / mobility corridors, treaty corridors, oral-history geometry, archaeology adjacency, or living-person data. Approves or denies the rollback's exposure posture. |
+| **Validator / proof reviewer** | Re-runs `ValidationReport`, `VerifyReceipt`, and the rollback drill fixture against the rollback target; signs the drill receipt. |
+| **Communications steward** | Drafts and dispatches steward, downstream-consumer, and public-surface notices; records the notice references in the incident ledger. |
+| **Auditor (post-hoc)** | Reviews the closed incident, the appended tombstone, the rollback receipt chain, and the post-mortem. |
+
+> [!TIP]
+> The watcher-as-non-publisher invariant still applies in rollback: a worker / watcher can **propose** a rollback candidate and emit receipts, but it MUST NOT execute the release-authority step. Automated rollback shortcuts that bypass this rule become the normal public path and harden into bypass authority.
+
+---
+
+## 6. Rollback flow at a glance
+
+```mermaid
+flowchart TD
+  A[Defect observed in PUBLISHED release] --> B{Defect class<br/>identifiable?}
+  B -- No --> Z1[Open CorrectionNotice candidate;<br/>quarantine surface; do not roll back blind]
+  B -- Yes --> C[Lane owner names release_id<br/>+ rollback_target candidate]
+  C --> D{Rollback target valid?<br/>policy = PUBLISHED,<br/>rights known, sensitivity = public,<br/>evidence_refs + artifact hashes present,<br/>rollback_supported = true}
+  D -- No --> Z1
+  D -- Yes --> E[Release authority approves;<br/>steward approval if sensitive lane]
+  E --> F[Withdraw / mark stale<br/>affected public surfaces]
+  F --> G[Shift LayerManifest / TileArtifactManifest /<br/>StyleManifest pointers to rollback target]
+  G --> H[Invalidate CDN + client caches;<br/>emit invalidation receipt]
+  H --> I[Append tombstone receipt to audit ledger<br/>pointing at retracted release_id]
+  I --> J[Verify: digests match,<br/>VerifyReceipt passes,<br/>RuntimeProbeResult within budget,<br/>policy gate fixtures green]
+  J --> K[Publish superseding ReleaseManifest;<br/>previous rollback chain preserved]
+  K --> L[Notify stewards, downstream consumers,<br/>public surface; close incident]
+  L --> M[Post-mortem;<br/>add fixture if new failure mode;<br/>update VERIFICATION_BACKLOG]
+
+  classDef danger fill:#fde2e2,stroke:#c33,color:#600
+  classDef safe fill:#e3f5e3,stroke:#2a8,color:#063
+  class Z1 danger
+  class K,L,M safe
+```
+
+> [!NOTE]
+> The diagram is a **doctrinal flow**. Concrete tool names, CLI commands, dashboard URLs, and CI job identifiers are `UNKNOWN` until verified against mounted-repo evidence.
+
+---
+
+## 7. Procedure
+
+Each step lists: *who*, *what*, *evidence required*, and *exit condition*. Do not skip ahead. Stop at any step whose exit condition is not met and escalate.
+
+### 7.1 Step 1 — Triage and classify
+
+- **Who.** Incident initiator + lane owner.
+- **What.** Confirm the surface is in `PUBLISHED` state. Name the affected `release_id`(s). Map the defect to one or more rows in §3.
+- **Evidence required.** Current `ReleaseManifest`; the surface, drawer, or AI response that exposed the defect; any user / steward report.
+- **Exit condition.** Defect class is named in the incident ticket; severity is set; sensitive-lane flag is set if applicable.
+
+### 7.2 Step 2 — Identify and validate the rollback target
+
+- **Who.** Lane owner + validator.
+- **What.** Fetch the previous `ReleaseManifest` (or earlier, if the previous one is also affected). Re-verify against the public runtime rule:
+
+  > A public client may consume a `ReleaseManifest` only when `release_state == PUBLISHED`, `policy_label != unknown`, `rights_status != unknown`, `sensitivity == public`, `evidence_refs` are present, artifact hashes are present, `rollback_supported == true`, and policy `allow == true`.
+
+  Re-verify `EvidenceBundle` digests, `RunReceipt` lineage, and (for tile artifacts) `root_hash` / tile-checksum sets.
+- **Evidence required.** Prior `ReleaseManifest`, its `RunReceipt`, its `ValidationReport`, its `EvidenceBundle` digests, its `VerifyReceipt`.
+- **Exit condition.** A specific rollback target is named and passes the public-runtime rule. If no valid target exists, **escalate to a new governed release** rather than rolling back to an unverified manifest.
+
+### 7.3 Step 3 — Approvals
+
+- **Who.** Release authority; cultural / rights steward when sensitive-lane flag is set.
+- **What.** Record approvals as `ReviewRecord` entries (`reviewer`, `role`, `decision = ALLOW`, `evidence_refs`, `policy_ref`, `time`).
+- **Exit condition.** All required approvals are recorded and digitally identifiable. Author of the original release MUST NOT be the sole approver for sensitive lanes.
+
+### 7.4 Step 4 — Withdraw or mark-stale the affected public surfaces
+
+- **Who.** Release authority (or designated operator).
+- **What.** Mark the affected `LayerManifest`, `TileArtifactManifest`, `StyleManifest`, Evidence Drawer payloads, Focus Mode answers, and any derived `MovementStoryNode` exposures as **stale / withdrawn** in the UI state. Public clients SHOULD see a stale-state badge before any pointer-shift completes.
+- **Evidence required.** `AutomationBadgePayload` projection for trust-visible state; UI feature-flag or stale-state toggle.
+- **Exit condition.** No public surface continues to advertise the retracted artifacts as authoritative.
+
+### 7.5 Step 5 — Shift pointers to the rollback target
+
+- **Who.** Release authority + tile / artifact maintainer.
+- **What.** Shift the `LayerManifest`, `TileArtifactManifest`, and `StyleManifest` references back to the rollback target's `root_hash`, tile-checksum set, and `spec_hash`. **Do not delete tile variants.** Pointer-based rollback preserves both variants and keeps the audit trail explorable.
+- **Evidence required.** Rollback target's tile digest set; spec_hash; signed manifest.
+- **Exit condition.** Pointers resolve cleanly; no dangling references; the old set remains in the artifact store with a `superseded` marker, not a delete.
+
+### 7.6 Step 6 — Invalidate caches
+
+- **Who.** Release authority + ops.
+- **What.** Trigger CDN purge / cache invalidation for the affected tile URLs and version-specific routes. Emit a **cache invalidation receipt**.
+- **Evidence required.** Cache-key list from the affected `ReleaseManifest`; invalidation receipt schema.
+- **Exit condition.** No stale tile may be reissued from cache; the invalidation receipt is appended to the audit ledger.
+
+> [!CAUTION]
+> Skipping cache invalidation makes the rollback partial. Stale PMTiles / vector-tile fragments can survive in CDN and client caches, leaking retracted content. The C6-08 doctrine is explicit: **revocation that does not invalidate caches is incomplete.**
+
+### 7.7 Step 7 — Tombstone the retracted release
+
+- **Who.** Release authority.
+- **What.** Append a signed tombstone receipt to the audit ledger. The tombstone points at the retracted `release_id`, records the defect class and reason, names the supersession reference (rollback target or future superseding release), and is signed by the release authority. UI and API filters thereafter hide the tombstoned items from public views; lineage and audit views remain explorable.
+- **Evidence required.** Tombstone schema; ledger append succeeds; signature verifies.
+- **Exit condition.** A `run_receipt.tombstone.json` (or equivalent named tombstone artifact) is appended and discoverable through the audit surface.
+
+### 7.8 Step 8 — Verify
+
+- **Who.** Validator / proof reviewer.
+- **What.** Run the rollback drill fixture:
+
+  1. Verify the previous `ReleaseManifest` resolves and its digests match.
+  2. Verify the tile digest set matches the rollback target's manifest.
+  3. Run `VerifyReceipt` (digest_verified, bounds_verified, schema_verified) on at least one representative tile of each affected layer.
+  4. Run `RuntimeProbeResult` against the renderer / tile budget for the rollback target's tileset.
+  5. Run the OPA / Rego release-manifest policy fixture against the new superseding `ReleaseManifest`.
+  6. Run Roads / Rail / Trade lane-specific fixtures: route-membership/designation separation, OSM/GNIS legal-status denial, historic-overprecision denial, public-generalization receipt presence, transport-graph projection rollback.
+
+- **Evidence required.** Green test results; signed `VerifyReceipt`; signed `ValidationReport`; signed `PolicyDecision = allow`.
+- **Exit condition.** All fixtures pass deterministically. Any failure here aborts the rollback and either escalates to a different rollback target or to a new governed release.
+
+### 7.9 Step 9 — Publish the superseding ReleaseManifest
+
+- **Who.** Release authority.
+- **What.** Publish a new `ReleaseManifest` that records the rollback chain: it identifies the retracted release, the rollback target, the defect class, and re-asserts a valid `rollback_target` for the new release itself.
+- **Evidence required.** New `ReleaseManifest` passes the public runtime rule; `evidence_refs` resolve; artifact hashes verify; `rollback_supported = true`.
+- **Exit condition.** Public surfaces and governed API begin resolving to the superseding manifest; finite outcomes (`ANSWER` / `ABSTAIN` / `DENY` / `ERROR`) remain coherent.
+
+### 7.10 Step 10 — Communicate
+
+- **Who.** Communications steward.
+- **What.** Send notices in this order: cultural / rights stewards (if sensitive-lane), internal downstream consumers, public surface (release notes, stale-state banner, correction page). Record each notice's reference in the incident ledger.
+- **Evidence required.** Notice templates; recipient list; transmission timestamps.
+- **Exit condition.** All notices sent and acknowledged where acknowledgment is required.
+
+### 7.11 Step 11 — Post-mortem and backlog
+
+- **Who.** Auditor + lane owner.
+- **What.** Within one working week: write a post-mortem (Friday check-in pattern), add or strengthen a fixture for the failure mode, record any new verification items in `docs/registers/VERIFICATION_BACKLOG.md`, and update `docs/registers/DRIFT_REGISTER.md` if the defect revealed structural drift.
+- **Evidence required.** Post-mortem document; new fixture PR(s); register entries.
+- **Exit condition.** Incident closed; lineage preserved; next-time path narrower than this-time path.
+
+---
+
+## 8. Roads / Rail / Trade-specific concerns
+
+These are doctrinal carve-outs the lane MUST respect during rollback. Each is **CONFIRMED doctrine / PROPOSED implementation** unless otherwise noted.
+
+### 8.1 Indigenous trade and mobility corridors
+
+Indigenous trade and mobility corridors, oral-history corridors, treaty corridors, and culturally interpretive evidence default to **steward review + generalized public geometry**. A rollback that involves any of these MUST include a cultural / rights steward in the approval chain (§5) and MUST NOT republish at finer precision than the steward authorizes — even when the rollback target's original release used finer precision. If the rollback target itself violates this rule, escalate to a **forward-fix governed release** instead.
+
+### 8.2 Historic route claims vs. surveyed alignment
+
+Historic routes (wagon, military, mail, emigrant, stage, cattle, trade) are **claims with uncertainty**, not surveyed alignments. A rollback that restores a release where claim and surveyed centerline were collapsed is itself defective; the rollback target must carry a `GeneralizationReceipt` and explicit uncertainty class. Historic overprecision is a named denial gate — restoring overprecision is not a valid rollback.
+
+### 8.3 OSM / GNIS legal-status denial
+
+OSM and GNIS rows are typically `observation` or `context` for the lane's purposes, not `authority`. A rollback that re-asserts OSM- or GNIS-derived rows as `authority` for legal road / rail designations re-triggers the source-role denial gate. Source role is **fixed at admission** and MUST NOT be promoted by rollback.
+
+### 8.4 WZDx and live transport feeds
+
+Work-zone (WZDx) and other live transport feeds carry license terms, ETag / `Last-Modified` provenance, and Indigenous-sovereignty checks at admission. A rollback that restores a release built on a feed snapshot whose license, attribution, or provenance is now broken MUST quarantine the feed at admission before re-publication, even if the prior `ReleaseManifest` passed at its time.
+
+### 8.5 Critical transport facilities
+
+Bridges, ferries, river crossings, depots, sidings, yards, and other facilities classified as **critical infrastructure** require review before public exposure of precise geometry, condition, or inspection detail. A rollback that re-exposes precise critical-facility geometry without current review records MUST instead republish at generalized geometry with a `GeneralizationReceipt`.
+
+### 8.6 Network-edge / graph projections
+
+Routing graphs, traversal graphs, and network-edge projections are **derived artifacts**, not canonical records. A rollback restores graph projections only through the rollback target's manifest; it MUST NOT promote a graph projection back to canonical-record status, and MUST NOT let a routing graph become the public surface in place of the evidence-bearing layer.
+
+### 8.7 Operator-status and route-event temporality
+
+`OperatorStatus` and `RouteEvent` are temporal. A rollback MUST preserve the distinct time fields — source, observed, valid, retrieval, release, correction — and MUST NOT collapse `valid_time` with `observed_time` to make a rollback look cleaner.
+
+### 8.8 Consent-bound and PII-adjacent overlays
+
+Where a transport surface intersects a consent-bound overlay (e.g., a historical-mobility narrative tied to identifiable individuals), the consent metadata pointer-only pattern applies: no raw PII in tiles or artifacts, render-time consent verification, fail-closed on revoked / expired / missing proof. A rollback that re-exposes a previously consent-blocked surface is a defect, not a recovery.
+
+---
+
+## 9. Verification checklist
+
+Run through this list before declaring the rollback complete. Every line must be checkable from a receipt or fixture; "looks fine" is not a check.
+
+- [ ] Defect class is named and recorded in the incident ledger.
+- [ ] Affected `release_id` is named; current `ReleaseManifest` and its digests are captured.
+- [ ] Rollback target is named; its `ReleaseManifest` passes the public runtime rule.
+- [ ] Approvals recorded as `ReviewRecord`s with distinct author and approver where the lane is sensitive.
+- [ ] Affected public surfaces show stale / withdrawn state **before** pointer shift.
+- [ ] `LayerManifest`, `TileArtifactManifest`, and `StyleManifest` pointers shifted to rollback target.
+- [ ] Tile variants preserved in artifact store (pointer rollback, not delete).
+- [ ] CDN and client cache invalidations issued; invalidation receipt appended.
+- [ ] Tombstone receipt appended to audit ledger; signed and discoverable.
+- [ ] `VerifyReceipt` passes (digest_verified, bounds_verified, schema_verified).
+- [ ] `RuntimeProbeResult` within budget.
+- [ ] OPA / Rego release-manifest policy fixture passes against superseding manifest.
+- [ ] Roads / Rail / Trade fixtures pass: route-membership/designation, operator-status temporality, OSM/GNIS legal-status denial, historic-overprecision denial, generalization receipt, transport-graph rollback.
+- [ ] If sensitive-lane: steward approval recorded; generalization posture intact.
+- [ ] Superseding `ReleaseManifest` published; `rollback_target` re-asserted; finite outcomes coherent.
+- [ ] Notices sent (steward, downstream, public) and recorded.
+- [ ] Post-mortem scheduled; fixture / backlog updates filed.
+
+---
+
+## 10. Failure modes and anti-patterns
+
+> [!WARNING]
+> Each row below is a way a Roads / Rail / Trade rollback can quietly fail. Every one is recoverable, but only if it's named. If the runbook starts feeling clean and the ledger is silent, suspect one of these.
+
+| Failure mode | What goes wrong | Counter-rule |
+|---|---|---|
+| **Delete-as-rollback** | Tile artifacts and receipts removed instead of pointers shifted; lineage is destroyed. | Pointer-shift only. Old variants remain in the artifact store with a superseded marker. |
+| **Cache-stale leak** | Pointers shifted, but CDN / client caches keep serving retracted PMTiles. | Issue invalidation receipt; verify cache-purge before declaring complete. |
+| **Hidden author-approver collapse** | The author of the affected release is also the rollback approver. | Separation of duties (§5); sensitive lanes require a steward in addition. |
+| **Rollback to an unsafe target** | Target's `policy_label`, `rights_status`, or `sensitivity` is unknown or non-public. | Verify the public runtime rule against the target before approval. |
+| **Tombstone-as-delete** | Tombstone written but item is also hard-deleted; explainability lost. | Tombstone preserves the retracted run_id; hard delete violates audit. |
+| **Forward-fix masquerading as rollback** | New release pushed without an explicit rollback chain; treated as "a new version". | Rollback chain must be recorded in the superseding `ReleaseManifest`. |
+| **Indigenous corridor re-exposure** | Rollback target predates current steward review; restoring it re-exposes generalized-only geometry at precision. | Steward approval is mandatory for sensitive lanes; honor the **current** generalization posture, not the original. |
+| **OSM/GNIS role promotion at rollback** | Rollback restores a release where OSM / GNIS rows were `authority`. | Source role is fixed at admission; rollback cannot upgrade it. |
+| **Historic overprecision restoration** | Rollback target collapses claim onto surveyed centerline. | Historic overprecision denial gate applies to rollback targets too. |
+| **Watcher self-rollback** | A worker / watcher rolls back without release-authority sign-off. | Watcher-as-non-publisher; workers emit candidates and receipts only. |
+| **Graph-projection promotion** | Routing graph becomes the public surface during rollback. | Graph projections remain derived; canonical records carry truth. |
+| **Cache-only rollback** | Tile pointer shifted but graph-projection / Evidence Drawer caches not invalidated. | Invalidate every cache layer tied to the affected `LayerManifest`. |
+| **AI receipt drift** | Domain rolled back, but Focus Mode `AIReceipt`s still cite retracted evidence. | Trigger `governed_ai_ROLLBACK.md` after the domain rollback completes. |
+| **Silent admin-shortcut rollback** | An admin / infra path performs the rollback outside the governed release path. | Admin shortcuts MUST stay off the normal public path; rollback runs through the governed release path. |
+
+---
+
+## 11. Artifacts touched
+
+The artifacts below are the doctrinal touch-points of a Roads / Rail / Trade rollback. Concrete paths are **PROPOSED** until verified against mounted-repo evidence; the responsibility roots follow Directory Rules.
+
+| Artifact | Responsibility root (PROPOSED) | Role in rollback |
+|---|---|---|
+| `ReleaseManifest` (retracted + rollback target + superseding) | `release/candidates/roads-rail-trade/` → `release/published/...` | Binds tiles, evidence, policy, sensitivity, receipts, rollback, correction lineage, spec_hash, attestations. |
+| `RunReceipt` | `data/receipts/roads-rail-trade/` | Build / run provenance; inputs, config / spec hash, artifact digests, source_head, attestations. |
+| `ValidationReport` | `data/receipts/roads-rail-trade/` or `data/proofs/roads-rail-trade/` | Validator outcome under deterministic inputs. |
+| `PolicyDecision` | `data/proofs/roads-rail-trade/` | Rego / OPA decision on the superseding manifest. |
+| `VerifyReceipt` | `data/proofs/roads-rail-trade/` | Runtime verification of tile activation: digest / bounds / schema. |
+| `RuntimeProbeResult` | `data/proofs/roads-rail-trade/` | Renderer / tile budget pass-fail. |
+| `EvidenceBundle` | `data/catalog/roads-rail-trade/` | Admissible evidence object resolved from `EvidenceRef`; outranks maps and tiles. |
+| `EvidenceDrawerPayload` | `data/published/layers/roads-rail-trade/` (governed projection) | Governed UI projection; must reflect stale / withdrawn state during rollback. |
+| `LayerManifest`, `TileArtifactManifest`, `StyleManifest` | `data/published/layers/roads-rail-trade/` (governed projection) | Pointer-shift target; tile variants kept. |
+| `CorrectionNotice` | `release/corrections/roads-rail-trade/` | Records the defect and the invalidated derivatives. |
+| `RollbackCard` / tombstone receipt | `data/receipts/roads-rail-trade/` or audit ledger | Signed retraction marker pointing at retracted `release_id`. |
+| `ReviewRecord` | `data/receipts/roads-rail-trade/` | Approvals (lane owner, release authority, steward, validator). |
+| Schema home | `schemas/contracts/v1/domains/roads-rail-trade/` per ADR-0001 | Shape for envelopes, manifests, receipts. PROPOSED; verify with Directory Rules and ADR. |
+| Policy home | `policy/domains/roads-rail-trade/` | Release / sensitivity / source-role denial rules. |
+| Fixtures | `fixtures/domains/roads-rail-trade/` and `tests/domains/roads-rail-trade/` | Rollback drill, generalization receipt, historic-overprecision denial, OSM/GNIS legal-status denial, transport-graph rollback. |
+| Audit ledger | `data/AUDIT/receipts/YYYY/MM/...` or OCI evidence registry (per C1-06; backend ADR pending) | Append-only; tombstones live here. |
+
+---
+
+## 12. Appendix — receipt and manifest sketches
+
+> [!NOTE]
+> The shapes below are **illustrative sketches** drawn from doctrinal language. Exact field names, types, and the canonical schema home for Roads / Rail / Trade are **PROPOSED** and depend on `schemas/contracts/v1/domains/roads-rail-trade/` content, which is `NEEDS VERIFICATION`.
+
+<details>
+<summary><strong>A. Tombstone receipt — illustrative shape</strong></summary>
+
+```json
+{
+  "object_type": "RollbackTombstone",
+  "version": "v1-PROPOSED",
+  "retracted_release_id": "rrt-release-2026-04-22-xyz",
+  "rollback_target_release_id": "rrt-release-2026-04-15-abc",
+  "defect_class": "sensitivity-corridor-exposure",
+  "defect_summary": "Historic mobility corridor exposed at precision finer than steward authorization.",
+  "supersession_ref": "rrt-release-2026-05-12-def",
+  "approvals": [
+    { "reviewer": "release-authority/<id>", "role": "release_authority", "decision": "ALLOW", "time": "2026-05-12T12:34:00Z" },
+    { "reviewer": "cultural-steward/<id>",  "role": "rights_steward",    "decision": "ALLOW", "time": "2026-05-12T12:30:00Z" }
+  ],
+  "signature": { "alg": "cosign-keyless", "keyid": "cosign://fulcio/<issuer>", "sig": "<base64>" },
+  "time": "2026-05-12T12:35:00Z"
+}
+```
+
+</details>
+
+<details>
+<summary><strong>B. Public runtime rule for ReleaseManifest — doctrinal restatement</strong></summary>
+
+A public client may consume a `ReleaseManifest` only when **all** of the following hold:
+
+- `release_state == PUBLISHED`
+- `policy_label != "unknown"`
+- `rights_status != "unknown"`
+- `sensitivity == "public"`
+- `evidence_refs` are present and resolve
+- artifact hashes are present and verify
+- `rollback.rollback_supported == true`
+- policy `allow == true`
+
+This rule applies to **both** the original release and the superseding rollback release. If the rollback target itself does not satisfy this rule, the rollback is unsafe and must be replaced by a forward-fix governed release.
+
+</details>
+
+<details>
+<summary><strong>C. Roads / Rail / Trade rollback drill — fixture checklist</strong></summary>
+
+The rollback drill fixture validates:
+
+1. Previous `ReleaseManifest` resolves; digests match.
+2. Tile digest set matches rollback target's manifest.
+3. `VerifyReceipt` digest_verified / bounds_verified / schema_verified all pass for a representative tile per affected layer.
+4. `RuntimeProbeResult` decode, hash, heap, and token-latency budgets pass on the device-profile under test.
+5. OPA / Rego `release_manifest.rego` denies an unknown policy_label, unknown rights_status, non-public sensitivity, missing evidence_refs, missing artifacts, and unsupported rollback — i.e., fail-closed under each negative case.
+6. Roads / Rail / Trade lane fixtures:
+   - Route-membership and designation separation.
+   - Operator-status / route-event temporal separation.
+   - OSM / GNIS legal-status denial.
+   - Historic overprecision denial.
+   - Public generalization receipt presence.
+   - Transport-graph projection rollback.
+
+PROPOSED locations: `tests/domains/roads-rail-trade/rollback/` and `fixtures/domains/roads-rail-trade/rollback/`. NEEDS VERIFICATION against mounted-repo evidence.
+
+</details>
+
+<details>
+<summary><strong>D. Defect-class → posture quick-card</strong></summary>
+
+| Defect | First action | Rollback? | Forward-fix? |
+|---|---|---|---|
+| Evidence gap | Withdraw surface; open `CorrectionNotice` | Yes | If new evidence admissible |
+| Source-role error | Reclassify at admission | Yes | No — role is fixed at admission |
+| Rights / license | Quarantine source | Yes | After rights re-verified |
+| Sensitivity / sovereignty | Steward; generalize | **Yes — immediately** | After steward `ALLOW` |
+| Geometry overprecision | Add `GeneralizationReceipt` | Yes | Yes |
+| Temporal error | Recompute scope | Yes | Yes |
+| Policy gate slip | Treat as incident | Yes | After fixtures pass |
+| Validation drift | Re-run validators | Yes | Yes |
+| Rendering / tile drift | Shift root_hash pointer | Yes | Yes |
+| API contract drift | Withdraw route | Yes | After contract test |
+| AI cite-of-retracted | Domain rollback first; then AI rollback | Yes | After domain rollback |
+
+</details>
+
+---
+
+## 13. Verification backlog
+
+The items below are `NEEDS VERIFICATION` until mounted-repo evidence is inspected. Each is parked here rather than asserted in the body of the runbook.
+
+| Item | Evidence that would settle it | Status |
+|---|---|---|
+| Exact governed-API route for Roads / Rail / Trade resolvers (e.g., feature/detail, layer manifest, Evidence Drawer payload, Focus Mode) | `apps/governed-api/` route table; OpenAPI / contract tests | NEEDS VERIFICATION |
+| Schema home for `RoadsRailDecisionEnvelope`, `LayerManifest`, `TileArtifactManifest`, `StyleManifest`, `ReleaseManifest`, receipts | `schemas/contracts/v1/domains/roads-rail-trade/` directory contents; ADR-0001 alignment | NEEDS VERIFICATION |
+| CI workflow that enforces the rollback drill on every release PR | `.github/workflows/*` | NEEDS VERIFICATION |
+| Audit ledger backend choice (filesystem vs OCI vs both) | Accepted ADR; tooling presence | UNKNOWN |
+| Cache invalidation surfaces (CDN, tile server, client) and their receipt schema | `infra/` config; invalidation receipt schema | NEEDS VERIFICATION |
+| Identity of release authority and lane owner for Roads / Rail / Trade | `CODEOWNERS`; lane README | NEEDS VERIFICATION |
+| Cultural / rights steward roster and contact path for sensitive-lane approvals | `docs/governance/stewards.md` (PROPOSED) | UNKNOWN |
+| Whether `docs/runbooks/<domain>/<NAME>_RUNBOOK.md` is the agreed runbook subdirectory pattern, or whether the flat `docs/runbooks/<domain>_<NAME>.md` form is preferred | `docs/runbooks/README.md` (PROPOSED) or an accepted ADR on runbook structure | NEEDS VERIFICATION |
+| Whether prior released artifacts must remain hot-fetchable or may move to cold-store while pointers shift | Operational ADR; infra retention policy | NEEDS VERIFICATION |
+| Drift register and verification backlog files exist and are linked | `docs/registers/DRIFT_REGISTER.md`, `docs/registers/VERIFICATION_BACKLOG.md` | NEEDS VERIFICATION |
+
+---
+
+## 14. Related docs
+
+- [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) — Domain Placement Law (§12), responsibility roots, anti-patterns.
+- [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — `RAW → … → PUBLISHED`; promotion as governed state transition.
+- [`docs/doctrine/trust-membrane.md`](../../doctrine/trust-membrane.md) — public clients use governed APIs; never canonical / internal stores.
+- [`docs/architecture/correction-and-rollback.md`](../../architecture/correction-and-rollback.md) — corpus-level rollback and correction model. *(PROPOSED home; verify against repo.)*
+- [`docs/domains/roads-rail-trade/README.md`](../../domains/roads-rail-trade/README.md) — lane scope, ubiquitous language, object families, sensitivity posture. *(PROPOSED home.)*
+- [`docs/runbooks/governed_ai_ROLLBACK.md`](../governed_ai_ROLLBACK.md) — AI adapter rollback and kill switch; trigger after a domain rollback that retracted cited evidence.
+- [`docs/runbooks/ui_ROLLBACK.md`](../ui_ROLLBACK.md) — UI rollback, feature flag, and schema-deprecation steps for any shell-level changes that accompany a domain rollback.
+- [`docs/adr/ADR-0001-schema-home.md`](../../adr/ADR-0001-schema-home.md) — canonical schema home (`schemas/contracts/v1/...`). *(PROPOSED id; verify.)*
+- [`release/candidates/roads-rail-trade/`](../../../release/candidates/roads-rail-trade/) — release candidates and rollback targets for this lane.
+- [`data/receipts/README.md`](../../../data/receipts/README.md) and [`data/proofs/README.md`](../../../data/proofs/README.md) — proof and receipt homes.
+
+---
+
+<sub>**Last updated:** 2026-05-12 · **Doc id:** `kfm://doc/runbook/roads-rail-trade/rollback` · **Status:** draft · [Back to top ↑](#top)</sub>

--- a/docs/runbooks/roads-rail-trade/SOURCE_REFRESH_RUNBOOK.md
+++ b/docs/runbooks/roads-rail-trade/SOURCE_REFRESH_RUNBOOK.md
@@ -1,3 +1,637 @@
-# roads-rail-trade :: SOURCE_REFRESH runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbooks/roads-rail-trade/source-refresh
+title: Roads, Rail, and Trade Routes — Source Refresh Runbook
+type: standard
+version: v0.1
+status: draft
+owners: TODO — Roads/Rail domain steward; Docs steward; Sources steward
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/trust-membrane.md
+  - docs/domains/roads-rail-trade/README.md            # PROPOSED
+  - docs/sources/SOURCE_DESCRIPTOR_STANDARD.md         # PROPOSED
+  - docs/runbooks/roads-rail-trade/VALIDATION.md       # PROPOSED sibling
+  - docs/runbooks/roads-rail-trade/ROLLBACK.md         # PROPOSED sibling
+  - docs/adr/ADR-watcher-non-publisher.md              # PROPOSED
+tags: [kfm, runbook, roads-rail-trade, sources, refresh, governed-pipeline]
+notes:
+  - All repo paths are PROPOSED until verified against mounted-repo evidence.
+  - Source-family inventory CONFIRMED via DOM-ROADS / ENCY; cadence and rights NEEDS VERIFICATION per-source.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# 🛤️ Roads, Rail, and Trade Routes — Source Refresh Runbook
+
+> **Operational procedure for refreshing modern and historical transport sources into the KFM Roads/Rail/Trade Routes lane — without bypassing evidence, policy, review, or release controls.**
+
+![status: draft](https://img.shields.io/badge/status-draft-orange)
+![type: runbook](https://img.shields.io/badge/type-runbook-blue)
+![domain: roads--rail--trade](https://img.shields.io/badge/domain-roads--rail--trade-1f6feb)
+![lifecycle: RAW→PUBLISHED](https://img.shields.io/badge/lifecycle-RAW%E2%86%92PUBLISHED-555)
+![default posture: deny--by--default](https://img.shields.io/badge/posture-deny--by--default-critical)
+![last updated: 2026-05-12](https://img.shields.io/badge/last%20updated-2026--05--12-lightgrey)
+<!-- All badges above are decorative until wired to Shields.io endpoints; targets are TODO. -->
+
+| | |
+|---|---|
+| **Status** | `draft` |
+| **Owners** | TODO — Roads/Rail domain steward · Docs steward · Sources steward |
+| **Last updated** | 2026-05-12 |
+| **Authority** | This runbook OPERATIONALIZES doctrine; it does not override `docs/doctrine/lifecycle-law.md`, Directory Rules, or `policy/`. |
+| **Repo verification** | UNKNOWN — no mounted repo this session. All paths PROPOSED. |
+
+---
+
+## 📑 Contents
+
+1. [Purpose & non-purpose](#1-purpose--non-purpose)
+2. [Repo fit](#2-repo-fit)
+3. [Prerequisites](#3-prerequisites)
+4. [Source family inventory](#4-source-family-inventory)
+5. [Refresh cadence & triggers](#5-refresh-cadence--triggers)
+6. [Lifecycle walkthrough · RAW → PUBLISHED](#6-lifecycle-walkthrough--raw--published)
+7. [Promotion gates (A–G)](#7-promotion-gates-ag)
+8. [Sensitivity, rights, and generalization](#8-sensitivity-rights-and-generalization)
+9. [Stale-state and supersession](#9-stale-state-and-supersession)
+10. [Negative paths & quarantine reasons](#10-negative-paths--quarantine-reasons)
+11. [Validation hooks](#11-validation-hooks)
+12. [Correction & rollback](#12-correction--rollback)
+13. [Receipts & emitted artifacts](#13-receipts--emitted-artifacts)
+14. [Failure modes & anti-patterns](#14-failure-modes--anti-patterns)
+15. [FAQ](#15-faq)
+16. [Related docs](#16-related-docs)
+17. [Appendix · pseudocode and command stubs](#17-appendix--pseudocode-and-command-stubs)
+
+---
+
+## 1. Purpose & non-purpose
+
+CONFIRMED doctrine basis: Roads/Rail/Trade Routes is a governed domain lane that owns modern roads, historic roads, wagon/military/emigrant/stage/cattle trails, rail corridors, depots, sidings, yards, crossings, bridges, ferries, river crossings, freight corridors, and derived network graph projections; **it must not expose culturally sensitive corridors or confuse route narrative with surveyed alignment** (DOM-ROADS / ENCY).
+
+This runbook describes **how to refresh upstream source data into that lane** while preserving the lifecycle invariant **RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED**.
+
+> [!IMPORTANT]
+> **A refresh is not a publish.** Promotion across phases is a governed state transition supported by receipts, validators, and review — **never a file move, mirror, or watcher auto-publish**.
+
+### Out of scope
+
+- Defining object meaning. That lives in `contracts/domains/roads-rail-trade/` (PROPOSED).
+- Defining object shape. That lives in `schemas/contracts/v1/domains/roads-rail-trade/` (PROPOSED).
+- Deciding allow / deny / restrict. That lives in `policy/domains/roads-rail-trade/` (PROPOSED).
+- Public render styling, MapLibre style packs, or 3D scene assembly.
+- Live operational alerting. KFM is never an alert authority.
+
+---
+
+## 2. Repo fit
+
+> [!NOTE]
+> All paths below are **PROPOSED** until verified against mounted-repo evidence. Convention conflict flagged: prior Whole-UI Expansion Report uses flat `docs/runbooks/<subsystem>_<phase>.md`; Directory Rules §12 favors a domain segment. This file uses the §12 form. Reconcile via ADR if the repo uses a single canonical pattern.
+
+```text
+docs/runbooks/roads-rail-trade/
+├── SOURCE_REFRESH_RUNBOOK.md      # ← this file
+├── VALIDATION.md                  # PROPOSED sibling — validation runs
+├── ROLLBACK.md                    # PROPOSED sibling — rollback drills
+└── LOCAL_DEV.md                   # PROPOSED sibling — local fixture setup
+```
+
+```mermaid
+flowchart LR
+    subgraph Upstream["Upstream sources (DOM-ROADS)"]
+        KDOT[KDOT / KanPlan / KanDrive / KS GIS]:::ext
+        TIGER[Census TIGER/Line roads]:::ext
+        HPMS[FHWA HPMS / NHFN]:::ext
+        WZDx[WZDx feeds]:::ext
+        BRIDGE[County/state bridge & restriction]:::ext
+        GNIS[GNIS names]:::ext
+        OSM[OpenStreetMap]:::ext
+        HIST[Historical maps · trail archives]:::ext
+        STEWARD[Steward sources<br/>sensitive cultural corridors]:::sens
+    end
+
+    subgraph Connectors["connectors/domains/roads-rail-trade/  (PROPOSED)"]
+        WATCH[Watcher · conditional GET]:::kfm
+        FETCH[Fetcher · spec_hash + HEAD proof]:::kfm
+    end
+
+    subgraph Lifecycle["data/  (lifecycle invariant)"]
+        RAW[(data/raw/<br/>roads-rail-trade)]:::raw
+        WORK[(data/work/<br/>roads-rail-trade)]:::work
+        QUAR[(data/quarantine/<br/>roads-rail-trade)]:::quar
+        PROC[(data/processed/<br/>roads-rail-trade)]:::proc
+        CAT[(data/catalog/domain/<br/>roads-rail-trade)]:::cat
+        PUB[(data/published/layers/<br/>roads-rail-trade)]:::pub
+    end
+
+    subgraph Release["release/  (decisions)"]
+        MAN[ReleaseManifest]:::rel
+        ROLL[RollbackCard]:::rel
+        CORR[CorrectionNotice]:::rel
+    end
+
+    Upstream --> WATCH --> FETCH --> RAW --> WORK --> PROC --> CAT --> PUB
+    WORK -. fail-closed .-> QUAR
+    CAT --> MAN --> PUB
+    PUB -. when defects found .-> CORR
+    PUB -. when defects found .-> ROLL
+
+    classDef ext fill:#eef5ff,stroke:#5b8def,color:#1a3a8a
+    classDef sens fill:#f8e3e3,stroke:#b54242,color:#7a1f1f
+    classDef kfm fill:#fff7e0,stroke:#caa54b,color:#5a4310
+    classDef raw fill:#e6e6e6,stroke:#888,color:#333
+    classDef work fill:#fff3c2,stroke:#bb9a26,color:#5a4310
+    classDef quar fill:#f8d7da,stroke:#a33,color:#7a1f1f
+    classDef proc fill:#dde9ff,stroke:#5b8def,color:#1a3a8a
+    classDef cat fill:#d4edda,stroke:#3c8a4a,color:#1c4d28
+    classDef pub fill:#cfe9c6,stroke:#2e7d32,color:#1a4d1a
+    classDef rel fill:#ede0ff,stroke:#6f42c1,color:#3b1a78
+```
+
+<sub>Diagram reflects doctrine (lifecycle-law.md, DOM-ROADS, watcher-as-non-publisher). Path names PROPOSED.</sub>
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 3. Prerequisites
+
+Before you run a refresh, confirm:
+
+- [ ] `SourceDescriptor` exists for each source you will touch, with **source role**, **authority**, **rights / SPDX**, **sensitivity class**, **cadence**, **steward**, and **release class** populated (CONFIRMED doctrine; per-source values **NEEDS VERIFICATION**).
+- [ ] You have **read** access to the source endpoints. Do **not** request elevated/secret credentials to refresh a public-safe layer.
+- [ ] A current `ReviewRecord` is on file for any source feeding a **sensitive** lane (cultural corridors, historic route claims, critical facilities). Refresh is **deny-by-default** without it.
+- [ ] CI runners for the Roads/Rail promotion workflow are healthy (`gate_a_identity_integrity` through `gate_g_release` — PROPOSED job names).
+- [ ] Cosign / DSSE signing keys are reachable to the runner (or the run is a **dry-run** that explicitly skips signing and is **forbidden from promotion**).
+- [ ] No active kill-switch is set for Roads/Rail map promotion.
+
+> [!CAUTION]
+> If any prerequisite is **UNKNOWN**, treat the run as a dry-run, emit a `RunReceipt` with `outcome: ABSTAIN`, and do not write anything past `data/work/roads-rail-trade/`.
+
+---
+
+## 4. Source family inventory
+
+Source families and roles are **CONFIRMED** via DOM-ROADS / ENCY. Rights, cadence, and current API surfaces are per-source and **NEEDS VERIFICATION** before activation.
+
+| Source family | Typical role | Sensitivity defaults | Cadence (PROPOSED) | Rights / SPDX |
+|---|---|---|---|---|
+| **KDOT / KanPlan / KanDrive / Kansas GIS** | authority (state roads, restrictions) | public-safe; restrictions may be operationally sensitive | quarterly + event-driven WZDx | NEEDS VERIFICATION |
+| **Census TIGER/Line roads** | authority / observation (admin geometry) | public-safe | annual (TIGER vintage) | US Public Domain (NEEDS VERIFICATION) |
+| **FHWA HPMS** | authority (highway performance) | public-safe (aggregate) | annual | NEEDS VERIFICATION |
+| **FHWA National Highway Freight Network** | authority (freight designation) | public-safe | annual | NEEDS VERIFICATION |
+| **WZDx work-zone feeds** | observation (status / events) | public-safe; transient | live / 5–300 s debounce | NEEDS VERIFICATION |
+| **County / state bridge & restriction data** | authority / observation | mixed; weight/closure can be sensitive | varies | NEEDS VERIFICATION per county |
+| **GNIS names** | observation / context (gazetteer) | public-safe | low-cadence | US Public Domain (NEEDS VERIFICATION) |
+| **OpenStreetMap (OSM)** | observation / context (community) | public-safe; **NOT legal/regulatory authority** | continuous; sample on cadence | ODbL (NEEDS VERIFICATION) |
+| **County atlases · historical maps · trail archives** | context / source-of-claim (historic) | uncertainty + generalization required | one-shot per scan vintage | per-archive |
+| **Military · emigrant · stage · cattle trail sources** | source-of-claim (historic) | **sensitive when overlapping Indigenous corridors** | per-archive | per-archive |
+| **Bridges / ferries / river-crossing records** | authority / observation | mixed | per-source | per-source |
+| **Steward sources for sensitive cultural corridors** | source-of-claim under stewardship | **default DENY public exposure; generalized geometry only** | by steward consent | restricted |
+
+> [!WARNING]
+> **OSM and GNIS are observation/context, not legal authority.** Validators MUST refuse to promote OSM- or GNIS-derived claims that imply legal road status, jurisdictional ownership, or freight designation. (PROPOSED test: *OSM/GNIS legal-status denial.*)
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 5. Refresh cadence & triggers
+
+Three trigger classes apply. Each emits a `RunReceipt` regardless of outcome.
+
+| Trigger class | When it fires | Required guards |
+|---|---|---|
+| **Scheduled** | Per-source cadence from `SourceDescriptor` (e.g. KDOT quarterly, TIGER annual) | Conditional GET (ETag / Last-Modified); no-change → heartbeat receipt only |
+| **Event-driven** | Upstream notification (WZDx push, partner webhook, change-data-capture stream) | Debounce/coalesce window per source class; aggregate to delta manifest |
+| **Manual / steward-initiated** | Steward correction, rights change, or rollback rehearsal | Justification in PR body; full receipt chain |
+
+**Debounce windows (PROPOSED starting points, from KFM ingestion doctrine):**
+
+| Source class | Window | Notes |
+|---|---|---|
+| High-churn (WZDx live events) | 5–30 s | Aggregate to delta manifest; emit only if `spec_hash` changes |
+| Moderate (KanDrive incident feeds) | 30–120 s | Same |
+| Heavy batch (KDOT vintage, TIGER, HPMS) | 120–300 s (or per-batch) | Materialize only on `spec_hash` change |
+
+> [!TIP]
+> **Unchanged sources must not invalidate caches or emit new catalog entities.** A no-change poll should emit a heartbeat receipt and nothing else. This protects downstream tile / style caches from churn.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 6. Lifecycle walkthrough · RAW → PUBLISHED
+
+CONFIRMED doctrine: every Roads/Rail refresh traverses the lifecycle invariant. Each transition has a gate; **no gate, no transition**.
+
+```mermaid
+flowchart TB
+    A((Admission)) -->|SourceDescriptor + payload hash| RAW[RAW]
+    RAW -->|Normalize schema · geometry · time · identity · evidence · rights · policy| WORK[WORK]
+    WORK -.->|Validation or policy fail| QUAR[QUARANTINE]
+    WORK -->|ValidationReport pass · receipts present| PROC[PROCESSED]
+    PROC -->|EvidenceBundle · catalog matrix close| CAT[CATALOG / TRIPLET]
+    CAT -->|ReleaseManifest · ReviewRecord · rollback target| PUB[PUBLISHED]
+    PUB -.->|Defect detected| CORR[CorrectionNotice → PUBLISHED']
+
+    style RAW fill:#e6e6e6,stroke:#888
+    style WORK fill:#fff3c2,stroke:#bb9a26
+    style QUAR fill:#f8d7da,stroke:#a33
+    style PROC fill:#dde9ff,stroke:#5b8def
+    style CAT fill:#d4edda,stroke:#3c8a4a
+    style PUB fill:#cfe9c6,stroke:#2e7d32
+    style CORR fill:#ede0ff,stroke:#6f42c1
+```
+
+### Phase responsibilities
+
+| Phase | What happens | What gets emitted | Failure-closed outcome |
+|---|---|---|---|
+| **RAW** | Capture immutable payload (or reference) + source-role, rights, sensitivity, citation, time, hash. | `SourceDescriptor`, raw payload, fetch `RunReceipt`. | Source not admitted; logged as candidate awaiting steward. |
+| **WORK** | Normalize schema · geometry · time · identity · evidence · rights · policy. | `TransformReceipt`, `ValidationReport` (working set), `PolicyDecision`. | **Quarantine** with structured reason; **never silently promote**. |
+| **QUARANTINE** | Hold failing records; record why. | Quarantine entry with reason class (license, schema, policy, sensitivity, hash mismatch, …). | Stay until steward disposition (refresh / supersede / mark stale). |
+| **PROCESSED** | Emit validated normalized objects + public-safe candidates. | `EvidenceRef` resolves, `ValidationReport` pass, `RedactionReceipt` if sensitivity applies. | Stay in WORK; structured FAIL. |
+| **CATALOG / TRIPLET** | Catalog records + `EvidenceBundle` + graph/triplet projections + release candidates. | `CatalogMatrix` entry, `EvidenceBundle`, graph projection. | HOLD at PROCESSED; no public edge. |
+| **PUBLISHED** | Serve released public-safe artifacts through governed APIs / manifests. | `ReleaseManifest`, rollback target, correction path, `ReviewRecord` where required. | HOLD at CATALOG; no public surface change. |
+
+> [!IMPORTANT]
+> **Watcher-as-non-publisher.** Connectors and watchers emit candidates and receipts only. They MUST NOT publish, mutate canonical records, mutate the graph projection, or invalidate map caches without going through the release path.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 7. Promotion gates (A–G)
+
+CONFIRMED doctrine basis: KFM uses default-deny promotion gates with signed receipts and a deterministic `spec_hash`. The seven gates apply uniformly to Roads/Rail.
+
+| Gate | Name | Primary check | Fail-closed result |
+|---|---|---|---|
+| **A** | Identity & Integrity | `spec_hash` computed via JCS-canonicalized JSON; HEAD probe with ETag + Last-Modified + Content-Length | Block; emit `RunReceipt(status=quarantine, reason=identity_integrity)` |
+| **B** | License & Provenance | SPDX in allowlist; rights status resolves; provenance chain present | Quarantine if SPDX absent / ambiguous; restricted-with-obligations if conditional |
+| **C** | Schema & Shape | Validate against `schemas/contracts/v1/domains/roads-rail-trade/*.schema.json` (PROPOSED home) | Quarantine with schema-diff diagnostic |
+| **D** | Sensitivity & Generalization | Per-policy check for cultural/Indigenous corridor exposure, historic overprecision, critical-facility detail | DENY public path; route to steward review |
+| **E** | Evidence Closure | Every consequential claim has a resolving `EvidenceRef → EvidenceBundle` | ABSTAIN; record gap in `VERIFICATION_BACKLOG` |
+| **F** | Steward Review | `ReviewRecord` present where required by source role or sensitivity tier | HOLD; emit review-pending receipt |
+| **G** | Release Authority | `ReleaseManifest` issued; **release authority distinct from author** when materiality applies; rollback target named | HOLD at CATALOG; no public surface change |
+
+**Validator commands** (PROPOSED — verify names against the repo before quoting them in PRs):
+
+```bash
+# PROPOSED — actual tool names NEEDS VERIFICATION
+tools/validators/identity/compute_spec_hash.py --spec spec.json
+tools/validators/license/check_spdx.py        --descriptor source_descriptor.yaml
+tools/validators/schemas/validate_jsonschema.py \
+    --schema schemas/contracts/v1/domains/roads-rail-trade/road_segment.schema.json \
+    --instance data/work/roads-rail-trade/road_segment.candidate.json
+tools/validators/sensitivity/check_generalization.py --layer roads-rail-trade
+tools/validators/evidence/verify_evidence_refs.py    --bundle evidence_bundle.json
+tools/validators/release/check_release_manifest.py   --manifest release/manifests/roads-rail-trade-<vintage>.yaml
+```
+
+> [!WARNING]
+> The fail-closed posture means **absence of evidence blocks promotion**. A missing `ReviewRecord`, an unresolvable `EvidenceRef`, or an unknown SPDX is *enough* to quarantine — even if everything else looks fine.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 8. Sensitivity, rights, and generalization
+
+CONFIRMED doctrine: Indigenous trade and mobility corridors, oral history, treaty, cultural, and interpretive evidence default to **steward review and generalized public geometry**. Critical transport facilities require review.
+
+### Per-class refresh posture
+
+| Sensitivity class | Default public posture | Refresh-time requirement |
+|---|---|---|
+| **Public-safe modern road / rail geometry** | Public layer + Evidence Drawer | Standard gates A–G |
+| **Operator status / restriction event (WZDx, KanDrive)** | Public, time-aware | Gate A integrity proof; honor source freshness markers |
+| **Historic route claim (low-uncertainty)** | Public with uncertainty class + generalization receipt | Gate C must include `RouteUncertaintyProfile` (PROPOSED) |
+| **Historic route claim (high-uncertainty / multi-source disagreement)** | Generalized corridor view only | Steward review (Gate F); explicit generalization transform receipt |
+| **Indigenous / culturally sensitive corridor** | **DENY exact geometry by default**; generalized corridor only with steward consent | Steward review **mandatory**; rights status must explicitly authorize the granularity |
+| **Critical transport facility (exact)** | **DENY exact precision by default** | Steward review; published only after threat-model check |
+
+### Generalization receipts
+
+When geometry is generalized for public release, the transform MUST emit a `GeneralizationReceipt` recording: input bundle digest, transform parameters (snap distance, simplification tolerance, corridor buffer), output digest, justification, and reviewer. The receipt resolves through `EvidenceRef → EvidenceBundle`.
+
+> [!CAUTION]
+> Do **not** publish raw historic-trail geometry derived from archival scans without a generalization step. *Historic overprecision denial* is a PROPOSED required validator for this lane.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 9. Stale-state and supersession
+
+CONFIRMED doctrine: a **stale** claim has aged past declared tolerance; a **wrong** claim is substantively incorrect. Both have visible markers.
+
+Refresh time is when stale-state is discovered. The runbook MUST check the following markers and act:
+
+| Marker | What to do |
+|---|---|
+| **Source freshness expired** (cadence in `SourceDescriptor` passed without a new admission) | Re-admit; if upstream is gone, supersede or mark dependents stale |
+| **Schema version drift** (object schema upgraded past the published claim's schema version) | Migrate, re-validate, re-release; or mark stale with migration ADR link |
+| **Geography version drift** (`GeographyVersion` replaced; published claim still bound to prior version) | Rebind, re-release; or mark stale |
+| **Time-scope outside support** | Mark stale; do not silently refresh |
+| **Rights status changed** | Re-evaluate tier; emit `CorrectionNotice` if needed; potentially downgrade public access |
+| **Policy version changed** | Re-run Gate D / F; potentially supersede release |
+| **Review aged out** (`ReviewRecord` past tolerance for a sensitive lane) | Trigger steward review; potentially downgrade tier |
+
+Supersession lineage MUST be preserved: prior `SourceDescriptor`, `EvidenceBundle`, schema, and `ReleaseManifest` versions remain queryable with forward links.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 10. Negative paths & quarantine reasons
+
+Refresh runs that **must quarantine** rather than promote:
+
+| Condition | Quarantine reason class |
+|---|---|
+| Missing or invalid signature on a candidate `RunReceipt` | `signature_invalid` |
+| DSSE envelope malformed | `dsse_invalid` |
+| Unknown / disallowed SPDX | `license_unknown` |
+| `EvidenceRef` does not resolve | `evidence_missing` |
+| Policy decision returns DENY | `policy_mismatch` |
+| `spec_hash` re-computation does not match signed payload | `hash_mismatch` |
+| Source-role conflict (OSM-derived claim asserting legal authority) | `role_overreach` |
+| Historic geometry exceeds documented precision support | `overprecision` |
+| Sensitive lane lacks steward consent | `sensitivity_unresolved` |
+| Source freshness expired beyond stale tolerance | `freshness_expired` |
+
+Each quarantine MUST emit a `RunReceipt(status=quarantine, reason=<class>, actor=<who>)` and a structured note for the steward queue.
+
+> [!NOTE]
+> **Validators MUST include negative fixtures.** A validator that has never seen a deny case has not been proven to deny. Fixtures live under `tests/fixtures/domains/roads-rail-trade/` (PROPOSED).
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 11. Validation hooks
+
+PROPOSED Roads/Rail-specific validators (DOM-ROADS / ENCY):
+
+- **Route membership and designation separation tests** — a freight designation MUST NOT be inferred from observation-only sources (OSM, GNIS).
+- **Operator / status temporal tests** — operator-of-record and status events have distinct, non-overlapping time scopes per segment.
+- **OSM / GNIS legal-status denial** — claims of legal road status, jurisdiction, or designation derived from observation sources fail closed.
+- **Historic overprecision denial** — historic geometry whose declared precision exceeds source support fails closed.
+- **Public generalization receipt tests** — every public-sensitive layer release has a matching `GeneralizationReceipt`.
+- **Transport graph projection rollback tests** — graph projections can be rolled back without orphaning canonical records.
+
+CI should also run the shared promotion-pipeline checks (Gates A–G), STAC / DCAT / PROV catalog validation, and tile-artifact digest checks where the refresh feeds map tiles.
+
+See the sibling [VALIDATION runbook](./VALIDATION.md) (PROPOSED) for execution details.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 12. Correction & rollback
+
+CONFIRMED doctrine: a released claim, layer, catalog record, artifact, or answer MUST have a visible correction path and rollback target before it is treated as safely publishable.
+
+| Defect class | Correction posture | Rollback posture |
+|---|---|---|
+| Evidence gap | ABSTAIN or withdraw unsupported claim; emit `CorrectionNotice` | Restore prior evidence-supported release |
+| Source-role overreach (e.g. OSM-as-authority) | Re-classify source role; supersede `SourceDescriptor`; emit notice | Restore prior release that respected role |
+| Rights change | Tier downgrade or withdrawal; notice with rationale | Restore prior compliant release |
+| Sensitivity exposure (cultural corridor leak) | Immediate withdrawal; redaction receipt; steward notice | Restore prior generalized release |
+| Geometry / temporal error | Republish corrected; notice with diff | Restore prior release |
+| Policy version change | Re-run gates; possibly supersede | Restore prior policy-aligned release |
+| Render / API regression | Forward fix preferred; rollback if regression is material | Restore prior `ReleaseManifest` + invalidate caches |
+| AI-output defect | Receipt-level correction; new `AIReceipt`, never retroactive overwrite | N/A — AI output is not source truth |
+
+Rollback steps (operational summary):
+
+1. Identify the affected `ReleaseManifest` and its declared rollback target.
+2. Verify digests on the rollback target (no silent file-copy rollbacks).
+3. Disable / withdraw the affected public surface (layer, manifest entry, API route).
+4. Restore the rollback target through the **same governed release path**.
+5. Invalidate downstream caches; emit a cache-invalidation record.
+6. Mark UI state stale / withdrawn; preserve audit receipts.
+
+See the sibling [ROLLBACK runbook](./ROLLBACK.md) (PROPOSED) for the rehearsal procedure.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 13. Receipts & emitted artifacts
+
+Each refresh leaves a paper trail. **Every** outcome (APPROVE, QUARANTINE, ABSTAIN, DENY, ERROR) emits at least one receipt.
+
+| Object | Purpose | Proposed home |
+|---|---|---|
+| `SourceDescriptor` | Source identity, role, rights, sensitivity, cadence, steward | `data/registry/sources/roads-rail-trade/` |
+| `RunReceipt` | Per-run evidence: source URL, ETag, `spec_hash`, artifacts, actor, outcome | `data/receipts/roads-rail-trade/` |
+| `ValidationReport` | Pass/fail per validator with fixture binding | `data/receipts/roads-rail-trade/validation/` |
+| `PolicyDecision` | ALLOW / DENY / ABSTAIN / ERROR + policy version | `data/receipts/roads-rail-trade/policy/` |
+| `TransformReceipt` | Normalization transforms applied | `data/receipts/roads-rail-trade/transform/` |
+| `GeneralizationReceipt` | Public-safe geometry transform (sensitive lanes) | `data/receipts/roads-rail-trade/generalization/` |
+| `RedactionReceipt` | Sensitivity redactions applied | `data/receipts/roads-rail-trade/redaction/` |
+| `EvidenceBundle` | Resolved support package for claims | `data/proofs/roads-rail-trade/` |
+| `CatalogMatrix` entry | Catalog membership and digest closure | `data/catalog/domain/roads-rail-trade/` |
+| `ReviewRecord` | Steward review state | `data/receipts/roads-rail-trade/review/` |
+| `ReleaseManifest` | Release decision, rollback target, correction path | `release/manifests/roads-rail-trade/` |
+| `CorrectionNotice` | Public notice of a corrected claim | `release/correction_notices/roads-rail-trade/` |
+| `RollbackCard` | Rollback decision artifact | `release/rollback_cards/roads-rail-trade/` |
+
+> [!NOTE]
+> All paths above are **PROPOSED**. Verify against Directory Rules §6 / §12 and the current `data/`, `release/`, and `data/registry/` layouts before committing.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 14. Failure modes & anti-patterns
+
+> [!WARNING]
+> If you find yourself doing any of these, **stop the refresh and re-plan.**
+
+- **Watcher auto-publish.** A connector or watcher writes directly to `data/published/` or to the live tile cache. Watchers are non-publishers.
+- **OSM-as-authority.** Promoting an OSM-derived claim as legal road status, jurisdictional ownership, or freight designation.
+- **Generalization skip.** Releasing raw historic-trail geometry from archival scans without a `GeneralizationReceipt`.
+- **Cultural-corridor leak.** Releasing exact Indigenous / cultural corridor geometry without explicit steward consent at the requested granularity.
+- **Operator-status retro-overwrite.** Silently mutating a prior `OperatorStatus` event instead of superseding it.
+- **Stale-without-marker.** Letting a source age past its cadence without either re-admission or a stale marker on dependents.
+- **Cache invalidation on no-change.** Emitting tile / style cache invalidations on a heartbeat poll.
+- **Polished-but-unreceipted refresh.** Producing a beautiful run with no `RunReceipt`, no `ValidationReport`, no `PolicyDecision`.
+- **Graph as truth.** Treating the derived transport-network graph as the canonical record rather than as a derivative of released objects.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 15. FAQ
+
+**Q. Can I refresh a single source by hand without going through CI?**
+A. You can fetch and inspect locally. You cannot promote anything past `data/work/roads-rail-trade/`. Any promotion requires CI-signed receipts and a `ReleaseManifest`.
+
+**Q. WZDx is live and noisy. How do I avoid cache thrash?**
+A. Use the debounce/coalesce window for the source class (5–30 s for high-churn). Materialize only when `spec_hash` changes. Heartbeat receipts emit on no-change without invalidating caches.
+
+**Q. A county sent a corrected bridge restriction. What do I do?**
+A. Treat it as a corrective refresh: re-run Gates A–G; if it materially changes a published claim, issue a `CorrectionNotice`, supersede the affected `ReleaseManifest`, and invalidate caches.
+
+**Q. An OSM contributor relabeled a road as US-50 Business; should we publish?**
+A. No. OSM is **observation/context**, not legal authority. The *role-overreach* validator should refuse. If a separate authoritative source (KDOT) confirms, refresh from that source instead.
+
+**Q. The historic-trail scan shows exact alignment. Why can't I publish that?**
+A. Source precision rarely supports it, and the corridor may overlap a sensitive Indigenous mobility line. Default to a generalized corridor view; require steward review and a `GeneralizationReceipt`.
+
+**Q. What if the upstream source disappears?**
+A. Mark dependents stale. Open a supersession entry in the source register. Decide via steward whether to withdraw the affected releases or to preserve them as historic claims with a stale-source badge.
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 16. Related docs
+
+- `docs/doctrine/directory-rules.md` — placement and authority roots
+- `docs/doctrine/lifecycle-law.md` — RAW → PUBLISHED invariant
+- `docs/doctrine/trust-membrane.md` — public-client boundary
+- `docs/domains/roads-rail-trade/README.md` *(PROPOSED — domain landing page)*
+- `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` *(PROPOSED — descriptor fields)*
+- `docs/runbooks/roads-rail-trade/VALIDATION.md` *(PROPOSED sibling)*
+- `docs/runbooks/roads-rail-trade/ROLLBACK.md` *(PROPOSED sibling)*
+- `docs/runbooks/roads-rail-trade/LOCAL_DEV.md` *(PROPOSED sibling)*
+- `docs/adr/ADR-watcher-non-publisher.md` *(PROPOSED — codifies the non-publisher rule)*
+- `docs/registers/VERIFICATION_BACKLOG.md` — open verification items for this lane
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+## 17. Appendix · pseudocode and command stubs
+
+<details>
+<summary><strong>A. Watcher → proposal → human gate → attestation → promotion (fail-closed)</strong></summary>
+
+<sub>Doctrinal sketch from KFM ingestion notes. Function names PROPOSED. The shape is the point, not the names.</sub>
+
+```python
+# PROPOSED — pseudocode; verify tool paths before adopting.
+def watcher_tick(source):
+    manifest = fetch_manifest(source)                 # ETag/Last-Modified or event payload
+    new_fp = content_fingerprint(manifest)            # sha256 over normalized content
+    old_fp = load_last_fingerprint(source)
+    if new_fp == old_fp:
+        emit_heartbeat_receipt(source); return        # no-change; do NOT invalidate caches
+
+    delta = compute_delta(load_snapshot(source), manifest)
+    spec_hash = sha256(JCS(serialize_delta_record(delta)))
+
+    proposed = {
+        "decision_id": uuid4(),
+        "spec_hash": spec_hash,
+        "delta": delta,
+        "source_refs": build_source_refs(manifest),
+        "ingest_lane": "RAW→WORK",
+    }
+    score, explain = ai_change_scorer(proposed,
+                        context=source_policy_context(source))   # advisory only
+    proposal_ref = write_to_WORK(proposed, score=score, explain=explain)
+    notify_steward(proposal_ref, score=score, explain=explain)   # human review required
+
+
+def steward_decision(proposal_ref, approve: bool, reason: str | None):
+    proposed = read_WORK(proposal_ref)
+    if not approve:
+        mark_status(proposal_ref, status="quarantine", reason=reason)
+        emit_run_receipt(decision_id=proposed["decision_id"],
+                         status="quarantine", reason=reason, actor="steward")
+        return ABSTAIN
+
+    evidence = buildEvidenceBundle(
+        proposed,
+        run_metadata=collect_run_metadata(),
+        policy_label=resolve_policy_label(proposed),
+        rights_status=resolve_rights(proposed),
+        sensitivity=resolve_sensitivity(proposed),
+    )
+    signed_att = dsse_sign_or_cosign(evidence)
+    emit_run_receipt(decision_id=proposed["decision_id"],
+                     spec_hash=proposed["spec_hash"],
+                     attestation_ref=signed_att.ref,
+                     timestamps=now_iso(), actor="steward")
+    promote(record=proposed, status="active",
+            attestation_ref=signed_att.ref,
+            lane="WORK→PROCESSED→CATALOG/TRIPLET→PUBLISHED")
+    return ANSWER
+```
+
+</details>
+
+<details>
+<summary><strong>B. Gate A · identity & integrity (POSIX shell sketch)</strong></summary>
+
+<sub>Adapted from KFM promotion-gate notes. Tooling presence in the repo is **NEEDS VERIFICATION**.</sub>
+
+```bash
+# PROPOSED — verify against actual workflow files before quoting in PRs.
+set -euo pipefail
+HEADERS=$(mktemp)
+curl -sI "$SOURCE_URL" > "$HEADERS"
+ETAG=$(awk         '/ETag/{print $2}'         "$HEADERS" | tr -d '\r"')
+LAST_MODIFIED=$(awk -F": " '/Last-Modified/{print $2}'   "$HEADERS" | tr -d '\r')
+CONTENT_LENGTH=$(awk -F": " '/Content-Length/{print $2}' "$HEADERS" | tr -d '\r')
+
+SPEC_HASH=$(python3 - <<'PY'
+import json, hashlib
+with open("spec.json", "r", encoding="utf-8") as f:
+    payload = json.dumps(json.load(f), sort_keys=True, separators=(",", ":"))
+print(hashlib.sha256(payload.encode()).hexdigest())
+PY
+)
+
+test -n "$ETAG" -a -n "$LAST_MODIFIED" -a -n "$SPEC_HASH"
+echo "spec_hash=$SPEC_HASH"
+```
+
+</details>
+
+<details>
+<summary><strong>C. DSSE / cosign verification on a run receipt</strong></summary>
+
+```bash
+# PROPOSED — keys and paths NEEDS VERIFICATION against repo conventions.
+cosign verify-blob \
+  --key cosign.pub \
+  --signature run_receipt.sig \
+  envelope.json
+```
+
+DSSE structural checks the validator MUST make: `payload` exists, `payloadType` matches, `signatures` array exists, signature count ≥ 1.
+
+</details>
+
+<details>
+<summary><strong>D. Truth-label legend used in this runbook</strong></summary>
+
+| Label | Meaning |
+|---|---|
+| **CONFIRMED** | Verified this session against attached KFM doctrine documents |
+| **PROPOSED** | Design / path / placement not yet verified in mounted-repo evidence |
+| **NEEDS VERIFICATION** | Checkable, but not yet checked strongly enough to act as fact |
+| **UNKNOWN** | Not resolvable without more evidence |
+| **EXTERNAL** | Sourced from authoritative external research (not used in this file) |
+
+</details>
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)
+
+---
+
+**Related docs:** [Directory Rules](../../doctrine/directory-rules.md) · [Lifecycle Law](../../doctrine/lifecycle-law.md) · [Trust Membrane](../../doctrine/trust-membrane.md) · [Roads/Rail Domain README](../../domains/roads-rail-trade/README.md) *(PROPOSED)* · [Source Descriptor Standard](../../sources/SOURCE_DESCRIPTOR_STANDARD.md) *(PROPOSED)*
+
+**Last updated:** 2026-05-12 · **Version:** v0.1 (draft) · **Status:** awaiting Roads/Rail steward + repo verification
+
+[⤴ Back to top](#-roads-rail-and-trade-routes--source-refresh-runbook)

--- a/docs/runbooks/settlements-infrastructure/NO_NETWORK_TEST_RUNBOOK.md
+++ b/docs/runbooks/settlements-infrastructure/NO_NETWORK_TEST_RUNBOOK.md
@@ -1,3 +1,738 @@
-# settlements-infrastructure :: NO_NETWORK_TEST runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/settlements-infrastructure/no-network-test
+title: No-Network Test Runbook — Settlements / Infrastructure
+type: standard
+version: v0.1
+status: draft
+owners: Docs steward + Settlements/Infrastructure subsystem owner + QA steward (PLACEHOLDER, confirm CODEOWNERS)
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/domains/settlements-infrastructure/README.md (PROPOSED, NEEDS VERIFICATION)
+  - schemas/contracts/v1/domains/settlements-infrastructure/ (PROPOSED per ADR-0001)
+  - tests/domains/settlements-infrastructure/ (PROPOSED)
+  - fixtures/domains/settlements-infrastructure/ (PROPOSED)
+  - policy/domains/settlements-infrastructure/ (PROPOSED)
+  - pipelines/domains/settlements-infrastructure/ (PROPOSED)
+  - tools/validators/ (PROPOSED)
+  - docs/runbooks/README.md (PROPOSED, NEEDS VERIFICATION)
+tags: [kfm, runbook, settlements, infrastructure, no-network, fail-closed, fixtures]
+notes:
+  - Path is PROPOSED per Directory Rules §12 (Domain Placement Law); confirm against mounted repo before merge.
+  - All command paths PROPOSED until repo state is verified.
+  - Sensitive-infrastructure fixtures must be public-safe synthetic, never real geometry.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# No-Network Test Runbook — Settlements / Infrastructure
+
+Run the **Settlements / Infrastructure** validators, fixtures, and proof-pack drills with **all network egress blocked** so that the lane's first-slice gates (schema, source-role, evidence closure, sensitivity, policy deny, release closure) are exercised deterministically, offline, and fail-closed — before any live source is activated.
+
+![status: draft](https://img.shields.io/badge/status-draft-yellow)
+![lane: settlements--infrastructure](https://img.shields.io/badge/lane-settlements--infrastructure-blue)
+![posture: fail--closed](https://img.shields.io/badge/posture-fail--closed-critical)
+![network: blocked](https://img.shields.io/badge/network-blocked-important)
+![truth: cite--or--abstain](https://img.shields.io/badge/truth-cite--or--abstain-success)
+![docs: governance](https://img.shields.io/badge/docs-governance-informational)
+
+| Field | Value |
+|---|---|
+| **Document type** | Runbook (operational) |
+| **Status** | Draft — `NEEDS VERIFICATION` against mounted repo |
+| **Owners** | Docs steward + Settlements/Infrastructure subsystem owner + QA steward (PLACEHOLDER) |
+| **Last updated** | 2026-05-12 |
+| **Authority of doctrine cited** | `CONFIRMED` |
+| **Authority of any concrete path / command** | `PROPOSED` until verified against mounted-repo evidence |
+| **Lifecycle covered** | `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` (offline fixtures only) |
+
+> [!IMPORTANT]
+> No-network execution is a **safety property**, not a convenience. If any step in this runbook reaches the network — DNS, HTTPS, package index, model endpoint, telemetry — that is a **runbook failure**, not a test failure, and must be filed in `docs/registers/DRIFT_REGISTER.md` (PROPOSED path).
+
+---
+
+## Quick jump
+
+- [1. Purpose & scope](#1-purpose--scope)
+- [2. Truth labels & evidence basis](#2-truth-labels--evidence-basis)
+- [3. Preconditions](#3-preconditions)
+- [4. What "no-network" means here](#4-what-no-network-means-here)
+- [5. Fixture inventory](#5-fixture-inventory)
+- [6. Test families & expected outcomes](#6-test-families--expected-outcomes)
+- [7. Runbook — the actual steps](#7-runbook--the-actual-steps)
+- [8. Interpreting results](#8-interpreting-results)
+- [9. Failure modes & triage](#9-failure-modes--triage)
+- [10. CI integration](#10-ci-integration)
+- [11. Rollback & cleanup](#11-rollback--cleanup)
+- [12. Sensitivity & publication posture](#12-sensitivity--publication-posture)
+- [13. Open verification items](#13-open-verification-items)
+- [14. Appendix — illustrative fixtures](#14-appendix--illustrative-fixtures)
+- [15. Related docs](#15-related-docs)
+
+---
+
+## 1. Purpose & scope
+
+`CONFIRMED` doctrine, `PROPOSED` implementation.
+
+The Settlements / Infrastructure lane's first deliverable is **schema-and-fixture-first**: source descriptors, deterministic identity, validators, deny policies, no-network fixtures, and proof-pack / promotion fixtures **before** any live source is activated. This runbook is the operational handle for that first slice.
+
+It covers:
+
+- Bringing up an **offline** test environment that cannot reach the public internet, package registries, model endpoints, or live source APIs.
+- Running the **validators** (schema, source-role, evidence closure, temporal, geometry, sensitivity, policy, release).
+- Driving the **fixture catalog** through the lifecycle:
+  `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`.
+- Producing a **proof pack** (receipts, validation reports, policy decisions, release manifest, rollback target) that downstream gates can consume.
+- Verifying **finite outcomes** — `ANSWER`, `ABSTAIN`, `DENY`, `ERROR` — for every governed call.
+
+It does **not** cover:
+
+- Live-source ingestion, watcher activation, or any test that requires real authoritative APIs (KDOT, FEMA NFHL, USGS, Census TIGER, state municipal registries, utility operators, etc.). Those belong in a separate live-source runbook gated behind this one.
+- Cesium / 3D rendering, MapLibre adapter component tests, or browser e2e. Map-shell tests live in `docs/runbooks/ui_VALIDATION.md` (PROPOSED path, NEEDS VERIFICATION).
+- Authority-laden release decisions. Releases are governed by `release/` and the release runbook; this runbook only proves the fixtures pass the gates.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 2. Truth labels & evidence basis
+
+| Label | Use |
+|---|---|
+| `CONFIRMED` | Verified in the attached KFM doctrine (`directory-rules.md`, Domains Culmination Atlas ch. 14, Unified Implementation Manual §6.9, KFM Encyclopedia §K, Whole-UI Expansion Report §20). |
+| `PROPOSED` | Concrete path, command, or fixture name not yet verified against a mounted repository. |
+| `NEEDS VERIFICATION` | Checkable but unchecked this session — e.g., exact validator entry point, test framework, CI runner. |
+| `UNKNOWN` | Not resolvable without more evidence — e.g., final auth model for governed API in this lane. |
+
+> [!NOTE]
+> Memory is not evidence. Where this runbook quotes paths like `tools/validators/...` or commands like `pytest tests/domains/settlements-infrastructure/...`, treat them as `PROPOSED` until you've confirmed them with `ls` and a grep through the mounted repo. The **shape** of the runbook is doctrine-bound; the **specific incantations** are placeholders.
+
+### What is `CONFIRMED` doctrine
+
+- The lifecycle invariant `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` and promotion as a **governed state transition, not a file move**.
+- The cite-or-abstain truth posture; AI never sits at the root of truth.
+- The fixture rule: every major object family must have at least one valid, one invalid, one denied, one abstention, and one rollback/correction fixture. Sensitive lanes must use public-safe transforms in place of real exact locations.
+- The test catalogue named in the Encyclopedia §K: schema validation, source descriptor validation, rights validation, sensitivity validation, evidence closure, temporal logic, geometry validity, policy deny, citation validation, release manifest validation, rollback drill, **no-network fixtures**, non-regression.
+- The Settlements / Infrastructure object families: `Settlement`, `Municipality`, `CensusPlace`, `Townsite`, `GhostTown`, `Fort`, `Mission`, `ReservationCommunity`, `InfrastructureAsset`, `NetworkNode`, `NetworkSegment`, `Facility`, `ServiceArea`, `Operator`, `ConditionObservation`, `Dependency`, plus `EvidenceBundle` and `ReleaseManifest`.
+- The sensitivity posture: critical infrastructure, bridge/condition/inspection details, private or security-sensitive assets, and exact vulnerable facility geometry default to **policy gate, generalization, staged access, or denial**.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 3. Preconditions
+
+You need all of the following true before starting. If any item is `UNKNOWN`, stop and resolve it before running the suite — a partial run produces misleading receipts.
+
+| # | Precondition | Verify with | Status when missing |
+|---|---|---|---|
+| 1 | Repository cloned at a known commit | `git rev-parse HEAD` | `ERROR` — do not proceed |
+| 2 | Branch is clean (or dirty state recorded in the receipt) | `git status --short` | record in the run receipt |
+| 3 | Per-root README contracts satisfied for affected lanes | manual review (§15 of Directory Rules) | `PROPOSED` |
+| 4 | Schema home confirmed (`schemas/contracts/v1/domains/settlements-infrastructure/`) per **ADR-0001** | `ls schemas/contracts/v1/domains/settlements-infrastructure/` | `PROPOSED` — open ADR drift entry if absent |
+| 5 | Fixture home present (`fixtures/domains/settlements-infrastructure/`) | `ls fixtures/domains/settlements-infrastructure/` | `PROPOSED` |
+| 6 | Policy home present (`policy/domains/settlements-infrastructure/`) | `ls policy/domains/settlements-infrastructure/` | `PROPOSED` |
+| 7 | Validator tools installed (no-network) | `tools/validators/...` is invokable from a clean shell | `PROPOSED` |
+| 8 | No real secrets in `configs/test/` | `grep -R` for token patterns | **security incident** if found — escalate per `docs/runbooks/` (PROPOSED) |
+| 9 | Network kill-switch active | see §4 below | hard stop |
+
+> [!CAUTION]
+> If precondition 8 fails — a real secret in `configs/` or a fixture — treat it as a security incident: **rotate, audit, and file a runbook entry**. Do **not** continue the suite until the secret is purged from git history and the new credential issued.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 4. What "no-network" means here
+
+`CONFIRMED` posture / `PROPOSED` mechanism.
+
+"No-network" is a **deny-by-default egress posture** for the duration of the test run. The exact enforcement mechanism is environment-specific; pick **one** of the following and record which in the receipt:
+
+1. **Container/sandbox with no networking.** Run the test container with no network namespace or with an explicit `--network none` flag (or equivalent).
+2. **Egress firewall.** Block all outbound DNS, TCP, and UDP except `127.0.0.1` and the test process's UNIX sockets.
+3. **Python socket guard.** A pytest plugin or `conftest.py` that monkey-patches `socket.socket` and `socket.getaddrinfo` to raise on any non-loopback address. `PROPOSED`; treat as a **defence in depth** layer, not a substitute for OS-level isolation.
+4. **DNS sinkhole.** Resolve all hostnames to `127.0.0.1`. Weakest option; only acceptable layered behind one of the above.
+
+> [!WARNING]
+> A passing run under "Python socket guard" alone is **not sufficient** for a release-bearing receipt. If a validator inadvertently uses a subprocess, native extension, or HTTP client that bypasses `socket.socket`, the guard will not fire. Use OS-level isolation for any receipt that will be cited downstream.
+
+### Egress allowlist
+
+Loopback only. No DNS. No package install during the run.
+
+| Destination | Permitted | Notes |
+|---|---|---|
+| `127.0.0.1`, `::1` | Yes | local test harness, file-backed mock catalog |
+| Project workspace filesystem | Yes | fixtures and emitted artifacts |
+| Public DNS / HTTPS | **No** | any hit is a runbook failure |
+| Package indices (PyPI, npm, conda-forge, GHCR) | **No** | install before isolation |
+| Model endpoints (Ollama remote, OpenAI, etc.) | **No** | `MockAdapter` only |
+| Telemetry endpoints | **No** | record disabled state in the receipt |
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 5. Fixture inventory
+
+`PROPOSED` paths / `CONFIRMED` rule: every major object family must have at least one **valid**, one **invalid**, one **denied**, one **abstention**, and one **rollback / correction** fixture. Sensitive object families must use public-safe synthetic data, never real exact geometry.
+
+```text
+fixtures/domains/settlements-infrastructure/                  # PROPOSED root
+├── README.md
+├── sources/
+│   ├── municipal_legal_source.valid.json
+│   ├── census_place_source.valid.json
+│   ├── operator_source.unknown_rights.invalid.json
+│   └── critical_infra_source.restricted.json
+├── objects/
+│   ├── settlement/
+│   │   ├── valid.json
+│   │   ├── invalid_missing_evidence.json
+│   │   ├── denied_unreleased.json
+│   │   ├── abstain_uncited.json
+│   │   └── rollback_prior_lineage.json
+│   ├── municipality/        # legal-source-role tests live here
+│   ├── census_place/        # census-vs-municipality distinction
+│   ├── townsite/
+│   ├── ghost_town/
+│   ├── fort/
+│   ├── mission/
+│   ├── reservation_community/
+│   ├── infrastructure_asset/
+│   ├── network_node/
+│   ├── network_segment/
+│   ├── facility/
+│   ├── service_area/
+│   ├── operator/
+│   ├── condition_observation/   # observed_at temporal tests
+│   └── dependency/
+├── evidence/
+│   ├── evidence_bundle.valid.json
+│   ├── evidence_ref.unresolved.invalid.json
+│   └── evidence_bundle.spec_hash_mismatch.invalid.json
+├── policy/
+│   ├── deny_restricted_geometry.json
+│   ├── deny_unknown_rights.json
+│   ├── deny_source_role_mismatch.json
+│   └── allow_public_safe_aggregate.json
+├── release/
+│   ├── release_manifest.valid.json
+│   ├── release_manifest.missing_rollback.invalid.json
+│   └── rollback_card.valid.json
+└── runtime/
+    ├── decision_envelope.answer.valid.json
+    ├── decision_envelope.abstain.valid.json
+    ├── decision_envelope.deny.valid.json
+    └── decision_envelope.error.valid.json
+```
+
+> [!NOTE]
+> Fixtures **must be public-safe synthetic**. A fixture for `InfrastructureAsset` representing a real bridge with real coordinates is a sensitivity-leak risk even inside the repo. Use Kansas-plausible **but generated** coordinates and explicit `"synthetic": true, "do_not_release": true` markers.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 6. Test families & expected outcomes
+
+`CONFIRMED` doctrine / `PROPOSED` placement.
+
+The following families are required for this lane. Each row is paired with the doctrine source. Place each family under `tests/domains/settlements-infrastructure/<family>/` (PROPOSED).
+
+| # | Test family | What it asserts | Sample fixture(s) | Pass outcome |
+|---|---|---|---|---|
+| T-01 | **Schema validation** | Required fields and versions present per `schemas/contracts/v1/domains/settlements-infrastructure/`. | `objects/**/valid.json` | `ANSWER` |
+| T-02 | **Source descriptor validation** | Source role, rights, sensitivity, citation, time, and hash recorded. | `sources/*.valid.json` | `ANSWER` |
+| T-03 | **Rights validation** | Unknown rights deny release. | `sources/*.unknown_rights.invalid.json` | `DENY` |
+| T-04 | **Sensitivity validation** | Critical-infrastructure / exact-facility geometry are not promoted public. | `policy/deny_restricted_geometry.json` | `DENY` |
+| T-05 | **Source-role mismatch denial** | A source isn't used outside its authority (e.g., census source used to assert legal municipality). | `objects/municipality/invalid_*.json` + `objects/census_place/*` | `DENY` |
+| T-06 | **Census-vs-municipality distinction** | `CensusPlace` and `Municipality` cannot be silently merged; legal status events have distinct evidence. | `objects/municipality/*`, `objects/census_place/*` | `ANSWER` (positive) / `DENY` (cross-contamination) |
+| T-07 | **Infrastructure topology** | `NetworkNode` ↔ `NetworkSegment` ↔ `Facility` connectivity is consistent. | `objects/network_*/*`, `objects/facility/*` | `ANSWER` |
+| T-08 | **Condition `observed_at` temporal** | `ConditionObservation` carries distinct source, observed, valid, retrieval, release, and correction times where material. | `objects/condition_observation/*` | `ANSWER` |
+| T-09 | **Evidence closure** | `EvidenceRef` resolves to an `EvidenceBundle` or the call abstains. | `evidence/*.valid.json`, `evidence/evidence_ref.unresolved.invalid.json` | `ANSWER` / `ABSTAIN` |
+| T-10 | **Citation validation** | Every claim that depends on evidence cites it; uncited claims abstain. | `runtime/decision_envelope.abstain.valid.json` | `ABSTAIN` |
+| T-11 | **Restricted-geometry no-leak** | Public-safe layer artifacts contain no exact restricted geometry; tile/vector outputs respect generalization receipts. | `policy/deny_restricted_geometry.json` | `DENY` |
+| T-12 | **Policy deny tests** | Unknown rights, unresolved source role, missing evidence, unresolved sensitivity, or absent release state **block** public promotion. | `policy/deny_*.json` | `DENY` |
+| T-13 | **Catalog / proof / release closure** | `EvidenceBundle`, catalog record, `ReleaseManifest`, correction path, and rollback target all exist for a publishable candidate. | `release/release_manifest.valid.json`, `release/rollback_card.valid.json` | `ANSWER` |
+| T-14 | **Release manifest validation** | Missing rollback target denies. | `release/release_manifest.missing_rollback.invalid.json` | `DENY` |
+| T-15 | **Rollback drill** | Restoring a prior `ReleaseManifest` is exercised end-to-end against fixtures. | `objects/*/rollback_prior_lineage.json` | `ANSWER` |
+| T-16 | **Non-regression** | Prior lineage / scaffold semantics are preserved; renamed or deprecated objects keep working aliases. | `objects/*/rollback_prior_lineage.json` | `ANSWER` |
+| T-17 | **AI boundary (`MockAdapter`)** | The Focus runtime cannot answer without admissible evidence; uses `MockAdapter` only, no live model. | `runtime/decision_envelope.{answer,abstain,deny,error}.valid.json` | `ANSWER` / `ABSTAIN` / `DENY` / `ERROR` |
+
+### Finite outcomes (recap)
+
+```mermaid
+flowchart LR
+    Q["Test call<br/>(governed, offline)"] --> V{"Validator gate<br/>schema / source-role /<br/>evidence / sensitivity"}
+    V -->|"passes"| P{"Policy gate<br/>rights / sensitivity /<br/>release state"}
+    V -->|"missing evidence"| AB["ABSTAIN<br/>cite-or-abstain"]
+    V -->|"schema/role broken"| ER["ERROR"]
+    P -->|"allow"| AN["ANSWER<br/>+ EvidenceBundle ref"]
+    P -->|"deny"| DN["DENY<br/>+ reason"]
+    classDef ok fill:#dcfce7,stroke:#16a34a,color:#064e3b;
+    classDef abs fill:#fef9c3,stroke:#ca8a04,color:#713f12;
+    classDef no fill:#fee2e2,stroke:#dc2626,color:#7f1d1d;
+    classDef err fill:#e5e7eb,stroke:#6b7280,color:#111827;
+    class AN ok
+    class AB abs
+    class DN no
+    class ER err
+```
+
+> [!NOTE]
+> Diagram reflects `CONFIRMED` doctrine for finite outcomes (`ANSWER` / `ABSTAIN` / `DENY` / `ERROR`). Specific validator entry points are `PROPOSED` until verified against the mounted repo.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 7. Runbook — the actual steps
+
+`PROPOSED` commands. Replace every `tools/...`, `pytest ...`, and `conftest ...` invocation below with the verified equivalent from the mounted repo's `Makefile`, `pyproject.toml`, or `package.json` scripts. Where this runbook commits to a name, treat the **shape** as authoritative and the **string** as a placeholder.
+
+### Step 0 — Record the run header
+
+Before isolating the network, capture the run identity so the receipt is reconstructable.
+
+```bash
+# PROPOSED — adapt to the repo's actual receipt helper.
+mkdir -p data/receipts/runs/settlements-infrastructure/
+cat > data/receipts/runs/settlements-infrastructure/run_header.json <<'EOF'
+{
+  "lane": "settlements-infrastructure",
+  "run_kind": "no-network-suite",
+  "isolation_mode": "<container|firewall|socket-guard|sinkhole>",
+  "git_sha": "$(git rev-parse HEAD)",
+  "git_dirty": "$(git status --short)",
+  "started_at": "<ISO-8601 timestamp>",
+  "spec_normalization_set": "v1",
+  "operator": "<your handle>"
+}
+EOF
+```
+
+### Step 1 — Enter the offline environment
+
+Pick one. Do not stack two enforcement modes by accident; choose explicitly.
+
+```bash
+# Option A — container with no networking (preferred)
+# PROPOSED — replace image and entrypoint with the verified repo equivalents.
+docker run --rm -it \
+  --network none \
+  -v "$PWD:/work" -w /work \
+  kfm/test-runner:offline \
+  bash
+
+# Option B — host shell behind an egress firewall
+# PROPOSED — the firewall recipe lives in infra/firewall/ per Directory Rules §10.2.
+sudo /usr/local/bin/kfm-egress-deny
+trap 'sudo /usr/local/bin/kfm-egress-restore' EXIT
+```
+
+### Step 2 — Sanity-check that the network really is down
+
+> [!IMPORTANT]
+> Do this **before** you start running anything that emits a receipt. A "passing" suite under a quietly-online environment is a worse outcome than a failing suite under a verifiably offline one.
+
+```bash
+# All three of these MUST fail or hang within a short timeout.
+getent hosts example.com           ; echo "exit=$?"      # expect non-zero
+python3 -c "import socket; socket.create_connection(('1.1.1.1',53),timeout=2)" ; echo "exit=$?"   # expect non-zero
+curl --max-time 3 https://pypi.org ; echo "exit=$?"      # expect non-zero
+```
+
+### Step 3 — Schema and contract layer
+
+```bash
+# PROPOSED — adapt to whatever the repo actually uses (ajv / jsonschema / check-jsonschema).
+tools/validators/schema/check_dir.py \
+  --schema-root schemas/contracts/v1/domains/settlements-infrastructure/ \
+  --fixture-root fixtures/domains/settlements-infrastructure/ \
+  --emit-report data/receipts/runs/settlements-infrastructure/schema_report.json \
+  --fail-on-warning
+```
+
+Expected: every `*.valid.json` passes; every `*.invalid.json` fails with a named error. Mixed results indicate fixture drift.
+
+### Step 4 — Source descriptor, rights, and source-role tests
+
+```bash
+# T-02 / T-03 / T-05
+pytest tests/domains/settlements-infrastructure/sources/ \
+  -m "no_network" \
+  --maxfail=0 \
+  --junitxml=data/receipts/runs/settlements-infrastructure/sources.junit.xml
+```
+
+### Step 5 — Object-family suite (legal vs. census distinction, topology, observed_at)
+
+```bash
+# T-06 / T-07 / T-08
+pytest tests/domains/settlements-infrastructure/objects/ \
+  -m "no_network and not live_source" \
+  --junitxml=data/receipts/runs/settlements-infrastructure/objects.junit.xml
+```
+
+### Step 6 — Evidence closure and citation validation
+
+```bash
+# T-09 / T-10
+pytest tests/domains/settlements-infrastructure/evidence/ \
+  -m "no_network" \
+  --junitxml=data/receipts/runs/settlements-infrastructure/evidence.junit.xml
+```
+
+### Step 7 — Sensitivity, restricted-geometry no-leak, and policy denials
+
+```bash
+# T-04 / T-11 / T-12
+conftest test \
+  -p policy/domains/settlements-infrastructure/ \
+  --data data/registry/sensitivity/ \
+  --fixtures fixtures/domains/settlements-infrastructure/policy/ \
+  --output json \
+  > data/receipts/runs/settlements-infrastructure/policy.json
+```
+
+Expected: every fixture under `policy/deny_*.json` returns `deny`; `policy/allow_public_safe_aggregate.json` returns `allow`.
+
+### Step 8 — Release manifest, rollback drill, and non-regression
+
+```bash
+# T-13 / T-14 / T-15 / T-16
+pytest tests/domains/settlements-infrastructure/release/ \
+  -m "no_network" \
+  --junitxml=data/receipts/runs/settlements-infrastructure/release.junit.xml
+```
+
+### Step 9 — Governed-AI boundary (`MockAdapter` only)
+
+```bash
+# T-17 — Focus Mode evidence/citation/policy validation with MockAdapter.
+# Live providers (Ollama, OpenAI, etc.) MUST remain disabled.
+KFM_AI_PROVIDER=mock pytest tests/domains/settlements-infrastructure/runtime/ \
+  -m "no_network" \
+  --junitxml=data/receipts/runs/settlements-infrastructure/runtime.junit.xml
+```
+
+### Step 10 — Emit the run receipt
+
+```bash
+# PROPOSED — adapt to the repo's actual receipt builder; doctrine source: New_Ideas_5-8-26.pdf, run receipt schema.
+tools/attest/scripts/make_run_receipt.py \
+  --lane settlements-infrastructure \
+  --inputs data/receipts/runs/settlements-infrastructure/*.{json,xml} \
+  --network-mode "<container|firewall|socket-guard|sinkhole>" \
+  --out data/receipts/runs/settlements-infrastructure/run_receipt.json
+```
+
+> [!NOTE]
+> The receipt **must** record `network_mode`, `spec_hash`, `git_sha`, the schema-validation, policy, and release reports, and a `verdict ∈ {ANSWER, ABSTAIN, DENY, ERROR}` for the suite as a whole. Anything less is not a release-bearing receipt.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 8. Interpreting results
+
+Use the table below as the canonical reading. **Do not** promote a suite verdict on a partial run.
+
+| Suite verdict | Means | Allowed next step |
+|---|---|---|
+| **`ANSWER`** | All required validators passed; all denial / abstention fixtures denied / abstained as expected; receipt is complete. | Lane is eligible for the **next gate** (review, promotion). Not "publish." |
+| **`ABSTAIN`** | At least one required claim could not be supported by the present fixtures (e.g., missing `EvidenceBundle`). | Add the missing evidence fixture; rerun. Do not relax the gate. |
+| **`DENY`** | A policy gate blocked release — for the right reason in negative tests, or for the wrong reason on a positive fixture. | If on a negative fixture: that is success. If on a positive fixture: triage per §9. |
+| **`ERROR`** | Tooling broke (schema validator crash, network leak detected, non-deterministic serialization, hash algo drift). | Stop. File a drift entry. Receipt is **not** release-bearing. |
+
+> [!TIP]
+> A run that completes too fast is suspicious. If the test count drops between runs without a code change, your collection is silently filtering — investigate before trusting the receipt.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 9. Failure modes & triage
+
+<details>
+<summary><strong>9.1 — Network leak detected (`ERROR`)</strong></summary>
+
+**Symptom.** A test or subprocess reached a non-loopback address; the socket guard fired, or the firewall logged egress.
+
+**Triage.**
+
+1. Identify the call site (stack trace, audit log).
+2. Quarantine the offending test until refactored to use a local fixture.
+3. File a drift entry in `docs/registers/DRIFT_REGISTER.md` (PROPOSED).
+4. Do **not** count this run as a passing no-network suite.
+
+</details>
+
+<details>
+<summary><strong>9.2 — Positive fixture denied (`DENY` on `*.valid.json`)</strong></summary>
+
+**Symptom.** A `valid.json` fixture is denied by policy.
+
+**Triage.**
+
+1. Inspect the denial reason in the policy report.
+2. If the reason is `unknown_rights`, `sensitivity_unresolved`, `source_role_mismatch`, or `missing_evidence`, the fixture is the bug — fix the fixture.
+3. If the reason is structural (schema, hash, normalization), the validator or schema is the bug — fix per ADR-required path; do not silently relax the policy.
+
+</details>
+
+<details>
+<summary><strong>9.3 — Negative fixture accepted (`ANSWER` on `*.invalid.json`)</strong></summary>
+
+**Symptom.** An `invalid.json` or `deny_*.json` fixture was **not** rejected.
+
+**Triage.**
+
+1. This is the **most dangerous** failure mode for a fail-closed system — a gate that doesn't gate.
+2. Quarantine the lane from release until resolved.
+3. Reproduce the validator decision on the fixture in isolation.
+4. Open a drift entry. Add a regression test pinning the negative fixture's expected denial reason.
+
+</details>
+
+<details>
+<summary><strong>9.4 — Non-deterministic <code>spec_hash</code> (`ERROR`)</strong></summary>
+
+**Symptom.** Same logical record yields different `spec_hash` across machines or runs.
+
+**Triage.**
+
+1. Surface a `NormalizationError.nondeterministic_serialization` from the validator.
+2. Re-canonicalize per the project's documented JSON canonicalization rule (sorted keys, UTF-8, compact separators, normalized floats).
+3. Verify the hash across at least two runtimes / containers.
+4. Do not publish anything depending on the affected receipt until determinism is restored.
+
+</details>
+
+<details>
+<summary><strong>9.5 — Missing rollback target (`DENY` on release manifest)</strong></summary>
+
+**Symptom.** `release_manifest.missing_rollback.invalid.json` rightly denies; a previously-passing manifest now denies for the same reason.
+
+**Triage.**
+
+1. Verify the rollback card exists and is reachable from the release manifest.
+2. If the prior release omitted rollback, treat as a `CONFIRMED` invariant violation and open a correction notice rather than relaxing the gate.
+
+</details>
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 10. CI integration
+
+`PROPOSED`. Wire the suite into CI as a **required check** for any PR touching `schemas/contracts/v1/domains/settlements-infrastructure/`, `policy/domains/settlements-infrastructure/`, `fixtures/domains/settlements-infrastructure/`, `pipelines/domains/settlements-infrastructure/`, or `release/candidates/settlements-infrastructure/`.
+
+```yaml
+# .github/workflows/settlements-infrastructure-no-network.yml   (PROPOSED)
+name: settlements-infrastructure / no-network
+on:
+  pull_request:
+    paths:
+      - "schemas/contracts/v1/domains/settlements-infrastructure/**"
+      - "policy/domains/settlements-infrastructure/**"
+      - "fixtures/domains/settlements-infrastructure/**"
+      - "tests/domains/settlements-infrastructure/**"
+      - "pipelines/domains/settlements-infrastructure/**"
+      - "release/candidates/settlements-infrastructure/**"
+  push:
+    branches: [main]
+
+jobs:
+  no-network:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: kfm/test-runner:offline   # PROPOSED — replace with verified image
+      options: --network none           # ENFORCE no-network at the container layer
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify network is denied
+        run: |
+          ! getent hosts example.com
+          ! python3 -c "import socket; socket.create_connection(('1.1.1.1',53),timeout=2)"
+      - name: Run no-network suite
+        run: bash docs/runbooks/settlements-infrastructure/no_network_suite.sh   # PROPOSED
+      - name: Upload receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: run_receipt
+          path: data/receipts/runs/settlements-infrastructure/run_receipt.json
+```
+
+> [!IMPORTANT]
+> The `--network none` container option is the **enforcement** of the no-network contract. Any test framework that requires network access at install time must perform the install in a **previous** layer / step, with isolation switched on **after** install. If install is the bottleneck, that is an `infra/` problem, not a runbook problem.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 11. Rollback & cleanup
+
+This runbook does not publish anything by itself; rollback here means **restoring the developer environment** and **discarding any partial receipts** that would otherwise be misleading.
+
+| Condition | Action |
+|---|---|
+| Suite ended in `ANSWER` | Keep receipt under `data/receipts/runs/settlements-infrastructure/`. Optionally promote into `data/receipts/published/...` per the release runbook. |
+| Suite ended in `ABSTAIN` / `DENY` on a negative fixture | Keep receipt; it is a valid record of a working gate. |
+| Suite ended in `ERROR` or network leak | **Delete or quarantine** the receipt; do not let it be cited downstream. File a drift entry. |
+| Containerized run | `docker rm` the test container; nothing to undo on the host. |
+| Host firewall run | Restore egress with the `trap` handler from §7 Step 1; verify with `getent hosts example.com`. |
+| Socket-guard run | No host changes; ensure the next shell session does not inherit the guard. |
+
+> [!CAUTION]
+> Do not "fix" a failing no-network run by allowing network access "just for this PR." The next PR will inherit a hole that nobody documented. If a fixture genuinely cannot be made offline, the fixture is in the wrong runbook.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 12. Sensitivity & publication posture
+
+`CONFIRMED` doctrine.
+
+The Settlements / Infrastructure lane carries elevated sensitivity. Even **inside** offline fixtures, treat real-world exact geometry, condition reports, inspection details, operator records, and dependency graphs of utility / public-safety / critical infrastructure as **review-restricted**.
+
+- **No real exact geometry in fixtures.** Use synthetic Kansas-plausible coordinates and explicit `"synthetic": true, "do_not_release": true` markers.
+- **No living-person data, no archaeological coordinates, no rare-species locations** from sibling lanes leaking through cross-relations. The cross-lane relations (Roads/Rail, Hazards, Hydrology, People/Land) are defined in doctrine but constrained to ownership-preserving relations only.
+- **Public-safe outputs only.** The PUBLISHED stage emits aggregate views, service-area summaries, public-safe asset views — never restricted internal review views. Restricted views may exist in fixtures but **must** be denied by policy when promoted.
+- **Unknown rights, unresolved source role, missing evidence, unresolved sensitivity, or absent release state blocks public promotion.** This is `CONFIRMED` doctrine and is enforced by Step 7 of the runbook.
+
+> [!WARNING]
+> A passing no-network suite is necessary but **not sufficient** for publication. It exercises the gates; it does not stand in for steward review, rights review, sensitivity review, or release sign-off.
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 13. Open verification items
+
+These items are `NEEDS VERIFICATION` against the mounted repository. The runbook is operational once each is resolved; until then, treat the commands as `PROPOSED`.
+
+| # | Item | What would settle it |
+|---|---|---|
+| OV-01 | Confirm `schemas/contracts/v1/domains/settlements-infrastructure/` is the canonical schema home (per ADR-0001). | Mounted-repo inspection; ADR file. |
+| OV-02 | Confirm test home `tests/domains/settlements-infrastructure/` and the `no_network` pytest marker exist. | `pytest --collect-only -m no_network`. |
+| OV-03 | Confirm fixture home and the five-fixture rule (valid / invalid / denied / abstain / rollback) per object family. | Repository scan; fixture coverage report. |
+| OV-04 | Confirm policy home `policy/domains/settlements-infrastructure/` and the conftest invocation pattern. | Mounted-repo inspection. |
+| OV-05 | Confirm validator entry points (schema, source descriptor, evidence closure, release manifest). | Repository scan of `tools/validators/`. |
+| OV-06 | Confirm the `MockAdapter` is wired and that `KFM_AI_PROVIDER=mock` is the correct env var. | Mounted-repo inspection of `runtime/mock/`. |
+| OV-07 | Confirm the CI image `kfm/test-runner:offline` (or its real equivalent) and the workflow path. | `.github/workflows/`. |
+| OV-08 | Confirm the run-receipt builder path and field set. | `tools/attest/` inspection. |
+| OV-09 | Confirm whether the runbook's path (`docs/runbooks/settlements-infrastructure/`) or a flat alternative (`docs/runbooks/settlements-infrastructure_NO_NETWORK_TEST_RUNBOOK.md`) is the project's adopted convention. | `docs/runbooks/README.md`; PR review. |
+| OV-10 | Confirm whether a per-domain `docs/runbooks/<domain>/README.md` index is required by the runbooks-folder contract. | `docs/runbooks/README.md`. |
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 14. Appendix — illustrative fixtures
+
+> [!NOTE]
+> These are **illustrative** shapes drawn from KFM doctrine. They are **not** drawn from the mounted repo and must be reconciled with the actual schemas at `schemas/contracts/v1/domains/settlements-infrastructure/` before use. Fields with `...` are abbreviated.
+
+<details>
+<summary><strong>14.1 — <code>SourceDescriptor</code> (valid, public)</strong></summary>
+
+```json
+{
+  "schema_version": "v1",
+  "object_type": "SourceDescriptor",
+  "source_id": "src.kansas.municipal.legal.synthetic.001",
+  "source_role": "legal",
+  "rights_status": "public",
+  "rights_spdx": "CC0-1.0",
+  "sensitivity": "public",
+  "citation": "Synthetic municipal legal source — fixture, do not release",
+  "coverage_scope": "KS",
+  "times": {
+    "source_time": "2024-06-01",
+    "observed_at": "2024-06-01",
+    "retrieved_at": "2026-05-12T00:00:00Z"
+  },
+  "content_hash": "sha256:0000...",
+  "spec_hash": "sha256:0000...",
+  "synthetic": true,
+  "do_not_release": true
+}
+```
+</details>
+
+<details>
+<summary><strong>14.2 — <code>InfrastructureAsset</code> (denied — restricted geometry)</strong></summary>
+
+```json
+{
+  "schema_version": "v1",
+  "object_type": "InfrastructureAsset",
+  "asset_kind": "bridge",
+  "geometry_precision": "exact",
+  "sensitivity": "restricted",
+  "rights_status": "unknown",
+  "evidence_ref": null,
+  "synthetic": true,
+  "do_not_release": true,
+  "_expected_outcome": "DENY",
+  "_expected_reasons": ["sensitivity_restricted", "rights_unknown", "missing_evidence"]
+}
+```
+</details>
+
+<details>
+<summary><strong>14.3 — <code>EvidenceRef</code> (unresolved → ABSTAIN)</strong></summary>
+
+```json
+{
+  "schema_version": "v1",
+  "object_type": "EvidenceRef",
+  "ref_id": "evref.settle.synthetic.unresolved",
+  "spec_hash": "sha256:1111...",
+  "_expected_outcome": "ABSTAIN",
+  "_expected_reasons": ["evidence_bundle_missing"]
+}
+```
+</details>
+
+<details>
+<summary><strong>14.4 — <code>DecisionEnvelope</code> shapes (one per outcome)</strong></summary>
+
+```json
+[
+  {"outcome": "ANSWER",  "answer": "...", "citations": ["evref.settle.synthetic.valid"], "policy_decision": "allow"},
+  {"outcome": "ABSTAIN", "reason": "missing_evidence"},
+  {"outcome": "DENY",    "reason": "sensitivity_restricted", "remediation": "request_steward_review"},
+  {"outcome": "ERROR",   "error_kind": "non_deterministic_serialization"}
+]
+```
+</details>
+
+[Back to top](#no-network-test-runbook--settlements--infrastructure)
+
+---
+
+## 15. Related docs
+
+- `docs/doctrine/directory-rules.md` — placement law for runbooks and lanes.
+- `docs/architecture/settlements-infrastructure/README.md` — lane architecture (`PROPOSED`, `NEEDS VERIFICATION`).
+- `docs/domains/settlements-infrastructure/README.md` — domain dossier (`PROPOSED`).
+- `docs/runbooks/README.md` — runbooks index and contract (`PROPOSED`).
+- `docs/runbooks/release_RUNBOOK.md` — release flow this runbook feeds (`PROPOSED`).
+- `docs/runbooks/rollback_RUNBOOK.md` — rollback flow this runbook references (`PROPOSED`).
+- `docs/runbooks/governed_ai_VALIDATION.md` — `MockAdapter` boundary for T-17 (`PROPOSED`).
+- `docs/adr/ADR-0001-schema-home.md` — schema home authority (`PROPOSED` reference name).
+- `docs/registers/DRIFT_REGISTER.md` — where drift entries land (`PROPOSED`).
+- `docs/registers/VERIFICATION_BACKLOG.md` — where OV-01 … OV-10 are tracked (`PROPOSED`).
+
+---
+
+**Last updated:** 2026-05-12 · **Doctrine status:** `CONFIRMED` · **Implementation status:** `PROPOSED` / `NEEDS VERIFICATION` · [Back to top](#no-network-test-runbook--settlements--infrastructure)

--- a/docs/runbooks/settlements-infrastructure/PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/settlements-infrastructure/PROMOTION_RUNBOOK.md
@@ -1,3 +1,561 @@
-# settlements-infrastructure :: PROMOTION runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook-settlements-infrastructure-promotion
+title: Settlements & Infrastructure — Promotion Runbook
+type: standard
+version: v0.1
+status: draft
+owners: <docs steward + Settlements/Infrastructure lane owner — NEEDS VERIFICATION>
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/domains/settlements-infrastructure/README.md
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/trust-membrane.md
+  - contracts/release/promotion_decision.md
+  - contracts/release/release_manifest.md
+  - schemas/contracts/v1/release/
+  - policy/promotion/
+  - policy/domains/settlements-infrastructure/
+  - release/candidates/settlements-infrastructure/
+tags: [kfm, runbook, promotion, settlements, infrastructure, governance, fail-closed]
+notes:
+  - All repo-specific paths are PROPOSED until verified against mounted-repo evidence.
+  - Doctrine claims are CONFIRMED from the KFM corpus; lane application is PROPOSED.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+<a id="top"></a>
+
+# Settlements & Infrastructure — Promotion Runbook
+
+> Step-by-step operational procedure for promoting Settlements / Infrastructure objects through the KFM lifecycle — **RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED** — under evidence-first, fail-closed governance.
+
+<p align="center">
+  <b>Evidence-first · Cite-or-Abstain · Promotion is a governed state transition, not a file move</b>
+</p>
+
+![Status](https://img.shields.io/badge/status-draft-orange)
+![Doc Type](https://img.shields.io/badge/type-runbook-blue)
+![Lifecycle](https://img.shields.io/badge/lifecycle-governed-informational)
+![Policy](https://img.shields.io/badge/policy-fail--closed-critical)
+![Domain](https://img.shields.io/badge/domain-settlements%2Finfrastructure-success)
+![Last Updated](https://img.shields.io/badge/updated-2026--05--12-lightgrey)
+
+| Field | Value |
+|---|---|
+| **Doc class** | Standard / Operational Runbook |
+| **Authority** | Doctrine claims **CONFIRMED**; lane-specific implementation paths **PROPOSED / NEEDS VERIFICATION** |
+| **Owners** | Docs steward + Settlements / Infrastructure lane owner *(NEEDS VERIFICATION — populate from `CODEOWNERS`)* |
+| **Reviewers required** | Release manager · Domain steward · Policy admin *(per Master Action Matrix)* |
+| **Last reviewed** | 2026-05-12 |
+| **Supersedes** | None — first lane-specific promotion runbook |
+
+> [!IMPORTANT]
+> **Promotion is a governed state transition, not a file move.** No object reaches `PUBLISHED` without an explicit `PromotionDecision`, a verifiable evidence chain, a passing policy gate, a `ReleaseManifest`, and a recorded rollback target. If any required artifact is missing or unverifiable, the gate **MUST** fail closed.
+
+---
+
+## Quick Links
+
+- [1. Purpose & Scope](#1-purpose--scope)
+- [2. Doctrinal Anchors](#2-doctrinal-anchors)
+- [3. Domain Scope & Sensitivity Posture](#3-domain-scope--sensitivity-posture)
+- [4. Lifecycle Pipeline](#4-lifecycle-pipeline)
+- [5. Promotion Gates A–G — Domain Application](#5-promotion-gates-ag--domain-application)
+- [6. Sensitive / Deny-by-Default Register (Lane Slice)](#6-sensitive--deny-by-default-register-lane-slice)
+- [7. Procedure — RAW to PUBLISHED](#7-procedure--raw-to-published)
+- [8. Validators, Fixtures, and CI Hooks](#8-validators-fixtures-and-ci-hooks)
+- [9. Decision Envelope & Receipt Shapes](#9-decision-envelope--receipt-shapes)
+- [10. Correction, Rollback, and Stale-State](#10-correction-rollback-and-stale-state)
+- [11. Negative-Path Catalog (Fail-Closed Examples)](#11-negative-path-catalog-fail-closed-examples)
+- [12. FAQ & Common Pitfalls](#12-faq--common-pitfalls)
+- [13. Open Verification Backlog](#13-open-verification-backlog)
+- [14. Related Documents](#14-related-documents)
+- [Appendix A — Object Family Inventory](#appendix-a--object-family-inventory)
+- [Appendix B — Cross-Lane Relations](#appendix-b--cross-lane-relations)
+- [Appendix C — Glossary](#appendix-c--glossary)
+
+---
+
+## 1. Purpose & Scope
+
+This runbook is the operational procedure for moving Settlements / Infrastructure objects from admitted source material to released public-safe artifacts. It exists so that any reviewer, steward, release manager, or domain editor can execute and audit a promotion without re-deriving doctrine from scratch.
+
+**In scope.** The lifecycle path for objects owned by the Settlements / Infrastructure lane, the gate set that must be satisfied at each stage, the sensitivity posture that constrains what can become public-safe, and the receipts and manifests emitted along the way.
+
+**Out of scope.** Source-descriptor authoring (see `docs/sources/`), schema authoring (see `schemas/`), policy authoring (see `policy/`), and cross-lane relation governance (touched only where it gates this domain's promotion). Transport routes are owned by Roads / Rail; hydrologic evidence by Hydrology; living-person and parcel ownership data by People / Land; hazard events and warnings by Hazards. *(CONFIRMED non-ownership boundaries; status **CONFIRMED**.)*
+
+> [!NOTE]
+> This is a **lane-specific** runbook. Cross-cutting promotion mechanics — receipt schema, DSSE / cosign signing, OPA bundle digest pinning, two-key approval — live in the repo-wide promotion runbook and policy documents. This file specializes those mechanics to the Settlements / Infrastructure objects, gates, and sensitivity defaults.
+
+---
+
+## 2. Doctrinal Anchors
+
+Promotion in this lane inherits the following invariants. They are **CONFIRMED** from the KFM corpus and are non-negotiable.
+
+| Invariant | Source | Effect on this runbook |
+|---|---|---|
+| Lifecycle law: `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED` | Directory Rules; Encyclopedia | Every stage in §4 is a state, not a folder destination. |
+| Promotion is a governed state transition, not a file move | Directory Rules | `PromotionDecision` is the unit of work, not a `git mv`. |
+| Cite-or-abstain truth posture | Encyclopedia; Governed AI doctrine | An `EvidenceRef` MUST resolve to an `EvidenceBundle` before public claim authority. |
+| Trust membrane | Directory Rules; Whole-UI report | Public clients consume governed APIs and released artifacts only — never `RAW`, `WORK`, `QUARANTINE`, canonical stores, or unverified candidates. |
+| Fail-closed defaults | Master Action Matrix; Pass 10 (C5-02) | Absence of evidence, rights, or release state blocks promotion. |
+| Promotion Gate Matrix **A–G** | Pass 10 (C5-01) | Seven named gates; auto-merge fires only when all seven pass. |
+| Critical infrastructure default to restricted / review | Settlements dossier; Encyclopedia §13 | Exact facility geometry, conditions, dependencies, operator-sensitive details are restricted by default. |
+| Two-key separation of duties for release | Master Action Matrix | Domain steward + release manager (where maturity justifies). |
+
+---
+
+## 3. Domain Scope & Sensitivity Posture
+
+### 3.1 Owned object families (CONFIRMED doctrine; PROPOSED schema realization)
+
+`Settlement` · `Municipality` · `CensusPlace` · `Townsite` · `GhostTown` · `Fort` · `Mission` · `ReservationCommunity` · `InfrastructureAsset` · `NetworkNode` · `NetworkSegment` · `Facility` · `ServiceArea` · `Operator` · `ConditionObservation` · `Dependency` · `AnnexationEvent` · `UrbanGrowthObservation`
+
+### 3.2 Explicit non-ownership
+
+| Object class | Owning lane |
+|---|---|
+| Transport routes / rail lines / trade corridors | Roads / Rail |
+| Surface and groundwater evidence | Hydrology |
+| Hazard events, declarations, warnings | Hazards |
+| Living-person data, parcel ownership, residence ties | People / Land |
+
+### 3.3 Default sensitivity posture (CONFIRMED)
+
+> [!WARNING]
+> **Critical infrastructure, utilities, condition observations, dependencies, operator-sensitive details, and exact facility geometry default to `RESTRICTED` or `REVIEW`.** Unclear rights, unresolved source role, missing evidence, unresolved sensitivity, or absent release state **blocks public promotion** outright.
+
+The default-restricted classes most often hit in this lane:
+
+- Exact geometry of vulnerable facilities (water, wastewater, energy, communications, transport-critical bridges).
+- Condition observations and inspection records.
+- Dependency relations that map cascading failure surfaces.
+- Operator identity and contact details when rights are unclear.
+
+Public-safe outputs in this lane are typically: settlement timelines, place-identity reconciliation, public-safe asset views (generalized), service-area aggregates without precise node enumeration, and historic-place views where rights are clear.
+
+---
+
+## 4. Lifecycle Pipeline
+
+The lifecycle below is **CONFIRMED doctrine**; the specific gate artifacts and validators referenced are **PROPOSED** until verified against mounted-repo evidence.
+
+```mermaid
+flowchart LR
+  RAW["RAW<br/>SourceDescriptor admitted<br/>(role, rights, hash, time)"]
+  WORK["WORK / QUARANTINE<br/>Normalize: schema, geometry,<br/>time, identity, evidence,<br/>rights, policy"]
+  PROC["PROCESSED<br/>EvidenceRef + ValidationReport<br/>+ digest closure<br/>(public-safe candidates)"]
+  CAT["CATALOG / TRIPLET<br/>EvidenceBundle<br/>+ graph/triplet projections<br/>+ release candidate"]
+  PUB["PUBLISHED<br/>ReleaseManifest<br/>+ rollback target<br/>+ correction path"]
+
+  RAW --> WORK
+  WORK --> PROC
+  PROC --> CAT
+  CAT --> PUB
+
+  WORK -. quarantine reason recorded .-> WORK
+  PROC -. fail-closed: missing receipt/digest .-> WORK
+  CAT  -. fail-closed: unresolved sensitivity .-> WORK
+  PUB  -. CorrectionNotice / RollbackCard .-> CAT
+```
+
+| Stage | Required input | Gate condition | Emitted artifact(s) | Status |
+|---|---|---|---|---|
+| **RAW** | Immutable source payload (or reference) under approved `SourceDescriptor`: role, rights, sensitivity, citation, time, hash. | `SourceDescriptor` exists and is admissible. | `RawCaptureReceipt`, `RunReceipt` | PROPOSED implementation |
+| **WORK / QUARANTINE** | RAW reference. Apply normalization for schema, geometry, time, identity, evidence, rights, and policy. | Validation + policy gate pass — **or** quarantine reason recorded. | `ValidationReport`, quarantine record | PROPOSED implementation |
+| **PROCESSED** | Validated normalized objects, public-safe candidates. | `EvidenceRef` resolves to `EvidenceBundle`; `ValidationReport` clean; digest closure holds. | `RunReceipt`, `ValidationReport`, `EvidenceBundle` candidate | PROPOSED implementation |
+| **CATALOG / TRIPLET** | Processed candidates. | Catalog / proof closure passes; graph/triplet projections produced; release candidate assembled. | `EvidenceBundle`, catalog records, release candidate | PROPOSED implementation |
+| **PUBLISHED** | Approved release candidate. | `ReleaseManifest`, review state (where required), correction path, rollback target all exist; release-gate policy passes. | `ReleaseManifest`, `PromotionDecision`, `RollbackCard` | PROPOSED implementation |
+
+---
+
+## 5. Promotion Gates A–G — Domain Application
+
+The seven-gate matrix is **CONFIRMED** from the KFM corpus (Pass 10 §C5-01). The table below specializes each gate to settlements / infrastructure concerns. The check column points to the *kind* of machinery that satisfies the gate; concrete tool names, policy bundle paths, and CI workflow IDs are **PROPOSED** until verified against the mounted repo.
+
+| Gate | Human intent | Machine check (general) | Settlements / Infrastructure specialization |
+|---|---|---|---|
+| **A — Structure & Metadata** | MetaBlock present; zone correctness | `check_structure` | Doc / artifact carries KFM Meta Block; object identifiers map to permitted families (§3.1); temporal fields populated. |
+| **B — Schemas & Contracts** | Object shape valid | JSON Schema + OpenAPI validation against `schemas/contracts/v1/...` | `Settlement`, `InfrastructureAsset`, `ConditionObservation`, etc. validate against their `schemas/contracts/v1/domains/settlements-infrastructure/*.schema.json` (**PROPOSED** path). |
+| **C — Policy Parity** | CI policy equals runtime policy | Conftest / OPA decisions against pinned `policy-bundle.json` | `policy/domains/settlements-infrastructure/` bundle digest matches the runtime PDP digest; admissions evaluated identically. |
+| **D — Security & Sensitivity** | Sensitivity, rights, and license posture acceptable | Sensitivity scan; SPDX allowlist; geoprivacy transform check | Critical-infrastructure precision-class enforced; exact facility geometry blocked from public payloads unless explicit release support recorded; operator identity gated. |
+| **E — Data Quality** | Profilers / assertions meet thresholds | DQ profilers + threshold assertions | Place-identity reconciliation passes; census-vs-municipality distinction holds; topology assertions on networks/nodes/segments; `observed_at` present on `ConditionObservation`. |
+| **F — Provenance & Lineage** | Receipt + lineage validate | Receipt validator + OpenLineage events | `RunReceipt` is cosign-verifiable; `EvidenceRef → EvidenceBundle` resolves; source role distinctions (legal vs. census vs. modeled vs. historic) preserved. |
+| **G — Reviewability** | Two-key human approval | CODEOWNERS-enforced human approval + policy approval | Domain steward + release manager sign-off; restricted-class objects require additional sensitivity-review record. |
+
+> [!TIP]
+> The promotion gate is **fail-closed by construction**: any missing required field, unverifiable signature, absent Rekor proof, or undefined policy label blocks promotion and sets the candidate to `QUARANTINE` with reason. Treat ambiguous gate output as a deny.
+
+---
+
+## 6. Sensitive / Deny-by-Default Register (Lane Slice)
+
+This is the Settlements / Infrastructure slice of the cross-cutting Sensitive Register (CONFIRMED doctrine; specific identifiers are **PROPOSED** placeholders until inventoried).
+
+| Class | Examples | Default outcome | Required controls |
+|---|---|---|---|
+| Critical infrastructure | Exact facilities, dependency relations, condition observations | `RESTRICT` / `DENY` public precision | Public-safe aggregation; role-based access; geoprivacy transform receipt |
+| Operator-sensitive | Operator identity / contacts when rights unclear | `DENY` public | Rights register; attribution; no public derivative if barred |
+| Vulnerable-facility geometry | Pump stations, substations, choke-point bridges | `DENY` exact point publicly | Generalization to service area; sensitivity transform receipt |
+| Cross-lane spillover (archaeology, living-person, sacred) | Fort sites with cultural overlay; reservation-community residence ties | Defer to owning lane's deny rules | Cultural / privacy review; staged access; suppression |
+| Source-rights-limited records | Licensed municipal records, no-redistribution feeds | `DENY` public release until terms resolved | Rights register entry; rights-checked attribution |
+
+---
+
+## 7. Procedure — RAW to PUBLISHED
+
+The procedure below is the **operational ordering** of work for a single object family (e.g., `InfrastructureAsset`) advancing through the lifecycle. Multiple object families in a release candidate are advanced together only after each has satisfied gates A–F individually; gate G binds them at release time.
+
+### 7.1 Pre-flight (before opening a promotion PR)
+
+1. **Confirm the source descriptor exists.** Verify `SourceDescriptor` is admitted under an approved source role (e.g., Census/TIGER, GNIS, state/local GIS, municipal records, historical gazetteer, operator record). If unclear, halt and resolve via `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md`. *(PROPOSED path; NEEDS VERIFICATION.)*
+2. **Confirm rights and sensitivity classification.** Look up the source in the rights register; classify the candidate against §6. If any class is unresolved → **STOP, quarantine, escalate to policy admin.**
+3. **Confirm schema home.** Each emitted object must validate against a schema under `schemas/contracts/v1/domains/settlements-infrastructure/`. *(PROPOSED per Directory Rules §6.4 and ADR-0001; verify the schema exists before continuing.)*
+4. **Confirm policy bundle pin.** Note the digest of `policy/domains/settlements-infrastructure/` in the PR description. *(PROPOSED path.)*
+
+### 7.2 RAW → WORK / QUARANTINE
+
+1. Run the ingest connector under its `SourceDescriptor`. Emit `RawCaptureReceipt` and `RunReceipt` (signed, cosign-verifiable).
+2. Apply normalization: schema validation, geometry repair, temporal alignment, identity assignment using the proposed deterministic basis (`source_id + object_role + temporal_scope + normalized_digest`).
+3. If any normalizer fails, route the candidate to `QUARANTINE` with a recorded reason. **Do not silently retry; do not promote.**
+4. Run policy gate **C (Policy Parity)** against the WORK candidate. Any deny outcome → keep in `QUARANTINE`, emit `DecisionEnvelope { outcome: "DENY", reasons: [...] }`.
+
+### 7.3 WORK → PROCESSED
+
+1. Confirm `EvidenceRef` resolves to a complete `EvidenceBundle` (no dangling refs).
+2. Confirm `ValidationReport` is clean — including lane-specific checks: legal-municipality evidence, census-vs-municipality distinction, infrastructure topology coherence, `ConditionObservation.observed_at` present.
+3. Confirm **digest closure**: re-canonicalize the spec, recompute hash, compare to the `RunReceipt.spec_hash` field.
+4. Mark the object family `PROCESSED`. Public-safe candidates may now be derived; they are **not yet published**.
+
+### 7.4 PROCESSED → CATALOG / TRIPLET
+
+1. Assemble the `EvidenceBundle` for each object, attaching: source descriptors, validation report, run receipts, policy decisions, sensitivity transforms (with receipt), rights statement.
+2. Run **restricted-geometry no-leak** assertions on any derived public-safe layer. Failure here is a hard fail-closed — exact precision must never reach a publishable artifact unless explicit release support is recorded.
+3. Emit graph/triplet projections, taking care to preserve source-role distinctions across cross-lane edges (see Appendix B).
+4. Assemble the release candidate. The candidate references the bundle by digest; it does not copy it.
+
+### 7.5 CATALOG / TRIPLET → PUBLISHED
+
+1. Run gate **G (Reviewability)**. Obtain two-key approval: domain steward + release manager. For any restricted-class object reaching this stage with explicit release support, attach the `ReviewRecord` reference.
+2. Build the `ReleaseManifest`. It MUST bind: digests, evidence bundle reference, policy posture, sensitivity posture, rights status, review record, correction path, and **rollback target** (the prior release manifest reference).
+3. Verify signatures end-to-end. Re-verify the receipt envelope; verify the `ReleaseManifest` signature; confirm Rekor proof is present.
+4. Emit `PromotionDecision { outcome: "ANSWER", gate: "G.publish", spec_hash, attestation_ref, manifest_ref }`.
+5. Publish through the governed API surface (e.g., the Settlements / Infrastructure feature/detail resolver, the layer manifest resolver). Never expose canonical or `RAW` stores directly. *(Routes **PROPOSED**; concrete route names UNKNOWN until verified.)*
+6. Record the published artifact in `data/published/layers/settlements-infrastructure/` (or equivalent — **PROPOSED** path per Directory Rules §4 Step 3).
+
+### 7.6 Post-publication
+
+1. Open the release in the weekly material-change report (Friday cadence).
+2. Confirm the new release is referenced in `release/candidates/settlements-infrastructure/` history (or equivalent — **PROPOSED**).
+3. Add an entry to the lane's correction-path register so a future `CorrectionNotice` has a defined return path.
+
+[⬆ Back to top](#top)
+
+---
+
+## 8. Validators, Fixtures, and CI Hooks
+
+The validator and fixture list is **PROPOSED** for this lane per the Settlements / Infrastructure dossier (§K). Concrete file paths, tool names, and CI workflow IDs are **NEEDS VERIFICATION** until checked against the mounted repo.
+
+### 8.1 Required validator families
+
+- **Legal-municipality evidence tests** — verify that any object labeled `Municipality` carries the source-role evidence and temporal scope required for legal status assertions.
+- **Census-vs-municipality distinction** — block conflation of `CensusPlace` and `Municipality`; assert source-role separation.
+- **Infrastructure topology tests** — verify `NetworkSegment` endpoints resolve to declared `NetworkNode` ids; no orphan segments.
+- **Condition `observed_at` tests** — every `ConditionObservation` carries an `observed_at` timestamp distinct from retrieval / release time.
+- **Restricted-geometry no-leak tests** — assert that public-safe layers contain no exact-precision points from restricted classes.
+- **Catalog / proof / release closure tests** — for any release candidate, every referenced bundle, receipt, and policy decision exists and verifies.
+
+### 8.2 Negative fixtures (expected DENY)
+
+| Fixture | Expected outcome | Why |
+|---|---|---|
+| `missing_spec_hash.json` | `DENY` | Receipt cannot bind candidate to inputs. |
+| `unresolved_evidence.json` | `DENY` | `EvidenceRef` does not resolve. |
+| `restricted_exact_geometry.json` | `DENY` | Public-safe candidate contains exact restricted-class point. |
+| `stale_evidence.json` | `DENY` | Bundle exceeds staleness threshold. |
+| `unknown_policy_label.json` | `DENY` | Policy label not defined in access policy. |
+| `publication_before_review.json` | `DENY` | Restricted object reached release without `ReviewRecord`. |
+| `census_promoted_as_municipality.json` | `DENY` | Source-role conflation. |
+| `orphan_network_segment.json` | `DENY` | Topology invariant violated. |
+| `missing_observed_at_on_condition.json` | `DENY` | Temporal invariant violated. |
+
+### 8.3 CI ordering (recommended)
+
+> [!NOTE]
+> Recommended ordering, drawn from KFM doctrine. Concrete workflow names are **PROPOSED**.
+
+1. `opa fmt --fail .` and `opa check .` — policy lint before evaluation.
+2. JSON Schema validation against `schemas/contracts/v1/...`.
+3. Policy unit tests.
+4. Negative-path fixtures (§8.2).
+5. Promotion dry-run (`conftest test receipts/promotion_input.json --policy policy/`).
+6. Release-manifest validation.
+7. Cosign signature verification on `RunReceipt` and `ReleaseManifest`.
+
+---
+
+## 9. Decision Envelope & Receipt Shapes
+
+The shapes below are **CONFIRMED grammar** (ANSWER / ABSTAIN / DENY / ERROR) with **PROPOSED** field realization. Treat field names as illustrative until verified against the schemas.
+
+### 9.1 `DecisionEnvelope` (promotion-gate output)
+
+```json
+{
+  "decision_id": "dec-2026-05-12-001",
+  "outcome": "DENY",
+  "policy_family": "promotion",
+  "gate": "D.security_sensitivity",
+  "domain": "settlements-infrastructure",
+  "reasons": [
+    "restricted_exact_geometry",
+    "missing_sensitivity_transform_receipt"
+  ],
+  "obligations": [
+    { "type": "hold", "op": "steward_review" },
+    { "type": "transform", "op": "generalize_to_service_area" }
+  ],
+  "evidence_refs": ["evbundle://settle-asset-117@v3"],
+  "evaluated_at": "2026-05-12T00:00:00Z"
+}
+```
+
+### 9.2 Minimal `decision_log` entry (CI emit)
+
+```json
+{
+  "decision_id": "<uuid>",
+  "policy_id": "gate.D.security_sensitivity",
+  "spec_hash": "<sha256>",
+  "input_digest": "<sha256>",
+  "result": "deny",
+  "obligations": ["steward_review"],
+  "evidence_refs": ["evbundle://settle-asset-117@v3"],
+  "timestamp": "<ISO8601>",
+  "job_run_id": "<CI_RUN_ID>"
+}
+```
+
+> [!CAUTION]
+> Use `decision_id` as the join key across OPA decision logs, `RunReceipt`, attestations, and the published manifest. Streaming each gate event as JSONL into an append-only audit ledger is the recommended pattern; tampering with the chain breaks rollback drill replay.
+
+---
+
+## 10. Correction, Rollback, and Stale-State
+
+### 10.1 Correction
+
+When a published Settlements / Infrastructure artifact is found to be wrong (data error, source revocation, sensitivity reclassification, rights change):
+
+1. Open a `CorrectionNotice` referencing the offending `ReleaseManifest` by digest.
+2. Determine whether the fix is **forward-only** (issue a new release) or **rollback-required** (the current release is unsafe to leave in place).
+3. For rollback-required corrections, also issue a `RollbackCard` (§10.2).
+4. Re-run gates A–G on the corrected candidate. **A correction does not bypass gates.**
+
+### 10.2 Rollback
+
+Rollback **repoints current release state**. The prior published artifact is preserved as lineage; the active manifest pointer moves backward to a known-good `ReleaseManifest`.
+
+```mermaid
+flowchart LR
+  R3["Release v3 (active)"]
+  R2["Release v2"]
+  R1["Release v1"]
+  RC["RollbackCard<br/>(repoints to v2)"]
+  CN["CorrectionNotice"]
+
+  R3 -.->|defect| CN
+  CN --> RC
+  RC --> R2
+  R3 -. preserved as lineage .- R3
+```
+
+> [!WARNING]
+> Rollback **MUST** be drillable. Replay verification must demonstrate that the prior root hash and manifest are recoverable. Untested rollback paths are not rollback paths.
+
+### 10.3 Stale-state
+
+Settlements / Infrastructure objects degrade differently:
+
+- `Municipality` boundary changes via `AnnexationEvent` → republish required.
+- `ConditionObservation` ages → mark `stale` after the lane-specific window (NEEDS VERIFICATION).
+- `Operator` rights renewal lapses → demote to `RESTRICTED` until renewed.
+
+Stale-state badging is a cross-cutting viewing concern (`Evidence Drawer`, trust badges). The runbook's responsibility is to **trigger republication** when staleness thresholds are crossed.
+
+---
+
+## 11. Negative-Path Catalog (Fail-Closed Examples)
+
+> [!IMPORTANT]
+> Each row below is a documented refusal pattern. The promotion attempt is **denied**; the reviewer's job is not to soften the deny but to remediate the underlying gap.
+
+| Scenario | Failing gate | Required remediation |
+|---|---|---|
+| Operator-sensitive details in a public-safe layer payload | D (Security & Sensitivity) | Remove operator identity; re-derive public-safe view; attach sensitivity transform receipt. |
+| `Municipality` claim asserted from a single census-derived source | F (Provenance & Lineage) | Add a legal-municipality source; re-resolve `EvidenceRef`; rerun census-vs-municipality validator. |
+| `NetworkSegment` referencing missing `NetworkNode` | E (Data Quality) | Repair topology in WORK; re-run topology validator; do not promote until clean. |
+| `ConditionObservation` without `observed_at` | E (Data Quality) | Reject candidate; revisit normalizer; ensure temporal extraction from source. |
+| `ReleaseManifest` produced without a `rollback target` | G (Reviewability) + release-gate policy | Block release; add explicit rollback target; rerun release-manifest validation. |
+| Promotion candidate using a `policy_label` undefined in access policy | C (Policy Parity) | Define the label in access policy; refresh policy bundle digest; rerun parity check. |
+| Object family attempted via direct file move into `data/published/` | Lifecycle invariant | Reject the PR; promotion is a state transition, not a file move. |
+
+---
+
+## 12. FAQ & Common Pitfalls
+
+<details>
+<summary><b>Can I promote a "low-risk" infrastructure asset without a sensitivity transform receipt?</b></summary>
+
+No. The default sensitivity posture for infrastructure assets is `RESTRICTED` / `REVIEW`. A receipt-less promotion is exactly the failure mode the gate set is designed to prevent. If you believe an asset is genuinely low-risk and qualifies for public-safe precision, the burden is on the candidate to carry an explicit, reviewer-approved sensitivity transform receipt — not on the gate to assume good faith.
+
+</details>
+
+<details>
+<summary><b>The connector emits a candidate that fails gate C. Can I run gate D anyway to "save time"?</b></summary>
+
+No. Gates are **fail-closed and ordered**. A failing gate routes the candidate to `QUARANTINE` with a reason. Running downstream gates against a denied candidate generates misleading audit signal. Remediate at the failing gate.
+
+</details>
+
+<details>
+<summary><b>Do I need to re-resolve <code>EvidenceRef</code> if I'm only adjusting display text?</b></summary>
+
+Yes, if the adjustment is part of a release candidate. Re-resolution is cheap; trusting a previously-resolved reference across releases is exactly how stale or revoked evidence leaks into a manifest. The gate F requirement is *closure*, not *closure-once*.
+
+</details>
+
+<details>
+<summary><b>The CI bundle digest doesn't match the runtime PDP. Is that OK if "it's just a small bump"?</b></summary>
+
+No — gate C is **policy parity**. CI and runtime must evaluate against the same pinned bundle digest. A drift is a deny, even if the substantive policy is unchanged, because the parity invariant is what makes the policy machinery trustworthy in the first place.
+
+</details>
+
+<details>
+<summary><b>An AI assistant summarized an unpublished candidate as if it were public. Is that a runbook concern?</b></summary>
+
+Yes — it is a **trust-membrane violation**. Generated language is interpretive and never sovereign truth. Any AI surface in this lane MUST ABSTAIN where evidence is insufficient and DENY where policy, rights, sensitivity, or release state blocks the request. Treat the leak as an incident; record it; revisit the adapter boundary.
+
+</details>
+
+---
+
+## 13. Open Verification Backlog
+
+The items below are **NEEDS VERIFICATION**. Closing each requires inspecting actual repo evidence — files, schemas, policy bundles, CI workflows, runtime artifacts.
+
+| Item | Evidence that would settle it | Status |
+|---|---|---|
+| Verify source rights and municipal legal-source roles for this lane | Mounted-repo source descriptors, rights register | NEEDS VERIFICATION |
+| Verify critical-infrastructure policy bundle exists and is digest-pinned | Mounted policy/, OPA bundle, runtime PDP config | NEEDS VERIFICATION |
+| Verify public-safe layer registry for Settlements / Infrastructure | `data/registry/`, `data/published/layers/`, layer descriptors | NEEDS VERIFICATION |
+| Verify governed-API and Focus Mode auth/policy behavior in this lane | App route table, runtime test logs, e2e fixtures | NEEDS VERIFICATION |
+| Verify exact `schemas/contracts/v1/domains/settlements-infrastructure/` layout under ADR-0001 | Mounted `schemas/` tree, ADR-0001 status | NEEDS VERIFICATION |
+| Verify CODEOWNERS lane assignment for two-key approval | `CODEOWNERS` (root or `.github/`) | NEEDS VERIFICATION |
+| Verify rollback drill cadence and replay tooling | `infra/`, `tools/`, CI workflows | NEEDS VERIFICATION |
+
+[⬆ Back to top](#top)
+
+---
+
+## 14. Related Documents
+
+> Paths below are **PROPOSED** per the canonical structure in `docs/doctrine/directory-rules.md`. Replace `TODO` entries once verified.
+
+- `docs/doctrine/directory-rules.md` — placement law and lifecycle invariant *(CONFIRMED)*
+- `docs/doctrine/lifecycle-law.md` — `RAW → PUBLISHED` doctrine *(PROPOSED path)*
+- `docs/doctrine/trust-membrane.md` — public-surface containment *(PROPOSED path)*
+- `docs/domains/settlements-infrastructure/README.md` — lane overview *(PROPOSED — TODO)*
+- `contracts/release/promotion_decision.md` — `PromotionDecision` object meaning *(PROPOSED)*
+- `contracts/release/release_manifest.md` — `ReleaseManifest` object meaning *(PROPOSED)*
+- `schemas/contracts/v1/release/` — release schemas *(PROPOSED — ADR-0001)*
+- `schemas/contracts/v1/domains/settlements-infrastructure/` — domain schemas *(PROPOSED — ADR-0001)*
+- `policy/promotion/` — promotion-gate policy bundle *(PROPOSED)*
+- `policy/domains/settlements-infrastructure/` — lane sensitivity & admissibility policy *(PROPOSED)*
+- `docs/adr/ADR-0001-schema-home.md` — schema home decision *(CONFIRMED reference)*
+- `docs/runbooks/` — sibling runbooks (UI, governed-AI, ingest lanes) *(CONFIRMED canonical root)*
+
+---
+
+## Appendix A — Object Family Inventory
+
+<details>
+<summary><b>Full object family list with notes (click to expand)</b></summary>
+
+| Family | One-line role | Sensitivity default |
+|---|---|---|
+| `Settlement` | Generic temporal place; bounded by source role and evidence | Public-safe (where rights clear) |
+| `Municipality` | Legal municipal entity | Public-safe with legal-source evidence |
+| `CensusPlace` | Census-defined place | Public-safe; distinct from `Municipality` |
+| `Townsite` | Platted or historically recorded townsite | Public-safe (historical) |
+| `GhostTown` | Abandoned settlement | Public-safe (historical) |
+| `Fort` | Historic / current fort | Mostly public-safe; cultural overlay possible |
+| `Mission` | Religious mission settlement | Cultural review recommended |
+| `ReservationCommunity` | Tribal reservation community | Cultural / sovereignty review required |
+| `InfrastructureAsset` | Discrete asset (facility / structure) | `RESTRICTED` / `REVIEW` by default |
+| `NetworkNode` | Topology node | `RESTRICTED` (exact); aggregate OK |
+| `NetworkSegment` | Topology edge | `RESTRICTED` (exact); aggregate OK |
+| `Facility` | Functional facility (water plant, depot, etc.) | `RESTRICTED` / `REVIEW` |
+| `ServiceArea` | Aggregate coverage polygon | Typically public-safe |
+| `Operator` | Owning / operating entity | Rights-gated; `RESTRICTED` if unclear |
+| `ConditionObservation` | Inspection / condition record | `RESTRICTED` by default |
+| `Dependency` | Inter-asset dependency relation | `RESTRICTED` (cascade risk) |
+| `AnnexationEvent` | Boundary-change event | Public-safe |
+| `UrbanGrowthObservation` | Growth-trend observation | Public-safe (aggregate) |
+
+</details>
+
+---
+
+## Appendix B — Cross-Lane Relations
+
+<details>
+<summary><b>Cross-lane edges this domain participates in (click to expand)</b></summary>
+
+Promotion in this lane must preserve **ownership, source role, sensitivity, and EvidenceBundle support** across every cross-lane edge.
+
+| With | Relation types | Constraint |
+|---|---|---|
+| Roads / Rail | depot, bridge, crossing, transport facility | Transport identity stays with Roads / Rail; settlement-side preserves facility identity. |
+| Hazards | exposure, resilience, warnings, declarations | KFM is never an alert authority; hazard records are cited, not authored. |
+| Hydrology | water, wastewater, stormwater, floodplain, drainage | Hydrology owns water evidence; settlements cite. |
+| People / Land | residence, ownership, parcel, migration context | Living-person and parcel ownership stay with People / Land; restrictions apply. |
+| Archaeology | cultural temporal period / survey context | Cultural review; exact site coords denied. |
+
+</details>
+
+---
+
+## Appendix C — Glossary
+
+<details>
+<summary><b>KFM terms used in this runbook (click to expand)</b></summary>
+
+| Term | Meaning |
+|---|---|
+| **EvidenceRef** | Reference that must resolve to an `EvidenceBundle` before public claim authority. |
+| **EvidenceBundle** | Resolved evidence package for a claim. |
+| **Governed API** | Interface enforcing evidence, policy, release, finite outcomes, and audit. |
+| **Promotion** | Governed release transition. *Not* a file movement. |
+| **PromotionDecision** | Governed state-transition record enumerating gates A–G as auditable promotion memory. |
+| **ReleaseManifest** | Record of published artifact set, digests, policy posture, release state, correction path, and rollback target. |
+| **RollbackCard** | Rollback target and drill object that preserves history while repointing current release state. |
+| **RunReceipt** | Execution record pinning inputs, outputs, hashes, tool versions, timestamps, failures, policy posture, and evidence refs. |
+| **Redaction Receipt** | Record of a public-safe field or geometry transformation. |
+| **Runtime Response Envelope** | Finite-outcome envelope (ANSWER / ABSTAIN / DENY / ERROR) for AI and runtime surfaces. |
+| **Trust membrane** | Doctrine boundary preventing raw, unreviewed, restricted, or generated state from becoming public truth. |
+
+</details>
+
+---
+
+> **Related docs:** [Directory Rules](../../doctrine/directory-rules.md) · [Domain lane README](../../domains/settlements-infrastructure/README.md) *(PROPOSED)* · [Sibling runbooks](../) · [ADR-0001 Schema home](../../adr/ADR-0001-schema-home.md)
+>
+> **Last updated:** 2026-05-12 · **Doc class:** Standard / Operational Runbook · **Status:** draft
+>
+> [⬆ Back to top](#top)

--- a/docs/runbooks/settlements-infrastructure/ROLLBACK_RUNBOOK.md
+++ b/docs/runbooks/settlements-infrastructure/ROLLBACK_RUNBOOK.md
@@ -1,3 +1,507 @@
-# settlements-infrastructure :: ROLLBACK runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/settlements-infrastructure/rollback
+title: Settlements / Infrastructure — Rollback Runbook
+type: standard
+version: v1
+status: draft
+owners: Settlements/Infrastructure domain steward · Release steward · Docs steward
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - kfm://doctrine/lifecycle-law
+  - kfm://doctrine/trust-membrane
+  - kfm://doctrine/directory-rules
+  - kfm://schema/ReleaseManifest
+  - kfm://schema/RollbackCard
+  - kfm://schema/CorrectionNotice
+  - kfm://domain/settlements-infrastructure
+tags: [kfm, runbook, rollback, settlements, infrastructure, release, governance]
+notes:
+  - Path docs/runbooks/settlements-infrastructure/ROLLBACK_RUNBOOK.md is PROPOSED; prior expansion plan used flat docs/runbooks/<subsystem>_ROLLBACK.md naming. See §3.
+  - All routes, validators, reason codes, and schema homes remain PROPOSED until mounted-repo verification.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Settlements / Infrastructure — Rollback Runbook
+
+> Governed procedure for withdrawing, reverting, or superseding a **Settlements / Infrastructure** release whose claims, geometry, sensitivity posture, or supporting evidence is no longer safe to keep public.
+
+<!-- Badges: targets are placeholders until CI/release workflows are verified in the mounted repo. -->
+![status: draft](https://img.shields.io/badge/status-draft-blue)
+![authority: doctrine + PROPOSED ops](https://img.shields.io/badge/authority-doctrine%20%2B%20PROPOSED%20ops-orange)
+![lane: settlements--infrastructure](https://img.shields.io/badge/lane-settlements--infrastructure-2b7a78)
+![lifecycle: PUBLISHED → prior PUBLISHED](https://img.shields.io/badge/lifecycle-PUBLISHED%20%E2%86%92%20prior%20PUBLISHED-5b21b6)
+![sensitivity: deny-by-default for critical infra](https://img.shields.io/badge/sensitivity-deny--by--default-c0392b)
+<!-- TODO Shields: replace with real CI / last-updated badges once `.github/workflows/release-*.yml` is confirmed. -->
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` — operational doctrine **CONFIRMED**; this runbook's implementation hooks **PROPOSED** |
+| **Owners** | Settlements/Infrastructure domain steward · Release steward · Docs steward |
+| **Last updated** | 2026-05-12 |
+| **Applies to** | All released artifacts under the Settlements / Infrastructure lane (settlements, municipalities, census places, townsites, ghost towns, forts, missions, reservation communities, infrastructure assets, networks, nodes, segments, facilities, service areas, operators, condition observations, dependencies) |
+| **Lifecycle action** | A governed state transition — **PUBLISHED → prior PUBLISHED** (or withdrawal). Not a file move. |
+| **Pairs with** | `RELEASE_RUNBOOK.md` *(PROPOSED, NEEDS VERIFICATION)*, `VALIDATION_RUNBOOK.md` *(PROPOSED, NEEDS VERIFICATION)*, `CORRECTION_RUNBOOK.md` *(PROPOSED, NEEDS VERIFICATION)* |
+
+---
+
+## 🔎 Quick jump
+
+- [1. Purpose & scope](#1-purpose--scope)
+- [2. Doctrinal invariants](#2-doctrinal-invariants)
+- [3. Repo fit & path basis](#3-repo-fit--path-basis)
+- [4. When to roll back](#4-when-to-roll-back)
+- [5. Defect classes & postures](#5-defect-classes--postures)
+- [6. Rollback flow (diagram)](#6-rollback-flow-diagram)
+- [7. Step-by-step procedure](#7-step-by-step-procedure)
+- [8. Artifacts emitted](#8-artifacts-emitted)
+- [9. Domain-specific scenarios](#9-domain-specific-scenarios)
+- [10. Cross-lane impact](#10-cross-lane-impact)
+- [11. UI & governed-AI behavior during rollback](#11-ui--governed-ai-behavior-during-rollback)
+- [12. Validation, drills, and dry-runs](#12-validation-drills-and-dry-runs)
+- [13. Anti-patterns](#13-anti-patterns)
+- [14. Open verification items](#14-open-verification-items)
+- [15. Related docs](#15-related-docs)
+
+---
+
+## 1. Purpose & scope
+
+This runbook tells a steward, release operator, or on-call reviewer **how to safely withdraw or revert a Settlements / Infrastructure release** when the released artifact, claim, manifest, or AI surface should no longer be in public circulation.
+
+It is **CONFIRMED doctrine** in KFM that:
+
+- A released claim, layer, catalog record, artifact, or answer **must have a visible correction path and rollback target before it is treated as safely publishable**.
+- Rollback is a **governed state transition**, not a file copy, not a silent overwrite, not a CDN-only purge.
+- The durable public unit is the **inspectable claim** — every rollback preserves the original release record and emits a new, superseding decision.
+
+> [!IMPORTANT]
+> Settlements / Infrastructure has the highest sensitivity surface of the place-and-asset lanes: **critical infrastructure, utilities, condition observations, dependencies, operator-sensitive details, and exact facility geometry default to restricted or review.** When a rollback is in doubt, **fail closed** — disable the public surface first, decide the rollback target second.
+
+**In scope.** Rollback of `PUBLISHED` Settlements / Infrastructure artifacts, manifests, layer descriptors, Evidence Drawer payloads, Focus Mode answers, and downstream tile / catalog / triplet projections derived from them.
+
+**Out of scope.** Source-side ingestion errors (handled in `VALIDATION_RUNBOOK.md`, PROPOSED), schema migration (handled by ADRs and `migrations/`), and pre-publication review rejections (handled by the review console). Those defects do not require a public rollback because the affected artifact never reached `PUBLISHED`.
+
+---
+
+## 2. Doctrinal invariants
+
+The rollback procedure below exists to preserve these invariants — **never to bypass them**.
+
+| Invariant | What rollback must preserve | Source |
+|---|---|---|
+| **Lifecycle law** | `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`. Rollback re-enters `PUBLISHED` via the same governed gates, with a prior release as the target. | CONFIRMED doctrine (Directory Rules; Domain Atlas §H) |
+| **Trust membrane** | Public clients, normal UI, and released AI surfaces never reach `RAW`, `WORK`, `QUARANTINE`, canonical/internal stores, graph internals, vector indexes, or model runtimes — **during a rollback either**. | CONFIRMED doctrine (Map-Master §10; Encyclopedia) |
+| **Watcher-as-non-publisher** | Workers, watchers, and pipelines emit receipts and candidates; they do **not** publish a rollback. A human-governed release path executes the transition. | CONFIRMED doctrine (Directory Rules §7.3; Build Manual §6.9) |
+| **Cite-or-abstain** | A rollback that leaves residual public claims must accompany them with a `CorrectionNotice`; otherwise the AI / Evidence Drawer surface **must ABSTAIN**. | CONFIRMED doctrine (GAI; Encyclopedia §I) |
+| **Deterministic identity** | Rollback targets are pinned by **digest** (sha256 / blake3) and `release_id`, not by mutable paths. | CONFIRMED doctrine (Map-Master §9, ReleaseManifest) |
+| **Auditability** | Every rollback produces a `RollbackCard`, a `CorrectionNotice` (when public claims existed), and a cache-invalidation receipt. Nothing is deleted; superseded releases retain `release_state: SUPERSEDED` or `REVOKED`. | CONFIRMED doctrine (Build Manual §20; ReleaseManifest schema) |
+
+> [!NOTE]
+> If a step in §7 appears to require violating one of these invariants, **stop**. The correct action is to disable the affected public surface, open a `RollbackCard` in `pending` state, and escalate to the Release steward before proceeding.
+
+---
+
+## 3. Repo fit & path basis
+
+**Proposed path:** `docs/runbooks/settlements-infrastructure/ROLLBACK_RUNBOOK.md` — **PROPOSED / NEEDS VERIFICATION** against mounted-repo runbook naming.
+
+Two precedents coexist in project evidence:
+
+1. **Flat naming** (from the Whole-UI + Governed AI expansion plan): `docs/runbooks/ui_ROLLBACK.md`, `docs/runbooks/governed_ai_ROLLBACK.md`. Subsystem prefix; no per-lane subdirectory.
+2. **Per-domain subdirectory** (consistent with Directory Rules §4 Step 3 — *"the domain appears as a **segment** inside the responsibility root"*): `docs/runbooks/<domain>/ROLLBACK_RUNBOOK.md`.
+
+Both satisfy the Directory Rules `docs/` root responsibility. The per-domain subdirectory pattern (used here) scales better when each lane needs its own `RELEASE`, `VALIDATION`, `CORRECTION`, and `ROLLBACK` runbooks. **An ADR or a `docs/runbooks/README.md` should freeze one convention** before more lanes land.
+
+```text
+docs/
+└── runbooks/
+    ├── README.md                                   # PROPOSED — declare naming convention
+    └── settlements-infrastructure/
+        ├── README.md                               # PROPOSED — lane runbook index
+        ├── RELEASE_RUNBOOK.md                      # PROPOSED, NEEDS VERIFICATION
+        ├── VALIDATION_RUNBOOK.md                   # PROPOSED, NEEDS VERIFICATION
+        ├── CORRECTION_RUNBOOK.md                   # PROPOSED, NEEDS VERIFICATION
+        └── ROLLBACK_RUNBOOK.md                     # this file
+```
+
+> [!CAUTION]
+> No statement here implies the above tree exists in the mounted repo. Treat every path as **PROPOSED** until verified.
+
+---
+
+## 4. When to roll back
+
+Use this decision matrix. **Roll back when public exposure is unsafe and re-validation cannot resolve the defect inside the existing release window.** Otherwise, prefer a correction (`PUBLISHED → PUBLISHED'`) or a withdrawal (set `release_state: REVOKED`).
+
+| Signal | Severity | Action |
+|---|---|---|
+| Exact facility geometry leaked (e.g., utility node, substation, water intake) | **Critical** | Rollback + immediate cache invalidation + `RedactionReceipt` + steward notify |
+| Operator-sensitive details exposed (ownership, condition, inspection, vulnerability) | **Critical** | Rollback + withdrawal of affected artifact set |
+| Critical-infrastructure asset misclassified as public-safe | **High** | Rollback to prior generalized release; re-run policy gate |
+| Condition observation `observed_at` corrupted (stale or future-dated) | **High** | Correction first; rollback if downstream graphs already consumed it |
+| Legal municipality boundary cited the wrong source role (e.g., `model` upcast to `authority`) | **High** | Rollback; re-emit with correct `source_role` |
+| Census-place geography conflated with municipal boundary | **Medium** | Correction; rollback only if Focus Mode answers were generated |
+| Historic townsite / ghost-town identity reconciliation produced wrong predecessor link | **Medium** | Correction with `CorrectionNotice`; rollback if multi-domain downstream |
+| Tile digest mismatch on a published layer | **High** | Rollback to prior `MapReleaseManifest`; cache invalidation receipt mandatory |
+| Cross-lane derivative (e.g., Hazards exposure layer) used a withdrawn Infrastructure layer | **High** | Rollback infrastructure release **and** invalidate every cited derivative |
+
+> [!TIP]
+> When a defect is **borderline correction-vs-rollback**, ask: *"Did any public claim, AI answer, or downstream lane consume the bad artifact?"* If yes, rollback the underlying release and emit a `CorrectionNotice`. If no, correct in place with a superseding release.
+
+[Back to top ↑](#-quick-jump)
+
+---
+
+## 5. Defect classes & postures
+
+**CONFIRMED doctrine** (Build Manual §20; defect-class table). The correction posture is for in-place repair; the rollback posture is for withdrawing a bad public surface.
+
+| Defect class | Correction posture | Rollback posture |
+|---|---|---|
+| **Evidence gap** | ABSTAIN or withdraw unsupported claim | Restore prior evidence-supported release |
+| **Rights defect** | DENY public use; quarantine source / artifact | Withdraw affected artifacts |
+| **Sensitivity leak** | Redact / generalize; emit `RedactionReceipt`; notify stewards | **Immediate public disablement** |
+| **Geometry defect** | Rebuild derivative layer and evidence payload | Restore previous digest-pinned artifact |
+| **Temporal defect** | Correct `valid_time` / `source_time` / `retrieval_time` / `release_time` | Mark stale until rebuilt |
+| **Policy defect** | Re-run policy and `DecisionEnvelope` | Disable route / layer if gate failed |
+| **AI answer defect** | Invalidate `AIReceipt` and response envelope | Remove answer; preserve `EvidenceBundle` |
+| **Catalog defect** | Re-emit catalog closure after proof repair | Restore previous catalog state |
+
+**Reason codes** that should appear on a Settlements / Infrastructure `RollbackCard` (**PROPOSED catalog** from the gate-failure registry):
+
+`MISSING_EVIDENCE` · `MISSING_RECEIPT` · `MISSING_REVIEW` · `SCHEMA_MISMATCH` · `CONTRACT_DRIFT` · `RIGHTS_UNKNOWN` · `SENSITIVITY_UNRESOLVED` · `ROLE_COLLAPSE` · `ROLE_DOWNCAST_FORBIDDEN` · `REVIEW_NEEDED` · `REVIEW_INSUFFICIENT` · `REVIEW_REJECTED` · `RELEASE_MANIFEST_INVALID` · `ROLLBACK_TARGET_MISSING`
+
+---
+
+## 6. Rollback flow (diagram)
+
+The diagram below reflects the **CONFIRMED doctrinal flow** (Build Manual §20; ReleaseManifest schema; Map-Master rollback target). Routes and validator names are **PROPOSED**.
+
+```mermaid
+flowchart TD
+    A[Public defect signal<br/>steward, monitor, drill, correction request] --> B{Severity & scope}
+    B -- "Correction sufficient" --> C[Open CorrectionNotice<br/>publish superseding release]
+    B -- "Rollback required" --> D[Identify affected release_id<br/>+ EvidenceBundle + LayerManifest]
+    D --> E[Locate rollback target<br/>previous_release in ReleaseManifest]
+    E --> F[Verify prior artifact set<br/>sha256 / blake3 / spec_hash]
+    F -->|verified| G[Disable / withdraw public surface<br/>governed API + tiles + Focus Mode]
+    F -->|fail| Z1[STOP — ROLLBACK_TARGET_MISSING<br/>escalate to Release steward]
+    G --> H[Emit RollbackCard<br/>+ CorrectionNotice if public claims existed]
+    H --> I[Update ReleaseManifest<br/>release_state: REVOKED or SUPERSEDED]
+    I --> J[Restore / republish prior release<br/>through same governed gates]
+    J --> K[Emit cache invalidation receipt<br/>tiles, style, glyphs, sprites, drawer payloads]
+    K --> L[Mark stale / withdrawn UI state<br/>trust badge + correction banner]
+    L --> M[Notify cross-lane consumers<br/>Roads/Rail, Hazards, Hydrology, People/Land]
+    M --> N[Close RollbackCard<br/>append to release/changelog]
+    C --> N
+
+    classDef stop fill:#fde2e2,stroke:#c0392b,color:#7a1f1f;
+    class Z1 stop;
+```
+
+> [!NOTE]
+> If the mounted-repo flow diverges, this diagram is the **doctrinal reference**; update it via PR rather than diverging silently.
+
+[Back to top ↑](#-quick-jump)
+
+---
+
+## 7. Step-by-step procedure
+
+> [!WARNING]
+> **Do not perform any step that touches a public surface without an open `RollbackCard` in `pending` state.** A rollback executed without a card is, by doctrine, a hidden file copy — and is forbidden.
+
+### Step 1 — Acknowledge and bound the defect
+
+- Open a `RollbackCard` *(PROPOSED schema home: `schemas/contracts/v1/release/RollbackCard.schema.json` — NEEDS VERIFICATION)*.
+- Record: `defect_class` (§5), `reason_code` (§5), `release_id`, `affected_artifacts[]`, `discovered_by`, `discovered_at`, `public_claims_exist: bool`.
+- Set initial state to `pending`.
+
+### Step 2 — Identify the affected release
+
+- Resolve the affected `ReleaseManifest` by `release_id`.
+- Enumerate downstream artifacts: `LayerManifest`, `StyleManifest`, `TileArtifactManifest`, `MapReleaseManifest`, derived `triplets/`, and any cited `EvidenceBundle` projections.
+- Cross-reference `release/changelog/` for releases that consumed this one as a dependency.
+
+### Step 3 — Locate the rollback target
+
+The target is the **previous safe release**, identified by `ReleaseManifest.rollback.previous_release`. **CONFIRMED schema** (excerpt):
+
+```json
+{
+  "rollback": {
+    "rollback_supported": true,
+    "previous_release": "rel-settlements-infra-2026-005",
+    "rollback_plan_ref": "release/rollback_cards/rel-settlements-infra-2026-007.json"
+  }
+}
+```
+
+> [!CAUTION]
+> If `rollback_supported` is `false` or `previous_release` is `null`, **stop** with reason code `ROLLBACK_TARGET_MISSING`. The release should never have been published; escalate, open a correction notice, and treat the affected surface as withdrawn until a manual recovery plan is approved.
+
+### Step 4 — Verify the prior artifact set
+
+For every artifact referenced by the prior `ReleaseManifest`:
+
+- Verify `sha256` (and `blake3` where present).
+- Verify `spec_hash` continuity.
+- Verify `evidence_refs[]` still resolve to extant `EvidenceBundle`s.
+- Verify `policy_label`, `rights_status`, and `sensitivity` still satisfy the gate that admitted the prior release.
+
+If any verification fails, **abort the automatic path**. Open a manual recovery plan with the Release steward.
+
+### Step 5 — Disable / withdraw the public surface
+
+- Set the affected `LayerManifest` to a non-public state via the governed release path (not by editing files).
+- Withdraw the affected tile set from the CDN by emitting a **cache invalidation receipt** (see §8). Do **not** rely on TTL alone.
+- Force the Settlements / Infrastructure Evidence Drawer payload resolver to return `DENY` for the affected `release_id` until the rollback closes.
+- Cause Focus Mode to **ABSTAIN** on any prompt whose retrieved context cites the withdrawn release.
+
+### Step 6 — Update the `ReleaseManifest`
+
+- Set `release_state` on the affected manifest to `REVOKED` (if no replacement) or `SUPERSEDED` (if a corrected release replaces it).
+- **Never mutate `release_id`, `spec_hash`, or original artifact digests.** The historical record stays intact.
+- Append a `correction_lineage` entry pointing at the new `RollbackCard` and any `CorrectionNotice`.
+
+### Step 7 — Restore / republish the rollback target
+
+- The prior release re-enters `PUBLISHED` **through the same governed gates** that admitted it originally — admission, schema, validation, rights, sensitivity, source-role, review, catalog closure, release.
+- If any gate now fails (e.g., a referenced source has since been revoked), **do not publish the prior release**. Open a fresh release candidate against the now-current source posture.
+
+### Step 8 — Cache invalidation & UI stale-state
+
+- Emit a `cache invalidation record` covering tiles (PMTiles / MVT), styles, sprites, glyphs, drawer payloads, and any Focus Mode response caches.
+- The map UI must display a **stale or withdrawn trust badge** on affected layers until the cache invalidation receipt is observed.
+
+### Step 9 — Cross-lane notification
+
+See §10. A Settlements / Infrastructure rollback almost always touches Roads/Rail, Hazards, Hydrology, or People/Land derivatives.
+
+### Step 10 — Close the `RollbackCard`
+
+- State → `closed`.
+- Append to `release/changelog/`.
+- Link the closing `CorrectionNotice` and the cache invalidation receipt.
+
+[Back to top ↑](#-quick-jump)
+
+---
+
+## 8. Artifacts emitted
+
+Every Settlements / Infrastructure rollback produces these governed records. **PROPOSED schema homes** unless explicitly verified.
+
+| Artifact | Purpose | Proposed schema home | Status |
+|---|---|---|---|
+| `RollbackCard` | Decision record: who, why, what, when, target | `schemas/contracts/v1/release/RollbackCard.schema.json` | PROPOSED |
+| `CorrectionNotice` | Public-facing notice for any claims that escaped | `schemas/contracts/v1/release/CorrectionNotice.schema.json` | PROPOSED |
+| Updated `ReleaseManifest` | `release_state` flipped to `REVOKED` / `SUPERSEDED`, `correction_lineage` appended | `schemas/contracts/v1/release/ReleaseManifest.schema.json` | CONFIRMED schema shape |
+| `cache invalidation record` | Records what was invalidated and why; consumed by CDN / tile host | `schemas/contracts/v1/release/CacheInvalidationRecord.schema.json` | PROPOSED |
+| `RedactionReceipt` | Required when the defect was a sensitivity leak | `schemas/contracts/v1/receipts/RedactionReceipt.schema.json` | PROPOSED |
+| `AIReceipt` invalidation | Marks Focus Mode answers built on the withdrawn release as invalid | `schemas/contracts/v1/receipts/AIReceipt.schema.json` | PROPOSED |
+| `ReviewRecord` (when policy demanded review) | Steward sign-off on the rollback itself | `schemas/contracts/v1/review/ReviewRecord.schema.json` | PROPOSED |
+
+**CONFIRMED** `ReleaseManifest.rollback` shape (from project evidence):
+
+```json
+{
+  "rollback": {
+    "rollback_supported": true,
+    "previous_release": "rel-settlements-infra-2026-005",
+    "rollback_plan_ref": "release/rollback_cards/rel-settlements-infra-2026-007.json"
+  }
+}
+```
+
+`release_state` enum (**CONFIRMED**): `DRAFT` · `REVIEW` · `PUBLISHED` · `REVOKED` · `SUPERSEDED`.
+
+---
+
+## 9. Domain-specific scenarios
+
+<details>
+<summary><b>9.1 Critical-infrastructure precision leak (utility, substation, water intake)</b></summary>
+
+**Trigger.** A published infrastructure layer exposed exact geometry that should have been generalized or restricted (Settlements / Infrastructure default for `InfrastructureAsset` critical detail is `T4` — denied by default; `T1` only via generalized footprint).
+
+**Posture.** *Sensitivity leak* → immediate public disablement.
+
+**Procedure.**
+1. **Disable first, decide second.** Step 5 of §7 executes before steps 1–4 in this case; the `RollbackCard` is opened in parallel.
+2. Emit `RedactionReceipt` documenting which fields and geometry were exposed.
+3. Restore the prior generalized footprint release (if one exists). If none exists, the rollback target is **no public layer** — set the layer's public state to `withdrawn` indefinitely until a properly generalized release is admitted.
+4. Notify Hazards lane stewards (exposure derivatives may have consumed the precise geometry).
+5. `CorrectionNotice` is **mandatory** and **public**.
+
+</details>
+
+<details>
+<summary><b>9.2 Operator-sensitive condition observation exposed</b></summary>
+
+**Trigger.** A `ConditionObservation` for a bridge, dam, plant, or utility asset reached `PUBLISHED` with operator-sensitive fields (inspection findings, vulnerability flags) intact.
+
+**Posture.** *Rights defect* + *Sensitivity leak*.
+
+**Procedure.** Withdraw the affected artifacts; rebuild the public-safe derivative without the sensitive fields; restore prior release if available. Steward review **required**.
+
+</details>
+
+<details>
+<summary><b>9.3 Legal-municipality source-role upcast (e.g., model → authority)</b></summary>
+
+**Trigger.** A municipal boundary was published with `source_role: authority` but the supporting evidence is a modeled or candidate derivation.
+
+**Posture.** *Role collapse* (`ROLE_COLLAPSE`) — the source-role discipline forbids upcast to `authority`.
+
+**Procedure.** Roll back to the last release that correctly carried `source_role: model` (or `candidate`); emit `CorrectionNotice` flagging the role correction; re-emit downstream legal-status-event views with the corrected role label.
+
+</details>
+
+<details>
+<summary><b>9.4 Historic townsite / ghost-town identity reconciliation error</b></summary>
+
+**Trigger.** A historical-identity comparison view linked a present-day settlement to the wrong predecessor townsite, or merged two distinct ghost towns under one identity.
+
+**Posture.** *Catalog defect* — affects identity reconciliation and place-identity aliases.
+
+**Procedure.** Roll back the affected catalog records; rebuild the historical identity comparison view; emit `CorrectionNotice` with `AnnexationEvent` / identity-alias correction lineage.
+
+</details>
+
+<details>
+<summary><b>9.5 Tile digest mismatch on a published Settlements / Infrastructure layer</b></summary>
+
+**Trigger.** A `TileArtifactManifest` digest no longer matches the served PMTiles bytes (e.g., post-CDN corruption, accidental rebuild, swapped artifact).
+
+**Posture.** *Geometry defect* / integrity failure.
+
+**Procedure.** Roll back to the previous `MapReleaseManifest`; verify prior PMTiles by sha256 and blake3; emit cache invalidation receipt; re-run runtime probes (decode, hash throughput, heap soak) before re-promoting.
+
+</details>
+
+<details>
+<summary><b>9.6 Focus Mode answer cited a withdrawn release</b></summary>
+
+**Trigger.** A Focus Mode `AIReceipt` references a Settlements / Infrastructure `EvidenceBundle` whose underlying release has been rolled back.
+
+**Posture.** *AI answer defect*.
+
+**Procedure.** Invalidate the `AIReceipt`; force ABSTAIN on the next request matching the same context envelope; preserve the `EvidenceBundle` for audit (do not delete); attach the invalidation to the closing `RollbackCard`.
+
+</details>
+
+[Back to top ↑](#-quick-jump)
+
+---
+
+## 10. Cross-lane impact
+
+**CONFIRMED / PROPOSED** cross-lane relations from the Domain Atlas. Every Settlements / Infrastructure rollback must check these neighbors.
+
+| Adjacent lane | Relation | What to invalidate |
+|---|---|---|
+| **Roads / Rail** | depot, bridge, crossing, transport-facility relation | Any transport-graph projection that consumed the withdrawn `Facility` or `NetworkNode` |
+| **Hazards** | exposure, resilience, warnings, declarations | Exposure derivatives, resilience views, declared-disaster overlays referencing the withdrawn asset |
+| **Hydrology** | water, wastewater, stormwater, floodplain, drainage | Service-area aggregates, drainage dependency graphs, water-system dependency views |
+| **People / Land** | residence, ownership, parcel, migration context (with restrictions) | Living-person joins (must remain restricted); parcel-residence rollups; migration-context summaries |
+
+> [!IMPORTANT]
+> If a cross-lane derivative cannot be invalidated through the governed API, **escalate** rather than leaving the derivative live. A stale derivative built on a withdrawn release is a public claim without evidence — the cite-or-abstain rule demands ABSTAIN until the derivative is rebuilt.
+
+---
+
+## 11. UI & governed-AI behavior during rollback
+
+| Surface | Required behavior during rollback |
+|---|---|
+| **Map layer** | Trust badge flips to `stale` or `withdrawn`; layer either disappears (revoked) or renders the prior release (superseded). |
+| **Evidence Drawer** | Resolves to a `DENY` envelope for the withdrawn `release_id`, with a human-readable correction message and a link to the `CorrectionNotice`. |
+| **Focus Mode** | **MUST ABSTAIN** on any prompt whose evidence retrieval depends on the withdrawn release. Cited prior answers display a stale-citation banner. |
+| **Story Nodes / exports** | Any export, screenshot, or Story Node citing the withdrawn release shows a correction banner; new exports refuse to cite it. |
+| **Review console** | The rollback is visible end-to-end: `RollbackCard`, prior `ReleaseManifest`, target `ReleaseManifest`, `CorrectionNotice`, cache invalidation receipt, cross-lane notifications. |
+| **CDN / tile host** | Cache invalidation receipt consumed; bytes for the withdrawn artifact return `404` or the prior release's bytes. **Never** serve mismatched bytes under the withdrawn `release_id`. |
+
+> [!NOTE]
+> The trust membrane is preserved **during** rollback: public clients still go through the governed API, never the canonical / internal store, even when the artifact they want has been withdrawn.
+
+---
+
+## 12. Validation, drills, and dry-runs
+
+**PROPOSED** validation surface for this runbook. Each item should land as a test or fixture once the lane is wired in the mounted repo.
+
+| Validation | What it proves | Status |
+|---|---|---|
+| Rollback drill — happy path | Prior release restores cleanly through governed gates | PROPOSED — `tests/runtime_proof/settlements-infrastructure/rollback_happy_path.*` |
+| Rollback drill — `ROLLBACK_TARGET_MISSING` | Procedure aborts safely, surface stays disabled | PROPOSED |
+| Rollback drill — sensitivity leak | Disable-first ordering is honored | PROPOSED |
+| Rollback drill — cross-lane invalidation | Roads/Rail, Hazards, Hydrology, People/Land derivatives detect and invalidate | PROPOSED |
+| Schema validation — `RollbackCard` | Card validates against schema; reason codes enumerated | PROPOSED |
+| Schema validation — `ReleaseManifest.rollback` block | `previous_release`, `rollback_supported`, `rollback_plan_ref` required where applicable | CONFIRMED schema shape; runtime presence NEEDS VERIFICATION |
+| Cache invalidation receipt — no-change deny | Invalidation receipts are not emitted for no-op rollbacks | PROPOSED |
+| Focus Mode ABSTAIN — withdrawn-release fixture | ABSTAIN on retrieved evidence whose release is `REVOKED` / `SUPERSEDED` | PROPOSED |
+| UI stale-state — withdrawn layer fixture | Trust badge renders `stale` / `withdrawn` | PROPOSED |
+| Replay verification | Restored release reproduces prior root hash and manifest | PROPOSED (per `ML-058-043`) |
+
+> [!TIP]
+> Run a **scheduled monthly rollback drill** on a low-risk synthetic Settlements / Infrastructure release. The drill should cover at least one of: §9.1 sensitivity leak, §9.5 tile-digest mismatch, §9.6 AI citation invalidation.
+
+[Back to top ↑](#-quick-jump)
+
+---
+
+## 13. Anti-patterns
+
+> [!WARNING]
+> These are doctrinal failure modes. None of them are acceptable, even under pressure.
+
+- **Hidden file copy.** Rolling back by overwriting a CDN object or replacing artifact bytes without emitting `RollbackCard`, updated `ReleaseManifest`, and cache invalidation receipt.
+- **Silent overwrite.** Mutating a prior `ReleaseManifest` in place rather than emitting a superseding release with `correction_lineage`.
+- **Cache-only purge.** Relying on CDN TTL or a one-off purge instead of an emitted invalidation receipt.
+- **Skipping cross-lane notification.** Withdrawing a Settlements / Infrastructure release while leaving Roads/Rail, Hazards, Hydrology, or People/Land derivatives that consumed it live.
+- **AI continues to answer.** Allowing Focus Mode to ANSWER from a withdrawn `EvidenceBundle` because the bundle still resolves.
+- **Style-hidden sensitive geometry.** Pretending exact restricted geometry is "rolled back" by hiding it with a style filter while the bytes remain in the tile set.
+- **Document-only rollback.** Updating `release/changelog/` without flipping `release_state`. Doctrine: *if no receipt exists, the operation did not happen in the governed sense.*
+- **One-person rollback for policy-significant content.** When materiality applies, the release authority for the rollback **MUST** be distinct from the original release author.
+
+---
+
+## 14. Open verification items
+
+These are the items this runbook **cannot resolve** without mounted-repo evidence. They are tracked here so reviewers can close them in order.
+
+| Item | Evidence that would settle it | Status |
+|---|---|---|
+| Final path: `docs/runbooks/settlements-infrastructure/ROLLBACK_RUNBOOK.md` vs. flat `docs/runbooks/settlements_infrastructure_ROLLBACK.md` | `docs/runbooks/README.md` or naming-convention ADR | NEEDS VERIFICATION |
+| Schema home for `RollbackCard`, `CorrectionNotice`, `CacheInvalidationRecord` | `schemas/contracts/v1/release/...` presence | NEEDS VERIFICATION |
+| Reason-code registry binding to validators | `tools/validators/release/` or equivalent | NEEDS VERIFICATION |
+| Governed-API routes for layer disable / withdraw | `apps/governed-api/` route inspection | UNKNOWN |
+| `tests/runtime_proof/settlements-infrastructure/` presence | Mounted repo | NEEDS VERIFICATION |
+| Cache invalidation receipt consumer (CDN / tile host) | `infra/` and `release/` workflow inspection | UNKNOWN |
+| Domain steward CODEOWNERS for Settlements / Infrastructure | `.github/CODEOWNERS` | UNKNOWN |
+| Existence of paired `RELEASE_RUNBOOK.md`, `VALIDATION_RUNBOOK.md`, `CORRECTION_RUNBOOK.md` | Mounted repo | PROPOSED |
+
+Add or close items via `docs/registers/VERIFICATION_BACKLOG.md`.
+
+---
+
+## 15. Related docs
+
+- `docs/doctrine/lifecycle-law.md` *(PROPOSED)* — RAW → PUBLISHED state-transition law
+- `docs/doctrine/trust-membrane.md` *(PROPOSED)* — public surfaces vs. canonical stores
+- `docs/doctrine/directory-rules.md` — placement authority *(CONFIRMED rules, PROPOSED presence)*
+- `docs/domains/settlements-infrastructure/README.md` *(PROPOSED)* — domain ownership and object families
+- `docs/runbooks/settlements-infrastructure/RELEASE_RUNBOOK.md` *(PROPOSED)*
+- `docs/runbooks/settlements-infrastructure/CORRECTION_RUNBOOK.md` *(PROPOSED)*
+- `docs/runbooks/settlements-infrastructure/VALIDATION_RUNBOOK.md` *(PROPOSED)*
+- `schemas/contracts/v1/release/ReleaseManifest.schema.json` — release decision shape *(CONFIRMED shape, PROPOSED location)*
+- `release/rollback_cards/` — emitted decision records
+- `release/correction_notices/` — emitted public notices
+- `release/changelog/` — release-level changelog
+- `docs/adr/ADR-runbook-naming-convention.md` *(PROPOSED)* — freeze flat vs. per-domain pattern
+
+---
+
+<sub>**Last updated:** 2026-05-12 · **Doc id:** `kfm://doc/runbook/settlements-infrastructure/rollback` · **Status:** draft · **Authority:** doctrine CONFIRMED, implementation hooks PROPOSED · [Back to top ↑](#settlements--infrastructure--rollback-runbook)</sub>

--- a/docs/runbooks/settlements-infrastructure/SOURCE_REFRESH_RUNBOOK.md
+++ b/docs/runbooks/settlements-infrastructure/SOURCE_REFRESH_RUNBOOK.md
@@ -1,3 +1,499 @@
-# settlements-infrastructure :: SOURCE_REFRESH runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/settlements-infrastructure/source-refresh
+title: Settlements / Infrastructure — Source Refresh Runbook
+type: standard
+version: v0.1
+status: draft
+owners: Settlements/Infrastructure domain steward, Source steward, Release steward
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/trust-membrane.md
+  - docs/domains/settlements-infrastructure/README.md
+  - docs/sources/SOURCE_DESCRIPTOR_STANDARD.md
+  - docs/runbooks/README.md
+  - docs/registers/VERIFICATION_BACKLOG.md
+tags: [kfm, runbook, settlements, infrastructure, source-refresh, governance]
+notes:
+  - Path PROPOSED until verified against mounted repo evidence.
+  - Implementation maturity UNKNOWN; gates and validators are PROPOSED unless verified.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Settlements / Infrastructure — Source Refresh Runbook
+
+Operational procedure for refreshing settlements and infrastructure source data through KFM's governed `RAW → PUBLISHED` lifecycle, with critical-infrastructure sensitivity gates and PR-first promotion.
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![authority](https://img.shields.io/badge/authority-doctrinal--PROPOSED--impl-blue)
+![policy](https://img.shields.io/badge/sensitivity-critical--infra--default--deny-red)
+![lifecycle](https://img.shields.io/badge/lifecycle-RAW%20%E2%86%92%20PUBLISHED-purple)
+![review](https://img.shields.io/badge/review-PR--first-success)
+![rollback](https://img.shields.io/badge/rollback-required-orange)
+
+| Field | Value |
+|---|---|
+| **Document type** | Operations runbook |
+| **Status** | `draft` — PROPOSED until verified against mounted repo evidence |
+| **Authority** | Doctrine CONFIRMED; implementation paths PROPOSED / NEEDS VERIFICATION |
+| **Domain** | `settlements-infrastructure` |
+| **Owners** | Settlements/Infrastructure steward · Source steward · Release steward |
+| **Last updated** | 2026-05-12 |
+| **Schema home (default)** | `schemas/contracts/v1/...` per ADR-0001 (verify against repo) |
+
+> [!IMPORTANT]
+> This domain owns critical-infrastructure context. Bridge / condition / inspection details, private or security-sensitive assets, and exact vulnerable facility geometry **default to restricted, generalized, staged, or denied** — never to "publish unless flagged." Default deny is the floor, not the ceiling.
+
+---
+
+## Contents
+
+1. [Scope and boundary](#1-scope-and-boundary)
+2. [When to run this runbook](#2-when-to-run-this-runbook)
+3. [Preflight checks](#3-preflight-checks)
+4. [Lifecycle map](#4-lifecycle-map)
+5. [Source family reference](#5-source-family-reference)
+6. [Refresh procedure](#6-refresh-procedure)
+7. [Sensitivity, rights, and publication posture](#7-sensitivity-rights-and-publication-posture)
+8. [Validation gates](#8-validation-gates)
+9. [Receipts and proof objects emitted](#9-receipts-and-proof-objects-emitted)
+10. [Failure modes and rollback](#10-failure-modes-and-rollback)
+11. [Verification backlog](#11-verification-backlog)
+12. [Related docs](#12-related-docs)
+13. [Appendix A — Domain object families](#appendix-a--domain-object-families)
+14. [Appendix B — Path-by-path placement notes](#appendix-b--path-by-path-placement-notes)
+
+---
+
+## 1. Scope and boundary
+
+**CONFIRMED doctrine / PROPOSED implementation.** This runbook governs the periodic refresh of source data feeding the **Settlements / Infrastructure** lane: legal municipalities, census places, historic townsites, ghost towns, forts, missions, reservation communities, infrastructure assets, networks, nodes, segments, facilities, service areas, operators, condition observations, dependencies, and the public-safe representations derived from them.
+
+**In scope**
+
+- Periodic and event-driven refresh of admitted Settlements / Infrastructure sources.
+- Promotion of refreshed material through `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`.
+- Sensitivity, rights, and review gates specific to critical infrastructure.
+- Receipts, manifests, correction, and rollback artifacts produced by the refresh.
+
+**Out of scope (owned elsewhere)**
+
+| Concern | Owner | Why excluded here |
+|---|---|---|
+| Transport route geometry, depots, crossings | Roads / Rail / Trade Routes lane | Facility identity is settlement-owned; **route geometry is not** |
+| Living-person ownership and parcel privacy | People / Genealogy / DNA / Land lane | Settlements does not own person-level data |
+| Hazard event records and warnings | Hazards lane | KFM is **never** an alert authority |
+| Water, wastewater, hydrology evidence | Hydrology lane | Cross-lane relation only |
+| Archaeological site coordinates | Archaeology / Cultural Heritage lane | Sites denied at exact coords; settlements may reference generalized context |
+
+> [!NOTE]
+> Cross-lane relations (depot/crossing, exposure, water/wastewater, parcel context) **must preserve ownership, source role, sensitivity, and EvidenceBundle support** even when this runbook touches data that crosses a lane boundary. PROPOSED.
+
+[↑ Back to top](#contents)
+
+---
+
+## 2. When to run this runbook
+
+Trigger this runbook for any of the following, **and only after** a watcher or operator has produced a material-change signal — never as a standing background "always-on publish."
+
+| Trigger | Description | Default cadence | Status |
+|---|---|---|---|
+| **Authoritative vintage release** | New Census/TIGER vintage; GNIS bulk update; KDOT bridge inventory release. | Source-specific (annual / quarterly) | PROPOSED |
+| **Watcher delta detected** | Watcher (`stac` / `gtfs` / `tile` / `file` / `api` family) reports a material change against signed prior state. | Event-driven | PROPOSED |
+| **Operator submission** | Steward or operator-supplied municipal record, annexation, or facility update with rights documented. | Event-driven | PROPOSED |
+| **Correction request** | Verified correction against a published settlement, place, or facility. | Event-driven | PROPOSED |
+| **Scheduled review drill** | Quarterly steward-led drill exercising rollback and policy gates without changing public artifacts. | Quarterly | PROPOSED |
+
+> [!CAUTION]
+> **Do not run a refresh** purely because the calendar says it is time. A no-change poll **MUST NOT** emit new catalog entities, manifests, or cache invalidations. CONFIRMED doctrine from the watcher / no-change posture.
+
+[↑ Back to top](#contents)
+
+---
+
+## 3. Preflight checks
+
+Before any RAW admission, confirm every item below. If any item is **NO** or **UNKNOWN**, stop and route to the correct register (`VERIFICATION_BACKLOG.md`, `DRIFT_REGISTER.md`, or a steward review issue).
+
+- [ ] **SourceDescriptor exists** for each source in scope (role, authority, rights, sensitivity, cadence, license, payload hash or reference). PROPOSED — verify against `data/registry/` and `docs/sources/`.
+- [ ] **Source role is set** (authority / observation / context / model). Mixed-role payloads are split before admission.
+- [ ] **Rights and license are current.** License travels with deltas; unknown license → fail closed.
+- [ ] **Sensitivity class set.** Critical infrastructure, condition, inspection, operator-sensitive, or exact vulnerable geometry → default deny on public detail.
+- [ ] **Cadence and freshness window** declared; stale-source threshold known.
+- [ ] **No direct route from this refresh to PUBLISHED.** Promotion is a governed state transition, not a file move.
+- [ ] **Rollback target identified** for any path that could reach a public surface.
+- [ ] **Kill-switch** state checked (refresh halts if asserted).
+- [ ] **No browser / public client touches `RAW`, `WORK`, `QUARANTINE`, canonical stores, or unpublished candidates.** CONFIRMED doctrine.
+- [ ] **Configs are non-secret.** Real secrets MUST NOT live under `configs/` — even for "test" or "local."
+
+> [!WARNING]
+> If a real secret is found anywhere in `configs/` during preflight, treat it as a **security incident**: rotate, audit, and open an entry in `docs/runbooks/` (per `directory-rules.md` §10.3).
+
+[↑ Back to top](#contents)
+
+---
+
+## 4. Lifecycle map
+
+**CONFIRMED doctrine:** every refresh follows the lifecycle invariant. Promotion between phases is a **governed state transition** — it requires the artifacts listed in §8 and §9, not a file move.
+
+```mermaid
+flowchart LR
+  classDef ok fill:#e6f4ea,stroke:#188038,color:#0b3d17;
+  classDef hold fill:#fff7e0,stroke:#b06000,color:#5b3700;
+  classDef deny fill:#fdecea,stroke:#b00020,color:#5b0010;
+  classDef pub  fill:#e3eafc,stroke:#1a47b8,color:#0b2766;
+
+  W[Watcher / Operator] -->|material change| A[Admission]
+  A -->|SourceDescriptor + hash| RAW[(RAW)]:::ok
+  RAW -->|normalize| WK[(WORK)]:::ok
+  RAW -->|policy / shape / role failure| QN[(QUARANTINE)]:::deny
+  WK -->|ValidationReport pass| PR[(PROCESSED)]:::ok
+  WK -->|fail or pending| WK
+  PR -->|EvidenceRef → EvidenceBundle, digest closure| CT[(CATALOG / TRIPLET)]:::ok
+  CT -->|ReleaseManifest + rollback target + review| PB[(PUBLISHED)]:::pub
+  PB -->|correction / rollback| CT
+  PB -.->|kill switch| HALT[Promotion halted]:::deny
+```
+
+Per-phase posture:
+
+| Phase | Handling | Gate (must pass) | Default failure |
+|---|---|---|---|
+| **Admission → RAW** | Capture immutable payload or reference with source role, rights, sensitivity, citation, time, and hash. | `SourceDescriptor` exists. | Reject; log candidate. |
+| **WORK / QUARANTINE** | Normalize schema, geometry, time, identity, evidence, rights, policy. Hold failures. | Validation + policy gate pass, or quarantine reason recorded. | Quarantine with reason. |
+| **PROCESSED** | Emit validated, normalized objects, receipts, and public-safe candidates. | `EvidenceRef`, `ValidationReport`, and digest closure exist. | Stay in WORK. |
+| **CATALOG / TRIPLET** | Emit catalog records, `EvidenceBundle`, graph/triplet projections, release candidates. | Catalog / proof closure passes. | Hold at PROCESSED. |
+| **PUBLISHED** | Serve released public-safe artifacts through the governed API and manifests. | `ReleaseManifest`, correction path, rollback target, review/policy state present. | Hold at CATALOG. |
+
+> [!NOTE]
+> Settlements / Infrastructure first-slice posture is **schema-and-fixture-first**: source descriptors, deterministic identity, validators, deny policies, no-network fixtures, and proof-pack / promotion fixtures should land **before** any live source is activated. PROPOSED.
+
+[↑ Back to top](#contents)
+
+---
+
+## 5. Source family reference
+
+Source families admitted into the Settlements / Infrastructure lane. Roles, rights, and freshness are source-specific — the table below names the **family** and the burden the runbook places on it. Specific authorities, endpoints, and license text are tracked in `data/registry/sources/` and the source descriptors (PROPOSED).
+
+| Source family | Typical role | Sensitivity default | Freshness cadence | Status |
+|---|---|---|---|---|
+| Census TIGER / Census Place geography | authority / observation | T0 aggregate; restricted joins | Decennial + annual | CONFIRMED doctrine, PROPOSED impl |
+| GNIS and historical gazetteers | authority (place names) / observation | T0 | Periodic | CONFIRMED doctrine, PROPOSED impl |
+| State / local GIS (Kansas Geoportal-style) | authority / observation / context | Source-specific | Source-specific | PROPOSED |
+| Municipal and local legal records | authority (legal place) | T0 / T1 where draft | Event-driven | PROPOSED |
+| Historical gazetteers and maps | context / observation | T0 generalized | Vintage-specific | PROPOSED |
+| Infrastructure operators and providers | authority / observation | **T2–T4** (default restricted) | Operator-specific | PROPOSED |
+| KDOT / bridge / facility sources | authority / observation | T2–T4 for condition, inspection | Periodic | PROPOSED |
+| FEMA / hazards / resilience context | context only (Hazards owns events) | T0 context | Event-driven | PROPOSED |
+| Roads / rail records (facility identity only) | context (Roads/Rail owns route) | T0 facility identity | Periodic | PROPOSED |
+| Fort / mission / reservation community archives | authority / context | Steward-reviewed | Source-specific | PROPOSED |
+
+> [!IMPORTANT]
+> **Sensitive joins fail closed.** A refresh that would combine, for example, infrastructure asset condition with operator identity and exact geometry must produce **no public artifact** until policy, review, and generalization gates have signed off. PROPOSED implementation; CONFIRMED doctrine.
+
+[↑ Back to top](#contents)
+
+---
+
+## 6. Refresh procedure
+
+The procedure is **PR-first**. Detected material change → branch + PR with machine-readable manifests + required checks → human review → governed promotion. Direct publication from a watcher or refresh job is forbidden.
+
+### 6.1 Detect and capture (Admission → RAW)
+
+> [!NOTE]
+> Connectors and watchers **do not publish**. Their output goes to `data/raw/<domain>/<source_id>/<run_id>/` or `data/quarantine/...` only. CONFIRMED placement rule.
+
+1. Watcher (or operator) records: source URL, ETag, `spec_hash`, license, version, retrieved_at, payload digest. This becomes the basis of the `RunReceipt`.
+2. Confirm the **SourceDescriptor** for this source is current (role, rights, sensitivity, cadence). If drift is detected, update the descriptor in its own PR before admitting payload.
+3. Compute deterministic identity per object. PROPOSED basis for this domain: `source_id + object_role + temporal_scope + normalized_digest`.
+4. Compare against signed prior state. If response is "no change," **emit a heartbeat only** and stop — no new catalog entities, no manifest churn, no cache invalidation.
+
+<details>
+<summary><strong>Example — SourceDescriptor fields commonly recorded</strong> (illustrative; verify against schema)</summary>
+
+```text
+source_id            : <stable id>
+source_family        : census_tiger | gnis | kdot_bridge | municipal_legal | ...
+role                 : authority | observation | context | model
+authority            : <issuing body>
+rights               : <license / terms / use posture>
+sensitivity_class    : T0 | T1 | T2 | T3 | T4
+cadence              : <annual | quarterly | event-driven | ...>
+retrieved_at         : <ISO 8601>
+etag / version       : <provider value>
+payload_digest       : <sha256 of payload or reference>
+notes                : <free text>
+```
+
+The list above is illustrative. The authoritative shape lives in `schemas/contracts/v1/source/source_descriptor.schema.json` (PROPOSED home — verify against `directory-rules.md` §6.1 and ADR-0001).
+</details>
+
+### 6.2 Normalize and validate (RAW → WORK / QUARANTINE → PROCESSED)
+
+1. Normalize schema, geometry, time, identity, evidence, rights, and policy.
+2. Run gates in cheap-to-expensive order (see §8). Hold any failure as `QUARANTINE` with a structured reason.
+3. Emit `TransformReceipt` and `ValidationReport`. If sensitivity applies, emit `RedactionReceipt`. If aggregation applies, emit `AggregationReceipt`.
+4. Distinguish **observed**, **valid**, **retrieval**, **release**, and **correction** times where material — they are kept distinct, never collapsed.
+
+### 6.3 Catalog and bundle (PROCESSED → CATALOG / TRIPLET)
+
+1. Resolve every `EvidenceRef` to an `EvidenceBundle` and prove digest closure.
+2. Emit catalog records and graph/triplet projections.
+3. Open a PR with the manifest diff. Required checks include OPA / Conftest policy gates, signature verification, citation validation, and acceptance harness checks (STAC / DCAT / PROV where applicable).
+4. Do **not** treat catalog, graph, triplet, or vector index as sovereign truth — they are derivative indexes built from released or review-authorized evidence.
+
+### 6.4 Promote (CATALOG / TRIPLET → PUBLISHED)
+
+1. Confirm the release authority is **distinct from the author** when materiality applies (separation of duties).
+2. `ReleaseManifest` MUST include: linked `EvidenceBundle`, `PolicyDecision`, `PromotionDecision`, `RunReceipt(s)`, rollback target, correction path, and review state where required.
+3. Run the Promotion Gate Summary. Any negative outcome fails closed.
+4. On merge, post-promotion jobs update STAC / DCAT / PROV records, graph deltas, API indices, Story Nodes, and Focus diffs — strictly downstream of the release manifest. PROPOSED implementation.
+
+### 6.5 Refresh-complete checklist
+
+- [ ] No direct route from connector / watcher to `data/published/` or to public routes.
+- [ ] All RAW payloads recorded with descriptor + digest; nothing admitted without a `SourceDescriptor`.
+- [ ] No-change polls emitted heartbeats only.
+- [ ] All gates in §8 passed or failed-closed with reason.
+- [ ] `ReleaseManifest` carries proof, correction path, and rollback target.
+- [ ] Critical-infrastructure precision audit ran and recorded its result.
+- [ ] Update-propagation matrix items handled (Object Map, fixtures, runbooks, continuity notes, rollback notes, verification backlog).
+
+[↑ Back to top](#contents)
+
+---
+
+## 7. Sensitivity, rights, and publication posture
+
+**Default posture for this domain is restrictive.** Critical infrastructure, condition observations, inspection data, dependencies, operator-sensitive details, and exact facility geometry default to restricted or review.
+
+| Concern | Default | Acceptable transforms before public release |
+|---|---|---|
+| Exact geometry of vulnerable facilities | **Deny** on public detail | Generalize, redact, or staged access only |
+| Bridge / inspection / condition records | **Restricted / review** | Aggregate or steward-approved generalization |
+| Operator identity tied to asset condition | **Restricted** | Generalized footprint; operator id withheld or staged |
+| Living-person ownership joined to facility | **Deny** | Owned by People/Land lane — not this runbook |
+| Critical infrastructure dependency graphs | **Restricted / review** | Aggregate, anonymized, steward-approved publication |
+| Historic forts / missions (non-sensitive) | T0 with provenance | Standard publication path |
+
+> [!WARNING]
+> **Unclear rights, unresolved source role, missing evidence, unresolved sensitivity, or absent release state blocks public promotion.** This is a doctrinal stop, not a warning. CONFIRMED doctrine.
+
+Cross-lane sensitivity reminders:
+
+- **Hazards** owns hazard events. Settlements may carry exposure context only; never present settlement data as a life-safety alert.
+- **People / Land** owns living-person privacy. Joining facility records to person-level data MUST follow that lane's rules.
+- **Archaeology** owns cultural sensitivity. Settlement history that touches sacred or sensitive sites must follow archaeology's denial / generalization rules.
+
+[↑ Back to top](#contents)
+
+---
+
+## 8. Validation gates
+
+Validation is a **promotion boundary, not a cleanup pass.** Run gates in cheap-to-expensive order; fail closed on the first definitive failure.
+
+| Order | Gate family | Must answer | Default failure |
+|---|---|---|---|
+| 1 | **Shape** | Does each object match its schema and required version? | `ERROR` / quarantine |
+| 2 | **Meaning** | Does it conform to contract and vocabulary (legal place vs census place vs historic place)? | `ERROR` / review |
+| 3 | **Source** | Is source role, rights, cadence, and sensitivity known and current? | `DENY` / quarantine |
+| 4 | **Evidence** | Do `EvidenceRef`s resolve to `EvidenceBundle`s? | `ABSTAIN` |
+| 5 | **Policy** | Is exposure allowed for this user, purpose, and release class? | `DENY` |
+| 6 | **Lifecycle** | Is object in the correct phase along `RAW → PUBLISHED`? | `DENY` |
+| 7 | **Receipt** | Are `RunReceipt`, `PromotionReceipt`, decision logs present? | `ERROR` |
+| 8 | **Release** | Does the manifest include proof, correction path, and rollback target? | `ERROR` |
+
+Domain-specific validators (PROPOSED — verify against `tests/` and `tools/validators/`):
+
+- Legal municipality evidence test (legal place ↔ source role correctness).
+- Census-vs-municipality distinction test (no silent collapse).
+- Infrastructure topology test (nodes / segments / facilities consistent).
+- `condition.observed_at` temporal field test (observed time preserved separately from retrieval and release time).
+- Restricted geometry no-leak test (precision audit; sensitive geometry never appears in public artifacts).
+- Catalog / proof / release closure test.
+
+Cross-cutting validators (PROPOSED):
+
+- `SourceDescriptor` schema validation.
+- OPA / Conftest policy-as-code on run manifests (fail closed on missing fields, rights, sensitivity, or release state).
+- Cosign / Rekor attestation check; UUID recorded back into the run manifest.
+- Acceptance harness for STAC / DCAT / PROV closure before release.
+- `spec_hash` reproducibility gate (drift blocks promotion).
+
+[↑ Back to top](#contents)
+
+---
+
+## 9. Receipts and proof objects emitted
+
+A successful refresh produces, at minimum, the artifacts below. Specific shapes live in `schemas/contracts/v1/...` (PROPOSED home; verify against ADR-0001).
+
+| Artifact | Purpose | Where it lives | Status |
+|---|---|---|---|
+| `SourceDescriptor` | Source identity, role, rights, sensitivity, cadence. | `data/registry/sources/<domain>/` (PROPOSED) | PROPOSED |
+| `RunReceipt` | Pipeline run inputs/outputs/`spec_hash`/timestamp/operator/result. | `data/receipts/` | PROPOSED |
+| `TransformReceipt` | Per-transform inputs, outputs, tool versions. | `data/receipts/` | PROPOSED |
+| `ValidationReport` | Pass/fail per gate; structured reasons. | `data/proofs/` | PROPOSED |
+| `EvidenceBundle` | Closed evidence for public claims. | `data/catalog/` projection | PROPOSED |
+| `RedactionReceipt` | Records generalization / redaction transforms and reasons. | `data/receipts/` | PROPOSED |
+| `PolicyDecision` | Allow / deny / restrict / abstain with rule ids. | `data/proofs/` | PROPOSED |
+| `PromotionDecision` | Gate results, proof, review state, target release, rollback target. | `release/` | PROPOSED |
+| `ReleaseManifest` | Coordinates layer / style / tile / catalog release and rollback. | `release/` | PROPOSED |
+| `CorrectionNotice` | Correction path for any released artifact. | `release/` | PROPOSED |
+| `RollbackCard` | Reversal anchor restoring prior manifest and invalidating caches. | `release/rollback/` | PROPOSED |
+
+> [!TIP]
+> Trust-bearing artifacts (receipts, proofs, manifests, release decisions) **do not** belong in `artifacts/`. Per `directory-rules.md` §8, `artifacts/` is build / docs / qa / temporary only.
+
+[↑ Back to top](#contents)
+
+---
+
+## 10. Failure modes and rollback
+
+Common failure modes and their default response. Every public release MUST have a rollback target before promotion.
+
+| Failure mode | Where it surfaces | Default response |
+|---|---|---|
+| **Unknown or expired license** on a refreshed source | Source / policy gate | `DENY` — block layer admission; license-deny policy fixture asserts |
+| **Sensitive geometry attempt to publish** | Policy / precision audit | `DENY` — fail closed; emit `RedactionReceipt` if generalized re-attempt is permitted |
+| **Stale source** beyond declared threshold | Source / freshness check | UI stale badge; `ABSTAIN` on dependent claims; **never** rebrand as denial |
+| **Unsigned artifact** (tile / catalog / style / manifest) | Signature / Cosign / Rekor gate | `DENY` — unsigned artifact deny fixture asserts |
+| **Missing `RunReceipt` or `PromotionReceipt`** | Receipt gate | `ERROR` — promotion blocked |
+| **Catalog / proof closure fails** | Catalog closure gate | Hold at `PROCESSED`; no public edge |
+| **Kill switch asserted** | Promotion aggregator | Promotion fails closed; merge blocked |
+| **Released artifact found defective post-publication** | Correction path | Emit `CorrectionNotice`; execute rollback; invalidate caches with `cache invalidation record` |
+
+Rollback drill (PROPOSED steps):
+
+1. Identify the prior `ReleaseManifest` and its referenced artifact digests.
+2. Restore prior manifest; revert layer / tile / style / catalog references.
+3. Issue `cache invalidation record` (no no-change invalidations).
+4. Emit a **rollback attestation** linking the prior release.
+5. Update the verification backlog and any affected continuity notes.
+6. Run the rollback replay test to prove the restored state matches the prior digest.
+
+> [!CAUTION]
+> Rollback is a **first-class release operation**, not an emergency improvisation. If a rollback path cannot be drawn, the release is not ready to publish. CONFIRMED doctrine.
+
+[↑ Back to top](#contents)
+
+---
+
+## 11. Verification backlog
+
+These items are explicitly **not resolved** by this runbook and SHOULD be tracked in `docs/registers/VERIFICATION_BACKLOG.md`.
+
+| Item | Evidence that would settle it | Status |
+|---|---|---|
+| Exact schema home for `SourceDescriptor`, `RunReceipt`, `ReleaseManifest`, `EvidenceBundle` in mounted repo | Mounted `schemas/`, ADR-0001, per-root README | NEEDS VERIFICATION |
+| Connector module names and locations for Settlements / Infrastructure sources | Mounted `connectors/` and per-source README | UNKNOWN |
+| CI workflow names enforcing the gates in §8 | Mounted `.github/workflows/` | UNKNOWN |
+| Current Settlements / Infrastructure source rights and license text | `data/registry/sources/<domain>/` evidence | NEEDS VERIFICATION |
+| Validator names and entry points for the domain-specific tests in §8 | Mounted `tools/validators/` and `tests/` | NEEDS VERIFICATION |
+| Critical-infrastructure precision-audit tool name and thresholds | Mounted tool + threshold config | UNKNOWN |
+| Stale-source threshold values per source family | Source registry + `policy/` | UNKNOWN |
+| Whether `docs/runbooks/` uses flat `<subsystem>_TOPIC.md` or domain-segmented layout | Mounted `docs/runbooks/` listing + any local README | NEEDS VERIFICATION |
+
+[↑ Back to top](#contents)
+
+---
+
+## 12. Related docs
+
+> [!NOTE]
+> Links below are relative paths that assume the doc tree described in `directory-rules.md` §6.1. Verify against the mounted repo before relying on a specific target. Targets marked `TODO` indicate files not yet confirmed present.
+
+- [`docs/doctrine/directory-rules.md`](../../doctrine/directory-rules.md) — placement law and lifecycle invariant.
+- [`docs/doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — `RAW → PUBLISHED` invariant. `TODO` confirm.
+- [`docs/doctrine/trust-membrane.md`](../../doctrine/trust-membrane.md) — public client posture. `TODO` confirm.
+- [`docs/doctrine/truth-posture.md`](../../doctrine/truth-posture.md) — cite-or-abstain. `TODO` confirm.
+- [`docs/domains/settlements-infrastructure/README.md`](../../domains/settlements-infrastructure/README.md) — domain lane overview. `TODO` confirm.
+- [`docs/sources/SOURCE_DESCRIPTOR_STANDARD.md`](../../sources/SOURCE_DESCRIPTOR_STANDARD.md) — source descriptor contract. `TODO` confirm.
+- [`docs/runbooks/README.md`](../README.md) — runbook index. `TODO` confirm.
+- [`docs/registers/VERIFICATION_BACKLOG.md`](../../registers/VERIFICATION_BACKLOG.md) — open verification items.
+- [`docs/registers/DRIFT_REGISTER.md`](../../registers/DRIFT_REGISTER.md) — drift entries (e.g., runbook-layout convention).
+- [`docs/adr/`](../../adr/) — ADRs, including ADR-0001 (schema home) and any future Settlements / Infrastructure ADRs.
+
+[↑ Back to top](#contents)
+
+---
+
+## Appendix A — Domain object families
+
+PROPOSED object families owned by the Settlements / Infrastructure lane. Identity rule defaults shown for each.
+
+<details>
+<summary><strong>Object families and identity rule defaults</strong></summary>
+
+| Object | Purpose | PROPOSED identity basis |
+|---|---|---|
+| `Settlement` | Generic settlement evidence or derivative. | `source_id + object_role + temporal_scope + normalized_digest` |
+| `Municipality` | Legal municipality. | same pattern |
+| `CensusPlace` | Census-defined place. | same pattern |
+| `Townsite` | Historic townsite. | same pattern |
+| `GhostTown` | Abandoned / non-extant place. | same pattern |
+| `Fort` | Military fort, historic. | same pattern |
+| `Mission` | Historic mission. | same pattern |
+| `ReservationCommunity` | Reservation community context. | same pattern; steward review burden |
+| `InfrastructureAsset` | Infrastructure asset evidence or derivative. | same pattern; **default restricted** |
+| `NetworkNode` | Network node evidence or derivative. | same pattern; **default restricted** |
+| `NetworkSegment` | Network segment evidence or derivative. | same pattern; **default restricted** |
+| `Facility` | Facility evidence or derivative. | same pattern |
+| `ServiceArea` | Service area aggregate. | same pattern; aggregate preferred for publication |
+| `Operator` | Operator identity. | same pattern; **default restricted** |
+| `ConditionObservation` | Condition / inspection observation. | same pattern; **default restricted** |
+| `Dependency` | Dependency relation. | same pattern; **default restricted** |
+| `AnnexationEvent` | Annexation event. | same pattern |
+| `UrbanGrowthObservation` | Urban-growth observation derivative. | same pattern |
+
+Temporal handling for all of the above: **observed**, **valid**, **retrieval**, **release**, and **correction** times stay distinct where material. CONFIRMED doctrine.
+
+</details>
+
+[↑ Back to top](#contents)
+
+---
+
+## Appendix B — Path-by-path placement notes
+
+PROPOSED placements for files this runbook touches. Each row should be verified against `directory-rules.md` and the mounted repo. Do not treat as the current tree.
+
+<details>
+<summary><strong>Placement table (PROPOSED — verify against repo)</strong></summary>
+
+| Path | Action | Status | Directory Rules basis |
+|---|---|---|---|
+| `docs/runbooks/settlements-infrastructure/SOURCE_REFRESH_RUNBOOK.md` | CREATE | PROPOSED | §6.1 `docs/runbooks/`; §4 Step 3 domain-as-segment |
+| `docs/domains/settlements-infrastructure/README.md` | CREATE if absent | PROPOSED | §6.1 `docs/domains/<domain>/` |
+| `data/registry/sources/settlements-infrastructure/` | POPULATE per source | PROPOSED | §6.1 / §10.1; lifecycle and source-registry rules |
+| `connectors/<source>/` | EXTEND per source family | PROPOSED | §7.3 — connectors output to `data/raw/...` or `data/quarantine/...` only |
+| `schemas/contracts/v1/source/source_descriptor.schema.json` | CONFIRM | NEEDS VERIFICATION | ADR-0001 schema-home default |
+| `policy/domains/settlements-infrastructure/` | CREATE if absent | PROPOSED | §4 Step 3 domain-as-segment |
+| `tests/domains/settlements-infrastructure/` | CREATE if absent | PROPOSED | §4 Step 3 |
+| `fixtures/domains/settlements-infrastructure/` | CREATE if absent | PROPOSED | §4 Step 3 |
+| `release/candidates/settlements-infrastructure/` | CREATE if absent | PROPOSED | §4 Step 3 |
+| `tools/validators/domains/settlements-infrastructure/` | CREATE if absent | PROPOSED | §7.5 |
+
+</details>
+
+[↑ Back to top](#contents)
+
+---
+
+### Last reviewed
+
+`2026-05-12` — initial draft. Older than 6 months → flag for review (per `directory-rules.md` §15).
+
+### Related docs
+
+See [§12](#12-related-docs) above.
+
+[↑ Back to top](#contents)

--- a/docs/runbooks/soil/NO_NETWORK_TEST_RUNBOOK.md
+++ b/docs/runbooks/soil/NO_NETWORK_TEST_RUNBOOK.md
@@ -1,3 +1,457 @@
-# soil :: NO_NETWORK_TEST runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbooks/soil/no-network-test-runbook
+title: Soil — No-Network Test Runbook
+type: standard
+version: v1
+status: draft
+owners: <Docs steward + Soil domain owner — PLACEHOLDER>
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/domains/soil/README.md
+  - docs/runbooks/ROLLBACK.md
+  - schemas/contracts/v1/source/source-descriptor.json
+  - tests/fixtures/domains/soil/
+  - policy/domains/soil/
+tags: [kfm, runbook, soil, testing, no-network, phase-0]
+notes:
+  - "Path is PROPOSED until verified against mounted repo and Directory Rules §12."
+  - "Implementation status of every referenced validator, schema, and fixture remains PROPOSED."
+  - "Replaces no prior runbook in this session; treat as Phase-0 'Build first' deliverable."
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# 🌱 Soil — No-Network Test Runbook
+
+> Deterministic, evidence-first procedure for exercising the **Soil** trust spine against synthetic fixtures, with **zero outbound network traffic**, before any live-source code is admitted.
+
+![status: draft](https://img.shields.io/badge/status-draft-yellow)
+![lane: docs/runbooks/soil](https://img.shields.io/badge/lane-docs%2Frunbooks%2Fsoil-blue)
+![phase: 0 — build-first](https://img.shields.io/badge/phase-0%20build--first-informational)
+![truth: cite-or-abstain](https://img.shields.io/badge/truth-cite--or--abstain-success)
+![network: deny-by-default](https://img.shields.io/badge/network-deny--by--default-critical)
+![updated: 2026-05-12](https://img.shields.io/badge/updated-2026--05--12-lightgrey)
+
+| | |
+|---|---|
+| **Status** | `draft` · PROPOSED implementation |
+| **Owners** | Docs steward + Soil domain owner — *placeholder, NEEDS VERIFICATION* |
+| **Last reviewed** | 2026-05-12 |
+| **Authority of these rules** | CONFIRMED doctrine (derived from KFM Encyclopedia, Domains Atlas, Unified Manual) |
+| **Authority of every concrete path / fixture name** | **PROPOSED** until mounted-repo evidence confirms it |
+| **Supersedes** | None — first runbook in `docs/runbooks/soil/` |
+
+---
+
+## Quick jump
+
+- [1. Purpose](#1-purpose)
+- [2. Why this runbook exists first](#2-why-this-runbook-exists-first)
+- [3. Path placement & Directory Rules basis](#3-path-placement--directory-rules-basis)
+- [4. Preconditions](#4-preconditions)
+- [5. Trust spine the test must prove](#5-trust-spine-the-test-must-prove)
+- [6. Inputs — synthetic Soil fixtures](#6-inputs--synthetic-soil-fixtures)
+- [7. Procedure](#7-procedure)
+- [8. Validators invoked](#8-validators-invoked)
+- [9. Pass / fail / abstain / deny outcomes](#9-pass--fail--abstain--deny-outcomes)
+- [10. Soil-specific assertions](#10-soil-specific-assertions)
+- [11. Failure modes and rollback](#11-failure-modes-and-rollback)
+- [12. CI binding](#12-ci-binding)
+- [13. Open verification items](#13-open-verification-items)
+- [14. FAQ](#14-faq)
+- [Related docs](#related-docs)
+
+---
+
+## 1. Purpose
+
+This runbook describes how an operator **runs the deterministic, no-network test suite for the Soil domain** against synthetic fixtures. It is the *first* test gate in the Soil lane — it must pass before any live SSURGO, SDA, Kansas Mesonet, SCAN, USCRN, or SMAP connector is admitted, before any catalog record is emitted, and before any layer is promoted to a release candidate.
+
+The procedure exercises — without touching the network — the same trust spine that production Soil publication will eventually exercise: source admission → lifecycle state → validation → evidence resolution → policy decision → catalog/proof closure → release decision → governed API/UI payload → correction → rollback.
+
+> [!IMPORTANT]
+> **No-network is not a performance optimization.** It is a *governance* invariant. If this runbook's steps require outbound traffic to pass, the test has crossed the trust membrane and the result is not admissible as proof.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 2. Why this runbook exists first
+
+The KFM Encyclopedia lists **"Soil source registry + no-network fixture"** under the *Build first* group of the Soil feature backlog (PROPOSED). The Unified Manual's PROPOSED test pyramid puts deterministic no-network fixture tests at the **base** of the test pyramid — ahead of schema, contract, validator, policy, evidence-resolution, lifecycle-state, receipt/proof, release-manifest, governed-API-envelope, UI-trust-state, and live-source tests.
+
+The Encyclopedia's Phase-0 PR plan likewise opens with `PR-00 no-network fixture` — "*create synthetic fixtures for SourceDescriptor, EvidenceBundle, LayerManifest, ReleaseManifest and one [domain] object*". For Soil, this runbook is the operator-facing surface of that PR.
+
+| Source (doctrine) | What it establishes | Confidence |
+|---|---|---|
+| KFM Encyclopedia §K — Tests and validators | `no-network fixtures` is a required validator family | **CONFIRMED doctrine** |
+| KFM Encyclopedia §L — Soil feature backlog | "Soil source registry + no-network fixture" is *Build first* | **CONFIRMED doctrine** / PROPOSED implementation |
+| Unified Manual §26 — Testing strategy | No-network fixture tests sit at the base of the test pyramid | **CONFIRMED doctrine** / PROPOSED implementation |
+| Encyclopedia §14 — Implementation Roadmap | `PR-00 no-network fixture` is the first reversible PR | **CONFIRMED doctrine** |
+| Domains Atlas §Soil.H — Pipeline shape | Soil follows `RAW → WORK/QUARANTINE → PROCESSED → CATALOG/TRIPLET → PUBLISHED` | **CONFIRMED doctrine** |
+
+> [!NOTE]
+> Every concrete validator name, fixture path, CI job name, or schema home referenced below remains **PROPOSED** until inspected against the mounted repository. Doctrine is the load-bearing claim; implementation depth is not asserted by this runbook.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 3. Path placement & Directory Rules basis
+
+- **Owning root:** `docs/` — the canonical, human-facing control plane that owns doctrine, ADRs, runbooks, and registers (Directory Rules §5).
+- **Lane within root:** `docs/runbooks/` — established by the Whole-UI / Governed-AI expansion register (e.g., `docs/runbooks/ui_LOCAL_DEV.md`, `governed_ai_VALIDATION.md`).
+- **Domain segment:** `soil/` — per Directory Rules §12 (Domain Placement Law), a domain MUST appear as a **segment inside a responsibility root**, never as a root folder.
+- **Filename:** `NO_NETWORK_TEST_RUNBOOK.md` — `SCREAMING_SNAKE_CASE` matches the runbook precedent (`ui_LOCAL_DEV.md`, `ui_VALIDATION.md`).
+
+> [!WARNING]
+> An **alternative flat form** — `docs/runbooks/soil_NO_NETWORK_TEST_RUNBOOK.md` — would also be Directory-Rules-conformant and matches the verbatim precedent from the Whole-UI report. The folder-segment form chosen here keeps Soil's growing runbook set (validation, rollback, correction drill, etc.) collected. If the mounted repo already uses the flat form, file a `docs/registers/DRIFT_REGISTER.md` entry rather than silently mirror it. **Placement is PROPOSED until verified.**
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 4. Preconditions
+
+```text
+[ ] Local workspace checked out at a known commit (CONFIRMED requirement; commit SHA = NEEDS VERIFICATION)
+[ ] No environment variables present that point validators at live sources
+    (NRCS_SDA_URL, KSMESONET_KEY, AIRNOW_KEY, SMAP_TOKEN, etc.)
+[ ] Outbound network blocked at the test-runner level (firewall, container netns,
+    or pytest plugin — implementation choice PROPOSED)
+[ ] The Soil synthetic fixture set is present at the path listed in §6
+[ ] All schema files referenced in §8 resolve from disk (no remote $ref pulls)
+[ ] No cached HTTP responses are reachable from the test process
+```
+
+> [!CAUTION]
+> If the test runner can reach the public internet **at all** during execution, the run is invalid regardless of its pass/fail signal. The no-network constraint is enforced **at the runner boundary**, not by good intentions inside test code.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 5. Trust spine the test must prove
+
+```mermaid
+flowchart LR
+    A["Synthetic<br/>SourceDescriptor"] --> B["Source admission<br/>& rights check"]
+    B --> C["Lifecycle state<br/>RAW → WORK"]
+    C --> D["Schema +<br/>contract validation"]
+    D --> E["EvidenceRef →<br/>EvidenceBundle"]
+    E --> F["Policy decision<br/>(allow / deny / abstain)"]
+    F --> G["Catalog / proof<br/>closure"]
+    G --> H["ReleaseManifest<br/>(dry-run)"]
+    H --> I["Governed API<br/>envelope"]
+    I --> J["Correction +<br/>rollback drill"]
+
+    classDef gate fill:#e8f5e9,stroke:#2e7d32,stroke-width:1px;
+    classDef trust fill:#fff8e1,stroke:#f57f17,stroke-width:1px;
+    class B,D,F,G,H gate;
+    class E,I,J trust;
+
+    X(("✕ Network<br/>egress<br/>BLOCKED")):::deny
+    X -.-> B
+    X -.-> E
+    X -.-> H
+    classDef deny fill:#ffebee,stroke:#c62828,stroke-width:2px,color:#c62828;
+```
+
+> [!NOTE]
+> The diagram is illustrative of the **doctrinal** trust spine. The names and exact ordering of validator stages are **PROPOSED** and may be adjusted to match repo evidence once mounted.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 6. Inputs — synthetic Soil fixtures
+
+Per the Unified Manual's PROPOSED fixture rule, every major Soil object family receives **five** fixtures: valid, invalid, denied, abstention, and rollback/correction. Sensitive lanes use *public-safe transformed* fixtures — never real exact farm-owner or pedon coordinates.
+
+| Object family | Fixture root *(PROPOSED)* | Valid | Invalid | Denied | Abstain | Rollback |
+|---|---|:-:|:-:|:-:|:-:|:-:|
+| `SoilMapUnit` | `tests/fixtures/domains/soil/map_unit/` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `SoilComponent` | `tests/fixtures/domains/soil/component/` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Horizon` | `tests/fixtures/domains/soil/horizon/` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `SoilProperty` | `tests/fixtures/domains/soil/property/` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `HydrologicSoilGroup` | `tests/fixtures/domains/soil/hsg/` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `SoilMoistureObservation` | `tests/fixtures/domains/soil/moisture/` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Pedon` | `tests/fixtures/domains/soil/pedon/` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `ComponentHorizonJoin` | `tests/fixtures/domains/soil/chj/` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `LayerManifest` (Soil layer) | `tests/fixtures/domains/soil/layer_manifest/` | ✅ | ✅ | ✅ | — | ✅ |
+| `ReleaseManifest` (Soil) | `tests/fixtures/domains/soil/release_manifest/` | ✅ | ✅ | ✅ | — | ✅ |
+| `EvidenceBundle` (Soil) | `tests/fixtures/domains/soil/evidence_bundle/` | ✅ | ✅ | — | ✅ | ✅ |
+
+> [!IMPORTANT]
+> The KFM Encyclopedia names the **canonical Soil thin slice**: *"one county SSURGO fixture with map units, components, horizons, HSG, one soil-moisture station sample, profile view and EvidenceBundle-backed layer manifest."* The fixtures above MUST collectively realize that slice — but must do so with **synthesized** identifiers and **public-safe** geometry, not a verbatim county extract.
+
+The synthetic fixture set MUST include at least one example per *source role* enumerated in the SourceDescriptor schema — `observed`, `regulatory`, `modeled`, `aggregate`, `administrative`, `candidate`, `synthetic` — even where the role is implausible for Soil in production, so that source-role-mismatch denial is exercisable.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 7. Procedure
+
+> [!NOTE]
+> Commands below are **illustrative**. Concrete test commands depend on the chosen test runner (`pytest`, `vitest`, `go test`, etc.), which is **UNKNOWN** in this session. Adapt to the repo's actual `Makefile` / `package.json` / `pyproject.toml` once mounted.
+
+### Step 1 — Confirm network is denied
+
+```bash
+# Illustrative — verify the runner cannot reach common Soil endpoints.
+# Each MUST fail (non-zero exit) before proceeding.
+curl --max-time 2 https://sdmdataaccess.nrcs.usda.gov/ && echo "FAIL: network reachable"
+curl --max-time 2 https://mesonet.k-state.edu/ && echo "FAIL: network reachable"
+```
+
+If either succeeds, **abort the run** and re-establish the runner's no-network boundary.
+
+### Step 2 — Resolve schemas from disk
+
+```bash
+# Illustrative — validators MUST load schemas from local paths only.
+export KFM_SCHEMA_ROOT="$(pwd)/schemas/contracts/v1"   # PROPOSED per ADR-0001
+export KFM_DISABLE_NET_FETCH=1                          # PROPOSED env var
+```
+
+### Step 3 — Run the deterministic suite
+
+```bash
+# Illustrative — replace with the repo's actual invocation.
+make test-soil-no-network
+# or, equivalently:
+pytest tests/domains/soil/no_network/ -m "no_network"
+```
+
+### Step 4 — Inspect the generated receipt
+
+A passing run MUST emit a deterministic, signable receipt at a **PROPOSED** local-only location, e.g.:
+
+```text
+data/proofs/test/soil/no_network/<run_id>/run_receipt.json
+data/proofs/test/soil/no_network/<run_id>/validation_report.json
+```
+
+The `run_id` MUST be derived from `(spec_hash, fixture_set_hash, tool_versions)` — never from `time.now()` — so that re-running on identical inputs produces identical receipts (cross-run determinism).
+
+### Step 5 — Diff against the golden receipt
+
+```bash
+# Illustrative.
+diff -u \
+  tests/fixtures/domains/soil/golden/no_network_receipt.json \
+  data/proofs/test/soil/no_network/<run_id>/run_receipt.json
+```
+
+Any diff is a **failure**, even if every individual assertion passed. Determinism is part of the test.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 8. Validators invoked
+
+The runbook exercises — at minimum — every validator family the KFM Encyclopedia §K names as required.
+
+| Validator family *(per Encyclopedia §K)* | Exercised by | Expected outcome on `*_invalid` fixtures |
+|---|---|---|
+| Schema validation | Every fixture | **deny** (schema error) |
+| Source descriptor validation | `SourceDescriptor.*` fixtures | **deny** for unknown source / role / rights |
+| Rights validation | Fixtures with missing/ambiguous license | **deny** (rights-unknown) |
+| Sensitivity validation | Fixtures with farm-owner / pedon coords | **deny** until generalized |
+| Evidence closure | `EvidenceBundle.*` fixtures | **abstain** when `EvidenceRef` unresolved |
+| Temporal logic | Fixtures crossing `observed/valid/retrieval` boundaries | **deny** on improper collapse |
+| Geometry validity | `SoilMapUnit.*` fixtures | **deny** on invalid topology |
+| Policy deny | Sensitive / unreleased fixtures | **deny** (policy outcome) |
+| Citation validation | `EvidenceBundle.*` fixtures | **deny** on uncited claim |
+| Release manifest validation | `ReleaseManifest.*` fixtures | **deny** on missing proof / rollback target |
+| Rollback drill | `rollback.*` fixtures | **must successfully replay prior manifest** |
+| **No-network fixtures** | The runbook itself | **all of the above, with zero egress** |
+| Non-regression | Golden receipts | **byte-identical** to prior recorded state |
+
+> [!TIP]
+> The PROPOSED Soil-specific validators — `MUKEY/COKEY/CHKEY` lineage tests, horizon-depth sanity, soil-moisture unit/depth/QC, support-type separation denial, dual-hash stability, catalog closure and Evidence Drawer tests — plug into the families above. They are **domain refinements**, not replacements for the standard set.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 9. Pass / fail / abstain / deny outcomes
+
+Every Soil test assertion resolves to **one of four** finite outcomes — the same set the governed API envelope uses in production. Any other state (silent skip, "warning", "TODO") is a runbook failure.
+
+| Outcome | Meaning in this runbook | Example trigger |
+|---|---|---|
+| **ANSWER** | Trust spine closed: schema OK, evidence resolved, policy allow, catalog closed, manifest dry-runnable. | `SoilMapUnit_valid_county.json` |
+| **ABSTAIN** | Inputs syntactically valid but evidence is missing, stale, or ambiguous. | `EvidenceBundle_unresolved_ref.json` |
+| **DENY** | Policy, rights, sensitivity, or source-role forbids progression. | `SoilMoistureObservation_owner_geometry.json` |
+| **ERROR** | Something the test cannot adjudicate — treat as failure. | Schema file missing, runner crashed, network reached. |
+
+> [!IMPORTANT]
+> **`DENY` is a passing test outcome** when the fixture is a `*_denied.json` or `*_invalid.json` case. The runbook fails when a *denied* fixture *answers*, or a *valid* fixture *errors*. Negative-path coverage is mandatory.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 10. Soil-specific assertions
+
+Each MUST be exercised by at least one fixture in §6.
+
+1. **MUKEY / COKEY / CHKEY lineage**. Map-unit, component, and component-horizon keys MUST chain consistently; broken lineage is a `DENY`.
+2. **Horizon depth sanity**. `hzdept_r < hzdepb_r` for every horizon; overlapping horizons within a component is a `DENY`.
+3. **Soil-moisture unit / depth / QC**. Volumetric water content carries units, depth (cm), and a QA flag; mixed units across a station series is a `DENY`.
+4. **Support-type separation**. Static survey, gridded derivative, station reading, satellite grid, pedon evidence, and interpretation MUST NOT be presented as a single surface — attempting to do so is a `DENY`.
+5. **Dual-hash stability**. Canonical row hash + tile/bundle hash MUST be reproducible across runs given identical inputs (cross-run determinism).
+6. **Catalog closure**. Every `release candidate` fixture MUST carry an `EvidenceBundle`, a `ValidationReport`, a digest, and a rollback target — missing any one is a `DENY`.
+7. **Source-role mismatch denial**. A `regulatory` SourceDescriptor used as an `observed` source MUST `DENY` at admission.
+8. **Public-safe transformation**. Fixtures containing farm-specific, owner-specific, or operational sensor geometry MUST be generalized/redacted before release — un-generalized fixtures `DENY` at the publication gate.
+9. **Stale-state handling**. A fixture flagged stale beyond its source cadence MUST surface a stale badge **and** still produce a finite outcome.
+10. **Non-regression for prior lineage**. Renaming or re-keying any Soil object MUST be accompanied by a continuity entry; bare rename `DENY`s.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 11. Failure modes and rollback
+
+| Failure mode | Likely cause | Action |
+|---|---|---|
+| Test runner can reach `*.usda.gov`, `*.k-state.edu`, etc. | Network isolation not enforced | Re-establish runner boundary; **discard the run** |
+| `golden/no_network_receipt.json` diff | Non-determinism in run_id / tool versions / clock | Pin tool versions; remove time-based identity; re-run |
+| `EvidenceRef` resolves to nothing | Synthetic fixture missing companion `EvidenceBundle` | Add the bundle fixture; rerun |
+| Schema `$ref` fetch attempt | Schema authored with remote `$ref` | Localize the `$ref` to `schemas/contracts/v1/...`; rerun |
+| Valid fixture returns `DENY` | Policy bundle over-restrictive **or** fixture under-spec'd | File `docs/registers/VERIFICATION_BACKLOG.md` entry; do **not** weaken policy |
+| Denied fixture returns `ANSWER` | Policy gate not wired | **Block the PR.** Open a drift entry and fail the build |
+
+### Rollback path
+
+This runbook produces **no** public artifacts. Rollback for a failed run is:
+
+1. Discard the run's `run_id` directory under `data/proofs/test/soil/no_network/`.
+2. Do not promote any fixture, schema, or policy change merged in a PR whose no-network run failed.
+3. Open a `docs/registers/DRIFT_REGISTER.md` entry if the failure indicates a schema/policy/contract drift rather than a fixture bug.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 12. CI binding
+
+> [!NOTE]
+> The exact CI job name, workflow file, and reviewer policy are **UNKNOWN** in this session. Names below are **PROPOSED**.
+
+PROPOSED CI shape (illustrative `.github/workflows/test-soil-no-network.yml`):
+
+```yaml
+name: test-soil-no-network
+on:
+  pull_request:
+    paths:
+      - 'tests/fixtures/domains/soil/**'
+      - 'schemas/contracts/v1/**'
+      - 'policy/domains/soil/**'
+      - 'docs/runbooks/soil/NO_NETWORK_TEST_RUNBOOK.md'
+jobs:
+  no-network:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deny network egress
+        run: |
+          sudo iptables -A OUTPUT -m owner --uid-owner $(id -u) -j REJECT \
+            || echo "PROPOSED: choose network-isolation strategy"
+      - name: Run soil no-network suite
+        env:
+          KFM_DISABLE_NET_FETCH: "1"
+        run: make test-soil-no-network
+      - name: Verify golden receipt
+        run: |
+          diff -u tests/fixtures/domains/soil/golden/no_network_receipt.json \
+                  data/proofs/test/soil/no_network/*/run_receipt.json
+```
+
+The CI job MUST be a **required check** on PRs that touch any of the paths above. Without that branch-protection binding, the runbook documents a wish, not an enforced gate.
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 13. Open verification items
+
+| # | Item | Evidence that would settle it | Status |
+|---|---|---|---|
+| 1 | Confirm chosen test runner (pytest / vitest / go test / …) for Soil. | Mounted repo `Makefile` or runner config. | NEEDS VERIFICATION |
+| 2 | Confirm Soil fixture root path (`tests/fixtures/domains/soil/` vs alternative). | Mounted repo evidence; Directory Rules §4 application. | NEEDS VERIFICATION |
+| 3 | Confirm the SourceDescriptor schema home (`schemas/contracts/v1/source/source-descriptor.json` per ADR-0001). | Mounted repo + accepted ADR-0001. | NEEDS VERIFICATION |
+| 4 | Confirm whether `docs/runbooks/soil/<NAME>.md` (folder) or `docs/runbooks/soil_<NAME>.md` (flat) is the local convention. | Mounted repo `docs/runbooks/` listing. | NEEDS VERIFICATION |
+| 5 | Identify the deterministic `run_id` formula in use (PROPOSED: `(spec_hash, fixture_set_hash, tool_versions)`). | Mounted repo validator code. | NEEDS VERIFICATION |
+| 6 | Confirm the network-isolation strategy (iptables / netns / pytest-socket / container). | Mounted repo CI config. | NEEDS VERIFICATION |
+| 7 | Verify Kansas Mesonet, NRCS SCAN, USCRN, SMAP, SSURGO/SDA rights for any *eventual* live ingest. | Source registry entries with rights notes. | NEEDS VERIFICATION |
+| 8 | Confirm reviewer identity for Soil runbook PRs (CODEOWNERS). | `.github/CODEOWNERS`. | NEEDS VERIFICATION |
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## 14. FAQ
+
+<details>
+<summary><strong>Why no real SSURGO data, even read-only from a local cache?</strong></summary>
+
+Because the no-network runbook is also a *governance* runbook. Even a local cache of SSURGO is a non-synthetic artifact with rights, vintage, and sensitivity considerations that must be carried through a SourceDescriptor. The synthetic fixtures let the trust spine close *without* pulling those obligations into a unit test. The cached-SSURGO scenario belongs in a later **integration** runbook, not this one.
+
+</details>
+
+<details>
+<summary><strong>Can a fixture include real Kansas county geometry?</strong></summary>
+
+Real *administrative* geometry (county outlines from Census TIGER) is generally public-safe and may be used. Real **soil polygon** geometry tied to a real survey area is also generally public-safe — but combining it with farm-owner names, operational sensor coordinates, or anything that re-identifies a parcel is **not**. When in doubt, generalize and label the fixture as transformed.
+
+</details>
+
+<details>
+<summary><strong>What if a validator legitimately needs a remote vocabulary (e.g., a SKOS file)?</strong></summary>
+
+Vendor the vocabulary into `schemas/contracts/v1/vocab/` (PROPOSED path) and version it. The no-network runbook does not relax to accommodate "but it's just a vocabulary"; remote `$ref` and remote vocabulary fetches are equally disqualifying.
+
+</details>
+
+<details>
+<summary><strong>How does this runbook interact with the Soil Evidence Drawer and Focus Mode runbooks?</strong></summary>
+
+This runbook is **upstream** of both. The Evidence Drawer inspector and Focus Mode mock-adapter runbooks (each PROPOSED, not yet present) consume the fixtures and golden receipts produced here. A break in the no-network suite invalidates any downstream UI/AI fixture run that depended on it.
+
+</details>
+
+<details>
+<summary><strong>Is "no-network" the same as "offline"?</strong></summary>
+
+No. "Offline" usually means "the *user's* machine is disconnected." "No-network" here means the *test process* cannot reach any external endpoint — including loopback proxies that might tunnel out. The constraint is enforced at the runner boundary so it survives a developer's local environment.
+
+</details>
+
+[↑ Back to top](#-soil--no-network-test-runbook)
+
+---
+
+## Related docs
+
+- `docs/doctrine/directory-rules.md` — placement authority for this file (CONFIRMED rule; presence PROPOSED).
+- `docs/domains/soil/README.md` — Soil domain index *(PROPOSED — NEEDS VERIFICATION)*.
+- `docs/runbooks/soil/VALIDATION.md` — Soil validation runbook *(PROPOSED, not yet created)*.
+- `docs/runbooks/soil/ROLLBACK.md` — Soil rollback drill runbook *(PROPOSED, not yet created)*.
+- `docs/adr/ADR-0001-schema-home.md` — schema-home authority *(PROPOSED — NEEDS VERIFICATION)*.
+- `docs/registers/DRIFT_REGISTER.md` — where to log placement/convention drift.
+- `docs/registers/VERIFICATION_BACKLOG.md` — where to log open verification items.
+- `schemas/contracts/v1/source/source-descriptor.json` — canonical SourceDescriptor schema *(PROPOSED)*.
+- `tests/fixtures/domains/soil/` — Soil fixture root *(PROPOSED)*.
+- `policy/domains/soil/` — Soil policy bundle *(PROPOSED)*.
+
+---
+
+**Last updated:** 2026-05-12  ·  **Status:** `draft`  ·  **Authority:** CONFIRMED doctrine / PROPOSED implementation
+
+[↑ Back to top](#-soil--no-network-test-runbook)

--- a/docs/runbooks/soil/PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/soil/PROMOTION_RUNBOOK.md
@@ -1,3 +1,730 @@
-# soil :: PROMOTION runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbooks/soil/promotion-runbook
+title: Soil Promotion Runbook
+type: standard
+version: v0.1
+status: draft
+owners: [Soil domain steward, Release authority, Docs steward]
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/truth-posture.md
+  - docs/domains/soil/README.md
+  - docs/runbooks/soil/ROLLBACK_RUNBOOK.md
+  - docs/runbooks/soil/VALIDATION_RUNBOOK.md
+  - contracts/domains/soil/README.md
+  - schemas/contracts/v1/domains/soil/
+  - policy/domains/soil/
+  - release/README.md
+tags: [kfm, soil, runbook, promotion, lifecycle, governance]
+notes:
+  - File placement is PROPOSED; nested-domain pattern under docs/runbooks/ may be revised to a flat
+    soil_PROMOTION.md naming once a docs/runbooks/README.md convention is established.
+  - Tool commands shown are illustrative; verify against the mounted repo before relying on them.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# 🌱 Soil Promotion Runbook
+
+> Operational procedure for promoting Soil-domain candidates through the KFM lifecycle:
+> **RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED.**
+> Promotion is a **governed state transition**, not a file move.
+
+<!-- Badges are PLACEHOLDERS until the mounted repo confirms CI workflow names, branch protection rules,
+     and release-manifest endpoints. Replace targets when verified. -->
+
+![status](https://img.shields.io/badge/status-draft-orange)
+![doc%20type](https://img.shields.io/badge/doc%20type-runbook-blue)
+![domain](https://img.shields.io/badge/domain-soil-8B4513)
+![lifecycle](https://img.shields.io/badge/lifecycle-RAW%E2%86%92PUBLISHED-informational)
+![policy](https://img.shields.io/badge/policy-public-green)
+![gate%20parity](https://img.shields.io/badge/gate%20parity-CI%3DRuntime-purple)
+![last%20updated](https://img.shields.io/badge/last%20updated-2026--05--12-lightgrey)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` — PROPOSED implementation; doctrine CONFIRMED |
+| **Owners** | Soil domain steward · Release authority · Docs steward |
+| **Reviewers required** | Soil steward + Release authority (two-key, separation of duties) |
+| **Last updated** | 2026-05-12 |
+| **Truth posture** | cite-or-abstain · finite outcomes: `ANSWER` / `ABSTAIN` / `DENY` / `ERROR` |
+| **Lifecycle invariant** | RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED |
+| **Authority basis** | Directory Rules §0, §3 (Lifecycle invariant); Master Pipeline Gate Reference; Soil domain dossier (Atlas §5, Encyclopedia §7.3) |
+
+---
+
+## 📑 Contents
+
+1. [Purpose & Scope](#1-purpose--scope)
+2. [Repo Fit](#2-repo-fit)
+3. [Preconditions](#3-preconditions)
+4. [Promotion Flow Overview](#4-promotion-flow-overview)
+5. [Gate-by-Gate Procedure](#5-gate-by-gate-procedure)
+6. [The Promotion Gate Matrix A–G](#6-the-promotion-gate-matrix-ag)
+7. [Soil-Specific Validators & Fixtures](#7-soil-specific-validators--fixtures)
+8. [Rights, Sensitivity & Support-Type Separation](#8-rights-sensitivity--support-type-separation)
+9. [Quarantine Handling](#9-quarantine-handling)
+10. [Receipts, Manifests & Audit Trail](#10-receipts-manifests--audit-trail)
+11. [Rollback & Correction Path](#11-rollback--correction-path)
+12. [Decision Outcomes & Failure Modes](#12-decision-outcomes--failure-modes)
+13. [Steward Checklist](#13-steward-checklist)
+14. [Common Failure Modes & Remediation](#14-common-failure-modes--remediation)
+15. [FAQ](#15-faq)
+16. [Related Docs](#16-related-docs)
+17. [Appendix](#17-appendix)
+
+---
+
+## 1. Purpose & Scope
+
+This runbook tells a Soil-domain steward, release authority, or on-call reviewer **how to move a Soil candidate from admission to publication safely**, and **how to refuse to move it** when the evidence, rights, sensitivity, or release state cannot justify exposure.
+
+**In scope.** Promotion of Soil objects across the five lifecycle phases, the seven Promotion Gates (A–G), Soil-specific validators (MUKEY/COKEY/CHKEY lineage, horizon depth, support-type separation, soil-moisture QC, dual-hash stability, catalog closure), the receipts and manifests required at each gate, and the rollback / correction paths bound to each release.
+
+**Out of scope.** Source registration intake (see `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` — *PROPOSED*); raw connector implementation (see `connectors/`); cross-domain analytical joins (governed by the consuming domain's runbook); UI rendering of soil layers (see Map Shell architecture).
+
+**Soil objects in scope (CONFIRMED object-family spine / PROPOSED implementation):**
+
+`SoilMapUnit` · `SoilComponent` · `Horizon` · `SoilProperty` · `HydrologicSoilGroup` · `SoilMoistureObservation` · `ErosionRisk` · `SuitabilityRating` · `Pedon` · `SoilProfileView` · `ComponentHorizonJoin` · `SoilTimeCaveat`
+
+> [!IMPORTANT]
+> **Promotion is a governed state transition, not a file move.** A directory move that bypasses validators, policy gates, EvidenceBundle creation, catalog closure, and release-decision recording is a violation of the lifecycle invariant regardless of where the bytes ended up. If you find yourself reaching for `mv`, stop and consult §5.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 2. Repo Fit
+
+This runbook lives under the human-facing control plane (`docs/`), inside the runbooks branch that holds ops procedures, rollback drills, and validation runs.
+
+**Path (PROPOSED — see Notes):** `docs/runbooks/soil/PROMOTION_RUNBOOK.md`
+
+**Upstream doctrine (read first):**
+
+- `docs/doctrine/directory-rules.md` — placement and lifecycle authority
+- `docs/doctrine/lifecycle-law.md` — RAW → PUBLISHED invariant
+- `docs/doctrine/truth-posture.md` — cite-or-abstain
+- `docs/doctrine/trust-membrane.md` — watcher-as-non-publisher
+
+**Sibling runbooks (PROPOSED):**
+
+- `docs/runbooks/soil/VALIDATION_RUNBOOK.md`
+- `docs/runbooks/soil/ROLLBACK_RUNBOOK.md`
+- `docs/runbooks/soil/CORRECTION_RUNBOOK.md`
+
+**Downstream consumers (must read for cross-domain promotions touching Soil):**
+
+- `docs/runbooks/agriculture/PROMOTION_RUNBOOK.md` *(PROPOSED)*
+- `docs/runbooks/hydrology/PROMOTION_RUNBOOK.md` *(PROPOSED)*
+- `docs/runbooks/habitat/PROMOTION_RUNBOOK.md` *(PROPOSED)*
+
+**Machine-readable anchors:**
+
+| Concern | Where it lives |
+|---|---|
+| Soil object **meaning** | `contracts/domains/soil/` *(PROPOSED)* |
+| Soil object **shape** | `schemas/contracts/v1/domains/soil/` *(PROPOSED)* per ADR-0001 |
+| Soil **admissibility / policy** | `policy/domains/soil/` *(PROPOSED)* |
+| Soil **tests & fixtures** | `tests/domains/soil/`, `fixtures/domains/soil/` *(PROPOSED)* |
+| Soil **lifecycle data** | `data/{raw,work,quarantine,processed}/soil/...` |
+| Soil **release decisions** | `release/candidates/soil/`, `release/manifests/` |
+| Soil **rollback artifacts** | `data/rollback/soil/<release_id>/` |
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 3. Preconditions
+
+Do not begin a promotion attempt unless the following are present **and verifiable**.
+
+> [!CAUTION]
+> Default-deny is in force. Any unresolved item below halts the promotion and produces a structured `DENY` or `ABSTAIN`. Do not "fix it later" — fix it before re-running.
+
+### 3.1 Source-side preconditions
+
+- [ ] `SourceDescriptor` exists for every contributing source (SSURGO, gSSURGO, SDA, Mesonet, SCAN, USCRN, SMAP, NASIS-derived tables, etc.) — covers `source_id`, `source_role`, `authority`, `rights`, `sensitivity`, `cadence`, `ingest_hash`, `citation`, `time`.
+- [ ] Rights and terms for each source are recorded and currently valid. **Unknown rights fail closed.**
+- [ ] Source role is unambiguous — authority / observation / context / model / synthetic / candidate — and is not invented by AI.
+- [ ] Raw payload or reference is captured under `data/raw/soil/<source_id>/<run_id>/` with checksum.
+
+### 3.2 Candidate-side preconditions
+
+- [ ] Candidate carries normalized schema, geometry, time, identity, evidence, rights, and policy attributes.
+- [ ] `EvidenceRef`s are present for every consequential claim and resolve to admissible `EvidenceBundle`s.
+- [ ] Required receipts for the target phase are emitted (see §10).
+- [ ] Determinism: `spec_hash`, `content_hash`, and `geometry_hash` are computable and stable across a clean rebuild.
+
+### 3.3 Reviewer-side preconditions
+
+- [ ] Soil domain steward is available; release authority is **distinct** from the original author when materiality applies (two-key).
+- [ ] Open `ReviewRecord` queue is workable (no blocking unresolved corrections on prior releases).
+- [ ] Rollback target for the current `PUBLISHED` baseline is known and drilled.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 4. Promotion Flow Overview
+
+The Soil lane follows the KFM lifecycle invariant. Every arrow below is a **governed transition**, not a path move.
+
+```mermaid
+flowchart LR
+    A([Source candidate]) --> R[RAW]
+    R -- Admission gate --> WQ{WORK / QUARANTINE}
+    WQ -- Normalization fail --> Q[QUARANTINE<br/>reason recorded]
+    WQ -- Normalization pass --> P[PROCESSED]
+    P -- Validation gate --> P
+    P -- Catalog closure --> CT[CATALOG / TRIPLET]
+    CT -- Release gate<br/>2-key approval --> PUB[PUBLISHED]
+    PUB -- Correction --> PUB2[PUBLISHED′]
+    PUB -- Failed release --> RB[ROLLBACK]
+    RB --> CT
+
+    classDef phase fill:#f7f3e9,stroke:#8B4513,stroke-width:2px,color:#222
+    classDef quar fill:#fdecec,stroke:#a33,stroke-width:1.5px,color:#222
+    classDef pub fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:#222
+    class R,WQ,P,CT phase
+    class Q,RB quar
+    class PUB,PUB2 pub
+```
+
+> [!NOTE]
+> The diagram represents the **doctrinal** flow described in the Atlas §8 Master Pipeline Gate Reference and the Soil pipeline-shape table. Exact tool entrypoints and CI workflow names are NEEDS VERIFICATION — see §17.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 5. Gate-by-Gate Procedure
+
+Each subsection covers one lifecycle transition: **what it requires**, **what you do**, **how it can fail**, and **what receipts must exist when it succeeds**.
+
+### 5.1 Admission — (— → `RAW`)
+
+**Goal.** Capture an immutable source-native payload (or reference) with enough provenance that nothing downstream has to guess.
+
+**Inputs.** A registered `SourceDescriptor`; the source payload or pointer; minimal rights and source-role intent.
+
+**Actions.**
+
+1. Verify the source is in the **approved** state in `data/registry/sources/` *(PROPOSED)*. Retired or quarantined sources cannot admit.
+2. Compute the payload hash (or reference hash).
+3. Land the raw bytes under `data/raw/soil/<source_id>/<run_id>/` and emit `SourceDescriptor` and the admission receipt.
+
+**Failure-closed outcome.** Source not admitted; logged as a candidate awaiting steward.
+
+**Required artifacts on success.** `SourceDescriptor` · raw capture receipt with hash.
+
+> [!WARNING]
+> **No public RAW access.** RAW is never reachable from the public client, the governed API surface, the Evidence Drawer, or Focus Mode. If a route serves bytes out of `data/raw/`, escalate as a trust-membrane incident.
+
+### 5.2 Normalization — (`RAW` → `WORK` / `QUARANTINE`)
+
+**Goal.** Normalize schema, geometry, time, identity, evidence linkage, rights, and policy. Hold every failure in `QUARANTINE` with a recorded reason.
+
+**Inputs.** RAW payload; soil-domain schemas; soil-domain policy bundle.
+
+**Actions.**
+
+1. Run schema validation against `schemas/contracts/v1/domains/soil/` *(PROPOSED)*.
+2. Apply geometry normalization (reprojection, generalization, snap) and emit `TransformReceipt` for each step.
+3. Resolve identity: `MUKEY` / `COKEY` / `CHKEY` lineage must be coherent for SSURGO / gSSURGO derivatives (see §7).
+4. Run the source / rights / sensitivity policy gate.
+
+**Failure-closed outcome.** Quarantine with structured reason under `data/quarantine/soil/<reason>/<run_id>/`. **Never silently promote.**
+
+**Required artifacts on success.** `TransformReceipt`(s) · `ValidationReport` (working set) · `PolicyDecision`.
+
+### 5.3 Validation — (`WORK` → `PROCESSED`)
+
+**Goal.** Prove the normalized object passes deterministic validation, sensitivity transforms, and aggregation rules (where applicable), and that public-safe candidate fields are ready.
+
+**Inputs.** WORK candidate; soil validator suite (§7); applicable fixtures.
+
+**Actions.**
+
+1. Run the layered soil validator suite (Shape → Meaning → Source → Evidence → Policy → Lifecycle → Receipt → Release pre-flight).
+2. Apply `RedactionReceipt` if sensitivity transforms apply (rare for soil; common where pedon owner-identifying fields exist).
+3. Apply `AggregationReceipt` if the candidate aggregates station observations to public-safe units (e.g., decadal county roll-up).
+4. Confirm `EvidenceRef`s resolve to admissible `EvidenceBundle`s.
+
+**Failure-closed outcome.** Stay in WORK with a structured `FAIL` outcome attached to the run.
+
+**Required artifacts on success.** `ValidationReport` with `passes` and zero blocking `failures` · `RedactionReceipt` / `AggregationReceipt` where applied · `EvidenceRef`s.
+
+### 5.4 Catalog Closure — (`PROCESSED` → `CATALOG` / `TRIPLET`)
+
+**Goal.** Bind every published-candidate artifact to a catalog record, an `EvidenceBundle`, and (when applicable) a graph/triplet projection. **No orphan artifacts.**
+
+**Inputs.** PROCESSED candidates; catalog matrix; evidence resolver.
+
+**Actions.**
+
+1. Emit `CatalogRecord` / `CatalogMatrix` entries referencing source, schema, validation, policy, and release metadata.
+2. Resolve `EvidenceRef` → `EvidenceBundle` and persist the bundle under `data/proofs/evidence_bundle/`.
+3. Compute graph/triplet projection if the candidate participates in cross-lane relations (Soil ↔ Agriculture, Soil ↔ Hydrology, Soil ↔ Habitat, Soil ↔ Geology).
+4. Run **catalog closure validation** — every candidate dataset/layer carries source, schema, validation, policy, and release metadata.
+
+**Failure-closed outcome.** HOLD at `PROCESSED`; structured `FAIL`; no public edge.
+
+**Required artifacts on success.** `CatalogMatrix` entry · `EvidenceBundle` · `GraphDelta` / `Triplet` if applicable.
+
+### 5.5 Release — (`CATALOG` / `TRIPLET` → `PUBLISHED`)
+
+**Goal.** Move a release-candidate behind a `ReleaseManifest` with a known rollback target, a correction path, and a `ReviewRecord` where required. Two-key approval applies when materiality justifies it.
+
+**Inputs.** Catalog-closed candidate; `EvidenceBundle`; rollback target; review queue.
+
+**Actions.**
+
+1. Open a `ReviewRecord` and complete steward + release-authority review (two-key for material releases).
+2. Bind the release into a `ReleaseManifest` (`release_id`, `contents[]`, `digests`, `evidence_refs[]`, `rollback_target`, `time`).
+3. Run the **Promotion Gate Matrix A–G** (§6). Any deny → `DENY`, surface remediation.
+4. Sign the release receipt (cosign / DSSE expected; verify against `policy/release/` *(PROPOSED)*).
+5. Publish via the **governed API**, not by directory move. Public clients read released payloads only.
+
+**Failure-closed outcome.** HOLD at `CATALOG`; no public surface change; reviewer surface shows the gate failures with remediation.
+
+**Required artifacts on success.** `ReleaseManifest` · `ReviewRecord` (when required) · signed release receipt · `RollbackCard` (registered, even if rollback is "not safe to roll back; forward-fix only" with reason) · `CorrectionNotice` template prepared.
+
+### 5.6 Correction — (`PUBLISHED` → `PUBLISHED′`)
+
+**Goal.** When a published soil claim is wrong, **publish the correction**, invalidate downstream derivatives, and (if necessary) roll back. Corrections are governance events, not patches.
+
+**Inputs.** Detected error or new evidence; downstream derivative inventory.
+
+**Actions.** See `docs/runbooks/soil/CORRECTION_RUNBOOK.md` *(PROPOSED)*. Summary: open `ReviewRecord`, issue `CorrectionNotice` referencing the prior release, identify invalidated derivatives, optionally roll back via `RollbackCard`.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 6. The Promotion Gate Matrix A–G
+
+CONFIRMED doctrine: every dataset entering `PUBLISHED` passes these seven gates. **Auto-merge fires only when all seven pass. Any failure blocks the merge until remediation.** The Soil lane uses the same matrix as every other domain; remediation guidance below is Soil-specific where relevant.
+
+| Gate | Human-facing intent | Machine check (PROPOSED) | Required evidence | Common Soil failure |
+|---|---|---|---|---|
+| **A — Structure & Metadata** | The artifact is well-formed and self-describing. | `check_structure` (Meta-Block presence, zone correctness, file layout). | Meta block, path conformance. | Pedon dataset emitted to wrong lifecycle phase. |
+| **B — Schemas & Contracts** | Shape matches the contract; vocabulary is honored. | JSON Schema + OpenAPI validation. | `ValidationReport`, schema digest. | `Horizon.depth_top` exceeds `depth_bottom`; missing `HydrologicSoilGroup` enum. |
+| **C — Policy Parity** | CI policy result equals runtime policy result. | Conftest/OPA bundle pinned by digest; same bundle in CI and at runtime. | `PolicyDecision`, policy digest. | Rego bundle drift between CI and PDP — release blocked. |
+| **D — Security & Sensitivity** | Rights are allowlisted; sensitive geometry is generalized. | Sensitivity scan; license SPDX allowlist; rights register. | `RedactionReceipt`, `PolicyDecision`. | Pedon owner-identifying field present; rights status unknown for a derived layer. |
+| **E — Data Quality** | DQ thresholds pass; assertions hold. | DQ profilers/assertions with thresholds. | DQ report, `ValidationReport`. | Soil-moisture station with > N% gaps in window; support-type masquerade detected (see §7). |
+| **F — Provenance & Lineage** | Every claim is traceable to a receipt and a source. | Receipt presence + lineage validation; `EvidenceRef` → `EvidenceBundle` round-trip. | `EvidenceBundle`, `RunReceipt`, `TransformReceipt`. | Missing `spec_hash`; unresolved `EvidenceRef`. |
+| **G — Reviewability** | A human + policy approval is on record (two-key). | CODEOWNERS-enforced human approval + policy approval. | `ReviewRecord`. | Author and approver are the same identity; release authority absent. |
+
+> [!IMPORTANT]
+> **Policy Parity (Gate C) is the bedrock.** The same OPA bundle (pinned by digest) MUST run in CI (Conftest) and at runtime (PDP / Gatekeeper). A diverging bundle is a release-blocking incident.
+
+**Default-deny posture.** Promotion is denied unless: `spec_hash` is present and matches a recomputation; the run receipt is cosign-signed and verifiable; SPDX rights are in the allowlist; at least one attestation bundle is published; and every DQ check has `status: pass`. **Absence of evidence blocks promotion.**
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 7. Soil-Specific Validators & Fixtures
+
+The Soil domain carries six PROPOSED validator families. All are `PROPOSED implementation / CONFIRMED doctrine` until mounted-repo evidence confirms them.
+
+| Validator family | What it proves | Default failure | Status |
+|---|---|---|---|
+| **MUKEY / COKEY / CHKEY lineage** | SSURGO and gSSURGO derivatives carry coherent map-unit / component / horizon key chains; no orphan COKEYs. | `ERROR` / quarantine | PROPOSED |
+| **Horizon depth sanity** | `depth_top < depth_bottom`; horizons of a given pedon are non-overlapping and ordered. | `ERROR` / quarantine | PROPOSED |
+| **Soil-moisture unit / depth / QC** | Station observations carry units (VWC % or fraction), standardized depth (5 / 10 / 20 / 50 cm or documented), and QC flag passes. | `ERROR` / quarantine | PROPOSED |
+| **Support-type separation denial** | Static survey, gridded derivative, station reading, satellite grid, pedon evidence, and interpretation cannot masquerade as a single surface. | `DENY` | PROPOSED |
+| **Dual-hash stability** | `spec_hash` and `content_hash` are stable across clean rebuilds; receipts pin both. | `ERROR` / release block | PROPOSED |
+| **Catalog closure + Evidence Drawer** | Every released soil feature resolves to an `EvidenceBundle` and renders in the Evidence Drawer with citations. | `ABSTAIN` (Drawer) / `DENY` (release) | PROPOSED |
+
+> [!TIP]
+> **Support-type separation is the load-bearing Soil validator.** A 30-meter gNATSGO raster, a 1-km SMAP grid, a Kansas Mesonet station reading, an SSURGO polygon, and a pedon profile are not interchangeable. Any candidate that mixes them into a single surface without an explicit `RepresentationReceipt` and a Reality Boundary Note fails the gate.
+
+**Resolution-tagging convention (Soil-specific).** When a derived product mixes resolutions (10 m SSURGO vs 30 m gNATSGO vs 250 m SoilGrids vs 1 km SMAP), each derived value MUST carry the source resolution and resampling method as exposed catalog tags. Silent resampling that conflates resolutions is a release-blocking violation.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 8. Rights, Sensitivity & Support-Type Separation
+
+CONFIRMED doctrine: **unclear rights, unresolved source role, missing evidence, unresolved sensitivity, or absent release state blocks public promotion.**
+
+### 8.1 Rights posture
+
+| Source family | Rights status (per dossier) | Promotion behavior |
+|---|---|---|
+| NRCS SSURGO / gSSURGO / gNATSGO / SDA | NEEDS VERIFICATION — sensitive joins fail closed | Confirm current terms before public release |
+| Kansas Mesonet soil moisture | NEEDS VERIFICATION — written consent / attribution may apply | Confirm REST feed terms; record attribution in `ReleaseManifest` |
+| NRCS SCAN · NOAA USCRN | NEEDS VERIFICATION | Confirm terms; record attribution |
+| NASA SMAP | NEEDS VERIFICATION | Confirm Earthdata terms; record attribution |
+| NASIS-derived tables | NEEDS VERIFICATION — may carry owner-identifying fields | Default to redaction; review pedon owner fields |
+
+### 8.2 Sensitivity posture
+
+Soil sensitivity is generally lower than fauna/flora/archaeology, but the following raise the bar:
+
+- **Pedon owner-identifying fields** (landowner, site descriptor, exact coordinates) — redact or generalize.
+- **Field-level joins with private agricultural operations** — these belong to the Agriculture domain's sensitive lane, not to Soil; refer the request rather than absorbing it.
+- **Cross-lane joins** with Habitat / Fauna / Flora must preserve `rare-location` controls owned by those lanes; Soil never publishes rare-location coordinates as a side effect of substrate context.
+
+> [!WARNING]
+> **Default-DENY:** Unreviewed exact sensitive Soil locations or private data MUST NOT publish for a public visitor. Policy approval + redaction receipt are mandatory before any restricted-to-public elevation.
+
+### 8.3 Support-type separation (CONFIRMED / PROPOSED)
+
+This is the Soil domain's signature publication discipline. The six support types are:
+
+1. `static_survey_soil` — SSURGO map-unit polygons, NASIS pedon descriptors.
+2. `gridded_derivative_soil` — gSSURGO / gNATSGO rasters.
+3. `station_soil_moisture` — Mesonet / SCAN / USCRN observations.
+4. `satellite_grid_soil` — SMAP and similar.
+5. `pedon_evidence` — individual pedon descriptors.
+6. `interpretation` — Soil/Crop Suitability, Hydrologic Soil Group, Erosion Risk.
+
+They **must not masquerade as one surface**. Each released layer carries a support-type badge; mixed-support products require a `RepresentationReceipt` and a `RealityBoundaryNote`.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 9. Quarantine Handling
+
+Quarantine is **not a publishable staging area**. Anything in `data/quarantine/soil/<reason>/<run_id>/` is held until either: (a) the failure is repaired upstream and the candidate is re-admitted through Normalization; or (b) the candidate is rejected and the entry deprecated.
+
+**Common quarantine reasons (Soil):**
+
+- `rights_unknown` — source terms not yet recorded.
+- `support_type_masquerade` — candidate mixes support types without a `RepresentationReceipt`.
+- `mukey_lineage_break` — orphan COKEY or CHKEY; broken SSURGO chain.
+- `horizon_depth_invalid` — overlapping / inverted horizons.
+- `unit_mismatch` — soil-moisture observation lacks unit or depth.
+- `sensitivity_unresolved` — pedon owner-identifying field present without a redaction plan.
+
+**Workflow.** A quarantined candidate gets a `PolicyDecision` with reason; the Soil steward reviews; remediation either lands as a re-ingest with a fresh `run_id` or a deprecation entry under `release/deprecation_register.yaml` *(PROPOSED)*.
+
+> [!NOTE]
+> Quarantine is governance memory. Do not delete quarantine entries; deprecate them. A quarantined run that is later understood to have been a false-positive on a validator should remain visible as a lineage receipt — the validator is the artifact that learned.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 10. Receipts, Manifests & Audit Trail
+
+CONFIRMED doctrine: **if no receipt exists, the operation did not happen in the governed sense.**
+
+| Receipt / artifact | Triggered by | Phase emitted | Soil-specific notes |
+|---|---|---|---|
+| `SourceDescriptor` | Source admission | all | One per soil source family; never invented by AI. |
+| `TransformReceipt` | Geometry / projection / generalization | RAW → WORK · WORK → PROCESSED · PROCESSED → CATALOG | Pin reprojection (e.g., to `EPSG:5070`) and any generalization tolerance. |
+| `RedactionReceipt` | Sensitivity transform | WORK · PROCESSED · CATALOG · PUBLISHED | Required for pedon owner-identifying fields. |
+| `AggregationReceipt` | Aggregation roll-up | WORK · PROCESSED · CATALOG · PUBLISHED | Required for county-year / HUC roll-ups; pins geometry scope, time scope, suppression rule. |
+| `ModelRunReceipt` | Model-derived output | WORK · PROCESSED · CATALOG · PUBLISHED | Required for SuitabilityRating, ErosionRisk modeled surfaces. |
+| `RepresentationReceipt` | Representation step where surface fidelity ≠ evidence fidelity | PROCESSED · CATALOG · PUBLISHED | **Mandatory for mixed-support products and 3D scenes.** |
+| `ValidationReport` | Validator run | WORK · PROCESSED · CATALOG | Carries the six Soil validator families' results (§7). |
+| `PolicyDecision` | Every gate | all | `ANSWER` / `ABSTAIN` / `DENY` / `ERROR`. |
+| `EvidenceBundle` | Catalog closure | PROCESSED · CATALOG · PUBLISHED | Content-addressed by `spec_hash`. |
+| `CatalogMatrix` | Catalog closure | CATALOG | Soil entry must link source, schema, validation, policy, release metadata. |
+| `ReviewRecord` | Two-key review | WORK · PROCESSED · CATALOG · PUBLISHED | Required for material soil releases. |
+| `ReleaseManifest` | Release decision | CATALOG · PUBLISHED | Binds `release_id`, contents, digests, evidence refs, **rollback_target**, time. |
+| `RollbackCard` | Failed release / correction | CATALOG · PUBLISHED | Required for **every** soil release, even when forward-fix-only. |
+| `CorrectionNotice` | Post-publication correction | PUBLISHED | Names what changed, why, and which derivatives are invalidated. |
+| `AIReceipt` | Focus Mode answer over soil evidence | PUBLISHED (Focus only) | AI never root truth; must cite released `EvidenceBundle`s. |
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 11. Rollback & Correction Path
+
+CONFIRMED doctrine: **rollback untested is not reliable.** Every soil release has a `RollbackCard` and an executed rollback drill on record.
+
+```mermaid
+sequenceDiagram
+    participant Steward as Soil Steward
+    participant Release as Release Authority
+    participant Gov as Governed API
+    participant Catalog as Catalog / Triplet
+    participant Pub as PUBLISHED
+    participant RB as ROLLBACK
+
+    Steward->>Release: Detect error / receive correction
+    Release->>Pub: Issue CorrectionNotice<br/>(invalidates[])
+    Pub-->>Gov: Public claim flagged corrected
+    alt Forward-fix only
+        Steward->>Catalog: Re-run validation + catalog closure
+        Catalog->>Pub: New ReleaseManifest (PUBLISHED′)
+    else Rollback required
+        Release->>RB: Activate RollbackCard.rollback_to
+        RB->>Pub: Restore prior ReleaseManifest
+        RB->>Gov: Invalidate cache / re-emit served payloads
+        Release->>Pub: Emit rollback attestation
+    end
+```
+
+**Rollback rules.**
+
+1. The rollback target is the prior `ReleaseManifest` and its digests; **not** a directory snapshot.
+2. A rollback emits its own attestation (a rollback receipt) and is reviewable.
+3. Derived layers (PMTiles, GeoParquet, tile caches, vector indexes, graph projections) MUST regenerate from the restored manifest; do not promote a stale derived artifact.
+4. The rollback drill is **rehearsed**, not theoretical — see `docs/runbooks/soil/ROLLBACK_RUNBOOK.md` *(PROPOSED)*.
+
+**Correction rules.**
+
+1. Always permitted; downgrade (`PUBLISHED` → restricted) requires only `CorrectionNotice` + `ReviewRecord`. Upgrade requires both a transform receipt and a review record.
+2. Corrections name the **derivative invalidation set**. Downstream consumers (Agriculture suitability, Hydrology soil-moisture joins, Habitat substrate context) MUST be notified.
+3. `CorrectionNotice` is published with the corrected claim; it does not silently overwrite.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 12. Decision Outcomes & Failure Modes
+
+CONFIRMED doctrine: every governed surface returns a finite outcome.
+
+| Outcome | When it applies in Soil promotion | Consequence |
+|---|---|---|
+| **ANSWER** | All gates pass; release admitted. | `PUBLISHED` transition recorded; `ReleaseManifest` available; public clients can resolve via the governed API. |
+| **ABSTAIN** | Material temporal scope missing; `EvidenceRef` does not resolve; identity ambiguity (e.g., MUKEY crosswalk uncertain); stale-source threshold reached. | No public claim; reviewer surface shows abstain reason. |
+| **DENY** | Rights unknown; support-type masquerade; sensitive geometry public-exposure attempt; policy bundle mismatch (Gate C). | Release blocked; remediation surfaced. |
+| **ERROR** | Validator failure (Gate B / E); receipt absent (Gate F); structural failure (Gate A). | Stay in current phase; structured FAIL outcome attached to the run. |
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 13. Steward Checklist
+
+Use this as the PR / promotion checklist. **Every box must be checked or explicitly labeled `N/A — <reason>` before the release authority signs.**
+
+**Source & rights**
+
+- [ ] `SourceDescriptor` present and current for every contributing source.
+- [ ] Source role unambiguous (authority / observation / context / model / synthetic).
+- [ ] Rights status confirmed and SPDX-allowlisted.
+- [ ] Stale-source check passes against expected cadence.
+
+**Shape & meaning**
+
+- [ ] Schema validation passes against `schemas/contracts/v1/domains/soil/` *(PROPOSED)*.
+- [ ] Contract vocabulary honored (no silent renaming of `MUKEY`, `HydrologicSoilGroup`, etc.).
+- [ ] MUKEY / COKEY / CHKEY lineage validator passes.
+- [ ] Horizon depth sanity validator passes.
+
+**Evidence & lineage**
+
+- [ ] `EvidenceRef`s resolve to admissible `EvidenceBundle`s.
+- [ ] `spec_hash` and `content_hash` recompute identically on a clean rebuild.
+- [ ] `RunReceipt` cosign signature verifies.
+- [ ] At least one attestation bundle published.
+
+**Policy & sensitivity**
+
+- [ ] Soil policy bundle (Conftest/OPA) passes; CI digest matches runtime digest (Gate C).
+- [ ] Support-type separation denial fixture passes; mixed-support products carry `RepresentationReceipt`.
+- [ ] Sensitivity transforms applied where pedon owner-identifying fields exist.
+- [ ] Resolution-tagging present on any multi-resolution derived product.
+
+**Data quality**
+
+- [ ] DQ thresholds met for soil-moisture observations (unit, depth, QC flag).
+- [ ] Aggregation suppression rule applied where county-year roll-ups exist.
+- [ ] No silent resampling between support types.
+
+**Catalog & release**
+
+- [ ] `CatalogMatrix` entry references source, schema, validation, policy, release metadata.
+- [ ] `EvidenceBundle` persisted under `data/proofs/evidence_bundle/`.
+- [ ] `ReleaseManifest` includes `rollback_target`, `correction_path`, `evidence_refs[]`.
+- [ ] `RollbackCard` registered; drill rehearsed or scheduled.
+
+**Review & two-key**
+
+- [ ] `ReviewRecord` open; steward + release-authority identities are distinct.
+- [ ] CODEOWNERS-enforced approval applied.
+- [ ] Branch-protection / required-checks rollup is green.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 14. Common Failure Modes & Remediation
+
+| Failure mode | Likely gate | Remediation |
+|---|---|---|
+| MUKEY orphan / COKEY without parent map unit | B, F | Re-ingest SSURGO snapshot; verify SDA pull integrity; fix join. |
+| Horizon depths overlap or invert | B, E | Reject candidate at WORK; surface as quarantine reason `horizon_depth_invalid`. |
+| Soil-moisture observation lacks unit or depth | B, E | Reject at WORK; reason `unit_mismatch`. |
+| Mixed-resolution product without resolution tags | E, F | Emit `RepresentationReceipt`; add resolution tags to catalog; or split into per-resolution layers. |
+| Pedon owner-identifying field reaches PROCESSED | D | Apply `RedactionReceipt` or quarantine with reason `sensitivity_unresolved`. |
+| OPA bundle digest in CI ≠ runtime | C | Block release; rebuild bundle from canonical source; re-run promotion. |
+| Missing `RollbackCard` at release | G | Block release; either register card or document `forward_fix_only` reason. |
+| `EvidenceRef` resolves to a stale bundle | F | Re-run catalog closure; refresh `EvidenceBundle`; verify content-address. |
+| Stale source (cadence breach) | D, E | Surface stale badge in UI; emit `ABSTAIN` on Focus Mode answers; do not publish derived layer. |
+| Author = approver | G | Reassign release authority to a distinct identity. |
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 15. FAQ
+
+**Q. Can I promote a Soil candidate by moving files between `data/work/` and `data/processed/`?**
+No. Promotion is a governed state transition. A directory move that bypasses validators, policy, EvidenceBundle creation, and catalog closure is a lifecycle-invariant violation regardless of where the bytes ended up.
+
+**Q. My candidate passes every validator but rights status is "NEEDS VERIFICATION". Can I publish behind a "preliminary" badge?**
+No. Default-deny applies. Unknown rights fail closed. Confirm terms first; either elevate to a restricted tier with `RedactionReceipt` + `PolicyDecision`, or keep at `CATALOG` until rights resolve.
+
+**Q. We need to ship a Soil layer that mixes gSSURGO and SMAP. How?**
+Emit a `RepresentationReceipt` documenting method and inputs, attach a `RealityBoundaryNote` to the layer, carry resolution tags on every derived value, and pass the support-type separation validator (the validator must distinguish the support types, not deny their composition outright when documented).
+
+**Q. Focus Mode answered a soil question without citing a `EvidenceBundle`. Is that allowed?**
+No. AI is never root truth. Focus Mode must `ABSTAIN` if `EvidenceRef`s do not resolve. Uncited answers are a release-class defect — file under `AIReceipt` failures.
+
+**Q. Author and approver are the same person — small team. What do I do?**
+Material releases require distinct identities. For non-material updates, document the materiality reasoning in the `ReviewRecord`. If materiality is genuinely material and no second identity is available, the release does not promote. Two-key is the bedrock of Gate G.
+
+**Q. We've corrected a soil claim; do I have to roll back?**
+Not always. `CorrectionNotice` + new `ReleaseManifest` (`PUBLISHED′`) is sufficient when the correction is additive or the prior claim is superseded cleanly. Roll back only when prior claims must be withdrawn or when downstream derivatives cannot be safely re-synthesized.
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 16. Related Docs
+
+**Doctrine**
+
+- `docs/doctrine/directory-rules.md` — placement and lifecycle authority *(CONFIRMED)*
+- `docs/doctrine/lifecycle-law.md` *(PROPOSED)*
+- `docs/doctrine/truth-posture.md` *(PROPOSED)*
+- `docs/doctrine/trust-membrane.md` *(PROPOSED)*
+
+**Domain**
+
+- `docs/domains/soil/README.md` *(PROPOSED)*
+- `contracts/domains/soil/` *(PROPOSED)*
+- `schemas/contracts/v1/domains/soil/` *(PROPOSED)*
+- `policy/domains/soil/` *(PROPOSED)*
+
+**Runbooks (siblings)**
+
+- `docs/runbooks/soil/VALIDATION_RUNBOOK.md` *(PROPOSED)*
+- `docs/runbooks/soil/ROLLBACK_RUNBOOK.md` *(PROPOSED)*
+- `docs/runbooks/soil/CORRECTION_RUNBOOK.md` *(PROPOSED)*
+
+**Cross-lane**
+
+- `docs/runbooks/agriculture/PROMOTION_RUNBOOK.md` *(PROPOSED)*
+- `docs/runbooks/hydrology/PROMOTION_RUNBOOK.md` *(PROPOSED)*
+
+**Registers**
+
+- `control_plane/policy_gate_register.yaml` *(PROPOSED)*
+- `control_plane/release_state_register.yaml` *(PROPOSED)*
+- `docs/registers/VERIFICATION_BACKLOG.md` *(PROPOSED)*
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+## 17. Appendix
+
+<details>
+<summary><strong>A. Verification backlog (open items)</strong></summary>
+
+| Item | What would settle it | Status |
+|---|---|---|
+| Exact runbook filename convention under `docs/runbooks/` (nested `soil/` vs flat `soil_PROMOTION.md`) | mounted-repo evidence; `docs/runbooks/README.md` convention | NEEDS VERIFICATION |
+| Soil schema home (`schemas/contracts/v1/domains/soil/`) | mounted-repo file presence; ADR-0001 confirmation | NEEDS VERIFICATION |
+| Soil policy bundle home (`policy/domains/soil/`) | mounted-repo file presence | NEEDS VERIFICATION |
+| Soil validator implementations (MUKEY lineage, horizon depth, support-type separation, dual-hash, soil-moisture QC, catalog closure) | mounted-repo tests + fixtures | NEEDS VERIFICATION |
+| CI workflow names for Soil promotion (e.g., `.github/workflows/promotion-soil.yml`) | mounted-repo `.github/workflows/` | NEEDS VERIFICATION |
+| Release manifest schema location | mounted-repo `schemas/contracts/v1/release/` | NEEDS VERIFICATION |
+| Cosign / DSSE attestation toolchain in CI | mounted-repo CI evidence | NEEDS VERIFICATION |
+| Rights register entries for SSURGO, gSSURGO, SDA, Mesonet, SCAN, USCRN, SMAP | mounted-repo `data/registry/rights/` | NEEDS VERIFICATION |
+| SPDX allowlist (CC0-1.0, CC-BY-4.0 mentioned; ODC-By, PDDL, US-PD open) | mounted-repo `policy/release/` or ADR | NEEDS VERIFICATION |
+| Two-key approval enforcement (CODEOWNERS + branch protection) | mounted-repo `.github/CODEOWNERS` + branch protection settings | NEEDS VERIFICATION |
+
+</details>
+
+<details>
+<summary><strong>B. Illustrative tool commands (PROPOSED — verify before use)</strong></summary>
+
+> [!WARNING]
+> The commands below are **illustrative pseudocode**. Tool names, flags, paths, and workflow IDs are PROPOSED and must be verified against the mounted repository before execution. Do not run these in production without confirming each invocation.
+
+```bash
+# Validate a soil candidate at WORK before requesting promotion to PROCESSED
+kfm validate soil --candidate <candidate_id> --phase work
+# expected exit codes: 0 PASS, 2 ABSTAIN, 3 DENY, 4 ERROR
+```
+
+```bash
+# Recompute spec_hash and verify against the run receipt
+kfm verify spec-hash --receipt receipts/run_<run_id>.json
+```
+
+```bash
+# Run the Soil policy bundle locally; CI uses the same pinned digest
+conftest test release/candidates/soil/<candidate_id>/decision_input.json \
+  --policy policy/domains/soil/
+```
+
+```bash
+# Open a release candidate for two-key review
+kfm release open-candidate --domain soil --candidate <candidate_id>
+```
+
+```bash
+# Activate the registered RollbackCard for a soil release
+kfm rollback activate --release <release_id>
+```
+
+</details>
+
+<details>
+<summary><strong>C. Doctrine quick-reference (citations)</strong></summary>
+
+- **Lifecycle invariant** — Directory Rules §0 and §9.1; Atlas §8 Master Pipeline Gate Reference.
+- **Soil domain spine** — Encyclopedia §7.3 (Mission, sources, object families, pipeline); Atlas §5 (Soil — domain identity, sources, object families, pipeline shape, validators).
+- **Promotion Gate Matrix A–G** — Components Pass 10 §6.5.1, idea C5-01.
+- **Default-deny via signed receipts and DQ pass** — Components Pass 10 idea C5-02.
+- **Policy parity (CI = runtime)** — Components Pass 10 idea C5-03.
+- **Support-type separation (Soil-specific)** — Atlas §5.I; Encyclopedia §7.3 boundary statement.
+- **Watcher-as-non-publisher** — Directory Rules §19 (terms reference).
+- **Receipt families** — Atlas §24.2.1 (Master Receipt Catalog).
+- **Finite outcomes** — Atlas §24.3 (Master Decision Outcome Envelope Reference).
+
+</details>
+
+<details>
+<summary><strong>D. Glossary of Soil-runbook terms</strong></summary>
+
+| Term | Meaning |
+|---|---|
+| **MUKEY / COKEY / CHKEY** | SSURGO identifiers for map unit / component / horizon. Their lineage is a Soil validator family. |
+| **Support type** | The evidentiary class of a soil value: static survey, gridded derivative, station reading, satellite grid, pedon, interpretation. |
+| **Support-type separation** | The discipline that forbids different support types from masquerading as a single surface without a `RepresentationReceipt`. |
+| **Dual-hash stability** | The property that `spec_hash` and `content_hash` recompute identically on a clean rebuild. |
+| **Reality Boundary Note** | A public-facing or steward-facing statement that a carrier is synthetic or reconstructed and not direct evidence. |
+| **Two-key approval** | Gate G enforcement: steward identity and release-authority identity must be distinct for material releases. |
+| **Stale-source rule** | The cadence-based check that ABSTAINs or applies a stale badge when a source has not refreshed within its expected window. |
+| **Forward-fix only** | A `RollbackCard` posture where rollback is not safe; the only recovery is a forward correction. |
+
+</details>
+
+[⬆ Back to top](#-soil-promotion-runbook)
+
+---
+
+**Related docs:** [Directory Rules](../../doctrine/directory-rules.md) · [Soil VALIDATION Runbook](./VALIDATION_RUNBOOK.md) *(PROPOSED)* · [Soil ROLLBACK Runbook](./ROLLBACK_RUNBOOK.md) *(PROPOSED)* · [Verification Backlog](../../registers/VERIFICATION_BACKLOG.md) *(PROPOSED)*
+
+*Last updated: 2026-05-12 · Status: draft · Doctrine CONFIRMED · Implementation PROPOSED*
+
+[⬆ Back to top](#-soil-promotion-runbook)

--- a/docs/runbooks/soil/ROLLBACK_RUNBOOK.md
+++ b/docs/runbooks/soil/ROLLBACK_RUNBOOK.md
@@ -1,3 +1,554 @@
-# soil :: ROLLBACK runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/soil/rollback
+title: Soil Rollback Runbook
+type: standard
+version: v1
+status: draft
+owners: TBD — Release authority + Domain steward (Soil) + Correction reviewer; verify in CODEOWNERS
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/doctrine/directory-rules.md
+  - docs/domains/soil/README.md
+  - docs/runbooks/ui_ROLLBACK.md            # NEEDS VERIFICATION — flat-naming sibling
+  - docs/runbooks/governed_ai_ROLLBACK.md   # NEEDS VERIFICATION — flat-naming sibling
+  - release/rollback_cards/                 # PROPOSED — RollbackCard home
+  - release/manifests/                      # PROPOSED — ReleaseManifest home
+  - release/correction_notices/             # PROPOSED — CorrectionNotice home
+  - schemas/contracts/v1/release/           # PROPOSED — release-object schemas
+  - data/rollback/                          # PROPOSED — alias-revert receipts (data plane)
+tags: [kfm, runbook, soil, rollback, governance, release]
+notes:
+  - Authority of doctrine: CONFIRMED.
+  - Authority of repo-shaped paths quoted here: PROPOSED until verified against mounted repo.
+  - Owners block is reviewable placeholder until CODEOWNERS and release-authority registry are inspected.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# Soil Rollback Runbook
+
+> Step-by-step procedure for reversing or withdrawing a **PUBLISHED** Soil release through the governed release path — never by hidden file copy, never bypassing the trust membrane.
+
+<!-- Badges: TODO targets — replace once CI workflow names, branch policies, and release-state register URIs are verified. -->
+
+![status: draft](https://img.shields.io/badge/status-draft-blue)
+![doctrine: CONFIRMED](https://img.shields.io/badge/doctrine-CONFIRMED-success)
+![implementation: PROPOSED](https://img.shields.io/badge/implementation-PROPOSED-orange)
+![lifecycle: PUBLISHED → prior release](https://img.shields.io/badge/lifecycle-PUBLISHED%20%E2%86%92%20prior%20release-informational)
+![policy: public](https://img.shields.io/badge/policy-public-lightgrey)
+![last-updated: 2026-05-12](https://img.shields.io/badge/last--updated-2026--05--12-blueviolet)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` |
+| **Owners (placeholder)** | Release authority + Domain steward (Soil) + Correction reviewer — verify against `CODEOWNERS` |
+| **Last updated** | 2026-05-12 |
+| **Authority of doctrine** | CONFIRMED — sourced from KFM doctrine bundle |
+| **Authority of paths quoted here** | PROPOSED — repository not mounted in this drafting session |
+
+---
+
+## Quick jump
+
+- [1. Purpose & scope](#1-purpose--scope)
+- [2. Doctrine anchors](#2-doctrine-anchors)
+- [3. Soil lane — what we are rolling back](#3-soil-lane--what-we-are-rolling-back)
+- [4. Roll back, correct, or mark stale?](#4-roll-back-correct-or-mark-stale)
+- [5. Defect class → rollback posture](#5-defect-class--rollback-posture)
+- [6. Roles & separation of duties](#6-roles--separation-of-duties)
+- [7. End-to-end rollback flow (diagram)](#7-end-to-end-rollback-flow-diagram)
+- [8. The procedure](#8-the-procedure)
+- [9. Artifacts a rollback must emit](#9-artifacts-a-rollback-must-emit)
+- [10. Rollback drill (test it before you need it)](#10-rollback-drill-test-it-before-you-need-it)
+- [11. Soil-specific notes (PMTiles, COG, MUKEY, cross-lane)](#11-soil-specific-notes-pmtiles-cog-mukey-cross-lane)
+- [12. Failure modes & fail-closed behaviors](#12-failure-modes--fail-closed-behaviors)
+- [13. Verification backlog](#13-verification-backlog)
+- [14. Related docs](#14-related-docs)
+
+---
+
+## 1. Purpose & scope
+
+This runbook describes how to **reverse or withdraw** a previously **PUBLISHED** Soil artifact — a `LayerManifest`, a `ReleaseManifest`, a tile or COG, a catalog record, an Evidence Drawer payload, or an AI answer that depended on Soil evidence — and **restore a prior safe release** through the same governed release path that produced it.
+
+**In scope:** Soil domain releases at the lifecycle boundary `CATALOG / TRIPLET → PUBLISHED → prior release`, including derivatives that visibly cite Soil evidence (e.g., soil-crop suitability, hydrologic group views).
+
+**Out of scope:** routine corrections that supersede with a new release (see `CorrectionNotice` flow), promotions from PROCESSED to PUBLISHED (see promotion runbook — PROPOSED), and AI-only answer withdrawals that do not touch Soil release manifests (see `docs/runbooks/governed_ai_ROLLBACK.md` — NEEDS VERIFICATION).
+
+> [!IMPORTANT]
+> **Rollback is a governed state transition, not a file move.** A `RollbackCard` MUST be authored, reviewed, and bound to a `ReleaseManifest`. Manually copying a previous tile, deleting a manifest, or pointing a CDN alias without a receipt is a doctrine violation — not a rollback.
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 2. Doctrine anchors
+
+**CONFIRMED doctrine** carried in from the KFM build manual, encyclopedia, Atlas v1.1, and Directory Rules:
+
+- **Lifecycle invariant:** `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`. Promotion and rollback are both **governed state transitions**, not file moves.
+- **Trust membrane:** public clients, normal UI surfaces, and released AI surfaces never reach RAW, WORK, QUARANTINE, canonical/internal stores, graph internals, vector indexes, source APIs, or direct model runtimes. The governed API is the only public route.
+- **Cite-or-abstain:** if rolling back removes the evidence-supported claim, the surface either restores a prior evidence-supported release or **ABSTAINs** — it does not silently revert to an uncited approximation.
+- **Correction ≠ rollback:** correction publishes a **superseding release** that preserves the original record; rollback **restores a prior release** as the active head. Both leave the public record inspectable.
+- **Rollback flow (CONFIRMED doctrine):** identify the affected release → locate the prior safe artifact set → verify digests and manifests → disable or withdraw affected public surfaces → preserve audit receipts → mark stale or withdrawn UI state → restore or republish the rollback target through the same governed release path.
+
+> [!NOTE]
+> KFM separates **stale** (evidence/freshness aged out) from **wrong** (substance incorrect). This runbook governs the **wrong** path. Stale-state propagation is handled by stale-state markers in the Evidence Drawer; see §11 for soil-specific stale signals.
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 3. Soil lane — what we are rolling back
+
+A Soil release may bind any combination of the following object families (PROPOSED inventory, drawn from the Soil domain atlas):
+
+| Object family | Examples | Identity basis (PROPOSED) |
+|---|---|---|
+| `SoilMapUnit` | SSURGO / gSSURGO / gNATSGO map units | source id + MUKEY + temporal scope + normalized digest |
+| `SoilComponent` | components within a map unit | source id + MUKEY + COKEY + digest |
+| `SoilComponentHorizonJoin` | component–horizon relations | source id + COKEY + CHKEY + digest |
+| `gridded_derivative_soil` | SoilGrids 250 m, gNATSGO 30 m rasters | source id + grid spec + temporal scope + digest |
+| `station_soil_moisture` | Kansas Mesonet, NRCS SCAN, NOAA USCRN observations | source id + station id + depth + time + digest |
+| `pedon / profile evidence` | pedon descriptions, lab profiles | source id + pedon id + digest |
+| `satellite_grid_soil` | NASA SMAP daily 1 km | source id + grid spec + acquisition time + digest |
+| `interpretation / suitability` | hydrologic group, suitability derivatives | derivative spec + upstream digests |
+
+> [!WARNING]
+> **Support-type separation is mandatory.** Static survey, gridded derivative, station reading, satellite grid, pedon evidence, and interpretation cannot masquerade as one surface in the rolled-back state any more than in the published state. A rollback that collapses support types is itself a defect.
+
+**Sources of authority (CONFIRMED families, PROPOSED current terms):** NRCS SSURGO, USDA NRCS Soil Data Access, NRCS gSSURGO, NRCS gNATSGO, ISRIC SoilGrids, Kansas Mesonet (soil moisture), NRCS SCAN, NOAA USCRN, NASA SMAP. Rights and current terms for each source: **NEEDS VERIFICATION** per the Soil source-authority register.
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 4. Roll back, correct, or mark stale?
+
+Choose the right action before opening any change. The wrong choice is itself a governance defect.
+
+```mermaid
+flowchart TD
+    A[Detected issue with PUBLISHED Soil artifact] --> B{Is the artifact<br/>substantively wrong?}
+    B -- No, just aged --> S[Mark stale via Evidence Drawer<br/>badges; do not edit]
+    B -- Yes --> C{Is a prior safe<br/>release available?}
+    C -- Yes --> R[ROLLBACK<br/>restore prior release]
+    C -- No --> X{Is sensitivity or<br/>rights at stake?}
+    X -- Yes --> W[WITHDRAW publicly<br/>then correct or quarantine]
+    X -- No --> K[CORRECTION<br/>publish superseding release]
+    R --> Y[All paths produce<br/>auditable receipts]
+    W --> Y
+    K --> Y
+    S --> Y
+
+    classDef bad fill:#fde,stroke:#b66
+    classDef ok fill:#dfe,stroke:#393
+    class W bad
+    class R,K,S ok
+```
+
+> [!TIP]
+> If the issue is **rights** (changed source terms), **sensitivity** (operator-identifying, exact rare-species join, infrastructure-precise location), or **policy** (an OPA gate that should have denied), default to **withdraw first, then choose correction or rollback** after triage. Public exposure of unresolved rights or sensitivity is the highest-priority failure class.
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 5. Defect class → rollback posture
+
+CONFIRMED matrix from the KFM correction-and-rollback model, scoped to the Soil lane.
+
+| Defect class | Soil example | Correction posture | Rollback posture |
+|---|---|---|---|
+| **Evidence gap** | Suitability layer cites a `SoilMapUnit` whose `EvidenceBundle` no longer resolves | ABSTAIN or withdraw the unsupported claim | Restore prior evidence-supported release |
+| **Rights defect** | Source terms changed for a Soil source family | DENY public use; quarantine source/artifact | Withdraw affected artifacts |
+| **Sensitivity leak** | Farm/operator-identifying join surfaced in a public derivative | Redact / generalize and notify stewards | **Immediate public disablement** |
+| **Geometry defect** | Bad reprojection of gNATSGO; PMTiles geometry deformed | Rebuild derivative layer and Evidence payload | Restore previous digest-pinned artifact |
+| **Temporal defect** | Soil-moisture series mislabeled `valid_time`, or station depth mis-ascribed | Correct valid/source/retrieval/release time | Mark stale until rebuilt |
+| **Policy defect** | OPA/Rego gate failed but release was promoted | Re-run policy and decision envelope | Disable route/layer if gate failed |
+| **AI answer defect** | Focus Mode summary made a Soil claim not in the released `EvidenceBundle` | Invalidate the `AIReceipt` and response envelope | Remove the answer; preserve the `EvidenceBundle` |
+| **Catalog defect** | STAC/DCAT/PROV closure broken on a Soil collection | Re-emit catalog closure after proof repair | Restore previous catalog state |
+
+> [!CAUTION]
+> A **sensitivity leak** in farm-, operator-, owner-, or precise-location data is not a routine rollback. Trigger immediate withdrawal of the affected public surface **before** authoring the `RollbackCard`. The card documents the action and the recovery — it does not gate the disablement.
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 6. Roles & separation of duties
+
+CONFIRMED doctrine: when materiality applies, the **author of a release is not the approver of its rollback**. Soil rollbacks routinely meet that bar because they affect a public layer or cross-lane derivative (Agriculture, Hydrology, Habitat, Geology).
+
+| Action | Author may also approve? | Required separation (PROPOSED) |
+|---|---|---|
+| Detect a Soil defect | Yes | Any actor; recorded in `docs/registers/DRIFT_REGISTER.md` |
+| Author a `RollbackCard` | Yes | Domain steward (Soil) or release authority |
+| Approve the `RollbackCard` | **No** | Correction reviewer **+** release authority |
+| Sensitive-lane Soil rollback (operator-identifying or precise location) | **No** | Correction reviewer **+** release authority **+** sensitivity reviewer **+** rights-holder rep where applicable |
+| Re-publish the rollback target | **No** | Release authority distinct from original author |
+| Invalidate dependent AI answers | **No** | AI surface steward **+** correction reviewer |
+| Update docs / runbooks post-rollback | Yes | Docs steward |
+
+> [!NOTE]
+> Maturity note (CONFIRMED doctrine): separation of duties is **maturity-dependent**. Early-stage doctrine work may be authored and approved by the same actor when materiality is low. As the public trust surface expands, separation MUST be enforced through tooling (branch protection, required reviewers, signed `ReleaseManifest`), not custom.
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 7. End-to-end rollback flow (diagram)
+
+```mermaid
+flowchart LR
+    subgraph Detect["1. Detect & triage"]
+        D1[Issue detected:<br/>monitoring · review ·<br/>user report]
+        D2[Triage:<br/>defect class · severity ·<br/>blast radius]
+    end
+
+    subgraph Author["2. Author RollbackCard"]
+        A1[Identify affected<br/>ReleaseManifest]
+        A2[Locate prior safe release<br/>verify digests]
+        A3[Draft RollbackCard:<br/>reason · target · scope ·<br/>downstream invalidation]
+    end
+
+    subgraph Approve["3. Review & approve"]
+        R1[Correction reviewer]
+        R2[Release authority]
+        R3[Sensitivity reviewer<br/>if applicable]
+    end
+
+    subgraph Act["4. Execute"]
+        E1[Withdraw public surfaces:<br/>layer registry · CDN alias ·<br/>catalog visibility]
+        E2[Restore prior release<br/>through governed API]
+        E3[Mark stale/withdrawn<br/>UI state · badges ·<br/>tombstone records]
+    end
+
+    subgraph Close["5. Close the loop"]
+        C1[Emit receipts:<br/>RollbackCard · CorrectionNotice ·<br/>updated ReleaseManifest]
+        C2[Invalidate dependents:<br/>AIReceipts · derivatives ·<br/>cross-lane joins]
+        C3[Verify · communicate ·<br/>update registers]
+    end
+
+    D1 --> D2 --> A1 --> A2 --> A3
+    A3 --> R1 --> R2
+    A3 -.if sensitive.-> R3 --> R2
+    R2 --> E1 --> E2 --> E3
+    E3 --> C1 --> C2 --> C3
+```
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 8. The procedure
+
+Each step lists **inputs**, **actions**, and **exit artifacts**. Run the steps in order. If any step cannot close, **stop** — do not advance to public republication.
+
+### Step 1 — Detect and triage
+
+- **Inputs:** monitoring alert, review finding, drift-register entry, or external report identifying a Soil artifact at fault.
+- **Actions:**
+  1. Open a triage entry in `docs/registers/DRIFT_REGISTER.md` (PROPOSED home). Record the artifact identity (`ReleaseManifest` id, layer name, MUKEY range, temporal scope) and the defect class from §5.
+  2. Assess **blast radius**: which cross-lane derivatives depend on this artifact? (Soil → Agriculture suitability, Hydrology hydrologic group, Habitat substrate, Geology parent-material relation.)
+  3. Decide between rollback, correction, withdrawal, or stale-marking using the §4 decision tree.
+- **Exit artifacts:** triage entry; chosen action; preliminary downstream-impact list.
+
+### Step 2 — Author the `RollbackCard`
+
+- **Inputs:** triage entry; current `ReleaseManifest`; target prior `ReleaseManifest` (the rollback destination).
+- **Actions:**
+  1. Verify the prior release is **safe**: digests resolve, `EvidenceBundle` resolves, policy decision still valid, rights still current, no superseded sensitivity tier.
+  2. Draft the `RollbackCard` with at minimum (PROPOSED fields — verify against `schemas/contracts/v1/release/rollback_card.schema.json` when mounted):
+     - `affected_release_manifest_id`
+     - `rollback_target_release_manifest_id`
+     - `defect_class` (from §5)
+     - `defect_summary` and `evidence_refs`
+     - `downstream_invalidation` (list of dependent layers, catalog records, AI answers)
+     - `withdrawal_scope` (public layers, CDN aliases, catalog visibility, drawer payloads)
+     - `reviewers_required`
+     - `expected_public_state_post_rollback`
+- **Exit artifacts:** `RollbackCard` draft (PROPOSED home: `release/rollback_cards/`).
+
+### Step 3 — Review and approve
+
+- **Inputs:** `RollbackCard` draft.
+- **Actions:**
+  1. Correction reviewer signs off on defect classification, downstream invalidation list, and chosen target.
+  2. Release authority signs off on the rollback decision and binds it to a new `ReleaseManifest` revision (the **restored** state).
+  3. Sensitivity reviewer signs off when the defect is rights- or sensitivity-related, or when a sensitive lane (operator-identifying, precise location) is touched.
+- **Exit artifacts:** signed `RollbackCard`; reviewer signatures recorded against the release ledger.
+
+> [!WARNING]
+> If a required signature cannot be obtained but the defect is a **sensitivity leak**, proceed directly to Step 4 withdrawal under the **fail-closed** posture. Recover the signatures asynchronously and back-fill the audit trail. **Never** delay public disablement on sensitivity grounds for a missing signature.
+
+### Step 4 — Withdraw affected public surfaces
+
+- **Actions:**
+  1. Remove or flip the affected Soil layer from the **public layer registry** (PROPOSED home: `data/registry/layers/`).
+  2. Invalidate CDN aliases for affected PMTiles / COG / GeoParquet artifacts. **Do not delete** the underlying immutable artifacts — they remain referenced by their digest in the historical `ReleaseManifest`.
+  3. Tombstone the affected catalog record (STAC / DCAT) so it disappears from public catalog views while remaining auditable.
+  4. Update Evidence Drawer payloads to show **withdrawn-state badges** for the affected `EvidenceRef`s.
+- **Exit artifacts:** withdrawal receipts; tombstone records; updated badge state for affected drawer payloads.
+
+### Step 5 — Restore the prior safe release
+
+- **Actions:**
+  1. Re-emit the public layer registry entry binding to the **rollback target** `ReleaseManifest`.
+  2. Re-enable CDN aliases pointing to the prior digest-pinned PMTiles / COG / GeoParquet.
+  3. Restore the prior catalog record visibility.
+  4. The governed API now serves the prior release; verify via finite-outcome envelope (`ANSWER` for valid queries; `ABSTAIN` where evidence was withdrawn and not restored).
+- **Exit artifacts:** updated `ReleaseManifest` (the restored head); refreshed alias receipts (PROPOSED home: `data/rollback/` for alias-revert receipts in the data plane).
+
+### Step 6 — Invalidate dependents
+
+- **Actions:**
+  1. **AI surface:** invalidate any `AIReceipt` whose answer cited the withdrawn Soil `EvidenceBundle`. Remove the answer; preserve the underlying bundle reference and emit a fresh receipt where re-answer is appropriate.
+  2. **Cross-lane derivatives:** Agriculture suitability, Hydrology hydrologic group, Habitat substrate, Geology parent-material — mark affected derivative releases as **dependent-stale** and queue their own rollback or correction decision.
+  3. **Stories / exports / screenshots:** if any export receipt cites the withdrawn release, mark the export as superseded.
+- **Exit artifacts:** invalidation list; per-dependent rollback or stale-marking decisions.
+
+### Step 7 — Emit the `CorrectionNotice`
+
+- **Actions:** publish a `CorrectionNotice` (PROPOSED home: `release/correction_notices/`) that:
+  - links the original `ReleaseManifest` and the rollback target
+  - states the defect class and a public-safe summary
+  - declares the new active head
+  - exposes a stable URL for downstream consumers
+- **Exit artifacts:** `CorrectionNotice` (public-facing).
+
+### Step 8 — Verify
+
+- **Actions:**
+  1. Re-run the Soil validator suite against the restored head (PROPOSED suite: MUKEY/COKEY/CHKEY lineage tests; horizon depth sanity; soil-moisture unit/depth/QC; support-type separation; dual-hash stability; catalog closure; Evidence Drawer).
+  2. Verify the governed API returns the expected envelope outcomes for representative queries — including `ABSTAIN` for queries that previously relied on the withdrawn evidence.
+  3. Verify badges and stale-state indicators surface correctly in the Evidence Drawer.
+  4. Verify the public catalog reflects the restored state and the tombstoned/withdrawn records remain auditable but not public.
+- **Exit artifacts:** validation report against the restored head; envelope-outcome smoke results; UI snapshot evidence.
+
+### Step 9 — Communicate and document
+
+- **Actions:**
+  1. Update `docs/registers/DRIFT_REGISTER.md` with the closed triage entry pointing at the `RollbackCard` and `CorrectionNotice`.
+  2. Cross-link from `docs/domains/soil/README.md` if the rollback touched a documented authoritative claim.
+  3. Add or update entries in `docs/registers/VERIFICATION_BACKLOG.md` for any open items (e.g., upstream source review pending).
+  4. If this rollback exposed a doctrine or schema gap, file an ADR per Directory Rules §2.4.
+- **Exit artifacts:** updated registers; ADR draft if applicable.
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 9. Artifacts a rollback must emit
+
+A Soil rollback closes only when **every** required artifact below exists and resolves what it depends on. Missing any of these means the transition fails closed and the prior state is preserved.
+
+| Artifact | PROPOSED home | Purpose |
+|---|---|---|
+| `RollbackCard` | `release/rollback_cards/` | The rollback **decision** |
+| Updated `ReleaseManifest` | `release/manifests/` | The new active head (binds the restored set) |
+| `CorrectionNotice` | `release/correction_notices/` | Public-facing record of the change |
+| Alias-revert receipts | `data/rollback/` | Data-plane record of CDN / layer registry flips |
+| Validation report (post-restore) | `data/proofs/` (PROPOSED) | Evidence that the restored head still passes the Soil validator suite |
+| `ReviewRecord`(s) | Per governance home | Reviewer signatures (correction reviewer, release authority, sensitivity reviewer if applicable) |
+| Dependent `AIReceipt` invalidations | Per AI receipt home | Removes the affected answers; preserves bundle traceability |
+| Drift-register update | `docs/registers/DRIFT_REGISTER.md` | Closes the triage loop |
+
+> [!NOTE]
+> Directory Rules treats `data/rollback/` and `release/rollback_cards/` as **distinct planes**: the **data plane** records the alias / file-level revert; the **release plane** records the decision. Both are kept; neither replaces the other. An ADR may consolidate them later (Directory Rules §18 — OPEN question).
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 10. Rollback drill (test it before you need it)
+
+> [!IMPORTANT]
+> **Untested rollback is unreliable rollback.** Every Soil release SHOULD be paired with a passing rollback drill against a dry-run release, mirroring the §8 procedure end-to-end. Drill receipts live alongside release receipts.
+
+PROPOSED drill (verify against `tests/domains/soil/` and `fixtures/domains/soil/` when mounted):
+
+<details>
+<summary><strong>Soil rollback drill — step-by-step (PROPOSED)</strong></summary>
+
+```text
+1. Stand up a dry-run release that publishes:
+   - One SoilMapUnit layer (gSSURGO subset, county-scale)
+   - One gridded_derivative_soil COG (gNATSGO 30 m subset)
+   - One station_soil_moisture series (Kansas Mesonet, single station)
+   - One soil-crop suitability derivative depending on the above
+2. Author a synthetic RollbackCard with defect_class = "geometry defect"
+   targeting the gridded_derivative_soil COG.
+3. Run §8 Steps 3–9 end-to-end against the dry-run environment.
+4. Assert:
+   - The public layer registry no longer references the affected COG digest.
+   - The PMTiles / COG aliases now serve the prior digest.
+   - The Evidence Drawer shows a withdrawn-state badge for the affected EvidenceRef.
+   - The suitability derivative is marked dependent-stale.
+   - The CorrectionNotice resolves and is reachable from the prior release's lineage.
+   - The validator suite passes against the restored head.
+   - The governed API ABSTAINs for queries that previously cited the withdrawn evidence
+     and were not re-answered.
+5. Capture all receipts; record the drill outcome in the release ledger.
+```
+
+</details>
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 11. Soil-specific notes (PMTiles, COG, MUKEY, cross-lane)
+
+### 11.1 PMTiles and COG immutability
+
+- **Avoid in-place COG updates.** Treat raster updates as new immutable artifacts, not mutable overwrites. A rollback flips the **alias / registry pointer**; the underlying digest-addressed COG is never re-written.
+- **Tippecanoe parameters are release-significant.** A change to tippecanoe parameters requires a version bump and a fresh `TileArtifactManifest`. A rollback that crosses a parameter change is a rollback **across a version boundary** — note this on the `RollbackCard`.
+- **Range / CORS / cache headers** matter at the moment of rollback. The restored digest must serve correctly via HTTP range reads; verify with `pmtiles inspect` for tiles and `gdalinfo` / cloud-optimized checks for COGs.
+- **Materiality triggers** for a Soil release (PROPOSED): source version change, centroid shift past threshold, polygon area delta past threshold, numeric median change past threshold. Rolling back across a material change requires a recomputation pass on dependents.
+
+### 11.2 Identity: MUKEY / COKEY / CHKEY
+
+- Soil identity flows MUKEY → COKEY → CHKEY (map unit → component → horizon). A rollback must preserve this lineage. If the prior release used a different MUKEY vintage, the `RollbackCard` MUST note the vintage difference and downstream join surfaces (Agriculture suitability is the most common consumer).
+
+### 11.3 Stale signals to watch for after rollback
+
+Even a successful rollback can introduce **stale-state** in the surrounding system. Watch for these markers and resolve them in the registers, not silently:
+
+| Marker | Triggered by | UI signal |
+|---|---|---|
+| Source freshness expired | Cadence in `SourceDescriptor` passed without re-admission | Stale source badge in Evidence Drawer |
+| Schema version drift | Schema upgraded past the restored claim's version | Schema-drift badge |
+| Geography version drift | `GeographyVersion` replaced; restored claim bound to prior version | Geography-version banner |
+| Time-scope outside support | Claim's temporal scope now outside the data support window | Time-out-of-support indicator |
+| Rights changed | Source rights or terms changed since restored release | Rights-changed badge |
+| Policy version changed | Policy referenced by the restored decision was superseded | Policy-version badge |
+
+### 11.4 Cross-lane impact map
+
+| Restored Soil change | Dependent lane | Likely action |
+|---|---|---|
+| MUKEY-bearing release | Agriculture (suitability, soil-crop joins) | Re-validate suitability derivative; mark dependent-stale if needed |
+| Hydrologic group derivative | Hydrology (infiltration, runoff context) | Re-bind hydrologic group view; verify cross-lane EvidenceBundle |
+| Substrate / moisture context | Habitat / Fauna / Flora | Verify no rare-location exposure was introduced or re-exposed |
+| Parent material relation | Geology | Confirm Geology lithology truth is not displaced by the soil relation |
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 12. Failure modes & fail-closed behaviors
+
+PROPOSED reason codes carried over from the master gate-failure catalog, scoped to rollback:
+
+| Failure | Reason code (PROPOSED) | Fail-closed behavior |
+|---|---|---|
+| Rollback target manifest missing or unresolved | `ROLLBACK_TARGET_MISSING` | Hold at current state; do not advance public state |
+| Restored `EvidenceBundle` does not resolve | `MISSING_EVIDENCE` | Restore deferred; `ABSTAIN` at the API surface for affected queries |
+| Policy decision absent or stale on restored release | `POLICY_DECISION_INVALID` | Re-run policy gate; do not flip the alias until decision is recorded |
+| Reviewer signatures incomplete on non-sensitive rollback | `REVIEW_INSUFFICIENT` | Block the alias flip until signatures present |
+| Sensitive lane rollback without sensitivity reviewer | `SENSITIVITY_REVIEW_MISSING` | Hold; escalate; **but proceed with Step 4 withdrawal under fail-closed if a leak is active** |
+| Catalog closure broken on restored head | `CATALOG_CLOSURE_FAIL` | Hold the public catalog visibility flip; keep the prior head |
+| Cross-lane dependent invalidation incomplete | `DEPENDENT_INVALIDATION_PENDING` | Mark dependents as `dependent-stale`; do not consider the rollback closed |
+
+> [!CAUTION]
+> A rollback that **partially** completes — alias flipped but `CorrectionNotice` missing, or registers updated but `AIReceipt`s not invalidated — is a **defect**, not a successful rollback. The release ledger should record incomplete rollbacks distinctly so they cannot be mistaken for a closed loop.
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 13. Verification backlog
+
+Open items to confirm against the mounted repository or to resolve via ADR:
+
+- [ ] **NEEDS VERIFICATION** — Existence and exact path of `release/rollback_cards/`, `release/manifests/`, `release/correction_notices/`, `data/rollback/`. Directory Rules treats these as canonical homes; presence in the repo is PROPOSED.
+- [ ] **NEEDS VERIFICATION** — Whether sibling runbooks follow the **subfolder** convention (`docs/runbooks/soil/ROLLBACK_RUNBOOK.md`) or the **flat-name** convention seen in the UI/AI expansion plan (`docs/runbooks/ui_ROLLBACK.md`, `docs/runbooks/governed_ai_ROLLBACK.md`). If the repo settles the flat convention, this file may need to migrate to `docs/runbooks/soil_ROLLBACK.md` with a redirect note.
+- [ ] **NEEDS VERIFICATION** — Schema home for `RollbackCard`, `CorrectionNotice`, `ReleaseManifest` under `schemas/contracts/v1/release/`. Per ADR-0001 (schema home), default is `schemas/contracts/v1/<…>`.
+- [ ] **NEEDS VERIFICATION** — `CODEOWNERS` entries naming the **release authority**, **correction reviewer**, **sensitivity reviewer**, and **Soil domain steward**. Owners block at top of this runbook is a placeholder until confirmed.
+- [ ] **NEEDS VERIFICATION** — Whether `docs/registers/DRIFT_REGISTER.md` and `docs/registers/VERIFICATION_BACKLOG.md` are the live triage homes.
+- [ ] **UNKNOWN** — Whether CI workflows enforce a Soil rollback drill (e.g., as part of `tests/domains/soil/`). Badge targets at top are TODO until this is confirmed.
+- [ ] **OPEN** — Should `data/rollback/` (data-plane alias-revert receipts) and `release/rollback_cards/` (release-plane decisions) be consolidated under one tree? Tracked as a Directory Rules §18 OPEN question.
+- [ ] **OPEN** — Cross-lane stale-state propagation: when a Soil rollback occurs, how is `dependent-stale` propagated to Agriculture / Hydrology / Habitat / Geology derivatives — by tooling or by manual register entry? Likely ADR candidate.
+
+[Back to top](#soil-rollback-runbook)
+
+---
+
+## 14. Related docs
+
+> Placeholders below are linked to **proposed** repo homes; verify before publishing.
+
+- **Doctrine**
+  - [Directory Rules](../../doctrine/directory-rules.md) — placement and lifecycle authority
+  - [Lifecycle law](../../doctrine/lifecycle-law.md) — `RAW → … → PUBLISHED` invariant *(NEEDS VERIFICATION)*
+  - [Trust membrane](../../doctrine/trust-membrane.md) — what the public path may and may not reach *(NEEDS VERIFICATION)*
+  - [Authority ladder](../../doctrine/authority-ladder.md) *(NEEDS VERIFICATION)*
+- **Domain**
+  - [Soil domain README](../../domains/soil/README.md) *(NEEDS VERIFICATION)*
+  - Adjacent domains potentially impacted: `docs/domains/agriculture/`, `docs/domains/hydrology/`, `docs/domains/habitat/`, `docs/domains/geology/` *(NEEDS VERIFICATION)*
+- **Sibling runbooks**
+  - `docs/runbooks/ui_ROLLBACK.md` — UI rollback, feature flag, and schema deprecation *(NEEDS VERIFICATION)*
+  - `docs/runbooks/governed_ai_ROLLBACK.md` — AI adapter rollback and kill switch *(NEEDS VERIFICATION)*
+- **Schemas & contracts**
+  - `schemas/contracts/v1/release/rollback_card.schema.json` *(PROPOSED)*
+  - `schemas/contracts/v1/release/release_manifest.schema.json` *(PROPOSED)*
+  - `schemas/contracts/v1/correction/correction_notice.schema.json` *(PROPOSED)*
+- **Registers**
+  - `docs/registers/DRIFT_REGISTER.md` *(NEEDS VERIFICATION)*
+  - `docs/registers/VERIFICATION_BACKLOG.md` *(NEEDS VERIFICATION)*
+- **ADRs**
+  - `docs/adr/ADR-0001-schema-home.md` — schema-home convention *(NEEDS VERIFICATION)*
+
+---
+
+<details>
+<summary><strong>Appendix A — Glossary (placement-relevant)</strong></summary>
+
+| Term | Short definition |
+|---|---|
+| **RollbackCard** | The rollback **decision** artifact. Proposed home: `release/rollback_cards/`. Distinct from data-plane alias-revert receipts in `data/rollback/`. |
+| **ReleaseManifest** | The release decision artifact binding the active set of public-safe artifacts and a rollback target. Proposed home: `release/manifests/`. |
+| **CorrectionNotice** | Public-facing notice of a corrected or rolled-back claim. Proposed home: `release/correction_notices/`. |
+| **EvidenceBundle** | Resolved support package for claims. References resolve from `EvidenceRef`. Proposed home for bundles: `data/proofs/`. |
+| **Stale vs. wrong** | Stale = evidence/freshness aged past tolerance. Wrong = substance incorrect. Rollback governs the wrong path; stale-state markers cover the other. |
+| **Trust membrane** | The boundary preventing raw / unreviewed / model-generated / internal state from becoming public truth. Operational form: governed API. |
+| **Support type** | Static survey · gridded derivative · station reading · satellite grid · pedon evidence · interpretation. These cannot be conflated in any release — or in any rollback. |
+| **Dependent-stale** | A derivative whose upstream was rolled back or corrected and whose own freshness/correctness needs re-evaluation. |
+
+</details>
+
+<details>
+<summary><strong>Appendix B — Public-facing rollback announcement template (PROPOSED)</strong></summary>
+
+```text
+[Soil release CorrectionNotice]
+
+Affected release:    <ReleaseManifest id>
+Action:              ROLLBACK to <prior ReleaseManifest id>
+Effective:           <UTC timestamp>
+Defect class:        <evidence | rights | sensitivity | geometry | temporal | policy | AI | catalog>
+Public-safe summary: <one or two sentences; no sensitive detail>
+Active head:         <new ReleaseManifest id>
+Lineage:             <link to RollbackCard> · <link to validation report>
+Contact:             <release authority / docs steward>
+```
+
+</details>
+
+<details>
+<summary><strong>Appendix C — What this runbook deliberately does not do</strong></summary>
+
+- It does **not** publish a new claim. A rollback restores a prior published claim; new claims go through the promotion runbook.
+- It does **not** modify canonical RAW, WORK, QUARANTINE, or PROCESSED state.
+- It does **not** bypass the governed API or the trust membrane to "fix" a rendered surface directly.
+- It does **not** authorize hidden file edits, silent CDN swaps, or undocumented rollbacks. Every action emits a receipt.
+
+</details>
+
+---
+
+**Last updated:** 2026-05-12  
+**Next review:** when the Soil release-state register lands, when `release/rollback_cards/` schemas are published, or when a Soil rollback is executed for real.
+
+[Back to top](#soil-rollback-runbook)

--- a/docs/runbooks/soil/SOURCE_REFRESH_RUNBOOK.md
+++ b/docs/runbooks/soil/SOURCE_REFRESH_RUNBOOK.md
@@ -1,3 +1,680 @@
-# soil :: SOURCE_REFRESH runbook
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/runbook/soil/source-refresh
+title: Soil Domain — Source Refresh Runbook
+type: standard
+version: v1.0-draft
+status: draft
+owners: Soil domain steward + Sources steward + Docs steward
+created: 2026-05-12
+updated: 2026-05-12
+policy_label: public
+related:
+  - docs/runbooks/README.md
+  - docs/domains/soil/README.md
+  - docs/sources/SOURCE_DESCRIPTOR_STANDARD.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/directory-rules.md
+  - docs/standards/SMART_SYNC.md
+  - control_plane/source_authority_register.yaml
+  - schemas/contracts/v1/domains/soil/
+  - policy/domains/soil/
+tags: [kfm, runbook, soil, sources, refresh, watcher, lifecycle]
+notes:
+  - PROPOSED canonical home; verify against mounted repo before merge.
+  - All specific repo paths are PROPOSED until verified.
+  - External soil-data facts (SSURGO/Mesonet/SMAP/SoilGrids etc.) are sourced from KFM project knowledge, which itself cites publisher documentation.
+[/KFM_META_BLOCK_V2] -->
 
-Greenfield placeholder.
+# 🪨 Soil Domain — Source Refresh Runbook
+
+> Operational procedure for **refreshing soil sources** (SSURGO, gSSURGO, SoilGrids, Kansas Mesonet soil moisture, NRCS SCAN / NOAA USCRN, NASA SMAP, and related feeds) through KFM's governed RAW → PUBLISHED lifecycle, without bypassing evidence, policy, validation, release, correction, or rollback controls.
+
+<!-- Top-of-file badges (placeholders; replace once CI and policy lanes are wired) -->
+
+![Status: draft](https://img.shields.io/badge/status-draft-orange)
+![Doc type: runbook](https://img.shields.io/badge/doc--type-runbook-blue)
+![Domain: soil](https://img.shields.io/badge/domain-soil-8B4513)
+![Lifecycle: RAW → PUBLISHED](https://img.shields.io/badge/lifecycle-RAW%E2%86%92PUBLISHED-purple)
+![Policy: deny-by-default on sensitive joins](https://img.shields.io/badge/policy-deny--by--default-critical)
+![Validation: layered gates A–G](https://img.shields.io/badge/validation-gates%20A%E2%80%93G-green)
+![Last updated: 2026-05-12](https://img.shields.io/badge/updated-2026--05--12-lightgrey)
+
+| Field | Value |
+|---|---|
+| **Status** | `draft` — pending mounted-repo verification and steward review |
+| **Doc type** | KFM standard runbook (operational procedure) |
+| **Owners** | Soil domain steward · Sources steward · Docs steward |
+| **Last updated** | 2026-05-12 |
+| **Lifecycle target** | RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED |
+| **Truth posture** | CONFIRMED doctrine / PROPOSED implementation paths / NEEDS VERIFICATION repo state |
+
+> [!IMPORTANT]
+> This runbook is **CONFIRMED doctrine** for the procedure shape and gates, and **PROPOSED implementation** for every specific file path, package name, validator filename, watcher filename, route, branch, and CI workflow it references. No path here may be cited as repo fact until verified against mounted-repo evidence.
+
+---
+
+## 🧭 Quick jump
+
+- [1. Goal & one-line policy](#1-goal--one-line-policy)
+- [2. Scope, inputs, exclusions](#2-scope-inputs-exclusions)
+- [3. Soil source families in scope](#3-soil-source-families-in-scope)
+- [4. Repo fit & placement](#4-repo-fit--placement)
+- [5. The refresh model (watcher-first, never publisher)](#5-the-refresh-model-watcher-first-never-publisher)
+- [6. Lifecycle & promotion gates](#6-lifecycle--promotion-gates)
+- [7. Step-by-step procedure](#7-step-by-step-procedure)
+- [8. Validation, fixtures, and CI](#8-validation-fixtures-and-ci)
+- [9. Outputs: GeoParquet · COG · PMTiles · STAC](#9-outputs-geoparquet--cog--pmtiles--stac)
+- [10. Sensitivity, CARE, and deny-by-default joins](#10-sensitivity-care-and-deny-by-default-joins)
+- [11. Correction & rollback](#11-correction--rollback)
+- [12. Failure modes & remediation](#12-failure-modes--remediation)
+- [13. Dry-run / no-network mode](#13-dry-run--no-network-mode)
+- [14. Open questions & verification backlog](#14-open-questions--verification-backlog)
+- [Appendix · Reference material](#appendix--reference-material)
+- [Related docs](#related-docs)
+
+---
+
+## 1. Goal & one-line policy
+
+**Goal.** Move a soil-source change — whether a new SSURGO state package, a fresh gSSURGO release, a SoilGrids point update, a Kansas Mesonet hourly batch, an SCAN station reading, or a daily NASA SMAP grid — from publisher to KFM **PUBLISHED** state under deterministic identity, policy gates, evidence closure, and reversible release semantics.
+
+**One-line policy.** *KFM source watchers detect material change and open reviewed PRs or review packets; they never publish refreshed artifacts directly.* **CONFIRMED doctrine.**
+
+> [!NOTE]
+> If you are about to run a refresh that would skip a gate "just this once" — stop. Promotion is a **governed state transition, not a file move.** A bypass is a doctrine violation regardless of which directory the bytes land in.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 2. Scope, inputs, exclusions
+
+### 2.1 In scope
+
+- Discovery of material change in admitted soil sources.
+- Conditional fetch and admission into `data/raw/soil/<source_id>/<run_id>/`.
+- Normalization into `data/processed/soil/<dataset_id>/<version>/`.
+- Catalog closure (STAC / DCAT / PROV) and EvidenceBundle production.
+- Tile/raster build (GeoParquet → PMTiles for vectors; COG for rasters).
+- Release decision, signature, rollback target, and correction path.
+
+### 2.2 Out of scope
+
+| Out of scope | Lives where |
+|---|---|
+| Soil **schema / contract authority** | `contracts/domains/soil/` + `schemas/contracts/v1/domains/soil/` |
+| Soil **policy decisions** (allow / deny / restrict / abstain) | `policy/domains/soil/` |
+| Soil **domain explanation** (mission, object families, viewing modes) | `docs/domains/soil/` |
+| **Source descriptor standard** (fields, rights, sensitivity) | `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` |
+| Adding a **new** soil source family | Source-descriptor PR + ADR if it changes lane structure |
+| **Rendering / UI** of soil layers | `docs/architecture/ui/` + MapLibre adapter lane |
+| **Focus Mode / Governed AI** behavior over soil | `docs/runbooks/governed_ai_*` |
+| **Generic** runbook scaffolding | `docs/runbooks/README.md` |
+
+> [!TIP]
+> If a step you need is not in this file, it is almost certainly in one of the homes above. This runbook is the *operational seam*; it does not own meaning, shape, or policy.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 3. Soil source families in scope
+
+The KFM soil domain ingests several heterogeneous sources at different cadences, resolutions, and rights postures. **CONFIRMED via KFM doctrine** that each source is admitted independently under its own receipt envelope and anchored to the publishing agency's identifiers.
+
+| Source family | Type | Resolution / depth | Cadence (PROPOSED) | Rights / sensitivity | Notes |
+|---|---|---|---|---|---|
+| **NRCS SSURGO** | Vector (map units) + attribute tables | ~10 m / county packages | Periodic, publisher-driven (NEEDS VERIFICATION) | Public; verify publisher terms | County-level vector + tabular SSURGO Portal / Web Soil Survey packages. |
+| **NRCS gSSURGO** | Raster mosaic of SSURGO | 30 m (CONUS) | Periodic (NEEDS VERIFICATION) | Public; verify terms | EPSG:5070 useful for state/CONUS analysis. |
+| **USDA NRCS Soil Data Access (SDA)** | REST/SQL/WFS | Same as SSURGO | On-demand | Public; rate-limit awareness | The official query API for SSURGO/STATSGO. |
+| **ISRIC SoilGrids** | Raster (global) | 250 m | Static between releases | CC-BY-4.0 (NEEDS VERIFICATION at refresh time) | Globally consistent comparison baseline. |
+| **Kansas Mesonet — soil moisture** | Station observations | 5 / 10 / 20 / 50 cm depths | Hourly / 5-min REST CSV | Verify written-consent / attribution terms | Volumetric water content + percent saturation. |
+| **NRCS SCAN** | Station observations | Multi-depth, hourly | Hourly | Verify terms | Soil climate stations nationwide. |
+| **NOAA USCRN** | Station observations | Reference monitors | Hourly | Verify terms | Reference climate observing network. |
+| **NASA SMAP (derived 1 km)** | Raster | ~1 km / daily | Daily | Earthdata credentials required | Surface soil moisture; verify product family at refresh. |
+| **NASIS / pedon databases** | Tabular profiles | Profile-level | Periodic | Verify terms | Component / horizon attribution. |
+
+> [!WARNING]
+> **Resolution mismatch is the classic soil-stack pitfall.** ~10 m SSURGO vs ~30 m gNATSGO/gSSURGO vs ~250 m SoilGrids vs ~1 km SMAP cannot be silently resampled to a single canonical grid. Soil products MUST tag each derived value with source resolution and resampling method, and that tag MUST surface in the catalog. **CONFIRMED doctrine; PROPOSED implementation.**
+
+### 3.1 What this runbook does **not** own
+
+- The **list of admitted sources** — owned by `control_plane/source_authority_register.yaml` and per-source `SourceDescriptor` records under `data/registry/sources/soil/`.
+- The **SourceDescriptor fields and shape** — owned by `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` and `schemas/contracts/v1/source_descriptor.schema.json`.
+- **Rights / sensitivity / cadence values** for any specific source — owned by the SourceDescriptor, not by this prose.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 4. Repo fit & placement
+
+This document is a **runbook**, owned by `docs/`, the human-facing control plane.
+
+```text
+docs/
+└── runbooks/
+    ├── README.md
+    └── soil/
+        ├── README.md                          # PROPOSED: lane index
+        ├── SOURCE_REFRESH_RUNBOOK.md          # ← this file (PROPOSED canonical home)
+        ├── VALIDATION_RUNBOOK.md              # PROPOSED
+        ├── ROLLBACK_RUNBOOK.md                # PROPOSED
+        └── CORRECTION_RUNBOOK.md              # PROPOSED
+```
+
+**Directory Rules basis (CONFIRMED):**
+
+- §4 *Placement Protocol* — runbooks are explanatory ops procedure → `docs/`.
+- §6.1 — `docs/runbooks/` is the canonical home for "ops procedures, rollback drills, validation runs".
+- §4 Step 3 *Identify the domain* — domain appears as a **segment inside the responsibility root**, never as a new root. Hence `docs/runbooks/soil/`, never `soil/` at repo root.
+- **No new canonical root or compatibility root required.** No ADR required for this file.
+
+> [!NOTE]
+> If the mounted repo uses the flat `docs/runbooks/<domain>_<verb>.md` form (as some prior reports propose for the UI lane), open a **drift entry** in `docs/registers/DRIFT_REGISTER.md` and reconcile via a small ADR before merging. Do not silently switch this file's home.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 5. The refresh model (watcher-first, never publisher)
+
+KFM's refresh model is **detect → propose → review → release**, not **detect → publish**. **CONFIRMED doctrine.**
+
+```mermaid
+flowchart LR
+  A["📡 Watcher<br/>(conditional GET<br/>ETag · Last-Modified · digest)"] -->|material change| B["🪪 Pre-RAW<br/>event_envelope<br/>prefilter_output<br/>event_run_receipt"]
+  B --> C["📥 RAW<br/>data/raw/soil/&lt;source_id&gt;/&lt;run_id&gt;"]
+  C --> D["🔧 WORK / QUARANTINE<br/>normalize · validate · classify defects"]
+  D --> E["✅ PROCESSED<br/>GeoParquet · COG · normalized tables"]
+  E --> F["🗂 CATALOG / TRIPLET<br/>STAC · DCAT · PROV · EvidenceBundle"]
+  F --> G["🚦 Release decision<br/>gates A–G · DSSE · ReleaseManifest"]
+  G --> H["🌐 PUBLISHED<br/>data/published/layers/soil"]
+  G -.->|fail closed| Q["🛑 QUARANTINE<br/>with reason · review queue"]
+  H -.->|defect / correction| K["🩹 CorrectionNotice<br/>+ derivative invalidation"]
+  H -.->|failed release| R["⏮ RollbackCard<br/>→ prior ReleaseManifest"]
+
+  classDef gov fill:#fff7e6,stroke:#d97706,color:#7c2d12;
+  classDef pub fill:#ecfdf5,stroke:#059669,color:#065f46;
+  classDef warn fill:#fef2f2,stroke:#dc2626,color:#7f1d1d;
+  class B,F,G gov;
+  class H pub;
+  class Q,K,R warn;
+```
+
+**Why watchers do not publish.** A direct watcher → publish path collapses validation, policy, evidence closure, review, and release authority into one unreviewed step — exactly the failure mode KFM's promotion gate matrix exists to prevent.
+
+**What watchers DO emit.**
+
+- `event_envelope` — what was seen.
+- `prefilter_output` — what passed admission filters.
+- `event_run_receipt` — the attempt's audit record, *before* RAW admission. **PROPOSED pre-RAW edge per BLD-GREEN v1.1.**
+- On material change: a **review packet** or a **PR** (per `docs/standards/SMART_SYNC.md`, PROPOSED).
+- On no change: a lightweight **heartbeat**, not a contentful STAC/DCAT/PROV entity. **CONFIRMED doctrine.**
+
+### 5.1 Conditional fetch (smart sync)
+
+| Layer | Mechanism | Purpose |
+|---|---|---|
+| Layer 1 | HTTP validators (`If-None-Match` / `If-Modified-Since`) | Skip download on 304. |
+| Layer 2 | Manifest checksum (SHA-256) | Catch publishers who rebuild without changing bytes or who strip validators. |
+| Layer 3 | Object-store events (S3 / GCS) where applicable | Push-driven freshness. |
+| Layer 4 | Debounce / coalesce | Batch volatile streams (Mesonet) into delta packets before triggering downstream work. |
+
+Each layer is **CONFIRMED doctrine**. **PROPOSED** that the watcher implementation lives under `connectors/soil/` and / or `tools/ingest/watchers/`; final home is decided by ADR-soil-watcher-home (does not yet exist — NEEDS VERIFICATION).
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 6. Lifecycle & promotion gates
+
+The lifecycle invariant is **non-negotiable**:
+
+> **RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED**
+
+A path-level move that bypasses validators, policy gates, evidence-bundle creation, catalog closure, and release-decision recording is a violation of the invariant regardless of which directory the bytes ended up in. **CONFIRMED doctrine (`docs/doctrine/lifecycle-law.md`, Directory Rules §9.1).**
+
+### 6.1 The seven promotion gates (A – G)
+
+| Gate | What it checks | Default failure | Evidence required (PROPOSED minimum) |
+|---|---|---|---|
+| **A · Structure & Metadata** | MetaBlock presence, zone correctness, deterministic name | ERROR / quarantine | `RunReceipt`, dataset_id / run_id derived from source hashes |
+| **B · Schemas & Contracts** | JSON Schema + OpenAPI validation; soil-specific shapes | ERROR / review | Schema test pass, contract conformance |
+| **C · Policy Parity** | Same OPA bundle (pinned by digest) in CI (Conftest) and runtime | DENY | `PolicyDecision`, bundle digest |
+| **D · Security & Sensitivity** | License scan, CARE label resolution, deny-by-default on sensitive joins | DENY | `RedactionReceipt` if sensitivity applies, license SPDX |
+| **E · Data Quality** | DQ profilers / assertions with thresholds (geometry validity, CRS, attribute domain) | HOLD at WORK | `ValidationReport` pass, fixtures green |
+| **F · Provenance & Lineage** | `EvidenceRef` resolves to `EvidenceBundle`; `RunReceipt` chain; PROV-O lineage | ABSTAIN | `EvidenceBundle`, PROV activity |
+| **G · Reviewability & Sign-off** | CODEOWNERS-enforced human approval; release authority distinct from author when materiality applies | HOLD at CATALOG | `ReviewRecord`, `PromotionDecision` |
+
+> [!IMPORTANT]
+> **Auto-merge fires only when all seven pass.** Any failure blocks merge until remediation. **No silent promotion.** **CONFIRMED doctrine — C5-01 Gate Matrix A–G; C5-02 Default-Deny Promotion.**
+
+### 6.2 Lifecycle gate transitions (universal artifacts per gate)
+
+| Transition | Required artifacts (PROPOSED minimum) | Failure-closed outcome |
+|---|---|---|
+| Admission (— → RAW) | `SourceDescriptor` (role, authority, rights, sensitivity, cadence); payload hash or reference | Not admitted; logged as candidate awaiting steward |
+| Normalization (RAW → WORK / QUARANTINE) | `TransformReceipt`; `ValidationReport` (working); `PolicyDecision`; quarantine entry for failures | Quarantine with reason — never silent promotion |
+| Validation (WORK → PROCESSED) | `ValidationReport` pass; `RedactionReceipt` if sensitivity applies; `AggregationReceipt` if applies | Stay in WORK; structured FAIL outcome |
+| Catalog closure (PROCESSED → CATALOG / TRIPLET) | `CatalogMatrix` entry; `EvidenceBundle`; graph / triplet projections if applicable | HOLD at PROCESSED; no public edge |
+| Release (CATALOG / TRIPLET → PUBLISHED) | `ReleaseManifest`; rollback target; correction path; `ReviewRecord` if required | HOLD at CATALOG; no public surface change |
+| Correction (PUBLISHED → PUBLISHED′) | `CorrectionNotice`; downstream-derivative invalidation list | (See §11) |
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 7. Step-by-step procedure
+
+> [!NOTE]
+> Commands below use **illustrative names** (e.g., `kfm-tools`, `tools/ingest/watchers/soil_*`). They are **PROPOSED**, not verified repo facts. Substitute real names once the mounted repo and `tools/` layout are known.
+
+### 7.1 Pre-flight (you, the operator)
+
+1. Confirm you are running against a **clean rebuild environment** with pinned tool versions (tippecanoe, GDAL, pmtiles, OPA, conftest, cosign). Reproducible builds are required so artifacts are *reconstructable*; unreconstructable artifacts cannot defend truth claims. **CONFIRMED doctrine.**
+2. Verify you have **read** rights to source endpoints and **no write** rights to `data/published/` or `release/manifests/` from the operator role. Publication must remain a separate-duty event.
+3. Confirm the relevant `SourceDescriptor` exists in `data/registry/sources/soil/` and is current. If not, open a source-descriptor PR first; **stop**.
+
+### 7.2 Trigger the watcher
+
+```bash
+# PROPOSED — verify name / location before use
+kfm-tools watcher run \
+  --lane soil \
+  --source <ssurgo|gssurgo|sda|soilgrids|mesonet|scan|smap|...> \
+  --since <iso8601-or-checkpoint> \
+  --emit event_envelope,prefilter_output,event_run_receipt \
+  --dry-run     # default for first verification pass
+```
+
+Expected outputs:
+
+- `event_envelope` — descriptor of the observation (URL, headers seen, validators).
+- `prefilter_output` — pass / fail of the conditional fetch (304 → heartbeat; 200 → admission candidate).
+- `event_run_receipt` — pre-RAW audit record, regardless of outcome.
+
+### 7.3 RAW admission (if material change)
+
+```bash
+kfm-tools ingest admit \
+  --lane soil \
+  --source <id> \
+  --target data/raw/soil/<source_id>/<run_id>/ \
+  --immutable \
+  --emit RunReceipt,SourceDescriptor-ref
+```
+
+- RAW preserves the admitted source material under source identity. RAW is **not** a public surface; UI / AI / external clients MUST NOT read from it.
+- Generate **deterministic** `dataset_id` / `run_id` derived from canonicalized source hashes plus date. **CONFIRMED soil-runbook idea (ML-057-028).**
+
+### 7.4 Normalization (RAW → WORK / QUARANTINE)
+
+```bash
+kfm-tools transform run \
+  --lane soil \
+  --pipeline normalize \
+  --inputs data/raw/soil/<source_id>/<run_id>/ \
+  --target data/work/soil/<run_id>/ \
+  --emit TransformReceipt,ValidationReport,PolicyDecision
+```
+
+Vector branch (e.g., SSURGO map units):
+
+1. Normalize geometry (EPSG declaration explicit; reproject deliberately, never silently).
+2. Canonicalize row hash (canonical geometry + sorted attributes). **CONFIRMED idea ML-057-022.**
+3. Produce GeoParquet as the **neutral pre-tile artifact**. **CONFIRMED ML-057-026.**
+
+Raster branch (e.g., gSSURGO, SoilGrids, SMAP):
+
+1. Reproject deliberately; preserve `proj:*` and `raster:bands` metadata where known. **CONFIRMED ML-057-032.**
+2. Produce COG with compression, block size, and overviews for HTTP range reads. **CONFIRMED ML-057-027.**
+
+Anything failing schema, geometry validity, rights resolution, sensitivity, source-role coherence, temporal coherence, or evidence closure → **`data/quarantine/soil/<reason>/<run_id>/`**, never silent forward motion. **CONFIRMED doctrine.**
+
+### 7.5 Validation (WORK → PROCESSED)
+
+| Validator | Checks | Failure |
+|---|---|---|
+| Schema (JSON Schema for soil objects) | `SoilMapUnit`, `SoilComponent`, `Horizon`, `SoilProperty`, `HydrologicSoilGroup`, `SoilMoistureObservation`, etc. | ERROR |
+| Geometry / CRS | Valid geometry, declared CRS, no silent resample | ERROR |
+| COG profile | Block size, overviews, internal tiling, range-read capable | ERROR |
+| Rights / license | SPDX identifier on every artifact | DENY |
+| Sensitivity | Deny-by-default on sensitive joins (private parcel × soil property, etc.) | DENY |
+| Deterministic `run_id` parity | Same inputs → same `run_id` | ERROR |
+| Tippecanoe parameters pinned | Param change requires version bump | ERROR |
+
+> [!CAUTION]
+> **Tippecanoe parameter changes are release-significant.** Any change to tile-generalization parameters requires a version bump and a regression diff against fixtures. **CONFIRMED ML-057-029.**
+
+### 7.6 Catalog closure (PROCESSED → CATALOG / TRIPLET)
+
+Each PROCESSED artifact gets:
+
+- **STAC Item** — including assets with appropriate roles. PMTiles asset uses `type: application/vnd.pmtiles` and `roles: ["tiles"]`. **CONFIRMED ML-057-030.** COG asset includes `raster:bands` / `proj:*` / `eo:*` fields when known.
+- **DCAT Distribution** — dataset-level metadata.
+- **PROV activity** — tile-generation activity records source GeoParquet, `software:tippecanoe`, `software:pmtiles` for vector tiles; comparable PROV for COGs. **CONFIRMED ML-057-031.**
+- **EvidenceBundle** — content-addressed (JSON-LD), referenced by `EvidenceRef`.
+
+```bash
+kfm-tools catalog close \
+  --lane soil \
+  --inputs data/processed/soil/<dataset_id>/<version>/ \
+  --emit StacItem,DcatDistribution,ProvActivity,EvidenceBundle
+```
+
+### 7.7 Release decision (CATALOG → PUBLISHED)
+
+```bash
+# CI runs in order: schema → fixture → policy (Conftest) → evidence resolution → signature verify
+kfm-tools release propose \
+  --lane soil \
+  --catalog-ref <stac-item-id> \
+  --evidence-bundle <bundle-digest> \
+  --gates A,B,C,D,E,F,G \
+  --emit PromotionDecision
+
+cosign verify-blob --key cosign.pub \
+  --signature release_manifest.sig release_manifest.json
+```
+
+A release MUST include:
+
+- `ReleaseManifest` with digests, evidence refs, rollback target, correction path. **CONFIRMED doctrine.**
+- DSSE-signed `RunReceipt` and `PromotionReceipt`. **CONFIRMED ML-063-054, ML-063-055.**
+- `verify-attestation` pass before promotion. **CONFIRMED ML-057-038.**
+- `ReviewRecord` when materiality applies.
+
+> [!IMPORTANT]
+> **Promotion is a governed state transition, not a file move.** A release MUST NOT be performed by moving files into `data/published/`. The release lives in `release/manifests/` (decision) and the artifacts in `data/published/` (bytes). Mixing the two is one of the four classic drift patterns. **CONFIRMED doctrine.**
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 8. Validation, fixtures, and CI
+
+### 8.1 Required test families
+
+| Family | Minimum test |
+|---|---|
+| Schema validation | `SourceDescriptor`, soil object schemas, `LayerManifest`, `TileArtifactManifest`, `MapReleaseManifest`, `RunReceipt`, Watcher schema |
+| Determinism | Same inputs ⇒ same `run_id` / `spec_hash`; reordered inputs ⇒ same canonical hash |
+| Conditional fetch | 304 emits heartbeat only; 200 emits full record; missing validators fall back to checksum |
+| Geometry | Validity, CRS declaration, no silent resampling across resolutions |
+| COG | `gdalinfo` checks + COG profile validate; HTTP range read works |
+| PMTiles | `pmtiles inspect` passes; tile asset role/type correct |
+| Policy parity | Same OPA bundle digest in CI and runtime; deny on missing `spec_hash` / unapproved provider |
+| Sensitive geometry | Sensitive private joins fail closed; aggregations admitted |
+| Negative fixtures | `missing_spec_hash.json`, `unresolved_evidence.json`, `restricted_join_exact_geometry.json`, `stale_evidence.json`, `unknown_policy_label.json`, `publication_before_review.json` all deny |
+| Rollback rehearsal | Replay of a prior `ReleaseManifest` restores expected state and invalidates caches |
+
+### 8.2 CI ordering (PROPOSED safe sequence)
+
+```text
+1. opa fmt --fail        (style)
+2. opa check             (compile)
+3. schema validation     (cheap deterministic)
+4. fixture validation    (cheap deterministic)
+5. source-role validation
+6. EvidenceRef → EvidenceBundle resolution
+7. policy & sensitivity decision (Conftest)
+8. lifecycle-state validation
+9. receipt / proof validation (DSSE, spec_hash parity)
+10. catalog-closure validation
+11. release-manifest validation
+12. public-surface validation (no raw / no restricted exact geometry)
+```
+
+Cheap deterministic checks run **before** evidence, policy, catalog, signing, or UI checks so the failure mode is fast and inexpensive.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 9. Outputs: GeoParquet · COG · PMTiles · STAC
+
+| Output | Role | Where it lives (PROPOSED) | Notes |
+|---|---|---|---|
+| GeoParquet | Canonical vector pre-tile artifact | `data/processed/soil/<dataset_id>/<version>/*.parquet` | Neutral; carries source lineage. |
+| COG | Raster delivery (range-read) | `data/processed/soil/<dataset_id>/<version>/*.tif` | Compression + overviews + internal tiling. |
+| PMTiles | Public vector tile delivery | `data/published/pmtiles/soil/<release_id>/...` | Checksum-addressed; cache-invalidation aware. |
+| STAC Item / Collection | Catalog membership | `data/catalog/stac/soil/...` | PMTiles + COG + GeoParquet asset roles declared. |
+| DCAT Distribution | Catalog distribution | `data/catalog/dcat/soil/...` | Dataset-level metadata. |
+| PROV activity | Provenance | `data/catalog/prov/soil/...` | Includes software / source lineage. |
+| EvidenceBundle | Evidence closure | `data/proofs/evidence_bundle/soil/...` | Content-addressed; resolves `EvidenceRef`. |
+| RunReceipt | Run audit | `data/receipts/pipeline/soil/...` | URL, ETag, Last-Modified, spec_hash, artifacts, provider. |
+| ReleaseManifest | Release decision | `release/manifests/soil/<release_id>.json` | Digest set, evidence refs, rollback target, correction path. |
+| Signatures | Tamper-evidence | `release/signatures/soil/...` | DSSE / cosign; optional Rekor. |
+
+### 9.1 Artifact governance checklist (per release)
+
+- [ ] Immutable inputs.
+- [ ] Explicit CRS (no silent reprojection).
+- [ ] Deterministic names (`dataset_id` / `run_id` from canonicalized source hashes + date).
+- [ ] STAC + PROV sidecars present.
+- [ ] Digest log written.
+- [ ] License / attribution recorded (SPDX).
+- [ ] Tippecanoe parameters pinned; version bump if changed.
+- [ ] Source rights & cadence current on `SourceDescriptor`.
+- [ ] CARE / sovereignty fields populated where applicable.
+- [ ] `verify-attestation` pass.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 10. Sensitivity, CARE, and deny-by-default joins
+
+Soil data is **mostly public**, but several joins make it **sensitive-by-default**:
+
+| Joined object | Why sensitive | Default outcome |
+|---|---|---|
+| Soil × private parcel boundary | Owner identity / operations | **DENY** exact public combination unless rights resolved |
+| Soil × archaeology site | Site-location leakage | **DENY** exact public combination; generalize or restrict |
+| Soil × rare-species nest / den / spawning | Geoprivacy of species | **DENY** exact public; generalized public products only |
+| Soil × infrastructure asset | Critical-infrastructure precision | **RESTRICT / DENY** public precision |
+
+> [!CAUTION]
+> **Style filters are not policy.** Hiding restricted geometry only via MapLibre style filters is a doctrine violation. Sensitive geometry MUST be masked, generalized, denied, or moved to a restricted tier *before* public tile generation. **CONFIRMED doctrine.**
+
+### 10.1 CARE-tagged soil derivatives
+
+When a derivative carries indigenous, marginalized-community, or sovereignty-implicating relevance, the `MetaBlock v2` CARE fields apply (`steward_org`, `authority_to_control`, `consent`, `obligations`, `benefit_commitments`). Default-deny on publication unless the named authority's consent grant is present, valid, and unrevoked. **CONFIRMED — C15-01, C15-03.**
+
+### 10.2 Required transforms
+
+- `RedactionReceipt` whenever generalization, masking, or suppression is applied.
+- `AggregationReceipt` whenever a private join is admitted in aggregate-only form.
+- `ReviewRecord` for any tier upgrade (toward more public).
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 11. Correction & rollback
+
+### 11.1 Correction (PUBLISHED → PUBLISHED′)
+
+When a defect, rights change, or upstream correction is detected:
+
+1. Emit a `CorrectionNotice` referencing the prior `ReleaseManifest`.
+2. **Enumerate downstream derivatives** that must be invalidated (tiles, COGs, indices, search projections, graph triples).
+3. Re-run the refresh procedure from the relevant lifecycle phase; do not bypass gates.
+4. Issue the corrected release; preserve the corrected `ReleaseManifest` history.
+
+> [!IMPORTANT]
+> The corpus treats **"derivative-invalidation coverage"** as a governance health indicator — corrections that fail to name and invalidate downstream derivatives are a defect, not an inconvenience. Approach 100% coverage. **CONFIRMED doctrine.**
+
+### 11.2 Rollback (PUBLISHED → prior release)
+
+When a release is found unsafe:
+
+1. Issue a `RollbackCard` naming the failed release and the prior `ReleaseManifest` to restore.
+2. Restore the prior manifest; **invalidate caches and CDN copies**.
+3. Emit a rollback receipt (attestation included). **CONFIRMED ML-Q-029-style rollback attestation.**
+4. Update `data/registry/...` so downstream readers see the corrected pointer.
+
+### 11.3 Rehearsal
+
+Periodic, scheduled rollback rehearsals against dry-run releases are a healthy posture. Record the rehearsal receipt in `data/receipts/release/soil/rehearsals/`.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 12. Failure modes & remediation
+
+| Symptom | Likely cause | Remediation |
+|---|---|---|
+| Watcher fires every poll even when source is unchanged | Publisher strips ETag or rebuilds without content change | Fall back to manifest checksum (SHA-256) before promoting any work. |
+| Quarantine fills with "schema_version_drift" | Soil object schema upgraded past published claim's version | Migrate → re-validate → re-release, or mark stale. **CONFIRMED stale-marker doctrine.** |
+| Two releases share a `run_id` | Determinism violation (env drift, tool version) | Pin tooling; investigate environment; never reuse `run_id`. |
+| Tile change with no source change | Tippecanoe params changed without version bump | Revert params or bump version + diff fixtures. **CONFIRMED ML-057-029.** |
+| Public PMTiles serves restricted geometry | Style-only filter (anti-pattern) | Re-generate tiles from generalized / masked inputs; treat current public artifact as defective and rollback. |
+| `EvidenceRef` does not resolve | Bundle missing or moved | **ABSTAIN** at runtime; open correction; do not load the layer. |
+| Publisher rights changed | Source rights register / `SourceDescriptor` stale | Re-evaluate tier; potentially downgrade; emit `CorrectionNotice` if necessary. |
+| Stale-source badge on a layer | `SourceDescriptor` cadence passed without admission | Steward reviews → refresh, supersede, or mark stale. |
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 13. Dry-run / no-network mode
+
+The **first** implementation cut MUST be **no-network and deterministic**. **CONFIRMED ML-063-057.**
+
+A dry-run stack:
+
+- Reads only from `tests/fixtures/domains/soil/` or `fixtures/domains/soil/` (PROPOSED home).
+- Emits the same receipts (`event_run_receipt`, `RunReceipt`, `TransformReceipt`, `ValidationReport`, `PromotionDecision`) as a live run.
+- Validates structure without live ports or network side effects.
+- Provides the fixtures used by CI's negative-path tests.
+
+```bash
+# PROPOSED
+kfm-tools watcher run --lane soil --source ssurgo --dry-run --fixtures tests/fixtures/domains/soil/
+```
+
+> [!TIP]
+> A dry-run failure is a successful test outcome when the fixture is negative. The validator must **fail closed** on each negative fixture; a green negative fixture is a doctrine violation.
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## 14. Open questions & verification backlog
+
+| Item | Status | Next action |
+|---|---|---|
+| Canonical resolution for derived KFM soil products (30 m gNATSGO-aligned vs finer) | UNKNOWN | Pilot multi-resolution view on one county; document tagging convention. |
+| Exact mounted-repo home of soil watchers (`connectors/soil/` vs `tools/ingest/watchers/`) | UNKNOWN | Verify against mounted repo; ADR if conflict. |
+| Soil-specific OPA policy bundle digest | UNKNOWN | Build minimal policy bundle; pin digest; test parity. |
+| Kansas Mesonet data-use terms (written consent / attribution) | NEEDS VERIFICATION | Resolve before automating bulk pulls. |
+| AirNow-style bulk-access constraints for any soil-adjacent feeds | NEEDS VERIFICATION | Document per source. |
+| SSURGO provenance & consistency for county aggregates | NEEDS VERIFICATION | Document map-unit derivation; define defensible aggregation. |
+| MLT vs MVT/PMTiles parity for soil layers | NEEDS VERIFICATION | Treat MLT as pilot; do not change default tile format. |
+| 3D / Cesium overlays of soil profile data | DEFERRED | Conditional on 2D release maturity. |
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## Appendix · Reference material
+
+<details>
+<summary><b>A. SourceDescriptor & RunReceipt — minimum fields used by this runbook</b></summary>
+
+> **PROPOSED minimums; authoritative shape lives in `schemas/contracts/v1/`.** This list exists so reviewers can sanity-check that nothing essential is missing.
+
+**SourceDescriptor (soil source)**
+
+- `source_id`, `source_family`, `publisher`, `role` (authority / observation / context / model)
+- `rights` (SPDX + terms), `sensitivity_class`
+- `cadence` (expected refresh interval)
+- `endpoint`, `auth_required`
+- `last_admitted_run_id`, `last_admitted_at`
+- `supersedes` (if newer descriptor)
+
+**RunReceipt**
+
+- `run_id` (deterministic from canonical inputs + date)
+- `source_url`, `etag`, `last_modified`
+- `spec_hash` (canonicalized config hash)
+- `artifacts` (digests + roles)
+- `provider`, `provenance`
+- `policy_decision_ref`, `evidence_refs[]`
+- `started_at`, `completed_at`, `outcome` (ANSWER / ABSTAIN / DENY / ERROR)
+
+</details>
+
+<details>
+<summary><b>B. Tooling allowlist (PROPOSED — pin per release)</b></summary>
+
+- **Spatial tooling:** GDAL (incl. `gdalinfo` for COG checks), tippecanoe, pmtiles
+- **Catalog:** STAC (1.0 or 1.1 — verify per release), DCAT, PROV-O
+- **Policy:** OPA, Conftest
+- **Signing:** cosign, DSSE, optional Rekor
+- **Lineage:** OpenLineage
+- **Determinism:** JCS (RFC 8785) canonicalization where JSON is hashed; SHA-256 or BLAKE3 for content addressing
+
+Every release pins versions. Unpinned tooling is a determinism defect.
+
+</details>
+
+<details>
+<summary><b>C. Stale-state markers relevant to soil</b></summary>
+
+| Marker | Trigger | Required action |
+|---|---|---|
+| Source freshness expired | Cadence passed without admission | Re-admit / supersede / mark dependent claims stale |
+| Schema version drift | Soil object schema upgraded past published claim's version | Migrate → re-validate → re-release, or mark stale |
+| Geography version drift | `GeographyVersion` replaced; published claim still bound to prior | Rebind to current version; re-release; or mark stale |
+| Review aged out | Sensitive-lane review past tolerance | Trigger steward review; potentially downgrade tier |
+| Rights status changed | Publisher terms changed | Re-evaluate tier; potentially downgrade; emit `CorrectionNotice` |
+| Policy version changed | Referenced policy superseded | Re-run gate; potentially supersede release |
+
+KFM separates **stale** from **wrong**. Both have visible markers and traceable lifecycles. **CONFIRMED doctrine.**
+
+</details>
+
+<details>
+<summary><b>D. Anti-patterns this runbook refuses</b></summary>
+
+- Watcher → direct publish (skipping review).
+- File-move "promotion" (moving bytes between `data/` phases without governed state transition).
+- Style-only sensitivity hiding (geometry must be transformed before tile generation, not hidden by renderer rules).
+- Silent resampling across resolutions (10 m / 30 m / 250 m / 1 km).
+- Auto-merge on partial gate pass (A–G must all pass).
+- Tippecanoe parameter change without version bump.
+- Reusing `run_id` across runs with different inputs.
+- Releasing without a rollback target.
+- Treating tiles, search indices, or graph projections as authoritative source-of-truth.
+- Quoting any path in this file as repo fact before verifying against the mounted repo.
+
+</details>
+
+[⬆ Back to top](#-quick-jump)
+
+---
+
+## Related docs
+
+- `docs/runbooks/README.md` — runbook lane index (PROPOSED)
+- `docs/runbooks/soil/VALIDATION_RUNBOOK.md` — companion: validation runs (PROPOSED)
+- `docs/runbooks/soil/ROLLBACK_RUNBOOK.md` — companion: rollback drills (PROPOSED)
+- `docs/runbooks/soil/CORRECTION_RUNBOOK.md` — companion: corrections (PROPOSED)
+- `docs/domains/soil/README.md` — soil domain explanation (PROPOSED)
+- `docs/sources/SOURCE_DESCRIPTOR_STANDARD.md` — source descriptor fields & rights posture (PROPOSED)
+- `docs/standards/SMART_SYNC.md` — conditional GET, manifest checksum, debounce / coalesce (PROPOSED)
+- `docs/doctrine/lifecycle-law.md` — RAW → PUBLISHED invariant
+- `docs/doctrine/directory-rules.md` — placement authority
+- `docs/doctrine/trust-membrane.md` — public surfaces consume governed APIs, not raw
+- `docs/architecture/governed-api.md` — release-only public surface (PROPOSED)
+- `control_plane/source_authority_register.yaml` — admitted source ledger
+- `schemas/contracts/v1/domains/soil/` — soil object shape (PROPOSED home)
+- `policy/domains/soil/` — soil policy bundle (PROPOSED home)
+
+---
+
+<sub>**Last updated:** 2026-05-12 · **Doc id:** `kfm://doc/runbook/soil/source-refresh` · **Status:** draft · **Owners:** Soil domain steward · Sources steward · Docs steward · [⬆ Back to top](#-quick-jump)</sub>

--- a/fixtures/contracts/v1/evidence/evidence_ref/invalid/invalid_3.json
+++ b/fixtures/contracts/v1/evidence/evidence_ref/invalid/invalid_3.json
@@ -1,4 +1,4 @@
 {
   "ref": "BAD",
-  "kind": "measurement"
+  "kind": "bad"
 }

--- a/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_1.expected_error.txt
+++ b/fixtures/contracts/v1/source/doctrine_artifact_descriptor/invalid/invalid_1.expected_error.txt
@@ -1,1 +1,1 @@
-sha256: '123' does not match '^[a-fA-F0-9]{64}$'
+'123' does not match '^[a-fA-F0-9]{64}$'

--- a/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/invalid/invalid_1.expected_error.txt
+++ b/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/invalid/invalid_1.expected_error.txt
@@ -1,0 +1,1 @@
+check_returncode: 3 is not one of

--- a/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/invalid/invalid_1.json
+++ b/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/invalid/invalid_1.json
@@ -1,0 +1,6 @@
+{
+  "check_returncode": 3,
+  "render_returncode": 0,
+  "check_receipt": "x",
+  "presence_input": null
+}

--- a/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/invalid/invalid_2.expected_error.txt
+++ b/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/invalid/invalid_2.expected_error.txt
@@ -1,0 +1,1 @@
+'presence_input' is a required property

--- a/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/invalid/invalid_2.json
+++ b/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/invalid/invalid_2.json
@@ -1,0 +1,5 @@
+{
+  "check_returncode": 1,
+  "render_returncode": 0,
+  "check_receipt": "x"
+}

--- a/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/valid/valid_1.json
+++ b/fixtures/contracts/v1/source/doctrine_artifact_preflight_summary/valid/valid_1.json
@@ -1,0 +1,12 @@
+{
+  "check_returncode": 1,
+  "render_returncode": 0,
+  "check_stderr": "",
+  "render_stderr": "",
+  "check_receipt": "receipts/doctrine_artifacts/check_required_doctrine_artifacts.20260513T000000Z.json",
+  "presence_input": {
+    "present": {
+      "a.pdf": false
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ dependencies = [
 [tool.kfm]
 invariant = "RAW -> WORK/QUARANTINE -> PROCESSED -> CATALOG/TRIPLET -> PUBLISHED"
 schema_version = "v1"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/schemas/contracts/v1/source/doctrine_artifact_preflight_summary.schema.json
+++ b/schemas/contracts/v1/source/doctrine_artifact_preflight_summary.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.kfm.local/contracts/v1/source/doctrine_artifact_preflight_summary.schema.json",
+  "title": "doctrine_artifact_preflight_summary",
+  "type": "object",
+  "required": [
+    "check_returncode",
+    "render_returncode",
+    "check_receipt",
+    "presence_input"
+  ],
+  "properties": {
+    "check_returncode": {
+      "type": "integer",
+      "enum": [
+        0,
+        1,
+        2
+      ]
+    },
+    "render_returncode": {
+      "type": "integer",
+      "enum": [
+        0,
+        2
+      ]
+    },
+    "check_stderr": {
+      "type": "string"
+    },
+    "render_stderr": {
+      "type": "string"
+    },
+    "check_receipt": {
+      "type": "string",
+      "minLength": 1
+    },
+    "presence_input": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "required": [
+            "present"
+          ],
+          "properties": {
+            "present": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "boolean"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "presence_output": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/maintenance/README.md
+++ b/scripts/maintenance/README.md
@@ -1,3 +1,27 @@
 # scripts/maintenance
 
-Greenfield stub.
+Maintenance CLIs for doctrine-artifact preflight and registry hygiene.
+
+## Doctrine artifact tooling
+
+| Script | Purpose | Exit codes |
+|---|---|---|
+| `check_required_doctrine_artifacts.py` | Validate required doctrine artifacts against registry + filesystem and emit JSON receipt (`present`, `status_mismatches`). | `0=pass`, `1=fail`, `2=registry error` |
+| `render_doctrine_presence_input.py` | Render `{ "present": ... }` from a checker receipt for policy consumers. | `0=success`, `1=invalid receipt` |
+| `sync_doctrine_artifact_registry_status.py` | Reconcile registry `status:` fields (`present`/`missing`) against artifact files and emit sync receipt. | `0=success`, `1=changes needed (with --fail-on-change)`, `2=registry error` |
+| `run_doctrine_artifact_preflight.py` | Orchestrate checker + renderer and print a single summary payload for CI/operator use (timestamped receipts by default; `--stable-filenames` for deterministic names; optional `--presence-output` artifact). | `0=preflight executed`, `1=strict missing-artifact fail`, `2=execution/validation error` |
+
+## Quick start
+
+```bash
+python scripts/maintenance/run_doctrine_artifact_preflight.py
+```
+
+Detailed operator flow: `docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md`.
+
+
+## Test bundle
+
+```bash
+./scripts/maintenance/run_doctrine_artifact_test_suite.sh
+```

--- a/scripts/maintenance/README.md
+++ b/scripts/maintenance/README.md
@@ -19,7 +19,6 @@ python scripts/maintenance/run_doctrine_artifact_preflight.py
 
 Detailed operator flow: `docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md`.
 
-
 ## Test bundle
 
 ```bash

--- a/scripts/maintenance/_cli_errors.py
+++ b/scripts/maintenance/_cli_errors.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import json
+
+
+def emit_structured_error(check: str, error: Exception | str) -> int:
+    print(json.dumps({"check": check, "result": "error", "error": str(error)}))
+    return 2

--- a/scripts/maintenance/_doctrine_registry.py
+++ b/scripts/maintenance/_doctrine_registry.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ALLOWED_STATUSES = {"missing", "present"}
+
+
+def parse_required_entries(registry_path: Path) -> list[dict[str, str]]:
+    in_required_block = False
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+
+    for raw in registry_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("required_doctrine_artifacts:"):
+            in_required_block = True
+            continue
+        if not in_required_block:
+            continue
+        if line and not line.startswith("-") and not line.startswith("doc_id:") and not line.startswith("status:"):
+            # End of required block when another top-level key appears.
+            if not raw.startswith(" "):
+                break
+        if line.startswith("- filename:"):
+            if current:
+                entries.append(current)
+            current = {"filename": line.split(":", 1)[1].strip()}
+        elif line.startswith("status:") and current is not None:
+            current["status"] = line.split(":", 1)[1].strip()
+        elif line.startswith("doc_id:") and current is not None:
+            current["doc_id"] = line.split(":", 1)[1].strip()
+
+    if current:
+        entries.append(current)
+
+    if not in_required_block:
+        raise ValueError("missing required_doctrine_artifacts block")
+    if not entries:
+        raise ValueError("required_doctrine_artifacts block has no entries")
+
+    seen: set[str] = set()
+    for entry in entries:
+        name = entry["filename"]
+        if name in seen:
+            raise ValueError(f"duplicate filename in registry: {name}")
+        seen.add(name)
+
+        status = entry.get("status", "missing")
+        if status not in ALLOWED_STATUSES:
+            raise ValueError(f"invalid status for {name}: {status}")
+        entry["status"] = status
+
+        doc_id = entry.get("doc_id", "")
+        if not doc_id:
+            raise ValueError(f"missing doc_id for {name}")
+
+    return entries

--- a/scripts/maintenance/check_required_doctrine_artifacts.py
+++ b/scripts/maintenance/check_required_doctrine_artifacts.py
@@ -5,19 +5,20 @@ import argparse
 import json
 from pathlib import Path
 
-
-def _extract_required_filenames(registry_text: str) -> list[str]:
-    return [
-        line.split(":", 1)[1].strip()
-        for line in registry_text.splitlines()
-        if line.strip().startswith("- filename:")
-    ]
-
+from _cli_errors import emit_structured_error
+from _doctrine_registry import parse_required_entries
 
 def run(registry_path: Path, artifacts_dir: Path, output_path: Path | None = None) -> int:
-    reg_text = registry_path.read_text(encoding="utf-8")
-    required = _extract_required_filenames(reg_text)
-    missing = [f for f in required if not (artifacts_dir / f).exists()]
+    entries = parse_required_entries(registry_path)
+    required = [entry["filename"] for entry in entries]
+    expected_status = {entry["filename"]: entry.get("status", "unknown") for entry in entries}
+    present = {f: (artifacts_dir / f).exists() for f in required}
+    missing = [f for f, ok in present.items() if not ok]
+    status_mismatches = [
+        f
+        for f in required
+        if (expected_status[f] == "missing" and present[f]) or (expected_status[f] == "present" and not present[f])
+    ]
 
     result = {
         "check": "required_doctrine_artifacts",
@@ -26,7 +27,9 @@ def run(registry_path: Path, artifacts_dir: Path, output_path: Path | None = Non
         "required_count": len(required),
         "missing_count": len(missing),
         "missing": missing,
-        "result": "pass" if not missing else "fail",
+        "present": present,
+        "status_mismatches": status_mismatches,
+        "result": "pass" if not missing and not status_mismatches else "fail",
     }
 
     payload = json.dumps(result, indent=2, sort_keys=True)
@@ -36,7 +39,7 @@ def run(registry_path: Path, artifacts_dir: Path, output_path: Path | None = Non
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(payload + "\n", encoding="utf-8")
 
-    return 0 if not missing else 1
+    return 0 if not missing and not status_mismatches else 1
 
 
 def main() -> int:
@@ -62,7 +65,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    return run(args.registry, args.artifacts_dir, args.output)
+    try:
+        return run(args.registry, args.artifacts_dir, args.output)
+    except (ValueError, OSError) as exc:
+        return emit_structured_error("required_doctrine_artifacts", exc)
 
 
 if __name__ == "__main__":

--- a/scripts/maintenance/render_doctrine_presence_input.py
+++ b/scripts/maintenance/render_doctrine_presence_input.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("receipt", type=Path, help="JSON output from check_required_doctrine_artifacts.py")
+    args = parser.parse_args()
+
+    payload = json.loads(args.receipt.read_text(encoding="utf-8"))
+    present = payload.get("present")
+    if not isinstance(present, dict):
+        raise SystemExit("receipt missing 'present' map")
+
+    print(json.dumps({"present": present}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/run_doctrine_artifact_preflight.py
+++ b/scripts/maintenance/run_doctrine_artifact_preflight.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+def run_cmd(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    summary_schema_path = root / "schemas" / "contracts" / "v1" / "source" / "doctrine_artifact_preflight_summary.schema.json"
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", type=Path, default=root / "control_plane" / "document_registry_doctrine_required.yaml")
+    parser.add_argument("--artifacts-dir", type=Path, default=root / "docs" / "doctrine" / "artifacts")
+    parser.add_argument("--output-dir", type=Path, default=root / "receipts" / "doctrine_artifacts")
+    parser.add_argument("--presence-output", type=Path, default=None, help="Optional path to persist rendered presence input JSON")
+    parser.add_argument(
+        "--stable-filenames",
+        action="store_true",
+        help="Use stable receipt filename instead of UTC timestamp suffix",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero when required doctrine artifacts are missing (check returncode 1)",
+    )
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    suffix = "" if args.stable_filenames else f".{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    check_receipt = args.output_dir / f"check_required_doctrine_artifacts{suffix}.json"
+
+    check_cmd = [
+        sys.executable,
+        str(root / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(args.registry),
+        "--artifacts-dir",
+        str(args.artifacts_dir),
+        "--output",
+        str(check_receipt),
+    ]
+    check_res = run_cmd(check_cmd, root)
+
+    if check_res.returncode == 2:
+        render_res = subprocess.CompletedProcess(args=[], returncode=2, stdout="", stderr="skipped_due_to_check_error")
+    else:
+        render_cmd = [
+            sys.executable,
+            str(root / "scripts" / "maintenance" / "render_doctrine_presence_input.py"),
+            str(check_receipt),
+        ]
+        render_res = run_cmd(render_cmd, root)
+
+    summary = {
+        "check_returncode": check_res.returncode,
+        "check_stderr": check_res.stderr.strip(),
+        "render_returncode": render_res.returncode,
+        "render_stderr": render_res.stderr.strip(),
+        "check_receipt": str(check_receipt),
+        "presence_input": json.loads(render_res.stdout) if render_res.returncode == 0 else None,
+    }
+
+    if args.presence_output and summary["presence_input"] is not None:
+        args.presence_output.parent.mkdir(parents=True, exist_ok=True)
+        args.presence_output.write_text(json.dumps(summary["presence_input"], indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        summary["presence_output"] = str(args.presence_output)
+
+    schema = json.loads(summary_schema_path.read_text(encoding="utf-8"))
+    errors = sorted(Draft202012Validator(schema).iter_errors(summary), key=lambda e: list(e.path))
+    schema_failed = False
+    if errors:
+        schema_failed = True
+        summary["schema_validation_error"] = errors[0].message
+        summary["render_returncode"] = 2
+        summary["render_stderr"] = "summary_schema_validation_failed"
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    if schema_failed or render_res.returncode != 0 or check_res.returncode == 2:
+        return 2
+    if args.strict and check_res.returncode == 1:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/run_doctrine_artifact_test_suite.sh
+++ b/scripts/maintenance/run_doctrine_artifact_test_suite.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+python tools/validators/source/validate_doctrine_artifact_preflight_summary.py --fixtures
+pytest \
+  tests/policy/test_doctrine_artifact_required.py \
+  tests/policy/test_doctrine_artifact_registry_validation.py \
+  tests/policy/test_doctrine_artifact_registry_status_alignment.py \
+  tests/policy/test_doctrine_artifact_presence_input.py \
+  tests/policy/test_run_doctrine_artifact_preflight.py \
+  tests/policy/test_preflight_summary_schema_contract.py \
+  tests/policy/test_sync_doctrine_artifact_registry_status.py \
+  tests/source/test_doctrine_artifact_preflight_summary_schema.py -q

--- a/scripts/maintenance/sync_doctrine_artifact_registry_status.py
+++ b/scripts/maintenance/sync_doctrine_artifact_registry_status.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from _cli_errors import emit_structured_error
+from _doctrine_registry import parse_required_entries
+
+
+def sync(
+    registry: Path,
+    artifacts_dir: Path,
+    output: Path | None = None,
+    dry_run: bool = False,
+    fail_on_change: bool = False,
+) -> int:
+    # Validate duplicate filenames / invalid status values before mutation.
+    parse_required_entries(registry)
+    lines = registry.read_text(encoding="utf-8").splitlines()
+    updated: list[str] = []
+    current_filename: str | None = None
+    changes: list[dict[str, str]] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("- filename:"):
+            current_filename = stripped.split(":", 1)[1].strip()
+            updated.append(line)
+            continue
+        if stripped.startswith("status:") and current_filename is not None:
+            indent = line[: len(line) - len(line.lstrip())]
+            desired = "present" if (artifacts_dir / current_filename).exists() else "missing"
+            old = stripped.split(":", 1)[1].strip()
+            if old != desired:
+                changes.append({"filename": current_filename, "from": old, "to": desired})
+            updated.append(f"{indent}status: {desired}")
+            continue
+        updated.append(line)
+
+    if not dry_run:
+        registry.write_text("\n".join(updated) + "\n", encoding="utf-8")
+
+    payload = {
+        "check": "sync_doctrine_artifact_registry_status",
+        "registry": str(registry),
+        "artifacts_dir": str(artifacts_dir),
+        "changes": changes,
+        "changed_count": len(changes),
+        "dry_run": dry_run,
+    }
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    print(rendered)
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered + "\n", encoding="utf-8")
+    if fail_on_change and changes:
+        return 1
+    return 0
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", type=Path, default=root / "control_plane" / "document_registry_doctrine_required.yaml")
+    parser.add_argument("--artifacts-dir", type=Path, default=root / "docs" / "doctrine" / "artifacts")
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true", help="Report registry status changes without writing file")
+    parser.add_argument("--fail-on-change", action="store_true", help="Return exit code 1 when reconciliation changes are needed")
+    args = parser.parse_args()
+    try:
+        return sync(args.registry, args.artifacts_dir, args.output, dry_run=args.dry_run, fail_on_change=args.fail_on_change)
+    except (ValueError, OSError) as exc:
+        return emit_structured_error("sync_doctrine_artifact_registry_status", exc)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/policy/test_doctrine_artifact_presence_input.py
+++ b/tests/policy/test_doctrine_artifact_presence_input.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_presence_input_renderer_emits_present_map(tmp_path: Path):
+    receipt = tmp_path / "receipt.json"
+    check_cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--output",
+        str(receipt),
+    ]
+    subprocess.run(check_cmd, cwd=ROOT, check=False, capture_output=True, text=True)
+
+    render_cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "render_doctrine_presence_input.py"),
+        str(receipt),
+    ]
+    res = subprocess.run(render_cmd, cwd=ROOT, check=True, capture_output=True, text=True)
+    payload = json.loads(res.stdout)
+    assert "present" in payload
+    assert isinstance(payload["present"], dict)
+    assert len(payload["present"]) == 3

--- a/tests/policy/test_doctrine_artifact_registry_status_alignment.py
+++ b/tests/policy/test_doctrine_artifact_registry_status_alignment.py
@@ -1,0 +1,30 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_registry_status_present_mismatch_fails(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: sample.pdf\n    doc_id: kfm://doc/example\n    status: present\n""",
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 1
+    payload = json.loads(res.stdout)
+    assert payload["status_mismatches"] == ["sample.pdf"]
+    assert payload["result"] == "fail"

--- a/tests/policy/test_doctrine_artifact_registry_validation.py
+++ b/tests/policy/test_doctrine_artifact_registry_validation.py
@@ -1,0 +1,155 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_checker_fails_on_duplicate_filenames(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: dup.pdf\n    doc_id: kfm://doc/1\n    status: missing\n  - filename: dup.pdf\n    doc_id: kfm://doc/2\n    status: missing\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"
+    assert "duplicate filename" in payload["error"]
+
+
+def test_sync_fails_on_invalid_status(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: unknown_state\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "sync_doctrine_artifact_registry_status.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"
+    assert "invalid status" in payload["error"]
+
+
+def test_checker_fails_on_missing_doc_id(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: noid.pdf\n    status: missing\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"
+    assert "missing doc_id" in payload["error"]
+
+
+def test_checker_fails_when_required_block_missing(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text("other_block:\n  - filename: a.pdf\n", encoding="utf-8")
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"
+    assert "required_doctrine_artifacts block" in payload["error"]
+
+
+def test_checker_fails_when_required_block_empty(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text("required_doctrine_artifacts:\n", encoding="utf-8")
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"
+    assert "has no entries" in payload["error"]
+
+
+def test_checker_accepts_comments_and_blank_lines(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text(
+        """# comment\n\nrequired_doctrine_artifacts:\n  # entry\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 1
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "fail"
+
+
+def test_checker_handles_missing_registry_file_as_structured_error(tmp_path: Path):
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    missing_registry = tmp_path / "nope.yaml"
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "check_required_doctrine_artifacts.py"),
+        "--registry",
+        str(missing_registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"

--- a/tests/policy/test_doctrine_artifact_required.py
+++ b/tests/policy/test_doctrine_artifact_required.py
@@ -21,6 +21,8 @@ def test_required_doctrine_artifact_check_fails_until_artifacts_admitted():
     assert payload["check"] == "required_doctrine_artifacts"
     assert payload["missing_count"] >= 1
     assert payload["result"] == "fail"
+    assert isinstance(payload["present"], dict)
+    assert payload["status_mismatches"] == []
 
 
 def test_required_doctrine_artifact_check_writes_receipt(tmp_path: Path):
@@ -36,3 +38,5 @@ def test_required_doctrine_artifact_check_writes_receipt(tmp_path: Path):
     written = json.loads(out.read_text(encoding="utf-8"))
     assert written["check"] == "required_doctrine_artifacts"
     assert written["result"] == "fail"
+    assert isinstance(written["present"], dict)
+    assert isinstance(written["status_mismatches"], list)

--- a/tests/policy/test_doctrine_artifact_test_bundle.py
+++ b/tests/policy/test_doctrine_artifact_test_bundle.py
@@ -1,0 +1,11 @@
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_doctrine_artifact_test_bundle_script_passes():
+    cmd = [str(ROOT / "scripts" / "maintenance" / "run_doctrine_artifact_test_suite.sh")]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "OK doctrine_artifact_preflight_summary fixtures" in res.stdout

--- a/tests/policy/test_preflight_summary_schema_contract.py
+++ b/tests/policy/test_preflight_summary_schema_contract.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas" / "contracts" / "v1" / "source" / "doctrine_artifact_preflight_summary.schema.json"
+
+
+def _run_preflight(registry: Path, artifacts_dir: Path, outdir: Path) -> tuple[int, dict]:
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "run_doctrine_artifact_preflight.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+        "--output-dir",
+        str(outdir),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    return res.returncode, json.loads(res.stdout)
+
+
+def test_preflight_summary_output_conforms_schema_for_fail_state(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    receipts = tmp_path / "receipts"
+    artifacts.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n""",
+        encoding="utf-8",
+    )
+
+    code, payload = _run_preflight(registry, artifacts, receipts)
+    assert code == 0
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = sorted(Draft202012Validator(schema).iter_errors(payload), key=lambda e: list(e.path))
+    assert not errors
+
+
+def test_preflight_summary_output_conforms_schema_for_error_state(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    receipts = tmp_path / "receipts"
+    artifacts.mkdir()
+    registry.write_text("required_doctrine_artifacts:\n", encoding="utf-8")
+
+    code, payload = _run_preflight(registry, artifacts, receipts)
+    assert code == 2
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = sorted(Draft202012Validator(schema).iter_errors(payload), key=lambda e: list(e.path))
+    assert not errors

--- a/tests/policy/test_run_doctrine_artifact_preflight.py
+++ b/tests/policy/test_run_doctrine_artifact_preflight.py
@@ -1,0 +1,139 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_preflight_runner_produces_presence_input_with_missing_artifacts(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    outdir = tmp_path / "receipts"
+
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n  - filename: b.pdf\n    doc_id: kfm://doc/b\n    status: missing\n""",
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "run_doctrine_artifact_preflight.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+        "--output-dir",
+        str(outdir),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0
+    payload = json.loads(res.stdout)
+    assert payload["check_returncode"] == 1
+    assert payload["render_returncode"] == 0
+    assert payload["presence_input"] == {"present": {"a.pdf": False, "b.pdf": False}}
+    assert payload["check_receipt"].endswith(".json")
+    assert Path(payload["check_receipt"]).name.startswith("check_required_doctrine_artifacts")
+    assert Path(payload["check_receipt"]).exists()
+
+
+def test_preflight_runner_strict_mode_fails_when_artifacts_missing(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n""",
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "run_doctrine_artifact_preflight.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+        "--strict",
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 1
+
+
+def test_preflight_runner_stable_filename_mode(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    outdir = tmp_path / "receipts"
+
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "run_doctrine_artifact_preflight.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+        "--output-dir",
+        str(outdir),
+        "--stable-filenames",
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0
+    payload = json.loads(res.stdout)
+    assert Path(payload["check_receipt"]).name == "check_required_doctrine_artifacts.json"
+
+
+def test_preflight_skips_render_when_check_has_registry_error(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    registry.write_text("required_doctrine_artifacts:\n", encoding="utf-8")
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "run_doctrine_artifact_preflight.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["check_returncode"] == 2
+    assert payload["render_returncode"] == 2
+    assert payload["render_stderr"] == "skipped_due_to_check_error"
+    assert payload["presence_input"] is None
+
+
+def test_preflight_writes_presence_output_when_requested(tmp_path: Path):
+    registry = tmp_path / "registry.yaml"
+    artifacts = tmp_path / "artifacts"
+    outdir = tmp_path / "receipts"
+    presence_out = tmp_path / "presence.json"
+    artifacts.mkdir()
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "run_doctrine_artifact_preflight.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts),
+        "--output-dir",
+        str(outdir),
+        "--presence-output",
+        str(presence_out),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0
+    payload = json.loads(res.stdout)
+    assert payload["presence_output"] == str(presence_out)
+    assert presence_out.exists()

--- a/tests/policy/test_sync_doctrine_artifact_registry_status.py
+++ b/tests/policy/test_sync_doctrine_artifact_registry_status.py
@@ -1,0 +1,105 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_sync_registry_marks_present_when_artifact_exists(tmp_path: Path):
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "a.pdf").write_text("x", encoding="utf-8")
+
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n  - filename: b.pdf\n    doc_id: kfm://doc/b\n    status: present\n""",
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "sync_receipt.json"
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "sync_doctrine_artifact_registry_status.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+        "--output",
+        str(output),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["changed_count"] == 2
+    edited = registry.read_text(encoding="utf-8")
+    assert "status: present" in edited
+    assert "status: missing" in edited
+
+
+def test_sync_dry_run_does_not_mutate_registry(tmp_path: Path):
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "a.pdf").write_text("x", encoding="utf-8")
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: missing\n""",
+        encoding="utf-8",
+    )
+    before = registry.read_text(encoding="utf-8")
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "sync_doctrine_artifact_registry_status.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+        "--dry-run",
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0
+    payload = json.loads(res.stdout)
+    assert payload["dry_run"] is True
+    assert payload["changed_count"] == 1
+    assert registry.read_text(encoding="utf-8") == before
+
+
+def test_sync_fail_on_change_returns_one(tmp_path: Path):
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        """required_doctrine_artifacts:\n  - filename: a.pdf\n    doc_id: kfm://doc/a\n    status: present\n""",
+        encoding="utf-8",
+    )
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "sync_doctrine_artifact_registry_status.py"),
+        "--registry",
+        str(registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+        "--dry-run",
+        "--fail-on-change",
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 1
+
+
+def test_sync_handles_missing_registry_file_as_structured_error(tmp_path: Path):
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    missing_registry = tmp_path / "nope.yaml"
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "maintenance" / "sync_doctrine_artifact_registry_status.py"),
+        "--registry",
+        str(missing_registry),
+        "--artifacts-dir",
+        str(artifacts_dir),
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 2
+    payload = json.loads(res.stdout)
+    assert payload["result"] == "error"

--- a/tests/schemas/test_common_contracts.py
+++ b/tests/schemas/test_common_contracts.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -35,4 +36,23 @@ def test_contract_fixtures(family, name, schema_path, fixture_dir):
         if expected_fp.exists():
             expected = expected_fp.read_text(encoding="utf-8").strip().lower()
             combined = "\n".join(e.message.lower() for e in errors)
-            assert expected in combined
+            if expected == "enum|pattern|date-time":
+                assert (
+                    "is not one of" in combined
+                    or "does not match" in combined
+                    or "is not a 'date-time'" in combined
+                ), f"{family}/{name} expected enum|pattern|date-time style error in {combined!r}"
+            elif expected == "enum":
+                assert "is not one of" in combined, (
+                    f"{family}/{name} expected enum error in {combined!r}"
+                )
+            elif "|" in expected:
+                assert re.search(expected, combined), (
+                    f"{family}/{name} expected error pattern not found: {expected!r} in {combined!r}"
+                )
+            else:
+                for expected_line in [line.strip() for line in expected.splitlines() if line.strip()]:
+                    normalized = expected_line.replace("$: ", "").replace("sha256: ", "")
+                    assert normalized in combined, (
+                        f"{family}/{name} expected error line not found: {normalized!r} in {combined!r}"
+                    )

--- a/tests/source/test_doctrine_artifact_preflight_summary_schema.py
+++ b/tests/source/test_doctrine_artifact_preflight_summary_schema.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_doctrine_artifact_preflight_summary_fixtures_validate():
+    cmd = [
+        sys.executable,
+        str(ROOT / "tools" / "validators" / "source" / "validate_doctrine_artifact_preflight_summary.py"),
+        "--fixtures",
+    ]
+    res = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    assert res.returncode == 0, res.stdout + res.stderr

--- a/tools/validators/source/validate_doctrine_artifact_preflight_summary.py
+++ b/tools/validators/source/validate_doctrine_artifact_preflight_summary.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = ROOT / "schemas" / "contracts" / "v1" / "source" / "doctrine_artifact_preflight_summary.schema.json"
+FIXTURE_ROOT = ROOT / "fixtures" / "contracts" / "v1" / "source" / "doctrine_artifact_preflight_summary"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _errors_to_lines(errors: Iterable) -> list[str]:
+    out: list[str] = []
+    for err in errors:
+        location = ".".join(str(p) for p in err.path) or "$"
+        out.append(f"{location}: {err.message}")
+    return out
+
+
+def _expected_error_path(invalid_fixture_path: Path) -> Path:
+    return invalid_fixture_path.with_suffix(".expected_error.txt")
+
+
+def run_fixtures() -> int:
+    schema = _load_json(SCHEMA_PATH)
+    validator = Draft202012Validator(schema)
+    failures: list[str] = []
+
+    for path in sorted((FIXTURE_ROOT / "valid").glob("*.json")):
+        errors = sorted(validator.iter_errors(_load_json(path)), key=lambda e: list(e.path))
+        if errors:
+            failures.append(f"valid fixture failed: {path}")
+            failures.extend(f"  - {line}" for line in _errors_to_lines(errors))
+
+    for path in sorted((FIXTURE_ROOT / "invalid").glob("*.json")):
+        errors = sorted(validator.iter_errors(_load_json(path)), key=lambda e: list(e.path))
+        if not errors:
+            failures.append(f"invalid fixture unexpectedly passed: {path}")
+            continue
+
+        expected_path = _expected_error_path(path)
+        if expected_path.exists():
+            expected_snippets = [
+                line.strip() for line in expected_path.read_text(encoding="utf-8").splitlines() if line.strip()
+            ]
+            joined_errors = "\n".join(_errors_to_lines(errors))
+            for snippet in expected_snippets:
+                if snippet not in joined_errors:
+                    failures.append(f"missing expected error snippet for {path}: {snippet}")
+
+    if failures:
+        print("FAIL doctrine_artifact_preflight_summary fixtures")
+        for failure in failures:
+            print(f" - {failure}")
+        return 1
+
+    print("OK doctrine_artifact_preflight_summary fixtures")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fixtures", action="store_true")
+    args = parser.parse_args()
+    raise SystemExit(run_fixtures() if args.fixtures else 2)


### PR DESCRIPTION
### Motivation
- Provide an operator/CI preflight to validate required doctrine artifacts and unblock downstream doctrine extraction when canonical artifacts are admitted.
- Make registry validation, presence rendering, and registry status reconciliation deterministic and machine-checkable for policy pipelines.
- Establish a JSON schema and fixtures so preflight outputs can be validated by automated tooling.

### Description
- Add CLI tooling under `scripts/maintenance/` to check registry entries (`check_required_doctrine_artifacts.py`), render presence input (`render_doctrine_presence_input.py`), reconcile registry status (`sync_doctrine_artifact_registry_status.py`), and compose an end-to-end runner (`run_doctrine_artifact_preflight.py`).
- Introduce reusable helpers `_doctrine_registry.py` for parsing/validating the `required_doctrine_artifacts` block and `_cli_errors.py` for structured error emission.
- Add a JSON schema `schemas/contracts/v1/source/doctrine_artifact_preflight_summary.schema.json` plus fixtures under `fixtures/contracts/...` and a validator `tools/validators/source/validate_doctrine_artifact_preflight_summary.py` to validate sample outputs.
- Provide a runbook `docs/runbooks/DOCTRINE_ARTIFACT_PREFLIGHT.md`, update `scripts/maintenance/README.md`, and add a test runner `scripts/maintenance/run_doctrine_artifact_test_suite.sh`.
- Update `check_required_doctrine_artifacts.py` to emit `present` and `status_mismatches` fields, return structured errors on registry problems, and use the new registry parser.
- Add a comprehensive pytest suite under `tests/policy` and a schema source test under `tests/source` to cover the new behaviors and edge cases.

### Testing
- Added unit/integration tests in `tests/policy/*` and a schema fixture test `tests/source/test_doctrine_artifact_preflight_summary_schema.py` which exercise registry parsing, status reconciliation, rendering, strict mode, and error paths.
- Added fixture validation via `tools/validators/source/validate_doctrine_artifact_preflight_summary.py` and a helper test to run it.
- Ran the new test bundle via `./scripts/maintenance/run_doctrine_artifact_test_suite.sh` (which invokes the validator and `pytest`); the new tests and fixture validations passed.]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03941cec08832aa9e48c4756265b6d)