### PR TITLE
Add intake promotions and triage documentation scaffolds

### DIFF
--- a/docs/intake/canonicalization-policy.md
+++ b/docs/intake/canonicalization-policy.md
@@ -1,0 +1,11 @@
+# Canonicalization Policy
+
+Policy notes for converting exploratory or lineage language into stable, governed repo-native documentation.
+
+> Placeholder scaffold referenced by `docs/intake/promotions/README.md`.
+
+This file should define:
+- when a record becomes canonical
+- who approves canonicalization
+- what evidence is required
+- how rollback and demotion are handled

--- a/docs/intake/new-ideas-register.md
+++ b/docs/intake/new-ideas-register.md
@@ -1,0 +1,8 @@
+# New Ideas Register
+
+Canonical index for newly captured ideas in the intake lane.
+
+> This placeholder exists to satisfy references from `docs/intake/promotions/README.md`.
+> If `NEW_IDEAS_INDEX.md` remains the active canonical file, keep this file as a compatibility shim and link both directions.
+
+See also: `docs/intake/NEW_IDEAS_INDEX.md`.

--- a/docs/intake/promotion-criteria.md
+++ b/docs/intake/promotion-criteria.md
@@ -1,0 +1,12 @@
+# Promotion Criteria
+
+Criteria used to evaluate whether an intake item is ready to move toward an owning authority path.
+
+> Placeholder scaffold referenced by `docs/intake/promotions/README.md`.
+
+Minimum criteria should include:
+- source traceability
+- directory authority fit
+- rights/sensitivity screening
+- stewardship assignment
+- rollback feasibility

--- a/docs/intake/promotions/accepted/README.md
+++ b/docs/intake/promotions/accepted/README.md
@@ -1,0 +1,14 @@
+# Accepted Promotion Packets
+
+This folder stores promotion packets whose recommendation was accepted and whose substantive content moved to a verified owning path.
+
+## What belongs here
+- Final packet record retained for intake lineage and auditability.
+- Backlinks to the authoritative destination document(s), ADR(s), runbook(s), contract(s), schema(s), or policy artifact(s).
+
+## Naming
+Use:
+
+`<topic-or-source-family>.<short-purpose>.promotion.md`
+
+Keep packet metadata and workflow posture aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/promotions/candidates/README.md
+++ b/docs/intake/promotions/candidates/README.md
@@ -1,0 +1,14 @@
+# Candidate Promotion Packets
+
+This folder stores active promotion packets in the **candidate-for-promotion** state while review is in progress.
+
+## What belongs here
+- Packets that passed intake triage and are being evaluated for placement in an owning authority path.
+- Packet drafts with source references, proposed target path, reviewer/steward, and rollback target.
+
+## Naming
+Use:
+
+`<topic-or-source-family>.<short-purpose>.promotion.md`
+
+Keep packet metadata and workflow posture aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/promotions/deferred/README.md
+++ b/docs/intake/promotions/deferred/README.md
@@ -1,0 +1,14 @@
+# Deferred Promotion Packets
+
+This folder stores promotion packets paused in the **deferred** state pending evidence, ownership, policy clarification, or directory-authority decisions.
+
+## What belongs here
+- Packets waiting on verification tasks, steward assignment, rights/sensitivity review, or ADR resolution.
+- Packets that may re-enter candidate review after missing prerequisites are closed.
+
+## Naming
+Use:
+
+`<topic-or-source-family>.<short-purpose>.promotion.md`
+
+Keep packet metadata and workflow posture aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/promotions/rejected/README.md
+++ b/docs/intake/promotions/rejected/README.md
@@ -1,0 +1,14 @@
+# Rejected Promotion Packets
+
+This folder stores promotion packets that were reviewed and explicitly **rejected**.
+
+## What belongs here
+- Packets rejected for duplication, weak evidence, rights/sensitivity risks, ownership conflicts, or out-of-scope proposals.
+- Retained rationale records so decisions are explainable and source lineage is not lost.
+
+## Naming
+Use:
+
+`<topic-or-source-family>.<short-purpose>.promotion.md`
+
+Keep packet metadata and workflow posture aligned with `docs/intake/promotions/README.md`.

--- a/docs/intake/triage-rules.md
+++ b/docs/intake/triage-rules.md
@@ -1,0 +1,12 @@
+# Intake Triage Rules
+
+Baseline triage criteria for classifying new intake records before promotion review.
+
+> Placeholder scaffold referenced by `docs/intake/promotions/README.md`.
+
+Suggested triage outputs:
+- `triaged`
+- `candidate-for-promotion`
+- `exploratory-retained`
+- `lineage-only`
+- `rejected`


### PR DESCRIPTION
### Motivation
- Provide a set of placeholder, governed documentation scaffolds for the intake lane to capture promotion workflows and criteria. 
- Surface canonicalization, triage, and promotion-state guidance so promotion packets can follow a consistent, auditable path. 
- Satisfy inbound references from `docs/intake/promotions/README.md` and provide compatibility shims where needed. 

### Description
- Added several new intake docs including `docs/intake/canonicalization-policy.md`, `docs/intake/promotion-criteria.md`, and `docs/intake/triage-rules.md` as policy and triage scaffolds. 
- Introduced `docs/intake/new-ideas-register.md` as a compatibility shim pointing to `docs/intake/NEW_IDEAS_INDEX.md`. 
- Created folder READMEs for promotion packet states under `docs/intake/promotions/` (`accepted`, `candidates`, `deferred`, `rejected`) with naming guidance and retention rules. 

### Testing
- No automated tests were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d30f6ee4832ab03494ae91a3e502)