### PR TITLE
Add docs/intake scaffold: IDEA_INTAKE, NEW_IDEAS_INDEX, and subfolder READMEs

### DIFF
--- a/docs/intake/IDEA_INTAKE.md
+++ b/docs/intake/IDEA_INTAKE.md
@@ -1,0 +1,20 @@
+# Idea Intake
+
+Use this template to capture a single intake idea before promotion to a canonical lane.
+
+## Required fields
+- **id**:
+- **title**:
+- **status**: PROPOSED | EXPLORATORY | NEEDS VERIFICATION
+- **normalized_statement**:
+- **sources**:
+- **related_ideas**:
+- **dependencies**:
+- **tensions**:
+- **expansion_directions**:
+- **open_questions**:
+- **candidate_canonical_lane**:
+
+## Notes
+- Intake entries are not canonical authority.
+- Promote structural decisions through an ADR before relying on them.

--- a/docs/intake/NEW_IDEAS_INDEX.md
+++ b/docs/intake/NEW_IDEAS_INDEX.md
@@ -1,0 +1,11 @@
+# New Ideas Index
+
+Master index of intake items in `docs/intake/`.
+
+| id | title | status | category | related | expansion_direction | target_lane | last_updated |
+|---|---|---|---|---|---|---|---|
+
+## Usage
+- Add one row per idea card.
+- Keep status aligned with the source card.
+- Move stale or superseded entries to archive with a linked rationale.

--- a/docs/intake/cards/README.md
+++ b/docs/intake/cards/README.md
@@ -1,0 +1,7 @@
+# Cards
+
+This folder stores intake cards artifacts.
+
+- Status: PROPOSED
+- Authority: exploratory
+- Canonical use requires promotion/routing outside docs/intake/.

--- a/docs/intake/carry-forward/README.md
+++ b/docs/intake/carry-forward/README.md
@@ -1,0 +1,7 @@
+# Carry-forward
+
+This folder stores intake carry forward artifacts.
+
+- Status: PROPOSED
+- Authority: exploratory
+- Canonical use requires promotion/routing outside docs/intake/.

--- a/docs/intake/exploratory/README.md
+++ b/docs/intake/exploratory/README.md
@@ -1,0 +1,7 @@
+# Exploratory
+
+This folder stores intake exploratory artifacts.
+
+- Status: PROPOSED
+- Authority: exploratory
+- Canonical use requires promotion/routing outside docs/intake/.

--- a/docs/intake/promotions/README.md
+++ b/docs/intake/promotions/README.md
@@ -1,0 +1,7 @@
+# Promotions
+
+This folder stores intake promotions artifacts.
+
+- Status: PROPOSED
+- Authority: exploratory
+- Canonical use requires promotion/routing outside docs/intake/.


### PR DESCRIPTION
### Motivation
- The `docs/intake/README.md` documents an expected intake structure but the repository was missing concrete scaffold files and per-lane placeholders. 
- Provide a normalized template and an index so contributors can file and track intake ideas consistently and avoid accidental drift into canon.

### Description
- Add `docs/intake/IDEA_INTAKE.md`, a single-idea template with required fields and promotion notes. 
- Add `docs/intake/NEW_IDEAS_INDEX.md`, a master index table and simple usage guidance for tracking intake items. 
- Add `docs/intake/cards/README.md`, `docs/intake/exploratory/README.md`, `docs/intake/carry-forward/README.md`, and `docs/intake/promotions/README.md` as per-lane placeholders that state status and authority.

### Testing
- Confirmed the new files are present using `find docs/intake -maxdepth 2 -type f | sort`, which listed the created files. 
- Verified file contents with `nl -ba docs/intake/IDEA_INTAKE.md` and `nl -ba docs/intake/NEW_IDEAS_INDEX.md` and inspected the subfolder README files to ensure templates and notes are correct. 
- All validation commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07b91e5c00832a9b0b53f41eb46d5a)