### PR TITLE
Add READMEs for promotion packet state folders (accepted, candidates, deferred, rejected)

### DIFF
--- a/docs/intake/promotions/accepted/README.md
+++ b/docs/intake/promotions/accepted/README.md
@@ -1,0 +1,14 @@
+# Accepted Promotion Packets
+
+This folder stores promotion packets whose recommendation was accepted and whose substantive content moved to a verified owning path.
+
+## What belongs here
+- Final packet record retained for intake lineage and auditability.
+- Backlinks to the authoritative destination document(s), ADR(s), runbook(s), contract(s), schema(s), or policy artifact(s).
+
+## Naming
+Use:
+
+`<topic-or-source-family>.<short-purpose>.promotion.md`
+
+Keep packet metadata and workflow posture aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/promotions/candidates/README.md
+++ b/docs/intake/promotions/candidates/README.md
@@ -1,0 +1,14 @@
+# Candidate Promotion Packets
+
+This folder stores active promotion packets in the **candidate-for-promotion** state while review is in progress.
+
+## What belongs here
+- Packets that passed intake triage and are being evaluated for placement in an owning authority path.
+- Packet drafts with source references, proposed target path, reviewer/steward, and rollback target.
+
+## Naming
+Use:
+
+`<topic-or-source-family>.<short-purpose>.promotion.md`
+
+Keep packet metadata and workflow posture aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/promotions/deferred/README.md
+++ b/docs/intake/promotions/deferred/README.md
@@ -1,0 +1,14 @@
+# Deferred Promotion Packets
+
+This folder stores promotion packets paused in the **deferred** state pending evidence, ownership, policy clarification, or directory-authority decisions.
+
+## What belongs here
+- Packets waiting on verification tasks, steward assignment, rights/sensitivity review, or ADR resolution.
+- Packets that may re-enter candidate review after missing prerequisites are closed.
+
+## Naming
+Use:
+
+`<topic-or-source-family>.<short-purpose>.promotion.md`
+
+Keep packet metadata and workflow posture aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/promotions/rejected/README.md
+++ b/docs/intake/promotions/rejected/README.md
@@ -1,0 +1,14 @@
+# Rejected Promotion Packets
+
+This folder stores promotion packets that were reviewed and explicitly **rejected**.
+
+## What belongs here
+- Packets rejected for duplication, weak evidence, rights/sensitivity risks, ownership conflicts, or out-of-scope proposals.
+- Retained rationale records so decisions are explainable and source lineage is not lost.
+
+## Naming
+Use:
+
+`<topic-or-source-family>.<short-purpose>.promotion.md`
+
+Keep packet metadata and workflow posture aligned with `docs/intake/promotions/README.md`.


### PR DESCRIPTION
### Motivation
- Provide clear, per-folder guidance for promotion packet lifecycle states to improve intake auditability and reviewer expectations.
- Capture what content belongs in each state directory and surface required metadata and backlinks for traceability.
- Standardize naming and keep packet workflow posture aligned with the central `docs/intake/promotions/README.md` guidance.

### Description
- Add `docs/intake/promotions/accepted/README.md` to document storage of accepted promotion packets and backlink requirements.
- Add `docs/intake/promotions/candidates/README.md` to document packets in active candidate review with required draft fields.
- Add `docs/intake/promotions/deferred/README.md` to document packets paused pending evidence, ownership, or policy clarifications.
- Add `docs/intake/promotions/rejected/README.md` to document retention of rejected packet rationale and duplication/out-of-scope rules, and include a consistent naming convention of `<topic-or-source-family>.<short-purpose>.promotion.md` in each README.

### Testing
- No automated tests were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d30f6ee4832ab03494ae91a3e502)