### PR TITLE
Add MapLibre perf validator/verifier script scaffold

### DIFF
--- a/tools/validators/maplibre/validate_perf_correction_notice.py
+++ b/tools/validators/maplibre/validate_perf_correction_notice.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.validators._common.jsonschema_runner import run
+
+if __name__ == '__main__':
+    raise SystemExit(run(Path('schemas/maplibre/perf-correction-notice.schema.json'), None, sys.argv[1:]))

--- a/tools/validators/maplibre/validate_perf_envelope.py
+++ b/tools/validators/maplibre/validate_perf_envelope.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.validators._common.jsonschema_runner import run
+
+if __name__ == '__main__':
+    raise SystemExit(run(Path('schemas/maplibre/perf-envelope.schema.json'), None, sys.argv[1:]))

--- a/tools/validators/maplibre/validate_perf_failure_bundle.py
+++ b/tools/validators/maplibre/validate_perf_failure_bundle.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.validators._common.jsonschema_runner import run
+
+if __name__ == '__main__':
+    raise SystemExit(run(Path('schemas/maplibre/perf-failure-bundle.schema.json'), None, sys.argv[1:]))

--- a/tools/validators/maplibre/validate_perf_governance.py
+++ b/tools/validators/maplibre/validate_perf_governance.py
@@ -1,0 +1,16 @@
+"""Placeholder validator for perf governance checks."""
+
+from pathlib import Path
+import sys
+
+
+if __name__ == '__main__':
+    files = [Path(arg) for arg in sys.argv[1:]]
+    if not files:
+        print('No files provided', file=sys.stderr)
+        raise SystemExit(2)
+    for fp in files:
+        if not fp.exists():
+            print(f'FAIL {fp}: file does not exist')
+            raise SystemExit(1)
+        print(f'OK {fp}')

--- a/tools/validators/maplibre/validate_perf_proof_pack.py
+++ b/tools/validators/maplibre/validate_perf_proof_pack.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.validators._common.jsonschema_runner import run
+
+if __name__ == '__main__':
+    raise SystemExit(run(Path('schemas/maplibre/perf-proof-pack.schema.json'), None, sys.argv[1:]))

--- a/tools/validators/maplibre/validate_perf_receipt.py
+++ b/tools/validators/maplibre/validate_perf_receipt.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.validators._common.jsonschema_runner import run
+
+if __name__ == '__main__':
+    raise SystemExit(run(Path('schemas/maplibre/perf-receipt.schema.json'), None, sys.argv[1:]))

--- a/tools/validators/maplibre/validate_perf_release_manifest.py
+++ b/tools/validators/maplibre/validate_perf_release_manifest.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.validators._common.jsonschema_runner import run
+
+if __name__ == '__main__':
+    raise SystemExit(run(Path('schemas/maplibre/perf-release-manifest.schema.json'), None, sys.argv[1:]))

--- a/tools/validators/maplibre/validate_perf_rollback_plan.py
+++ b/tools/validators/maplibre/validate_perf_rollback_plan.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.validators._common.jsonschema_runner import run
+
+if __name__ == '__main__':
+    raise SystemExit(run(Path('schemas/maplibre/perf-rollback-plan.schema.json'), None, sys.argv[1:]))

--- a/tools/validators/maplibre/validate_render_diff_report.py
+++ b/tools/validators/maplibre/validate_render_diff_report.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.validators._common.jsonschema_runner import run
+
+if __name__ == '__main__':
+    raise SystemExit(run(Path('schemas/maplibre/render-diff-report.schema.json'), None, sys.argv[1:]))

--- a/tools/validators/maplibre/verify_perf_artifact_hashes.py
+++ b/tools/validators/maplibre/verify_perf_artifact_hashes.py
@@ -1,0 +1,19 @@
+"""Placeholder verifier for perf artifact hashes.
+
+This command is reserved for repository-specific hash verification logic.
+"""
+
+from pathlib import Path
+import sys
+
+
+if __name__ == '__main__':
+    files = [Path(arg) for arg in sys.argv[1:]]
+    if not files:
+        print('No files provided', file=sys.stderr)
+        raise SystemExit(2)
+    for fp in files:
+        if not fp.exists():
+            print(f'FAIL {fp}: file does not exist')
+            raise SystemExit(1)
+        print(f'OK {fp}')

