### PR TITLE
Add promotions intake state folders and README placeholders

### DIFF
--- a/docs/intake/promotions/accepted/README.md
+++ b/docs/intake/promotions/accepted/README.md
@@ -1,0 +1,5 @@
+# Accepted Promotion Packets
+
+This folder stores promotion packets in the **accepted** state for `docs/intake/promotions/`.
+
+Use a `<topic-or-source-family>.<short-purpose>.promotion.md` filename and keep packet metadata aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/promotions/candidates/README.md
+++ b/docs/intake/promotions/candidates/README.md
@@ -1,0 +1,5 @@
+# Candidates Promotion Packets
+
+This folder stores promotion packets in the **candidates** state for `docs/intake/promotions/`.
+
+Use a `<topic-or-source-family>.<short-purpose>.promotion.md` filename and keep packet metadata aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/promotions/deferred/README.md
+++ b/docs/intake/promotions/deferred/README.md
@@ -1,0 +1,5 @@
+# Deferred Promotion Packets
+
+This folder stores promotion packets in the **deferred** state for `docs/intake/promotions/`.
+
+Use a `<topic-or-source-family>.<short-purpose>.promotion.md` filename and keep packet metadata aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/promotions/rejected/README.md
+++ b/docs/intake/promotions/rejected/README.md
@@ -1,0 +1,5 @@
+# Rejected Promotion Packets
+
+This folder stores promotion packets in the **rejected** state for `docs/intake/promotions/`.
+
+Use a `<topic-or-source-family>.<short-purpose>.promotion.md` filename and keep packet metadata aligned with `docs/intake/promotions/README.md`.


### PR DESCRIPTION
### Motivation
- The `docs/intake/promotions/` README proposes state directories (`candidates`, `accepted`, `deferred`, `rejected`) that were not present, which prevents storing promotion packets in explicit lanes. 
- Scaffolding these folders and minimal READMEs makes the intended packet workflow visible and easy to use.

### Description
- Created four directories under `docs/intake/promotions/`: `candidates/`, `accepted/`, `deferred/`, and `rejected/`. 
- Added a `README.md` in each directory providing the folder title, intended state, and the recommended packet filename convention. 
- Files were added to the repository and the change was recorded in the working branch.

### Testing
- Ran `find docs/intake/promotions -maxdepth 2 -type f | sort` to verify the new files appear under the promotions tree, which succeeded. 
- Ran `git status --short` to confirm repository state, which succeeded. 
- Ran `git commit` to record the changes, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d30f6ee4832ab03494ae91a3e502)