### PR TITLE
Add missing docs/brand reference files and logo placeholders

### DIFF
--- a/docs/brand/accessibility-commitments.md
+++ b/docs/brand/accessibility-commitments.md
@@ -1,0 +1,6 @@
+# Accessibility Commitments
+
+KFM brand documentation targets WCAG 2.1 AA alignment:
+- Keyboard-first navigation and visible focus.
+- Non-color-only communication for all trust states.
+- Sufficient contrast and reduced-motion-safe behavior.

--- a/docs/brand/evidence-drawer-microcopy.md
+++ b/docs/brand/evidence-drawer-microcopy.md
@@ -1,0 +1,8 @@
+# Evidence Drawer Microcopy
+
+Field-level copy guidance for evidence presentation:
+- claim summary
+- source role
+- rights and sensitivity notes
+- freshness timestamp and interpretation
+- correction/release lineage

--- a/docs/brand/examples/trust-shell-annotated.md
+++ b/docs/brand/examples/trust-shell-annotated.md
@@ -1,0 +1,7 @@
+# Trust Shell Annotated Example
+
+Add annotated screenshots here showing:
+- trust badges
+- finite outcomes
+- evidence drawer context
+- freshness and correction cues

--- a/docs/brand/finite-outcome-microcopy.md
+++ b/docs/brand/finite-outcome-microcopy.md
@@ -1,0 +1,7 @@
+# Finite Outcome Microcopy
+
+Guidance for user-facing language per outcome:
+- `ANSWER`: summarize claim and show citations.
+- `ABSTAIN`: explain that admissible evidence is insufficient.
+- `DENY`: explain denial class without leaking restricted detail.
+- `ERROR`: explain system issue and recovery path.

--- a/docs/brand/logo/README.md
+++ b/docs/brand/logo/README.md
@@ -1,0 +1,7 @@
+# Logo Assets
+
+This folder contains logo usage guidance and asset inventory.
+
+- `usage.md`: usage rules.
+- `wordmark.svg`: source vector wordmark.
+- `exports/`: derivative exports for docs and previews.

--- a/docs/brand/logo/usage.md
+++ b/docs/brand/logo/usage.md
@@ -1,0 +1,6 @@
+# Logo Usage
+
+Usage conventions:
+- Maintain clear space around the mark.
+- Do not distort, rotate, or recolor outside approved variants.
+- Preserve legibility on light/dark backgrounds.

--- a/docs/brand/logo/wordmark.svg
+++ b/docs/brand/logo/wordmark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 120" role="img" aria-label="Kansas Frontier Matrix wordmark placeholder">
+  <rect width="640" height="120" fill="#f6f8fa"/>
+  <text x="24" y="74" font-family="Inter, Arial, sans-serif" font-size="40" fill="#111827">Kansas Frontier Matrix</text>
+</svg>

--- a/docs/brand/trust-state-visuals.md
+++ b/docs/brand/trust-state-visuals.md
@@ -1,0 +1,13 @@
+# Trust-State Visuals
+
+Document how trust signals are represented across the shell:
+- `source_role`
+- `rights`
+- `sensitivity`
+- `review_state`
+- `freshness`
+- `release_state`
+- `correction_state`
+- finite outcome (`ANSWER` / `ABSTAIN` / `DENY` / `ERROR`)
+
+Conventions must include non-color cues and plain labels.

--- a/docs/brand/visual-language.md
+++ b/docs/brand/visual-language.md
@@ -1,0 +1,8 @@
+# Visual Language
+
+This reference describes **roles** (not implementation values):
+- Color roles for trust and status signaling.
+- Typography roles for hierarchy and legibility.
+- Iconography roles that are never color-only.
+
+Implementation tokens and component code live in `packages/ui/`.

--- a/docs/brand/voice-and-tone.md
+++ b/docs/brand/voice-and-tone.md
@@ -1,0 +1,8 @@
+# Voice and Tone
+
+KFM voice priorities:
+- Cite evidence first.
+- Prefer plain language.
+- Treat `ANSWER`, `ABSTAIN`, `DENY`, and `ERROR` as first-class outcomes.
+
+See also: `finite-outcome-microcopy.md` and `evidence-drawer-microcopy.md`.


### PR DESCRIPTION
### Motivation
- Populate the `docs/brand/` landing area with the descriptive reference files listed in its README so brand guidance is available in-repo.
- Provide a minimal scaffold for voice, visual language, trust-state conventions, microcopy, accessibility commitments, and example annotations to guide implementers and writers.
- Include a small logo asset and usage guidance as a starter inventory for documentation and previews.

### Description
- Added `docs/brand/voice-and-tone.md`, `docs/brand/visual-language.md`, and `docs/brand/trust-state-visuals.md` to document voice, visual roles, and trust-state conventions.
- Added microcopy guidance files `docs/brand/finite-outcome-microcopy.md` and `docs/brand/evidence-drawer-microcopy.md` for finite outcomes and evidence presentation.
- Added `docs/brand/accessibility-commitments.md` to state WCAG 2.1 AA-aligned accessibility rules for brand docs.
- Added `docs/brand/logo/README.md`, `docs/brand/logo/usage.md`, and a placeholder `docs/brand/logo/wordmark.svg`, plus `docs/brand/examples/trust-shell-annotated.md` as an examples scaffold.

### Testing
- Verified the new files were created and present in the repo by listing and inspecting their contents with shell file-inspection commands (`nl -ba`), which displayed the expected content for each file.
- Performed a working-tree check to ensure there were no unexpected modified files after the change, which returned the created doc files only.
- All automated checks performed during this change succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071edcdb68832aba87803f23580aff)