--- a/tools/validators/maplibre/verify_perf_manifest_coverage.py
+++ b/tools/validators/maplibre/verify_perf_manifest_coverage.py
@@ -1,0 +1,16 @@
+"""Placeholder verifier for perf manifest coverage."""
+
+from pathlib import Path
+import sys
+
+
+if __name__ == '__main__':
+    files = [Path(arg) for arg in sys.argv[1:]]
+    if not files:
+        print('No files provided', file=sys.stderr)
+        raise SystemExit(2)
+    for fp in files:
+        if not fp.exists():
+            print(f'FAIL {fp}: file does not exist')
+            raise SystemExit(1)
+        print(f'OK {fp}')

--- a/tools/validators/maplibre/verify_perf_metrics_from_frames.py
+++ b/tools/validators/maplibre/verify_perf_metrics_from_frames.py
@@ -1,0 +1,16 @@
+"""Placeholder verifier for perf metrics computed from frame captures."""
+
+from pathlib import Path
+import sys
+
+
+if __name__ == '__main__':
+    files = [Path(arg) for arg in sys.argv[1:]]
+    if not files:
+        print('No files provided', file=sys.stderr)
+        raise SystemExit(2)
+    for fp in files:
+        if not fp.exists():
+            print(f'FAIL {fp}: file does not exist')
+            raise SystemExit(1)
+        print(f'OK {fp}')

--- a/tools/validators/maplibre/verify_perf_subject_links.py
+++ b/tools/validators/maplibre/verify_perf_subject_links.py
@@ -1,0 +1,16 @@
+"""Placeholder verifier for perf subject links."""
+
+from pathlib import Path
+import sys
+
+
+if __name__ == '__main__':
+    files = [Path(arg) for arg in sys.argv[1:]]
+    if not files:
+        print('No files provided', file=sys.stderr)
+        raise SystemExit(2)
+    for fp in files:
+        if not fp.exists():
+            print(f'FAIL {fp}: file does not exist')
+            raise SystemExit(1)
+        print(f'OK {fp}')

--- a/tools/validators/maplibre/verify_perf_thresholds.py
+++ b/tools/validators/maplibre/verify_perf_thresholds.py
@@ -1,0 +1,16 @@
+"""Placeholder verifier for perf threshold conformance."""
+
+from pathlib import Path
+import sys
+
+
+if __name__ == '__main__':
+    files = [Path(arg) for arg in sys.argv[1:]]
+    if not files:
+        print('No files provided', file=sys.stderr)
+        raise SystemExit(2)
+    for fp in files:
+        if not fp.exists():
+            print(f'FAIL {fp}: file does not exist')
+            raise SystemExit(1)
+        print(f'OK {fp}')

--- a/tools/validators/maplibre/verify_render_diff_coverage.py
+++ b/tools/validators/maplibre/verify_render_diff_coverage.py
@@ -1,0 +1,16 @@
+"""Placeholder verifier for render diff coverage."""
+
+from pathlib import Path
+import sys
+
+
+if __name__ == '__main__':
+    files = [Path(arg) for arg in sys.argv[1:]]
+    if not files:
+        print('No files provided', file=sys.stderr)
+        raise SystemExit(2)
+    for fp in files:
+        if not fp.exists():
+            print(f'FAIL {fp}: file does not exist')
+            raise SystemExit(1)
+        print(f'OK {fp}')


### PR DESCRIPTION
### Motivation
- Provide CLI entrypoints for validating MapLibre performance artifacts and to scaffold future domain-specific checks.
- Ensure there are schema-backed validators that correspond to the existing `schemas/maplibre/*` contracts so validation can be invoked from the repository tooling.

### Description
- Added 15 new Python scripts under `tools/validators/maplibre/`, including schema-backed validators that invoke `tools.validators._common.jsonschema_runner.run` against `schemas/maplibre/*.schema.json` files.
- Added placeholder verifier/validator scripts (`verify_*` and `validate_perf_governance.py`) that implement consistent CLI behavior by exiting `2` when no files are provided, exiting `1` for missing files, and printing `OK` for files that exist.
- The scripts are intentionally minimal to provide stable CLI surfaces that can be extended with repository-specific verification logic in follow-up work.

### Testing
- Ran `python -m py_compile tools/validators/maplibre/*.py` which succeeded with no syntax errors.
- No additional automated tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a067bcadadc832a9d0fb7e3d0526629)