### PR TITLE
Add missing docs/standards markdown stubs (34 files)

### DIFF
--- a/docs/standards/CANONICALIZATION.md
+++ b/docs/standards/CANONICALIZATION.md
@@ -1,0 +1,11 @@
+# CANONICALIZATION
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/CANONICALIZATION.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/CIDOC-CRM.md
+++ b/docs/standards/CIDOC-CRM.md
@@ -1,0 +1,11 @@
+# CIDOC-CRM
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/CIDOC-CRM.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/CONSENT_TOKENS.md
+++ b/docs/standards/CONSENT_TOKENS.md
@@ -1,0 +1,11 @@
+# CONSENT_TOKENS
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/CONSENT_TOKENS.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/DEBOUNCE_WINDOWS.md
+++ b/docs/standards/DEBOUNCE_WINDOWS.md
@@ -1,0 +1,11 @@
+# DEBOUNCE_WINDOWS
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/DEBOUNCE_WINDOWS.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/DP_BUDGETS.md
+++ b/docs/standards/DP_BUDGETS.md
@@ -1,0 +1,11 @@
+# DP_BUDGETS
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/DP_BUDGETS.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/DUBLIN-CORE.md
+++ b/docs/standards/DUBLIN-CORE.md
@@ -1,0 +1,11 @@
+# DUBLIN-CORE
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/DUBLIN-CORE.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/DUO_MAPPING.md
+++ b/docs/standards/DUO_MAPPING.md
@@ -1,0 +1,11 @@
+# DUO_MAPPING
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/DUO_MAPPING.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/Darwin_Core.md
+++ b/docs/standards/Darwin_Core.md
@@ -1,0 +1,11 @@
+# Darwin_Core
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/Darwin_Core.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/Evidence_Bundle.md
+++ b/docs/standards/Evidence_Bundle.md
@@ -1,0 +1,11 @@
+# Evidence_Bundle
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/Evidence_Bundle.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/FGDC-CSDGM.md
+++ b/docs/standards/FGDC-CSDGM.md
@@ -1,0 +1,11 @@
+# FGDC-CSDGM
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/FGDC-CSDGM.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/GEOPARQUET.md
+++ b/docs/standards/GEOPARQUET.md
@@ -1,0 +1,11 @@
+# GEOPARQUET
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/GEOPARQUET.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/IIIF.md
+++ b/docs/standards/IIIF.md
@@ -1,0 +1,11 @@
+# IIIF
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/IIIF.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/MVT.md
+++ b/docs/standards/MVT.md
@@ -1,0 +1,11 @@
+# MVT
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/MVT.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/OPENLINEAGE_FACETS.md
+++ b/docs/standards/OPENLINEAGE_FACETS.md
@@ -1,0 +1,11 @@
+# OPENLINEAGE_FACETS
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/OPENLINEAGE_FACETS.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/PROV-O.md
+++ b/docs/standards/PROV-O.md
@@ -1,0 +1,11 @@
+# PROV-O
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/PROV-O.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/PROVENANCE.md
+++ b/docs/standards/PROVENANCE.md
@@ -1,0 +1,11 @@
+# PROVENANCE
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/PROVENANCE.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/REDACTION_DETERMINISM.md
+++ b/docs/standards/REDACTION_DETERMINISM.md
@@ -1,0 +1,11 @@
+# REDACTION_DETERMINISM
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/REDACTION_DETERMINISM.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/REDACTION_PROFILES.md
+++ b/docs/standards/REDACTION_PROFILES.md
@@ -1,0 +1,11 @@
+# REDACTION_PROFILES
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/REDACTION_PROFILES.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/RUN_RECEIPT.md
+++ b/docs/standards/RUN_RECEIPT.md
@@ -1,0 +1,11 @@
+# RUN_RECEIPT
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/RUN_RECEIPT.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/SENSITIVITY_RUBRIC.md
+++ b/docs/standards/SENSITIVITY_RUBRIC.md
@@ -1,0 +1,11 @@
+# SENSITIVITY_RUBRIC
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/SENSITIVITY_RUBRIC.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/SIGNING.md
+++ b/docs/standards/SIGNING.md
@@ -1,0 +1,11 @@
+# SIGNING
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/SIGNING.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/SMART_SYNC.md
+++ b/docs/standards/SMART_SYNC.md
@@ -1,0 +1,11 @@
+# SMART_SYNC
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/SMART_SYNC.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/STAC-DwC.md
+++ b/docs/standards/STAC-DwC.md
@@ -1,0 +1,11 @@
+# STAC-DwC
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/STAC-DwC.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/STAC_DWC_PROFILE.md
+++ b/docs/standards/STAC_DWC_PROFILE.md
@@ -1,0 +1,11 @@
+# STAC_DWC_PROFILE
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/STAC_DWC_PROFILE.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/STAC_KFM_PROFILE.md
+++ b/docs/standards/STAC_KFM_PROFILE.md
@@ -1,0 +1,11 @@
+# STAC_KFM_PROFILE
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/STAC_KFM_PROFILE.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/TELEMETRY_MINIMUMS.md
+++ b/docs/standards/TELEMETRY_MINIMUMS.md
@@ -1,0 +1,11 @@
+# TELEMETRY_MINIMUMS
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/TELEMETRY_MINIMUMS.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/WMTS.md
+++ b/docs/standards/WMTS.md
@@ -1,0 +1,11 @@
+# WMTS
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/WMTS.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/canonicalization.md
+++ b/docs/standards/canonicalization.md
@@ -1,0 +1,11 @@
+# canonicalization
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/canonicalization.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/connector-rate-limits.md
+++ b/docs/standards/connector-rate-limits.md
@@ -1,0 +1,11 @@
+# connector-rate-limits
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/connector-rate-limits.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/iiif.md
+++ b/docs/standards/iiif.md
@@ -1,0 +1,11 @@
+# iiif
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/iiif.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/oai-pmh.md
+++ b/docs/standards/oai-pmh.md
@@ -1,0 +1,11 @@
+# oai-pmh
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/oai-pmh.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/snac-eac-cpf.md
+++ b/docs/standards/snac-eac-cpf.md
@@ -1,0 +1,11 @@
+# snac-eac-cpf
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/snac-eac-cpf.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/stac-dwc-hybrid.md
+++ b/docs/standards/stac-dwc-hybrid.md
@@ -1,0 +1,11 @@
+# stac-dwc-hybrid
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/stac-dwc-hybrid.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14

