### PR TITLE
Add missing docs/encyclopedia scaffold files

### DIFF
--- a/docs/encyclopedia/CHANGELOG.md
+++ b/docs/encyclopedia/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/INDEX.md
+++ b/docs/encyclopedia/INDEX.md
@@ -1,0 +1,3 @@
+# Index
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/01-cover.md
+++ b/docs/encyclopedia/chapters/01-cover.md
@@ -1,0 +1,3 @@
+# 01 Cover
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/02-executive-summary.md
+++ b/docs/encyclopedia/chapters/02-executive-summary.md
@@ -1,0 +1,3 @@
+# 02 Executive Summary
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/03-source-ledger.md
+++ b/docs/encyclopedia/chapters/03-source-ledger.md
@@ -1,0 +1,3 @@
+# 03 Source Ledger
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/04-operating-law.md
+++ b/docs/encyclopedia/chapters/04-operating-law.md
@@ -1,0 +1,3 @@
+# 04 Operating Law
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/05-master-domain-atlas.md
+++ b/docs/encyclopedia/chapters/05-master-domain-atlas.md
@@ -1,0 +1,3 @@
+# 05 Master Domain Atlas
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/06-cross-domain-capability-taxonomy.md
+++ b/docs/encyclopedia/chapters/06-cross-domain-capability-taxonomy.md
@@ -1,0 +1,3 @@
+# 06 Cross Domain Capability Taxonomy
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/07-domain-chapters.md
+++ b/docs/encyclopedia/chapters/07-domain-chapters.md
@@ -1,0 +1,3 @@
+# 07 Domain Chapters
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/08-cross-domain-systems.md
+++ b/docs/encyclopedia/chapters/08-cross-domain-systems.md
@@ -1,0 +1,3 @@
+# 08 Cross Domain Systems
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/09-master-feature-matrix.md
+++ b/docs/encyclopedia/chapters/09-master-feature-matrix.md
@@ -1,0 +1,3 @@
+# 09 Master Feature Matrix
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/10-master-action-matrix.md
+++ b/docs/encyclopedia/chapters/10-master-action-matrix.md
@@ -1,0 +1,3 @@
+# 10 Master Action Matrix
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/11-master-viewing-mode-atlas.md
+++ b/docs/encyclopedia/chapters/11-master-viewing-mode-atlas.md
@@ -1,0 +1,3 @@
+# 11 Master Viewing Mode Atlas
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/12-programming-possibilities-backlog.md
+++ b/docs/encyclopedia/chapters/12-programming-possibilities-backlog.md
@@ -1,0 +1,3 @@
+# 12 Programming Possibilities Backlog
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/13-sensitive-deny-by-default-register.md
+++ b/docs/encyclopedia/chapters/13-sensitive-deny-by-default-register.md
@@ -1,0 +1,3 @@
+# 13 Sensitive Deny By Default Register
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/14-implementation-roadmap.md
+++ b/docs/encyclopedia/chapters/14-implementation-roadmap.md
@@ -1,0 +1,3 @@
+# 14 Implementation Roadmap
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/15-validation-and-acceptance-plan.md
+++ b/docs/encyclopedia/chapters/15-validation-and-acceptance-plan.md
@@ -1,0 +1,3 @@
+# 15 Validation And Acceptance Plan
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/chapters/16-appendices.md
+++ b/docs/encyclopedia/chapters/16-appendices.md
@@ -1,0 +1,3 @@
+# 16 Appendices
+
+Status: PROPOSED placeholder.

--- a/docs/encyclopedia/encyclopedia.md
+++ b/docs/encyclopedia/encyclopedia.md
@@ -1,0 +1,3 @@
+# Encyclopedia
+
+Status: PROPOSED placeholder.


### PR DESCRIPTION
### Motivation
- The `docs/encyclopedia/` README described a proposed tree but several scaffold files were missing from the repository. 
- Provide the planned navigation and chapter placeholders so contributors can iterate on the manuscript without creating layout churn. 

### Description
- Added top-level placeholder documents `docs/encyclopedia/encyclopedia.md`, `docs/encyclopedia/INDEX.md`, and `docs/encyclopedia/CHANGELOG.md` with `Status: PROPOSED` headers. 
- Added chapter placeholders `docs/encyclopedia/chapters/01-cover.md` through `docs/encyclopedia/chapters/16-appendices.md` each with a minimal title and `Status: PROPOSED` marker. 
- Added `docs/encyclopedia/assets/.gitkeep` and `docs/encyclopedia/lineage/.gitkeep` to ensure those directories are tracked. 
- All files were added and saved in a single commit with the message `Add missing encyclopedia scaffold files`. 

### Testing
- Ran the creation script (Python) that wrote the scaffold files and it completed without error. 
- Verified the staged changes with `git status --short` and confirmed the new files were present. 
- Committed the changes with `git commit -m "Add missing encyclopedia scaffold files"` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0790e5a638832ab4fc1e792f6ca9d4)