### PR TITLE
Add Canonical Lineage Exploratory register document

### DIFF
--- a/docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md
+++ b/docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md
@@ -1,0 +1,29 @@
+---
+title: Canonical Lineage Exploratory Register
+status: PROPOSED
+authority: register
+owner: docs steward
+reviewers: [docs steward, subsystem owner]
+related_doctrine:
+  - docs/doctrine/directory-rules.md
+truth_labels:
+  doctrine: CONFIRMED
+  path: PROPOSED
+  content: PROPOSED
+created_by: codex-repo-bootstrap
+created_at: 2026-05-14T00:00:00Z
+---
+
+# Purpose
+Track exploratory lineage notes that may later be admitted into canonical lineage records after verification and steward review.
+
+## Entry template
+- `id`: unique identifier
+- `candidate_object`: object family or artifact under review
+- `lineage_claim`: PROPOSED claim text
+- `evidence_refs`: doctrine/ADR/test references
+- `verification_state`: `NEEDS VERIFICATION | VERIFIED | REJECTED`
+- `steward_notes`: review notes and next action
+
+## Initial entries
+- _None yet. Emptiness is intentional until verified submissions arrive._


### PR DESCRIPTION
### Motivation
- Provide a place to record exploratory lineage notes and candidate claims that may later be verified and admitted into canonical lineage records.

### Description
- Add a new file `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md` (status: PROPOSED) containing metadata, a short purpose statement, an entry template with fields `id`, `candidate_object`, `lineage_claim`, `evidence_refs`, `verification_state`, and `steward_notes`, and an explicit initial-empty state.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ec0b89a0832aa1f79696e75eeb0c)