### PR TITLE
Add MapLibre performance schema stubs

### DIFF
--- a/schemas/maplibre/perf-correction-notice.schema.json
+++ b/schemas/maplibre/perf-correction-notice.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/maplibre/perf-envelope.schema.json
+++ b/schemas/maplibre/perf-envelope.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/maplibre/perf-failure-bundle.schema.json
+++ b/schemas/maplibre/perf-failure-bundle.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/maplibre/perf-proof-pack.schema.json
+++ b/schemas/maplibre/perf-proof-pack.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/maplibre/perf-receipt.schema.json
+++ b/schemas/maplibre/perf-receipt.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/maplibre/perf-release-manifest.schema.json
+++ b/schemas/maplibre/perf-release-manifest.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/maplibre/perf-rollback-plan.schema.json
+++ b/schemas/maplibre/perf-rollback-plan.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/schemas/maplibre/render-diff-report.schema.json
+++ b/schemas/maplibre/render-diff-report.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true
+}


### PR DESCRIPTION
### Motivation
- Provide placeholder JSON Schema artifacts for MapLibre performance-related payloads so downstream code and schema registries can reference them during integration and iterative schema refinement.
- Ensure a consistent schema location (`schemas/maplibre/`) for future additions and validation of performance envelopes, receipts, reports, manifests, and related bundles.

### Description
- Added a new directory `schemas/maplibre/` containing eight schema stub files for the requested artifacts: `perf-envelope.schema.json`, `perf-receipt.schema.json`, `render-diff-report.schema.json`, `perf-release-manifest.schema.json`, `perf-proof-pack.schema.json`, `perf-correction-notice.schema.json`, `perf-rollback-plan.schema.json`, and `perf-failure-bundle.schema.json`.
- Each file is initialized as a minimal, valid JSON Schema (Draft 2020-12) with `"type": "object"` and `"additionalProperties": true` to act as placeholders for later refinement.

### Testing
- Verified the repository schema index with `rg --files schemas | head -n 200` and confirmed the new directory appears in the listing.
- Inspected the created files with `for f in schemas/maplibre/*.json; do nl -ba $f; done` to confirm file contents and valid JSON structure.
- Ran `git status --short` to confirm the new `schemas/maplibre/` path is present in the workspace (changes staged locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a067ae24538832a8f48189934c0c9fe)