### PR TITLE
Add MapLibre performance governance fixture and negative-path tests

### DIFF
--- a/tests/maplibre/perf_fixture_builder.py
+++ b/tests/maplibre/perf_fixture_builder.py
@@ -1,0 +1,51 @@
+"""Utilities for building MapLibre performance-governance fixtures for tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PerfGovernanceFixture:
+    """Represents a minimal governance payload used by policy tests."""
+
+    frame_budget_ms: float
+    memory_budget_mb: float
+    tile_error_rate: float
+
+
+DEFAULT_BUDGET = PerfGovernanceFixture(
+    frame_budget_ms=16.67,
+    memory_budget_mb=512.0,
+    tile_error_rate=0.01,
+)
+
+
+def build_perf_fixture(
+    *,
+    frame_budget_ms: float = DEFAULT_BUDGET.frame_budget_ms,
+    memory_budget_mb: float = DEFAULT_BUDGET.memory_budget_mb,
+    tile_error_rate: float = DEFAULT_BUDGET.tile_error_rate,
+) -> PerfGovernanceFixture:
+    """Build a fixture object for MapLibre performance governance tests."""
+
+    return PerfGovernanceFixture(
+        frame_budget_ms=frame_budget_ms,
+        memory_budget_mb=memory_budget_mb,
+        tile_error_rate=tile_error_rate,
+    )
+
+
+def validate_fixture(fixture: PerfGovernanceFixture) -> list[str]:
+    """Return validation errors for negative-path assertions."""
+
+    errors: list[str] = []
+
+    if fixture.frame_budget_ms <= 0:
+        errors.append("frame_budget_ms must be > 0")
+    if fixture.memory_budget_mb <= 0:
+        errors.append("memory_budget_mb must be > 0")
+    if not 0 <= fixture.tile_error_rate <= 1:
+        errors.append("tile_error_rate must be between 0 and 1")
+
+    return errors

--- a/tests/maplibre/test_perf_governance_negative_paths.py
+++ b/tests/maplibre/test_perf_governance_negative_paths.py
@@ -1,0 +1,24 @@
+"""Negative-path tests for MapLibre performance governance fixture validation."""
+
+from tests.maplibre.perf_fixture_builder import build_perf_fixture, validate_fixture
+
+
+def test_rejects_zero_frame_budget() -> None:
+    fixture = build_perf_fixture(frame_budget_ms=0)
+    errors = validate_fixture(fixture)
+
+    assert "frame_budget_ms must be > 0" in errors
+
+
+def test_rejects_negative_memory_budget() -> None:
+    fixture = build_perf_fixture(memory_budget_mb=-1)
+    errors = validate_fixture(fixture)
+
+    assert "memory_budget_mb must be > 0" in errors
+
+
+def test_rejects_out_of_range_tile_error_rate() -> None:
+    fixture = build_perf_fixture(tile_error_rate=1.5)
+    errors = validate_fixture(fixture)
+
+    assert "tile_error_rate must be between 0 and 1" in errors


### PR DESCRIPTION
### Motivation
- Provide a small, testable representation of MapLibre performance-governance constraints so policy tests can exercise validation logic.
- Add negative-path coverage to ensure invalid budget inputs are rejected and error messages are produced.

### Description
- Add `tests/maplibre/perf_fixture_builder.py` which defines a `PerfGovernanceFixture` dataclass, a `DEFAULT_BUDGET`, a `build_perf_fixture` helper, and a `validate_fixture` validator that returns validation errors.
- Add `tests/maplibre/test_perf_governance_negative_paths.py` with three negative-path tests that assert validation fails for a zero frame budget, a negative memory budget, and an out-of-range tile error rate.
- Both files are new test assets added under `tests/maplibre/` and are focused on simple, deterministic validation logic for governance constraints.

### Testing
- Ran `pytest -q tests/maplibre/test_perf_governance_negative_paths.py` which executed the three new tests.
- Result: `3 passed` (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a067d249248832a9cc4482efa2c5e2e)