--- a/docs/standards/stac.md
+++ b/docs/standards/stac.md
@@ -1,0 +1,11 @@
+# stac
+
+Status: PROPOSED
+
+This placeholder was created to satisfy in-repo references to `docs/standards/stac.md`.
+
+## Next steps
+- Replace this stub with a full conformance/profile document.
+- Add links to related schema, policy, validator, and fixtures.
+
+Last reviewed: 2026-05-14


### PR DESCRIPTION
### Motivation
- Numerous markdown files across the repo reference `docs/standards/<name>.md` paths that did not exist, producing broken in-repo links and unclear canonical placeholders for standards profiles. 
- Creating exact-name placeholders (including case-variants) ensures references resolve and provides a consistent scaffold for later authoring of full profiles.

### Description
- Added 34 new stub documents under `docs/standards/` named to exactly match repository references, including case variants such as `CANONICALIZATION.md` and `canonicalization.md`.
- Each stub contains a title, `Status: PROPOSED`, a short purpose note, a `## Next steps` checklist, and `Last reviewed: 2026-05-14` to standardize the placeholder format.
- Notable added filenames include `STAC_KFM_PROFILE.md`, `PROVENANCE.md`, `SMART_SYNC.md`, `SENSITIVITY_RUBRIC.md`, `DUO_MAPPING.md`, and others referenced by existing docs.
- This change is documentation-only and does not alter schemas, policies, or validator code.

### Testing
- Ran a repository-wide extraction script that scanned all `*.md` files for `docs/standards/<name>.md` references and produced the set of missing filenames, which completed successfully.
- Executed the generation script that created each missing stub with the standard scaffold and completed without errors.
- Verified the created files are present under `docs/standards/` via filesystem inspection.
- No unit or integration tests were affected by this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05dcf5cbf0832a821094f239fffb8f)