### PR TITLE
Add dashboard specifications and indicator catalog for governance health

### DIFF
--- a/docs/dashboards/DASHBOARD_CATALOG.md
+++ b/docs/dashboards/DASHBOARD_CATALOG.md
@@ -1,0 +1,159 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: Dashboard Catalog — index of all KFM dashboard specifications
+type: standard
+version: v0.1
+status: draft
+owners: <dashboards-stewards>  # PROPOSED placeholder; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/INDICATOR_CATALOG.md
+  - docs/registers/DRIFT_REGISTER.md
+  - docs/registers/VERIFICATION_BACKLOG.md
+tags: [kfm, docs, dashboards, catalog, index]
+notes:
+  - "Every dashboard spec under docs/dashboards/ MUST appear in this catalog."
+  - "Each spec is PROPOSED until mounted-repo evidence confirms a running implementation."
+[/KFM_META_BLOCK_V2] -->
+
+# Dashboard Catalog · `docs/dashboards/DASHBOARD_CATALOG.md`
+
+> The single index of every dashboard specification under `docs/dashboards/`. Each row
+> links a spec file to its category, its source Atlas card or indicator section, its
+> owning steward (PROPOSED), and where the dashboard actually runs.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Truth posture](https://img.shields.io/badge/truth-cite--or--abstain-blue)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+![Specs](https://img.shields.io/badge/specs-11%20proposed-yellow)
+
+**Status:** draft · **Owners:** `<dashboards-stewards>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> Every dashboard spec carries its own truth posture. The dashboards indexed here are
+> **PROPOSED designs**, not claims of running surfaces. A spec moves from PROPOSED to
+> a verified status only when mounted-repo evidence confirms a running implementation.
+
+---
+
+## Quick jump
+
+- [1. How to use this catalog](#1-how-to-use-this-catalog)
+- [2. Governance dashboards](#2-governance-dashboards)
+- [3. Operational dashboards](#3-operational-dashboards)
+- [4. Domain dashboards](#4-domain-dashboards)
+- [5. Observability dashboards](#5-observability-dashboards)
+- [6. Lifecycle states](#6-lifecycle-states)
+- [7. Open questions](#7-open-questions)
+
+---
+
+## 1. How to use this catalog
+
+- **Adding a dashboard?** Author the spec under the right category folder (see
+  [README §10](README.md#10-quickstart--authoring-a-dashboard-spec)), then add a row here.
+- **Auditing coverage?** Cross-check against [`INDICATOR_CATALOG.md`](INDICATOR_CATALOG.md)
+  — every Atlas v1.1 §24.11 indicator must be surfaced by some governance dashboard.
+- **Statuses** use the lifecycle vocabulary in [§6](#6-lifecycle-states).
+
+[↑ back to top](#dashboard-catalog--docsdashboardsdashboard_catalogmd)
+
+---
+
+## 2. Governance dashboards
+
+Governance-health dashboards mirror Atlas v1.1 Ch. 24.11. They **report** posture; the
+validator **enforces**.
+
+| Spec file | Documents | Source | Owner (PROPOSED) | Runs on (PROPOSED) | Status |
+|---|---|---|---|---|---|
+| [`governance/EVIDENCE_INTEGRITY.md`](governance/EVIDENCE_INTEGRITY.md) | EvidenceRef resolution, cite-or-abstain compliance, source-role drift, stale-source rate, quarantine throughput. | Atlas v1.1 §24.11.1 | Release / Source / AI surface stewards | `apps/review-console/` | PROPOSED |
+| [`governance/RELEASE_CORRECTION_ROLLBACK.md`](governance/RELEASE_CORRECTION_ROLLBACK.md) | Rollback-target coverage, correction lead time, derivative-invalidation coverage, rollback rehearsal rate, supersession lineage gaps. | Atlas v1.1 §24.11.2 | Release steward · Correction reviewer | `apps/review-console/` | PROPOSED |
+| [`governance/SENSITIVITY_RIGHTS.md`](governance/SENSITIVITY_RIGHTS.md) | Sensitive-lane fail-closed rate, RedactionReceipt coverage, review-aged-out incidence, rights-change response time, side-channel audit cadence. | Atlas v1.1 §24.11.3 | Sensitivity reviewer · Rights-holder representative | `apps/review-console/` | PROPOSED |
+| [`governance/AI_SURFACE_HEALTH.md`](governance/AI_SURFACE_HEALTH.md) | AIReceipt presence rate, ABSTAIN rate by template, DENY reason distribution, synthetic-claim incidence. | Atlas v1.1 §24.11.4 | AI surface steward | `apps/review-console/` | PROPOSED |
+| [`governance/DOCUMENTATION_DRIFT.md`](governance/DOCUMENTATION_DRIFT.md) | ADR completeness, drift register size, per-root README presence, atlas/supplement lineage clarity. | Atlas v1.1 §24.11.5 | Docs steward | `apps/review-console/` | PROPOSED |
+
+[↑ back to top](#dashboard-catalog--docsdashboardsdashboard_catalogmd)
+
+---
+
+## 3. Operational dashboards
+
+Feed, artifact, and QC dashboards. They watch the pipeline's day-to-day health.
+
+| Spec file | Documents | Source | Owner (PROPOSED) | Runs on (PROPOSED) | Status |
+|---|---|---|---|---|---|
+| [`operational/SLO_LIVE_FEEDS.md`](operational/SLO_LIVE_FEEDS.md) | Standards-first SLOs for live transit and other high-cadence feeds: freshness, schema validation, latency, deduplication, non-material suppression, agency license terms. | `KFM-P11-FEAT-0002` | Source steward · Observability steward | OpenTelemetry stack / `apps/review-console/` | PROPOSED |
+| [`operational/REALTIME_FEED_FRESHNESS.md`](operational/REALTIME_FEED_FRESHNESS.md) | Realtime feed health: schema validation, SLO freshness, canonical identity, partition output, promotion/hold state. | `KFM-P31-FEAT-0015` | Source steward | OpenTelemetry stack / `apps/review-console/` | PROPOSED |
+| [`operational/COG_ZARR_REPRODUCIBILITY.md`](operational/COG_ZARR_REPRODUCIBILITY.md) | Raster/datacube artifacts: build container, GDAL/numcodecs versions, chained hashes, overview/block layout, reproducibility verdict. | `KFM-P31-FEAT-0016` | Pipeline steward | `apps/review-console/` | PROPOSED |
+| [`operational/GEOSPATIAL_QC_PANEL.md`](operational/GEOSPATIAL_QC_PANEL.md) | Quick geospatial QC panel — fast inspectable surface for geometry / CRS / topology checks. | `KFM-P31-FEAT-0017` | Pipeline steward · Domain steward | `apps/review-console/` | PROPOSED |
+
+[↑ back to top](#dashboard-catalog--docsdashboardsdashboard_catalogmd)
+
+---
+
+## 4. Domain dashboards
+
+Domain-specific dashboards live under `domain/<domain>/`. The `<domain>` segment MUST
+match a Directory Rules §6.1 `docs/domains/` name.
+
+| Spec file | Documents | Source | Owner (PROPOSED) | Runs on (PROPOSED) | Status |
+|---|---|---|---|---|---|
+| [`domain/air/PM_SENSOR_CALIBRATION_REVIEW.md`](domain/air/PM_SENSOR_CALIBRATION_REVIEW.md) | PM-sensor trust scores, meteorology features, co-location windows, low-concentration safeguards. | `KFM-P30-FEAT-0001` | Atmosphere domain steward | `apps/review-console/` | PROPOSED |
+
+[↑ back to top](#dashboard-catalog--docsdashboardsdashboard_catalogmd)
+
+---
+
+## 5. Observability dashboards
+
+CI / pipeline observability surfaces — the stack the other dashboards may read from.
+
+| Spec file | Documents | Source | Owner (PROPOSED) | Runs on (PROPOSED) | Status |
+|---|---|---|---|---|---|
+| [`observability/OPENTELEMETRY_STACK.md`](observability/OPENTELEMETRY_STACK.md) | CI/pipeline observability via OpenTelemetry Collector → Tempo (traces) + Mimir (metrics) + Loki (logs), one agent shape across runners. | `KFM-P8-PROG-0026` | Observability steward | OpenTelemetry stack (Tempo · Mimir · Loki) | PROPOSED |
+
+[↑ back to top](#dashboard-catalog--docsdashboardsdashboard_catalogmd)
+
+---
+
+## 6. Lifecycle states
+
+PROPOSED vocabulary for the **Status** column. Aligns with the Atlas truth labels and
+Directory Rules §17.
+
+| Status | Meaning |
+|---|---|
+| `PROPOSED` | Spec drafted; no verified running implementation. Default for every new spec. |
+| `NEEDS VERIFICATION` | Spec claims a running surface, but mounted-repo evidence is not yet confirmed. |
+| `CONFIRMED` | Mounted-repo evidence confirms the dashboard runs and reads the receipts named in the spec. |
+| `SUPERSEDED` | Replaced by another spec; the row keeps a forward link to its successor. |
+| `RETIRED` | Dashboard decommissioned; spec kept for lineage. |
+
+[↑ back to top](#dashboard-catalog--docsdashboardsdashboard_catalogmd)
+
+---
+
+## 7. Open questions
+
+- [ ] **CAT-OQ-01 — Catalog completeness CI.** Add a check that every `.md` under
+  `docs/dashboards/{governance,operational,domain,observability}/` has a row here.
+- [ ] **CAT-OQ-02 — Running-surface verification.** Confirm each "Runs on" value against
+  mounted-repo state; downgrade unverified rows to `NEEDS VERIFICATION`.
+- [ ] **CAT-OQ-03 — Owner reconciliation.** Resolve every PROPOSED owner against
+  Atlas v1.1 §24.7 (tracked with `DASH-OQ-04`).
+
+[↑ back to top](#dashboard-catalog--docsdashboardsdashboard_catalogmd)
+
+---
+
+**Related docs:** [README.md](README.md) · [INDICATOR_CATALOG.md](INDICATOR_CATALOG.md) ·
+[registers/DRIFT_REGISTER.md](../registers/DRIFT_REGISTER.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<dashboards-stewards>` (PROPOSED)

--- a/docs/dashboards/INDICATOR_CATALOG.md
+++ b/docs/dashboards/INDICATOR_CATALOG.md
@@ -1,0 +1,191 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: Indicator Catalog — Master Governance Health Indicators (mirror of Atlas v1.1 Ch. 24.11)
+type: standard
+version: v0.1
+status: draft
+owners: <dashboards-stewards>  # PROPOSED placeholder; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/atlases/Kansas_Frontier_Matrix_-_Domains_v1_1.md   # Ch. 24.11 (authoritative source)
+  - docs/registers/VERIFICATION_BACKLOG.md                  # VB-11-08
+tags: [kfm, docs, dashboards, indicators, governance, health]
+notes:
+  - "This file is a human-readable MIRROR of Atlas v1.1 Ch. 24.11. The Atlas is authoritative."
+  - "If this mirror and the Atlas disagree, the Atlas wins; the discrepancy goes to the drift register."
+  - "Indicators are REPORTED, not enforced — enforcement is the validator's job (Atlas v1.1 §24.11 preamble)."
+[/KFM_META_BLOCK_V2] -->
+
+# Indicator Catalog · `docs/dashboards/INDICATOR_CATALOG.md`
+
+> A human-readable mirror of the **Master Governance Health Indicators** (Atlas v1.1
+> Ch. 24.11, CONFIRMED doctrine), with each indicator's measurement, healthy posture,
+> owning steward (PROPOSED), receipt sources, and the dashboard spec that surfaces it.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Truth posture](https://img.shields.io/badge/truth-cite--or--abstain-blue)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+![Source](https://img.shields.io/badge/source-Atlas%20v1.1%20Ch.%2024.11-informational)
+
+**Status:** draft · **Owners:** `<dashboards-stewards>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> **This catalog mirrors doctrine; it is not doctrine.** Atlas v1.1 Ch. 24.11 is the
+> authoritative source. This file adds dashboard mappings and receipt pointers for
+> day-to-day authoring. None of these indicators is a *sufficient* condition for trust —
+> together they describe a healthy posture. Indicators are **reported, not enforced**.
+
+---
+
+## Quick jump
+
+- [1. Scope](#1-scope)
+- [2. Category 24.11.1 — Evidence and source integrity](#2-category-24111--evidence-and-source-integrity)
+- [3. Category 24.11.2 — Release, correction, rollback](#3-category-24112--release-correction-rollback)
+- [4. Category 24.11.3 — Sensitivity and rights](#4-category-24113--sensitivity-and-rights)
+- [5. Category 24.11.4 — AI surface health](#5-category-24114--ai-surface-health)
+- [6. Category 24.11.5 — Documentation and drift](#6-category-24115--documentation-and-drift)
+- [7. Coverage matrix](#7-coverage-matrix)
+- [8. Open questions](#8-open-questions)
+
+---
+
+## 1. Scope
+
+This catalog enumerates the **23 governance health indicators** across five categories
+defined in Atlas v1.1 Ch. 24.11. For each indicator it records:
+
+- **Measures** — what the signal counts or computes.
+- **Healthy posture (PROPOSED)** — the target state per the Atlas.
+- **Owning steward (PROPOSED)** — the role accountable for the indicator; resolve against
+  Atlas v1.1 §24.7 (Reviewer Role and Separation-of-Duties Matrix).
+- **Receipt sources** — the receipt/record types a dashboard reads to compute the signal.
+- **Dashboard spec** — the `docs/dashboards/` spec file that surfaces the indicator.
+
+[↑ back to top](#indicator-catalog--docsdashboardsindicator_catalogmd)
+
+---
+
+## 2. Category 24.11.1 — Evidence and source integrity
+
+Surfaced by [`governance/EVIDENCE_INTEGRITY.md`](governance/EVIDENCE_INTEGRITY.md).
+
+| Indicator | Measures | Healthy posture (PROPOSED) | Owning steward (PROPOSED) | Receipt sources |
+|---|---|---|---|---|
+| EvidenceRef resolution rate | % of public-surface EvidenceRefs that resolve to an EvidenceBundle on demand. | > 99.9% over the trailing release window. | Release steward | `ValidationReport`, EvidenceBundle index |
+| Cite-or-abstain compliance | % of Focus Mode answers with non-empty, resolving evidence citations. | 100% (any miss is a defect to investigate). | AI surface steward | `AIReceipt` |
+| Source-role distribution drift | Distribution of admitted source roles over time per domain. | No silent shift without a documented ADR or steward note. | Source steward | Source descriptors, `ValidationReport` |
+| Stale source rate | % of admitted sources past their freshness cadence. | Stewards dispositioned (refresh / supersede / mark stale) within tolerance. | Source steward | Source descriptors, freshness cadence metadata |
+| Quarantine throughput | % of admitted records that quarantine + the rate of clearance. | Visible, with cause distribution; sustained backlog is a defect. | Source steward | `ValidationReport`, quarantine ledger |
+
+[↑ back to top](#indicator-catalog--docsdashboardsindicator_catalogmd)
+
+---
+
+## 3. Category 24.11.2 — Release, correction, rollback
+
+Surfaced by [`governance/RELEASE_CORRECTION_ROLLBACK.md`](governance/RELEASE_CORRECTION_ROLLBACK.md).
+
+| Indicator | Measures | Healthy posture (PROPOSED) | Owning steward (PROPOSED) | Receipt sources |
+|---|---|---|---|---|
+| Release with rollback target | % of PUBLISHED releases that name a valid rollback target. | 100%. | Release steward | `ReleaseManifest`, `RollbackCard` |
+| Correction lead time | Median time from defect detection to `CorrectionNotice`. | Visibly tracked; trend not regressing. | Correction reviewer | `CorrectionNotice` |
+| Derivative-invalidation coverage | % of corrections that name and invalidate downstream derivatives. | Approaches 100% as coverage matures. | Correction reviewer | `CorrectionNotice`, lineage graph |
+| Rollback rehearsal rate | Number of rehearsed rollbacks per release window. | Non-zero; periodic, scheduled. | Release steward | `RollbackCard` |
+| Supersession lineage gap | Number of supersessions without a forward link. | Zero. | Docs steward | `ReleaseManifest`, supersession entries |
+
+[↑ back to top](#indicator-catalog--docsdashboardsindicator_catalogmd)
+
+---
+
+## 4. Category 24.11.3 — Sensitivity and rights
+
+Surfaced by [`governance/SENSITIVITY_RIGHTS.md`](governance/SENSITIVITY_RIGHTS.md).
+
+| Indicator | Measures | Healthy posture (PROPOSED) | Owning steward (PROPOSED) | Receipt sources |
+|---|---|---|---|---|
+| Sensitive-lane fail-closed rate | % of unauthorized sensitive-lane requests that DENY at the first gate. | 100% at the first gate. | Sensitivity reviewer | `PolicyDecision` |
+| RedactionReceipt coverage | % of public-safe transformations that emit a `RedactionReceipt`. | 100% for sensitive lanes. | Sensitivity reviewer | `RedactionReceipt` |
+| Review-aged-out incidence | Number of sensitive-lane claims past their review cadence. | Visibly tracked; trend not regressing. | Sensitivity reviewer | `ReviewRecord` |
+| Rights-change response time | Median time from rights-change detection to tier reassignment. | Within stated tolerance per source family. | Rights-holder representative | Source descriptors, `ReviewRecord` |
+| Sensitive-content side-channel audit | Frequency of automated checks for label / popup / AI-text leaks. | Periodic; documented. | Sensitivity reviewer | Audit logs, `RepresentationReceipt` |
+
+[↑ back to top](#indicator-catalog--docsdashboardsindicator_catalogmd)
+
+---
+
+## 5. Category 24.11.4 — AI surface health
+
+Surfaced by [`governance/AI_SURFACE_HEALTH.md`](governance/AI_SURFACE_HEALTH.md).
+
+| Indicator | Measures | Healthy posture (PROPOSED) | Owning steward (PROPOSED) | Receipt sources |
+|---|---|---|---|---|
+| AIReceipt presence rate | % of Focus Mode answers with an `AIReceipt`. | 100%. | AI surface steward | `AIReceipt` |
+| ABSTAIN rate by template | How often each Focus Mode template abstains. | Visibly tracked; very low suggests over-fitting; very high suggests evidence gaps. | AI surface steward | `AIReceipt` |
+| DENY reason distribution | Reason codes returned by Focus Mode denials. | Stable; large new-reason spikes investigated. | AI surface steward | `AIReceipt`, `PolicyDecision` |
+| Synthetic-claim incidence | % of audited AI answers flagged for presenting synthetic content as observed. | Approaches zero; never silently. | AI surface steward | `AIReceipt`, audit sample |
+
+[↑ back to top](#indicator-catalog--docsdashboardsindicator_catalogmd)
+
+---
+
+## 6. Category 24.11.5 — Documentation and drift
+
+Surfaced by [`governance/DOCUMENTATION_DRIFT.md`](governance/DOCUMENTATION_DRIFT.md).
+
+| Indicator | Measures | Healthy posture (PROPOSED) | Owning steward (PROPOSED) | Receipt sources |
+|---|---|---|---|---|
+| ADR completeness | % of structural moves with an accepted ADR. | 100% for Directory Rules §2.4 cases. | Docs steward | `docs/adr/`, drift register |
+| Drift register size | Open entries in `docs/registers/DRIFT_REGISTER.md`. | Visibly tracked; aged entries investigated. | Docs steward | `DRIFT_REGISTER.md` |
+| Per-root README presence | % of canonical roots with a current README declaring authority class. | 100%. | Docs steward | Repo tree scan |
+| Atlas / supplement lineage clarity | Each Atlas/supplement carries a current supersession entry. | 100%. | Docs steward | Atlas front-matter, supersession entries |
+
+[↑ back to top](#indicator-catalog--docsdashboardsindicator_catalogmd)
+
+---
+
+## 7. Coverage matrix
+
+CONFIRMED: every Atlas v1.1 Ch. 24.11 indicator below maps to exactly one dashboard spec.
+Coverage is checked by `DASH-OQ-08` (indicator-coverage CI check).
+
+| Atlas section | Indicators | Dashboard spec | Status |
+|---|---|---|---|
+| §24.11.1 Evidence and source integrity | 5 | `governance/EVIDENCE_INTEGRITY.md` | PROPOSED |
+| §24.11.2 Release, correction, rollback | 5 | `governance/RELEASE_CORRECTION_ROLLBACK.md` | PROPOSED |
+| §24.11.3 Sensitivity and rights | 5 | `governance/SENSITIVITY_RIGHTS.md` | PROPOSED |
+| §24.11.4 AI surface health | 4 | `governance/AI_SURFACE_HEALTH.md` | PROPOSED |
+| §24.11.5 Documentation and drift | 4 | `governance/DOCUMENTATION_DRIFT.md` | PROPOSED |
+| **Total** | **23** | 5 governance specs | — |
+
+[↑ back to top](#indicator-catalog--docsdashboardsindicator_catalogmd)
+
+---
+
+## 8. Open questions
+
+- [ ] **IND-OQ-01 — Owner reconciliation.** Replace every PROPOSED owning-steward value
+  with a concrete role from Atlas v1.1 §24.7. Tracked alongside `DASH-OQ-04`.
+- [ ] **IND-OQ-02 — Receipt-source verification.** Confirm each "Receipt sources" cell
+  against the canonical receipt catalog (Atlas v1.1 §24.2) and `schemas/contracts/v1/receipts/`.
+- [ ] **IND-OQ-03 — Mirror freshness check.** Add a CI check that diffs this mirror
+  against Atlas v1.1 Ch. 24.11 and fails on divergence (links to `DASH-OQ-08`).
+- [ ] **IND-OQ-04 — `VB-11-08` linkage.** Atlas v1.1 Appendix G `VB-11-08` requires each
+  indicator to be "instrumented or owned by a steward." Close the catalog half here.
+
+[↑ back to top](#indicator-catalog--docsdashboardsindicator_catalogmd)
+
+---
+
+**Related docs:** [README.md](README.md) · [DASHBOARD_CATALOG.md](DASHBOARD_CATALOG.md) ·
+[atlases/ — Atlas v1.1 Ch. 24.11](../atlases/) ·
+[registers/VERIFICATION_BACKLOG.md](../registers/VERIFICATION_BACKLOG.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<dashboards-stewards>` (PROPOSED)

--- a/docs/dashboards/domain/air/PM_SENSOR_CALIBRATION_REVIEW.md
+++ b/docs/dashboards/domain/air/PM_SENSOR_CALIBRATION_REVIEW.md
@@ -1,0 +1,127 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: PM Sensor Calibration Review Dashboard — specification
+type: standard
+version: v0.1
+status: draft
+owners: <atmosphere-domain-steward>  # PROPOSED placeholder; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/domains/
+tags: [kfm, dashboards, domain, air, atmosphere, pm-sensor, calibration, air-quality]
+notes:
+  - "Source card: KFM-P30-FEAT-0001 (PM Sensor Calibration Review Dashboard) — UNCHANGED, active."
+  - "Card self-check: UNKNOWN — repository implementation status remains unverified."
+  - "Domain segment 'air' maps to the atmosphere domain — confirm against Directory Rules §6.1 docs/domains/."
+  - "This is a SPEC for a dashboard, not the running dashboard."
+[/KFM_META_BLOCK_V2] -->
+
+# PM Sensor Calibration Review Dashboard · `domain/air/PM_SENSOR_CALIBRATION_REVIEW.md`
+
+> Dashboard specification for the **PM Sensor Calibration Review Dashboard** (Atlas card
+> `KFM-P30-FEAT-0001`). A domain dashboard for low-cost particulate-matter (PM) sensors:
+> trust scores, meteorology features, co-location windows, and low-concentration
+> safeguards.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-domain%20%C2%B7%20air-teal)
+![Source](https://img.shields.io/badge/source-KFM--P30--FEAT--0001-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<atmosphere-domain-steward>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> A calibrated reading is still an *estimate*. This dashboard reports calibration quality
+> and a trust score; it does not turn a low-cost PM sensor into a reference monitor.
+> Calibration provenance belongs in the reading's `EvidenceBundle`.
+
+---
+
+> [!NOTE]
+> **Domain-segment placement.** This spec lives under `domain/air/`. The KFM canonical
+> domain name is **atmosphere** (Directory Rules §6.1 `docs/domains/`). Whether the
+> segment should be `air/` or `atmosphere/` is an open question — see `PMC-OQ-04`.
+
+---
+
+## 1. Description
+
+The PM Sensor Calibration Review dashboard answers: **how much should we trust each PM
+sensor's reading right now?** Low-cost PM sensors drift with humidity, temperature, and
+aging. This dashboard surfaces calibration quality against co-located reference monitors,
+the meteorology features used in the calibration model, and explicit safeguards for the
+low-concentration regime where these sensors are least reliable.
+
+## 2. Metrics surfaced (PROPOSED)
+
+| # | Metric | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | Sensor trust score | A composite trust score per sensor from calibration fit + recency. | Above the per-network trust threshold. | `SENSOR_LOW_TRUST` |
+| 2 | Meteorology features | Humidity / temperature features feeding the calibration model. | Present and within model-valid ranges. | `MET_FEATURE_MISSING` |
+| 3 | Co-location window | Recency and length of co-location with a reference monitor. | Within the required co-location cadence. | `COLOCATION_STALE` |
+| 4 | Low-concentration safeguard | Behavior in the low-concentration regime where PM sensors are least reliable. | Safeguard active; readings flagged or widened. | `LOW_CONC_UNSAFEGUARDED` |
+| 5 | Calibration residual | Error vs. the co-located reference monitor. | Within the network's residual tolerance. | `CALIBRATION_RESIDUAL_HIGH` |
+
+## 3. Panels (PROPOSED)
+
+- **Trust scores** — per-sensor trust score vs. the network threshold.
+- **Met features** — humidity/temperature feature availability and range checks.
+- **Co-location** — last co-location window per sensor; stale windows flagged.
+- **Low-concentration** — safeguard status and flagged low-concentration readings.
+- **Residuals** — calibration residual vs. reference, against the tolerance band.
+
+## 4. Inputs
+
+Mounted-repo paths NEEDS VERIFICATION.
+
+- PM sensor readings + calibration model outputs (atmosphere domain pipeline).
+- Reference-monitor data for co-located sensors.
+- Meteorology features (humidity, temperature) used by the calibration model.
+- `ValidationReport` — calibration-check outcomes.
+- `EvidenceBundle` — calibration provenance per reading.
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/domain/air/PM_SENSOR_CALIBRATION_REVIEW.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | `apps/review-console/` air-domain panel. | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning steward (PROPOSED):** Atmosphere (air) domain steward.
+- **Review burden:** docs steward + atmosphere domain steward. Resolve the placeholder
+  against Atlas v1.1 §24.7 before review.
+
+## 7. Acceptance
+
+- [ ] All five metrics present; the dashboard does not claim reference-grade accuracy.
+- [ ] Owner named (no anonymous spec at v1).
+- [ ] The `domain/<domain>/` segment matches a Directory Rules §6.1 `docs/domains/` name
+      (or `PMC-OQ-04` is open).
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../../DASHBOARD_CATALOG.md).
+- [ ] Negative states use the Unified Doctrine §19 vocabulary.
+
+## 8. Open questions
+
+- [ ] **PMC-OQ-01** — Confirm the running surface and downgrade if unverified.
+- [ ] **PMC-OQ-02** — Set per-network trust thresholds and residual tolerances.
+- [ ] **PMC-OQ-03** — Define the low-concentration regime boundary and safeguard rule.
+- [ ] **PMC-OQ-04** — Confirm the domain segment name: `air/` vs. `atmosphere/`
+      (Directory Rules §6.1 `docs/domains/`).
+- [ ] **PMC-OQ-05** — Confirm `KFM-P30-FEAT-0001` implementation status against
+      mounted-repo state (card self-check: UNKNOWN).
+
+---
+
+**Related docs:** [README.md](../../README.md) · [DASHBOARD_CATALOG.md](../../DASHBOARD_CATALOG.md) ·
+[domains/](../../../domains/)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<atmosphere-domain-steward>` (PROPOSED)

--- a/docs/dashboards/governance/AI_SURFACE_HEALTH.md
+++ b/docs/dashboards/governance/AI_SURFACE_HEALTH.md
@@ -1,0 +1,112 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: AI Surface Health Dashboard — specification
+type: standard
+version: v0.1
+status: draft
+owners: <ai-surface-steward>  # PROPOSED placeholder; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/INDICATOR_CATALOG.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/atlases/Kansas_Frontier_Matrix_-_Domains_v1_1.md   # §24.11.4
+  - docs/governed-ai/
+tags: [kfm, dashboards, governance, ai-surface, focus-mode, aireceipt, indicators]
+notes:
+  - "Source of indicators: Atlas v1.1 §24.11.4 (CONFIRMED doctrine)."
+  - "This is a SPEC for a dashboard, not the running dashboard. Indicators are reported, not enforced."
+  - "Mounted-repo state UNKNOWN; running-surface and receipt-path claims are PROPOSED / NEEDS VERIFICATION."
+[/KFM_META_BLOCK_V2] -->
+
+# AI Surface Health Dashboard · `governance/AI_SURFACE_HEALTH.md`
+
+> Dashboard specification for the **AI surface health** governance-health category
+> (Atlas v1.1 §24.11.4). Tracks whether Focus Mode answers carry receipts, abstain
+> honestly, and never present synthetic content as observed.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-governance-blue)
+![Source](https://img.shields.io/badge/source-Atlas%20%C2%A724.11.4-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<ai-surface-steward>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> The cite-or-abstain rule is doctrine: a Focus Mode answer either resolves to evidence
+> or it abstains. This dashboard **reports** how well that holds; the validator and the
+> `AIReceipt` are what **enforce** and **prove** it.
+
+---
+
+## 1. Description
+
+The AI Surface Health dashboard answers: **is the governed AI behaving honestly?** It
+surfaces the four Atlas v1.1 §24.11.4 indicators so the AI surface steward can see
+receipt coverage, abstain behavior by template, the distribution of denial reasons, and
+any incidence of synthetic claims being presented as observed fact.
+
+## 2. Indicators surfaced
+
+| # | Indicator | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | AIReceipt presence rate | % of Focus Mode answers with an `AIReceipt`. | 100%. | `MISSING_AIRECEIPT` |
+| 2 | ABSTAIN rate by template | How often each Focus Mode template abstains. | Visibly tracked; very low suggests over-fitting, very high suggests evidence gaps. | `REVIEW_PENDING` / `MISSING_EVIDENCE` |
+| 3 | DENY reason distribution | Reason codes returned by Focus Mode denials. | Stable; large new-reason spikes investigated. | `DENIED_BY_POLICY` |
+| 4 | Synthetic-claim incidence | % of audited AI answers flagged for presenting synthetic content as observed. | Approaches zero; never silently. | `SYNTHETIC_AS_OBSERVED` |
+
+## 3. Panels (PROPOSED)
+
+- **AIReceipt coverage** — single-stat at 100%; any miss drills to the answer.
+- **ABSTAIN by template** — bar chart per template, with over-fit / evidence-gap bands.
+- **DENY reasons** — stacked-area distribution; new-reason spikes flagged.
+- **Synthetic-claim audit** — incidence rate from the audit sample, target ~0.
+
+## 4. Inputs — receipts and records read
+
+CONFIRMED receipt types (Atlas v1.1 §24.2); mounted-repo paths NEEDS VERIFICATION.
+
+- `AIReceipt` — receipt presence, ABSTAIN flags, template identity, citations.
+- `PolicyDecision` — denial reason codes for Focus Mode requests.
+- Audit sample — manually-reviewed answers flagged for synthetic-as-observed content.
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/governance/AI_SURFACE_HEALTH.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | `apps/review-console/` AI-surface panel. | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning steward (PROPOSED):** AI surface steward (all four indicators).
+- **Review burden:** docs steward + AI surface steward. Resolve the placeholder role
+  against Atlas v1.1 §24.7 before review.
+
+## 7. Acceptance
+
+- [ ] All four §24.11.4 indicators present and matching [`INDICATOR_CATALOG.md`](../INDICATOR_CATALOG.md).
+- [ ] Every receipt type in §4 exists in the Atlas v1.1 §24.2 receipt catalog.
+- [ ] Owner named (no anonymous spec at v1).
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+- [ ] Truth badges are generated, not hand-edited (Atlas `KFM-P3-FEAT-0005`).
+
+## 8. Open questions
+
+- [ ] **AISH-OQ-01** — Confirm the running surface and downgrade if unverified.
+- [ ] **AISH-OQ-02** — Define the over-fit / evidence-gap ABSTAIN bands per template.
+- [ ] **AISH-OQ-03** — Define the audit-sample size and cadence for indicator 4.
+- [ ] **AISH-OQ-04** — Confirm `SYNTHETIC_AS_OBSERVED` against Unified Doctrine §19;
+      it may be a proposed addition.
+
+---
+
+**Related docs:** [README.md](../README.md) · [INDICATOR_CATALOG.md](../INDICATOR_CATALOG.md) ·
+[DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) · [governed-ai/](../../governed-ai/)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<ai-surface-steward>` (PROPOSED)

--- a/docs/dashboards/governance/DOCUMENTATION_DRIFT.md
+++ b/docs/dashboards/governance/DOCUMENTATION_DRIFT.md
@@ -1,0 +1,116 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: Documentation Drift Dashboard — specification
+type: standard
+version: v0.1
+status: draft
+owners: <docs-steward>  # PROPOSED placeholder; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/INDICATOR_CATALOG.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/atlases/Kansas_Frontier_Matrix_-_Domains_v1_1.md   # §24.11.5
+  - docs/doctrine/directory-rules.md
+  - docs/registers/DRIFT_REGISTER.md
+  - docs/adr/
+tags: [kfm, dashboards, governance, documentation, drift, adr, indicators]
+notes:
+  - "Source of indicators: Atlas v1.1 §24.11.5 (CONFIRMED doctrine)."
+  - "This is a SPEC for a dashboard, not the running dashboard. Indicators are reported, not enforced."
+  - "Mounted-repo state UNKNOWN; running-surface and receipt-path claims are PROPOSED / NEEDS VERIFICATION."
+[/KFM_META_BLOCK_V2] -->
+
+# Documentation Drift Dashboard · `governance/DOCUMENTATION_DRIFT.md`
+
+> Dashboard specification for the **Documentation and drift** governance-health category
+> (Atlas v1.1 §24.11.5). Tracks whether structural moves carry ADRs, whether the drift
+> register is managed, and whether every canonical root has a current README.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-governance-blue)
+![Source](https://img.shields.io/badge/source-Atlas%20%C2%A724.11.5-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<docs-steward>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> This dashboard measures the health of the documentation control plane itself —
+> including, recursively, the PROPOSED placement of `docs/dashboards/`. Its own folder
+> is a live drift case (see [README drift notice](../README.md)).
+
+---
+
+## 1. Description
+
+The Documentation Drift dashboard answers: **is the human-facing control plane keeping
+pace with the repo?** It surfaces the four Atlas v1.1 §24.11.5 indicators so the docs
+steward can see ADR completeness, the size and age of the drift register, README
+coverage of canonical roots, and Atlas/supplement lineage clarity.
+
+## 2. Indicators surfaced
+
+| # | Indicator | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | ADR completeness | % of structural moves with an accepted ADR. | 100% for Directory Rules §2.4 cases. | `ADR_MISSING` |
+| 2 | Drift register size | Open entries in `docs/registers/DRIFT_REGISTER.md`. | Visibly tracked; aged entries investigated. | `DRIFT_BACKLOG` |
+| 3 | Per-root README presence | % of canonical roots with a current README declaring authority class. | 100%. | `README_MISSING` |
+| 4 | Atlas / supplement lineage clarity | Each Atlas/supplement carries a current supersession entry. | 100%. | `LINEAGE_GAP` |
+
+## 3. Panels (PROPOSED)
+
+- **ADR completeness** — single-stat; structural moves without an accepted ADR drill out.
+- **Drift register** — open-entry count + age histogram, aged entries highlighted.
+- **README coverage** — % of canonical roots with a current authority-declaring README.
+- **Atlas lineage** — table of Atlas/supplements with their current supersession entry.
+
+## 4. Inputs — records read
+
+Mounted-repo paths NEEDS VERIFICATION.
+
+- `docs/adr/` — accepted ADRs, matched against structural moves.
+- `docs/registers/DRIFT_REGISTER.md` — open-entry count and entry ages.
+- Repo tree scan — canonical-root README presence and authority-class declaration.
+- Atlas / supplement front-matter — supersession entries.
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/governance/DOCUMENTATION_DRIFT.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | `apps/review-console/` documentation-health panel. | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning steward (PROPOSED):** Docs steward (all four indicators).
+- **Review burden:** docs steward. Resolve the placeholder role against Atlas v1.1 §24.7
+  before review.
+
+## 7. Acceptance
+
+- [ ] All four §24.11.5 indicators present and matching [`INDICATOR_CATALOG.md`](../INDICATOR_CATALOG.md).
+- [ ] Owner named (no anonymous spec at v1).
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+- [ ] The `docs/dashboards/` placement drift case is itself reflected in indicator 2's
+      source register once a `DRIFT_REGISTER.md` entry is opened (`DASH-OQ-01`).
+
+## 8. Open questions
+
+- [ ] **DD-OQ-01** — Confirm the running surface and downgrade if unverified.
+- [ ] **DD-OQ-02** — Define the canonical-root list indicator 3 scans against
+      (source: Directory Rules §6.1).
+- [ ] **DD-OQ-03** — Confirm negative-state names against Unified Doctrine §19.
+
+---
+
+**Related docs:** [README.md](../README.md) · [INDICATOR_CATALOG.md](../INDICATOR_CATALOG.md) ·
+[DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) ·
+[doctrine/directory-rules.md](../../doctrine/directory-rules.md) ·
+[registers/DRIFT_REGISTER.md](../../registers/DRIFT_REGISTER.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<docs-steward>` (PROPOSED)

--- a/docs/dashboards/governance/EVIDENCE_INTEGRITY.md
+++ b/docs/dashboards/governance/EVIDENCE_INTEGRITY.md
@@ -1,0 +1,119 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: Evidence Integrity Dashboard — specification
+type: standard
+version: v0.1
+status: draft
+owners: <release-steward>, <source-steward>  # PROPOSED placeholders; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/INDICATOR_CATALOG.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/atlases/Kansas_Frontier_Matrix_-_Domains_v1_1.md   # §24.11.1
+  - docs/standards/EVIDENCE_BUNDLE.md
+tags: [kfm, dashboards, governance, evidence, source-integrity, indicators]
+notes:
+  - "Source of indicators: Atlas v1.1 §24.11.1 (CONFIRMED doctrine)."
+  - "This is a SPEC for a dashboard, not the running dashboard. Indicators are reported, not enforced."
+  - "Mounted-repo state UNKNOWN; running-surface and receipt-path claims are PROPOSED / NEEDS VERIFICATION."
+[/KFM_META_BLOCK_V2] -->
+
+# Evidence Integrity Dashboard · `governance/EVIDENCE_INTEGRITY.md`
+
+> Dashboard specification for the **Evidence and source integrity** governance-health
+> category (Atlas v1.1 §24.11.1). Describes what the dashboard shows, what receipts it
+> reads, what posture is "healthy," and who owns it.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-governance-blue)
+![Source](https://img.shields.io/badge/source-Atlas%20%C2%A724.11.1-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<release-steward>`, `<source-steward>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> This dashboard **reports** evidence-integrity posture; it does **not** establish trust.
+> The canonical proof of any claim remains its `EvidenceBundle`. If the dashboard and a
+> receipt disagree, the receipt wins.
+
+---
+
+## 1. Description
+
+The Evidence Integrity dashboard answers one question for stewards: **can every public
+claim still be backed by resolvable evidence?** It surfaces the five Atlas v1.1 §24.11.1
+indicators as time-series panels with negative-state callouts, so that a degradation
+(an `EvidenceRef` that stopped resolving, a source past its freshness cadence) is visible
+before it becomes a release defect.
+
+## 2. Indicators surfaced
+
+| # | Indicator | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | EvidenceRef resolution rate | % of public-surface EvidenceRefs that resolve to an EvidenceBundle on demand. | > 99.9% over the trailing release window. | `MISSING_EVIDENCE` |
+| 2 | Cite-or-abstain compliance | % of Focus Mode answers with non-empty, resolving evidence citations. | 100% (any miss is a defect). | `MISSING_EVIDENCE` |
+| 3 | Source-role distribution drift | Distribution of admitted source roles over time per domain. | No silent shift without a documented ADR or steward note. | `SOURCE_ROLE_DRIFT` |
+| 4 | Stale source rate | % of admitted sources past their freshness cadence. | Stewards dispositioned within tolerance. | `SOURCE_STALE` |
+| 5 | Quarantine throughput | % of admitted records that quarantine + the clearance rate. | Visible, with cause distribution; sustained backlog is a defect. | `QUARANTINE_BACKLOG` |
+
+## 3. Panels (PROPOSED)
+
+- **Resolution rate** — line chart, trailing release window, with the 99.9% target line.
+- **Cite-or-abstain** — single-stat with drill-down to any answer missing a citation.
+- **Source-role mix** — stacked area per domain; an ADR/steward-note marker overlay.
+- **Stale sources** — table sorted by days-overdue, with disposition state.
+- **Quarantine flow** — admitted → quarantined → cleared, with cause distribution.
+
+## 4. Inputs — receipts and records read
+
+CONFIRMED receipt types (Atlas v1.1 §24.2); mounted-repo paths NEEDS VERIFICATION.
+
+- `ValidationReport` — quarantine causes, schema-validation outcomes.
+- `AIReceipt` — citation presence/resolution for Focus Mode answers.
+- EvidenceBundle index — resolution checks for `EvidenceRef`s.
+- Source descriptors + freshness cadence metadata (`connectors/`, `data/registry/`).
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/governance/EVIDENCE_INTEGRITY.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | `apps/review-console/` evidence-integrity panel. | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning stewards (PROPOSED):** Release steward (indicators 1–2), Source steward
+  (indicators 3–5).
+- **Review burden:** docs steward + the owning stewards above. Resolve placeholder roles
+  against Atlas v1.1 §24.7 before review.
+
+## 7. Acceptance
+
+A change to this spec is "correct enough to publish" when:
+
+- [ ] All five §24.11.1 indicators are present and match [`INDICATOR_CATALOG.md`](../INDICATOR_CATALOG.md).
+- [ ] Every receipt type in §4 exists in the Atlas v1.1 §24.2 receipt catalog.
+- [ ] Owners are named (no anonymous spec at v1).
+- [ ] Link check passes; the spec has a row in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+- [ ] Negative states use the Unified Doctrine §19 vocabulary.
+
+## 8. Open questions
+
+- [ ] **EI-OQ-01** — Confirm the running surface (`apps/review-console/`) and downgrade
+  to `NEEDS VERIFICATION` if unconfirmed.
+- [ ] **EI-OQ-02** — Define the precise "trailing release window" length for indicator 1.
+- [ ] **EI-OQ-03** — Decide whether `SOURCE_ROLE_DRIFT` is an existing negative state or
+  a proposed addition to the Unified Doctrine §19 vocabulary.
+
+---
+
+**Related docs:** [README.md](../README.md) · [INDICATOR_CATALOG.md](../INDICATOR_CATALOG.md) ·
+[DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) · [standards/EVIDENCE_BUNDLE.md](../../standards/EVIDENCE_BUNDLE.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<release-steward>`, `<source-steward>` (PROPOSED)

--- a/docs/dashboards/governance/RELEASE_CORRECTION_ROLLBACK.md
+++ b/docs/dashboards/governance/RELEASE_CORRECTION_ROLLBACK.md
@@ -1,0 +1,117 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: Release / Correction / Rollback Dashboard — specification
+type: standard
+version: v0.1
+status: draft
+owners: <release-steward>, <correction-reviewer>  # PROPOSED placeholders; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/INDICATOR_CATALOG.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/atlases/Kansas_Frontier_Matrix_-_Domains_v1_1.md   # §24.11.2
+  - docs/standards/RELEASE_MANIFEST.md
+  - docs/runbooks/ROLLBACK_RUNBOOK.md
+  - docs/runbooks/EVIDENCE_CORRECTION.md
+tags: [kfm, dashboards, governance, release, correction, rollback, indicators]
+notes:
+  - "Source of indicators: Atlas v1.1 §24.11.2 (CONFIRMED doctrine)."
+  - "This is a SPEC for a dashboard, not the running dashboard. Indicators are reported, not enforced."
+  - "Mounted-repo state UNKNOWN; running-surface and receipt-path claims are PROPOSED / NEEDS VERIFICATION."
+[/KFM_META_BLOCK_V2] -->
+
+# Release / Correction / Rollback Dashboard · `governance/RELEASE_CORRECTION_ROLLBACK.md`
+
+> Dashboard specification for the **Release, correction, rollback** governance-health
+> category (Atlas v1.1 §24.11.2). Tracks whether every PUBLISHED release can be safely
+> withdrawn and whether corrections propagate to their derivatives.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-governance-blue)
+![Source](https://img.shields.io/badge/source-Atlas%20%C2%A724.11.2-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<release-steward>`, `<correction-reviewer>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> This dashboard **reports** release-safety posture. A green panel is not a release
+> decision — the `ReleaseManifest` and the release steward's `ReviewRecord` are.
+
+---
+
+## 1. Description
+
+The Release / Correction / Rollback dashboard answers: **if a PUBLISHED release turns out
+to be wrong, can we withdraw it cleanly, and do corrections reach everything downstream?**
+It surfaces the five Atlas v1.1 §24.11.2 indicators so the release and correction
+reviewers see rollback readiness and correction propagation at a glance.
+
+## 2. Indicators surfaced
+
+| # | Indicator | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | Release with rollback target | % of PUBLISHED releases that name a valid rollback target. | 100%. | `RELEASE_NO_ROLLBACK` |
+| 2 | Correction lead time | Median time from defect detection to `CorrectionNotice`. | Visibly tracked; trend not regressing. | `CORRECTION_LAGGING` |
+| 3 | Derivative-invalidation coverage | % of corrections that name and invalidate downstream derivatives. | Approaches 100% as coverage matures. | `DERIVATIVE_NOT_INVALIDATED` |
+| 4 | Rollback rehearsal rate | Number of rehearsed rollbacks per release window. | Non-zero; periodic, scheduled. | `ROLLBACK_UNREHEARSED` |
+| 5 | Supersession lineage gap | Number of supersessions without a forward link. | Zero. | `SUPERSESSION_GAP` |
+
+## 3. Panels (PROPOSED)
+
+- **Rollback coverage** — single-stat, % of PUBLISHED releases with a valid target.
+- **Correction lead time** — median + p90 trend line, per defect class.
+- **Derivative invalidation** — Sankey from `CorrectionNotice` to invalidated derivatives.
+- **Rehearsal calendar** — heatmap of rehearsed rollbacks per release window.
+- **Lineage gaps** — table of supersessions missing a forward link (target: empty).
+
+## 4. Inputs — receipts and records read
+
+CONFIRMED receipt types (Atlas v1.1 §24.2); mounted-repo paths NEEDS VERIFICATION.
+
+- `ReleaseManifest` — release identity, rollback target, supersession entries.
+- `RollbackCard` — rehearsal records and rollback-target validity.
+- `CorrectionNotice` — defect-detection timestamps, derivative invalidation lists.
+- Lineage graph — derivative relationships for invalidation coverage.
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/governance/RELEASE_CORRECTION_ROLLBACK.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | `apps/review-console/` release-health panel. | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning stewards (PROPOSED):** Release steward (indicators 1, 4), Correction reviewer
+  (indicators 2–3), Docs steward (indicator 5).
+- **Review burden:** docs steward + the owning stewards. Resolve placeholders against
+  Atlas v1.1 §24.7 before review.
+
+## 7. Acceptance
+
+- [ ] All five §24.11.2 indicators present and matching [`INDICATOR_CATALOG.md`](../INDICATOR_CATALOG.md).
+- [ ] Every receipt type in §4 exists in the Atlas v1.1 §24.2 receipt catalog.
+- [ ] Owners named (no anonymous spec at v1).
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+- [ ] Cross-links to `docs/runbooks/ROLLBACK_RUNBOOK.md` and `EVIDENCE_CORRECTION.md` resolve.
+
+## 8. Open questions
+
+- [ ] **RCR-OQ-01** — Confirm the running surface and downgrade if unverified.
+- [ ] **RCR-OQ-02** — Define the "release window" unit (per tag? per calendar quarter?).
+- [ ] **RCR-OQ-03** — Confirm negative-state names against Unified Doctrine §19; several
+  here (`RELEASE_NO_ROLLBACK`, `SUPERSESSION_GAP`) may be proposed additions.
+
+---
+
+**Related docs:** [README.md](../README.md) · [INDICATOR_CATALOG.md](../INDICATOR_CATALOG.md) ·
+[DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) ·
+[runbooks/ROLLBACK_RUNBOOK.md](../../runbooks/ROLLBACK_RUNBOOK.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<release-steward>`, `<correction-reviewer>` (PROPOSED)

--- a/docs/dashboards/governance/SENSITIVITY_RIGHTS.md
+++ b/docs/dashboards/governance/SENSITIVITY_RIGHTS.md
@@ -1,0 +1,131 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: Sensitivity / Rights Dashboard — specification
+type: standard
+version: v0.1
+status: draft
+owners: <sensitivity-reviewer>, <rights-holder-representative>  # PROPOSED placeholders; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/INDICATOR_CATALOG.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/atlases/Kansas_Frontier_Matrix_-_Domains_v1_1.md   # §24.11.3
+  - docs/standards/SENSITIVITY_RUBRIC.md
+  - docs/standards/REDACTION_PROFILES.md
+  - docs/runbooks/SENSITIVITY_ESCALATION.md
+tags: [kfm, dashboards, governance, sensitivity, rights, redaction, indicators]
+notes:
+  - "Source of indicators: Atlas v1.1 §24.11.3 (CONFIRMED doctrine)."
+  - "This is a SPEC for a dashboard, not the running dashboard. Indicators are reported, not enforced."
+  - "This dashboard itself must not leak sensitive content; see §9 (anti-leakage)."
+  - "Mounted-repo state UNKNOWN; running-surface and receipt-path claims are PROPOSED / NEEDS VERIFICATION."
+[/KFM_META_BLOCK_V2] -->
+
+# Sensitivity / Rights Dashboard · `governance/SENSITIVITY_RIGHTS.md`
+
+> Dashboard specification for the **Sensitivity and rights** governance-health category
+> (Atlas v1.1 §24.11.3). Tracks whether sensitive lanes fail closed and whether
+> rights-holders' constraints are honored end to end.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-governance-blue)
+![Source](https://img.shields.io/badge/source-Atlas%20%C2%A724.11.3-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<sensitivity-reviewer>`, `<rights-holder-representative>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!WARNING]
+> This dashboard reports on sensitive lanes. It **must surface aggregate posture only** —
+> never the sensitive content itself. The dashboard reads `PolicyDecision` and
+> `RedactionReceipt` *outcomes*, not the protected payloads. See §9.
+
+---
+
+## 1. Description
+
+The Sensitivity / Rights dashboard answers: **does every unauthorized sensitive request
+get denied at the first gate, and do public-safe transformations always leave a
+`RedactionReceipt`?** It surfaces the five Atlas v1.1 §24.11.3 indicators so the
+sensitivity reviewer and rights-holder representative can see fail-closed behavior and
+rights-change responsiveness.
+
+## 2. Indicators surfaced
+
+| # | Indicator | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | Sensitive-lane fail-closed rate | % of unauthorized sensitive-lane requests that DENY at the first gate. | 100% at the first gate. | `DENIED_BY_POLICY` (expected); a non-first-gate deny is the defect |
+| 2 | RedactionReceipt coverage | % of public-safe transformations that emit a `RedactionReceipt`. | 100% for sensitive lanes. | `MISSING_REDACTION_RECEIPT` |
+| 3 | Review-aged-out incidence | Number of sensitive-lane claims past their review cadence. | Visibly tracked; trend not regressing. | `REVIEW_AGED_OUT` |
+| 4 | Rights-change response time | Median time from rights-change detection to tier reassignment. | Within stated tolerance per source family. | `RIGHTS_CHANGE_LAGGING` |
+| 5 | Sensitive-content side-channel audit | Frequency of automated checks for label / popup / AI-text leaks. | Periodic; documented. | `SIDE_CHANNEL_AUDIT_OVERDUE` |
+
+## 3. Panels (PROPOSED)
+
+- **Fail-closed rate** — single-stat at 100%; any deviation drills to the gate that failed.
+- **Redaction coverage** — % of public-safe transforms with a receipt, per sensitive lane.
+- **Review aging** — histogram of sensitive-lane claims by days-past-cadence.
+- **Rights-change responsiveness** — median + p90 reassignment time per source family.
+- **Side-channel audit cadence** — last-run timestamp + pass/fail per leak check.
+
+## 4. Inputs — receipts and records read
+
+CONFIRMED receipt types (Atlas v1.1 §24.2); mounted-repo paths NEEDS VERIFICATION.
+
+- `PolicyDecision` — gate-level DENY outcomes for sensitive-lane requests.
+- `RedactionReceipt` — coverage of public-safe transformations.
+- `ReviewRecord` — review cadence and aging for sensitive-lane claims.
+- `RepresentationReceipt` + audit logs — side-channel leak-check results.
+- Source descriptors — rights-change detection and tolerance per source family.
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/governance/SENSITIVITY_RIGHTS.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | `apps/review-console/` sensitivity panel (restricted view). | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning stewards (PROPOSED):** Sensitivity reviewer (indicators 1–3, 5),
+  Rights-holder representative (indicator 4).
+- **Review burden:** docs steward + sensitivity reviewer + rights-holder representative.
+  Resolve placeholders against Atlas v1.1 §24.7 before review.
+
+## 7. Acceptance
+
+- [ ] All five §24.11.3 indicators present and matching [`INDICATOR_CATALOG.md`](../INDICATOR_CATALOG.md).
+- [ ] Every receipt type in §4 exists in the Atlas v1.1 §24.2 receipt catalog.
+- [ ] Owners named (no anonymous spec at v1).
+- [ ] §9 anti-leakage constraints are satisfied — no sensitive payload field appears in
+      any panel definition.
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+
+## 8. Open questions
+
+- [ ] **SR-OQ-01** — Confirm the running surface and its access-control posture
+      (this panel itself is a restricted view).
+- [ ] **SR-OQ-02** — Define per-source-family rights-change tolerance values.
+- [ ] **SR-OQ-03** — Confirm negative-state names against Unified Doctrine §19.
+
+## 9. Anti-leakage constraints (CONFIRMED doctrine)
+
+- The dashboard reads **outcomes** (`DENY`, receipt-present/absent, age, timestamps),
+  never the protected payloads behind a sensitive lane.
+- Panel definitions MUST NOT include free-text fields sourced from sensitive records.
+- Access to the running surface is itself a sensitive lane — fail closed for
+  unauthorized viewers, exactly like the requests it measures.
+
+---
+
+**Related docs:** [README.md](../README.md) · [INDICATOR_CATALOG.md](../INDICATOR_CATALOG.md) ·
+[DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) ·
+[standards/SENSITIVITY_RUBRIC.md](../../standards/SENSITIVITY_RUBRIC.md) ·
+[runbooks/SENSITIVITY_ESCALATION.md](../../runbooks/SENSITIVITY_ESCALATION.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<sensitivity-reviewer>`, `<rights-holder-representative>` (PROPOSED)

--- a/docs/dashboards/observability/OPENTELEMETRY_STACK.md
+++ b/docs/dashboards/observability/OPENTELEMETRY_STACK.md
@@ -1,0 +1,148 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: OpenTelemetry Observability Stack — dashboard specification
+type: standard
+version: v0.1
+status: draft
+owners: <observability-steward>  # PROPOSED placeholder; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/dashboards/operational/SLO_LIVE_FEEDS.md
+  - docs/standards/TELEMETRY_MINIMUMS.md
+  - docs/standards/OPENLINEAGE_FACETS.md
+tags: [kfm, dashboards, observability, opentelemetry, tempo, mimir, loki, ci]
+notes:
+  - "Source card: KFM-P8-PROG-0026 (OpenTelemetry CI observability stack) — UNCHANGED, active."
+  - "Card self-check: UNKNOWN — repository implementation status remains unverified."
+  - "This is a SPEC for the observability surface, not the running stack."
+[/KFM_META_BLOCK_V2] -->
+
+# OpenTelemetry Observability Stack · `observability/OPENTELEMETRY_STACK.md`
+
+> Dashboard specification for KFM's **CI / pipeline observability stack** (Atlas card
+> `KFM-P8-PROG-0026`): OpenTelemetry Collector → **Tempo** (traces) + **Mimir** (metrics)
+> + **Loki** (logs), with one agent shape across all runners.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-observability-9cf)
+![Source](https://img.shields.io/badge/source-KFM--P8--PROG--0026-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<observability-steward>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> Telemetry is a **carrier**, not truth (`docs/standards/TELEMETRY_MINIMUMS.md`). Traces,
+> metrics, and logs help operate KFM; they do not establish trust in data. Release
+> evidence still comes from receipts and `EvidenceBundle`s, not from this stack.
+
+---
+
+## 1. Description
+
+This spec describes the observability stack that the other dashboards in
+`docs/dashboards/` read from. It standardizes CI and pipeline observability on a single
+agent shape — the **OpenTelemetry Collector** — fanning out to three backends:
+
+- **Tempo** — distributed traces (pipeline runs, connector fetches, validation passes).
+- **Mimir** — long-retention metrics (SLOs, freshness, validation rates).
+- **Loki** — structured logs.
+
+"One agent shape across runners" means every CI runner and pipeline worker emits OTLP to
+the same collector configuration, so dashboards do not need per-runner special cases.
+
+## 2. Stack components
+
+| Component | Role | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|
+| OpenTelemetry Collector | Single OTLP ingest + fan-out agent across all runners. | Reachable; no dropped spans/metrics. | `OTEL_COLLECTOR_DOWN` |
+| Tempo | Trace backend. | Traces queryable within retention. | `TRACE_BACKEND_UNAVAILABLE` |
+| Mimir | Metrics backend. | Metrics queryable within retention. | `METRICS_BACKEND_UNAVAILABLE` |
+| Loki | Log backend. | Logs queryable within retention. | `LOG_BACKEND_UNAVAILABLE` |
+
+## 3. Stack health panels (PROPOSED)
+
+- **Collector health** — ingest rate, dropped spans/metrics/logs, queue depth.
+- **Backend availability** — Tempo / Mimir / Loki up + query latency.
+- **Runner coverage** — % of CI runners and pipeline workers emitting OTLP.
+- **Retention** — oldest queryable trace / metric / log per backend.
+- **Telemetry minimums** — conformance to `docs/standards/TELEMETRY_MINIMUMS.md`.
+
+## 4. Architecture (PROPOSED)
+
+```mermaid
+flowchart LR
+  subgraph RUNNERS["CI runners + pipeline workers"]
+    R1[runner / worker A]
+    R2[runner / worker B]
+    R3[runner / worker C]
+  end
+  OTEL["OpenTelemetry Collector<br/>(one agent shape)"]
+  TEMPO[("Tempo · traces")]
+  MIMIR[("Mimir · metrics")]
+  LOKI[("Loki · logs")]
+  DASH["docs/dashboards/ specs<br/>read derived metrics"]
+
+  R1 -- OTLP --> OTEL
+  R2 -- OTLP --> OTEL
+  R3 -- OTLP --> OTEL
+  OTEL -- traces --> TEMPO
+  OTEL -- metrics --> MIMIR
+  OTEL -- logs --> LOKI
+  MIMIR -. feeds .-> DASH
+  TEMPO -. feeds .-> DASH
+  LOKI -. feeds .-> DASH
+```
+
+## 5. Inputs
+
+Mounted-repo / infra state NEEDS VERIFICATION.
+
+- OTLP exports from CI runners and pipeline workers (`infra/`, `connectors/`, `pipelines/`).
+- Collector configuration — the single shared agent shape.
+- `docs/standards/TELEMETRY_MINIMUMS.md` — the conformance baseline.
+
+## 6. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/observability/OPENTELEMETRY_STACK.md` | This stack specification. | PROPOSED — pending JCS+SHA-256 |
+| Running stack (PROPOSED) | Tempo · Mimir · Loki deployment, collector config. | NEEDS VERIFICATION |
+
+## 7. Ownership and review burden
+
+- **Owning steward (PROPOSED):** Observability steward.
+- **Review burden:** docs steward + observability steward + release steward (telemetry
+  gates release per `TELEMETRY_MINIMUMS.md`). Resolve the placeholder against
+  Atlas v1.1 §24.7 before review.
+
+## 8. Acceptance
+
+- [ ] All four stack components described with healthy posture + negative state.
+- [ ] One agent shape (single collector config) is documented across runners.
+- [ ] Owner named (no anonymous spec at v1).
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+- [ ] Cross-link to `docs/standards/TELEMETRY_MINIMUMS.md` resolves.
+
+## 9. Open questions
+
+- [ ] **OTEL-OQ-01** — Confirm the deployment home (`infra/`) and downgrade if unverified.
+- [ ] **OTEL-OQ-02** — Confirm retention windows per backend (Tempo / Mimir / Loki).
+- [ ] **OTEL-OQ-03** — Confirm whether dashboards query backends directly or via a
+      Grafana-equivalent surface.
+- [ ] **OTEL-OQ-04** — Confirm `KFM-P8-PROG-0026` implementation status against
+      mounted-repo state (card self-check: UNKNOWN).
+
+---
+
+**Related docs:** [README.md](../README.md) · [DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) ·
+[operational/SLO_LIVE_FEEDS.md](../operational/SLO_LIVE_FEEDS.md) ·
+[standards/TELEMETRY_MINIMUMS.md](../../standards/TELEMETRY_MINIMUMS.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<observability-steward>` (PROPOSED)

--- a/docs/dashboards/operational/COG_ZARR_REPRODUCIBILITY.md
+++ b/docs/dashboards/operational/COG_ZARR_REPRODUCIBILITY.md
@@ -1,0 +1,112 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: COG / Zarr Reproducibility Dashboard — specification
+type: standard
+version: v0.1
+status: draft
+owners: <pipeline-steward>  # PROPOSED placeholder; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/standards/COG.md
+  - docs/standards/GEOPARQUET.md
+tags: [kfm, dashboards, operational, cog, zarr, raster, datacube, reproducibility]
+notes:
+  - "Source card: KFM-P31-FEAT-0016 (COG/Zarr Reproducibility Dashboard) — UNCHANGED, active."
+  - "Card self-check: UNKNOWN — repository implementation status remains unverified."
+  - "This is a SPEC for a dashboard, not the running dashboard."
+[/KFM_META_BLOCK_V2] -->
+
+# COG / Zarr Reproducibility Dashboard · `operational/COG_ZARR_REPRODUCIBILITY.md`
+
+> Dashboard specification for the **COG / Zarr Reproducibility Dashboard** (Atlas card
+> `KFM-P31-FEAT-0016`). Tracks whether raster and datacube artifacts can be rebuilt
+> bit-identically: build container, tool versions, chained hashes, layout, verdict.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-operational-blueviolet)
+![Source](https://img.shields.io/badge/source-KFM--P31--FEAT--0016-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<pipeline-steward>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> Reproducibility is a property of the *artifact build*, not of the dashboard. The
+> verdict shown here is derived from chained hashes and recorded build inputs — the
+> `RunReceipt` / build record is the proof.
+
+---
+
+## 1. Description
+
+The COG / Zarr Reproducibility dashboard answers: **can each raster (COG) or datacube
+(Zarr) artifact be rebuilt and produce a bit-identical result?** It surfaces the build
+environment and a reproducibility verdict per artifact so the pipeline steward can catch
+non-determinism (a GDAL upgrade, a numcodecs change, an unpinned container) before it
+silently changes published data.
+
+## 2. Metrics surfaced (PROPOSED)
+
+| # | Metric | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | Build container identity | Whether the artifact records the exact build container digest. | Pinned digest recorded. | `BUILD_ENV_UNPINNED` |
+| 2 | Tool versions | GDAL / numcodecs / driver versions used in the build. | Recorded and pinned. | `TOOL_VERSION_DRIFT` |
+| 3 | Chained hashes | Input → intermediate → output hash chain integrity. | Chain verifies end to end. | `HASH_CHAIN_BROKEN` |
+| 4 | Overview / block layout | Whether overviews and block/chunk layout match the standard. | Matches `COG.md` / Zarr profile. | `LAYOUT_NONCONFORMANT` |
+| 5 | Reproducibility verdict | Rebuild produces a bit-identical artifact. | `REPRODUCIBLE`. | `NOT_REPRODUCIBLE` |
+
+## 3. Panels (PROPOSED)
+
+- **Build environment** — per-artifact container digest + tool versions; drift flagged.
+- **Hash chain** — input/intermediate/output hash chain with a verify status.
+- **Layout conformance** — overview levels and block/chunk layout vs. the standard.
+- **Verdict board** — `REPRODUCIBLE` / `NOT_REPRODUCIBLE` per artifact, with cause.
+
+## 4. Inputs
+
+Mounted-repo paths NEEDS VERIFICATION.
+
+- `RunReceipt` / build records — container digest, tool versions, input hashes.
+- Artifact metadata — COG overview/block layout, Zarr chunk layout.
+- Chained-hash manifests — input → intermediate → output integrity.
+- Standards: [`COG.md`](../../standards/COG.md), Zarr/datacube profile.
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/operational/COG_ZARR_REPRODUCIBILITY.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | `apps/review-console/` reproducibility panel. | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning steward (PROPOSED):** Pipeline steward.
+- **Review burden:** docs steward + pipeline steward. Resolve the placeholder against
+  Atlas v1.1 §24.7 before review.
+
+## 7. Acceptance
+
+- [ ] All five metrics present; the verdict is derived from chained hashes, not asserted.
+- [ ] Owner named (no anonymous spec at v1).
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+- [ ] Negative states use the Unified Doctrine §19 vocabulary.
+
+## 8. Open questions
+
+- [ ] **CZR-OQ-01** — Confirm the running surface and downgrade if unverified.
+- [ ] **CZR-OQ-02** — Confirm the canonical Zarr/datacube layout profile to check against.
+- [ ] **CZR-OQ-03** — Confirm `KFM-P31-FEAT-0016` implementation status against
+      mounted-repo state (card self-check: UNKNOWN).
+
+---
+
+**Related docs:** [README.md](../README.md) · [DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) ·
+[standards/COG.md](../../standards/COG.md) · [standards/GEOPARQUET.md](../../standards/GEOPARQUET.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<pipeline-steward>` (PROPOSED)

--- a/docs/dashboards/operational/GEOSPATIAL_QC_PANEL.md
+++ b/docs/dashboards/operational/GEOSPATIAL_QC_PANEL.md
@@ -1,0 +1,114 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: Quick Geospatial QC Panel — specification
+type: standard
+version: v0.1
+status: draft
+owners: <pipeline-steward>, <domain-steward>  # PROPOSED placeholders; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/dashboards/operational/COG_ZARR_REPRODUCIBILITY.md
+  - docs/standards/GEOPARQUET.md
+tags: [kfm, dashboards, operational, geospatial, qc, geometry, crs, topology]
+notes:
+  - "Source card: KFM-P31-FEAT-0017 (Quick Geospatial QC Panel) — UNCHANGED, active."
+  - "Card self-check: UNKNOWN — repository implementation status remains unverified."
+  - "This is a SPEC for a dashboard, not the running dashboard."
+[/KFM_META_BLOCK_V2] -->
+
+# Quick Geospatial QC Panel · `operational/GEOSPATIAL_QC_PANEL.md`
+
+> Dashboard specification for the **Quick Geospatial QC Panel** (Atlas card
+> `KFM-P31-FEAT-0017`). A fast, inspectable surface for geometry, CRS, and topology
+> checks on geospatial outputs.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-operational-blueviolet)
+![Source](https://img.shields.io/badge/source-KFM--P31--FEAT--0017-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<pipeline-steward>`, `<domain-steward>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> This is a *quick* QC panel — a fast first look, not the authoritative validator. A
+> green QC panel does not admit data; the full `ValidationReport` does. The panel exists
+> to catch obvious geometry/CRS/topology defects early.
+
+---
+
+## 1. Description
+
+The Quick Geospatial QC Panel answers: **does this geospatial output look structurally
+sane at a glance?** It surfaces fast checks — geometry validity, CRS correctness,
+topology consistency, bounds plausibility — so a pipeline or domain steward can spot a
+broken layer in seconds instead of waiting for a full validation pass.
+
+## 2. Checks surfaced (PROPOSED)
+
+| # | Check | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | Geometry validity | % of features with valid (OGC-simple) geometry. | 100%. | `GEOMETRY_INVALID` |
+| 2 | CRS correctness | Declared CRS present and matches the expected projection. | Matches expected CRS. | `CRS_MISMATCH` |
+| 3 | Topology consistency | Self-intersections, gaps, overlaps where not permitted. | None where not permitted. | `TOPOLOGY_ERROR` |
+| 4 | Bounds plausibility | Geometry bounds fall within the expected extent (e.g., Kansas). | Within expected extent. | `BOUNDS_OUT_OF_RANGE` |
+| 5 | Attribute completeness | Required attribute fields populated. | Required fields non-null. | `ATTRIBUTE_MISSING` |
+
+## 3. Panels (PROPOSED)
+
+- **Geometry validity** — pass rate + count of invalid features, with drill-down.
+- **CRS** — declared vs. expected CRS, mismatches flagged.
+- **Topology** — self-intersection / gap / overlap counts.
+- **Bounds** — a small map thumbnail of the bounding box against the expected extent.
+- **Attributes** — required-field completeness per layer.
+
+## 4. Inputs
+
+Mounted-repo paths NEEDS VERIFICATION.
+
+- Geospatial outputs — vector/raster layers from the pipeline (`pipelines/`).
+- `ValidationReport` — geometry/CRS/topology check outcomes, where already computed.
+- Expected-extent metadata — per-domain bounding extents.
+- Layer schemas — required attribute fields.
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/operational/GEOSPATIAL_QC_PANEL.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | `apps/review-console/` QC panel. | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning stewards (PROPOSED):** Pipeline steward (check plumbing), Domain steward
+  (expected extent and attribute expectations for the layer's domain).
+- **Review burden:** docs steward + the owning stewards. Resolve placeholders against
+  Atlas v1.1 §24.7 before review.
+
+## 7. Acceptance
+
+- [ ] All five checks present; the panel is positioned as a *quick* look, not the validator.
+- [ ] Owners named (no anonymous spec at v1).
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+- [ ] Negative states use the Unified Doctrine §19 vocabulary.
+
+## 8. Open questions
+
+- [ ] **GQC-OQ-01** — Confirm the running surface and downgrade if unverified.
+- [ ] **GQC-OQ-02** — Confirm the per-domain expected-extent source.
+- [ ] **GQC-OQ-03** — Confirm `KFM-P31-FEAT-0017` implementation status against
+      mounted-repo state (card self-check: UNKNOWN).
+
+---
+
+**Related docs:** [README.md](../README.md) · [DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) ·
+[operational/COG_ZARR_REPRODUCIBILITY.md](COG_ZARR_REPRODUCIBILITY.md) ·
+[standards/GEOPARQUET.md](../../standards/GEOPARQUET.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<pipeline-steward>`, `<domain-steward>` (PROPOSED)

--- a/docs/dashboards/operational/REALTIME_FEED_FRESHNESS.md
+++ b/docs/dashboards/operational/REALTIME_FEED_FRESHNESS.md
@@ -1,0 +1,116 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: Realtime Feed Freshness Monitor — specification
+type: standard
+version: v0.1
+status: draft
+owners: <source-steward>  # PROPOSED placeholder; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/dashboards/operational/SLO_LIVE_FEEDS.md
+  - docs/dashboards/observability/OPENTELEMETRY_STACK.md
+  - docs/standards/SMART_SYNC.md
+tags: [kfm, dashboards, operational, realtime, freshness, promotion, partitions]
+notes:
+  - "Source card: KFM-P31-FEAT-0015 (Realtime Feed Freshness Monitor) — UNCHANGED, active."
+  - "Card self-check: UNKNOWN — repository implementation status remains unverified."
+  - "This is a SPEC for a dashboard, not the running dashboard."
+[/KFM_META_BLOCK_V2] -->
+
+# Realtime Feed Freshness Monitor · `operational/REALTIME_FEED_FRESHNESS.md`
+
+> Dashboard specification for the **Realtime Feed Freshness Monitor** (Atlas card
+> `KFM-P31-FEAT-0015`). Tracks schema validation, SLO freshness, canonical identity,
+> partition output, and promotion/hold state for realtime feeds.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-operational-blueviolet)
+![Source](https://img.shields.io/badge/source-KFM--P31--FEAT--0015-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<source-steward>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> "Fresh" means recently ingested and well-formed. It does not mean "promoted." This
+> dashboard shows promotion/hold state explicitly so freshness is never mistaken for
+> admission into a PUBLISHED surface.
+
+---
+
+## 1. Description
+
+The Realtime Feed Freshness Monitor answers: **for each realtime feed, is the latest data
+recent, schema-valid, correctly identified, correctly partitioned, and is it held or
+promoted?** It complements [`SLO_LIVE_FEEDS.md`](SLO_LIVE_FEEDS.md): SLO_LIVE_FEEDS
+tracks SLO targets against published standards; this monitor tracks per-feed pipeline
+state through to the promotion gate.
+
+## 2. Metrics surfaced (PROPOSED)
+
+| # | Metric | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | Schema validation | % of realtime messages passing schema validation. | ~100%. | `SCHEMA_INVALID` |
+| 2 | SLO freshness | Age of the latest message vs. the feed's freshness SLO. | Within SLO. | `SOURCE_STALE` |
+| 3 | Canonical identity | % of records resolving to a stable canonical identity. | 100%. | `IDENTITY_UNRESOLVED` |
+| 4 | Partition output | Whether each ingest writes the expected partition layout. | Expected partitions present and complete. | `PARTITION_INCOMPLETE` |
+| 5 | Promotion / hold state | Whether the feed's latest window is promoted or held. | Held only with a documented reason. | `REVIEW_PENDING` / `PROMOTION_HELD` |
+
+## 3. Panels (PROPOSED)
+
+- **Schema validation** — per-feed pass rate, failures linked to `ValidationReport`.
+- **Freshness** — per-feed age vs. SLO line.
+- **Canonical identity** — % resolved; unresolved records drill out.
+- **Partition map** — expected vs. observed partitions per ingest window.
+- **Promotion board** — per-feed promoted / held state with hold reason.
+
+## 4. Inputs
+
+Mounted-repo paths NEEDS VERIFICATION.
+
+- Connector run telemetry — fetch and ingest timestamps (`connectors/`).
+- `ValidationReport` — schema validation and identity-resolution outcomes.
+- Partition manifests — expected vs. observed partition layout.
+- Promotion gate records — promoted / held state and hold reasons.
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/operational/REALTIME_FEED_FRESHNESS.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | OpenTelemetry-backed surface / `apps/review-console/`. | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning steward (PROPOSED):** Source steward.
+- **Review burden:** docs steward + source steward. Resolve the placeholder against
+  Atlas v1.1 §24.7 before review.
+
+## 7. Acceptance
+
+- [ ] All five metrics present; promotion/hold state is explicit and distinct from freshness.
+- [ ] Owner named (no anonymous spec at v1).
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+- [ ] Negative states use the Unified Doctrine §19 vocabulary.
+
+## 8. Open questions
+
+- [ ] **RFF-OQ-01** — Confirm the running surface and downgrade if unverified.
+- [ ] **RFF-OQ-02** — Reconcile scope overlap with [`SLO_LIVE_FEEDS.md`](SLO_LIVE_FEEDS.md);
+      decide whether they merge into one operational feed surface.
+- [ ] **RFF-OQ-03** — Confirm `KFM-P31-FEAT-0015` implementation status against
+      mounted-repo state (card self-check: UNKNOWN).
+
+---
+
+**Related docs:** [README.md](../README.md) · [DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) ·
+[operational/SLO_LIVE_FEEDS.md](SLO_LIVE_FEEDS.md) ·
+[observability/OPENTELEMETRY_STACK.md](../observability/OPENTELEMETRY_STACK.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<source-steward>` (PROPOSED)

--- a/docs/dashboards/operational/SLO_LIVE_FEEDS.md
+++ b/docs/dashboards/operational/SLO_LIVE_FEEDS.md
@@ -1,0 +1,116 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<uuid-pending>
+title: Live-Feeds SLO Dashboard — specification
+type: standard
+version: v0.1
+status: draft
+owners: <source-steward>, <observability-steward>  # PROPOSED placeholders; resolve before review
+created: 2026-05-20
+updated: 2026-05-20
+policy_label: public
+related:
+  - docs/dashboards/README.md
+  - docs/dashboards/DASHBOARD_CATALOG.md
+  - docs/dashboards/observability/OPENTELEMETRY_STACK.md
+  - docs/standards/TELEMETRY_MINIMUMS.md
+  - docs/standards/connector-rate-limits.md
+tags: [kfm, dashboards, operational, slo, live-feeds, gtfs-rt, freshness]
+notes:
+  - "Source card: KFM-P11-FEAT-0002 (Standards-first SLO dashboard for live feeds) — EXPANDED, active."
+  - "Card self-check: UNKNOWN — repository implementation status remains unverified."
+  - "This is a SPEC for a dashboard, not the running dashboard."
+[/KFM_META_BLOCK_V2] -->
+
+# Live-Feeds SLO Dashboard · `operational/SLO_LIVE_FEEDS.md`
+
+> Dashboard specification for **standards-first SLOs on live, high-cadence feeds**
+> (Atlas card `KFM-P11-FEAT-0002`). Covers live transit and similar feeds: freshness,
+> schema validation, latency, deduplication, non-material suppression, and agency
+> license terms.
+
+![Authority](https://img.shields.io/badge/authority-PROPOSED-orange)
+![Status](https://img.shields.io/badge/status-draft-lightgrey)
+![Category](https://img.shields.io/badge/category-operational-blueviolet)
+![Source](https://img.shields.io/badge/source-KFM--P11--FEAT--0002-informational)
+![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
+
+**Status:** draft · **Owners:** `<source-steward>`, `<observability-steward>` (PROPOSED) · **Last reviewed:** 2026-05-20
+
+---
+
+> [!IMPORTANT]
+> SLOs are **operational targets**, not trust claims. A feed meeting its SLO is fresh and
+> well-formed — it is not thereby *admitted*. Admission still runs through the validator.
+
+---
+
+## 1. Description
+
+The Live-Feeds SLO dashboard answers: **are our high-cadence external feeds healthy
+against published, standards-first service-level objectives?** It is "standards-first"
+because each SLO is anchored to a published spec (e.g., GTFS-Realtime) and to the source
+agency's license terms — not to ad-hoc thresholds.
+
+## 2. Metrics surfaced (PROPOSED)
+
+| # | Metric | Measures | Healthy posture (PROPOSED) | Negative state |
+|---|---|---|---|---|
+| 1 | Feed freshness | Age of the most recent successfully-ingested message vs. the feed's cadence. | Within the feed's declared cadence. | `SOURCE_STALE` |
+| 2 | Schema validation rate | % of fetched messages passing schema validation. | ~100%; sustained failures are a defect. | `SCHEMA_INVALID` |
+| 3 | Fetch latency | Time from scheduled fetch to ingest completion. | Within the per-feed latency budget. | `LATENCY_BUDGET_EXCEEDED` |
+| 4 | Deduplication rate | % of messages dropped as duplicates. | Stable; spikes investigated. | `DEDUP_ANOMALY` |
+| 5 | Non-material suppression | Updates suppressed as non-material (no meaningful change). | Visibly tracked; high rates reviewed. | — (informational) |
+| 6 | License-terms compliance | Whether ingest respects the agency's license / attribution / rate terms. | 100% compliant. | `LICENSE_VIOLATION` |
+
+## 3. Panels (PROPOSED)
+
+- **Freshness** — per-feed age vs. cadence, with the SLO line.
+- **Schema validation** — pass-rate trend, failures linked to `ValidationReport`.
+- **Latency** — p50 / p95 fetch-to-ingest, against the per-feed budget.
+- **Dedup & suppression** — duplicate and non-material rates side by side.
+- **License compliance** — per-agency status with attribution / rate-limit checks.
+
+## 4. Inputs
+
+Mounted-repo paths NEEDS VERIFICATION.
+
+- Connector run telemetry — fetch timestamps, latencies, message counts (`connectors/`).
+- `ValidationReport` — schema-validation outcomes per message.
+- Source descriptors — feed cadence, latency budget, license terms.
+- OpenTelemetry stack metrics — see [`observability/OPENTELEMETRY_STACK.md`](../observability/OPENTELEMETRY_STACK.md).
+
+## 5. Files
+
+| Path | Role | spec_hash |
+|---|---|---|
+| `docs/dashboards/operational/SLO_LIVE_FEEDS.md` | This dashboard specification. | PROPOSED — pending JCS+SHA-256 |
+| Running surface (PROPOSED) | OpenTelemetry-backed surface / `apps/review-console/`. | NEEDS VERIFICATION |
+
+## 6. Ownership and review burden
+
+- **Owning stewards (PROPOSED):** Source steward (feed health), Observability steward
+  (telemetry plumbing).
+- **Review burden:** docs steward + the owning stewards. Resolve placeholders against
+  Atlas v1.1 §24.7 before review.
+
+## 7. Acceptance
+
+- [ ] Every SLO is anchored to a published standard and the source's license terms.
+- [ ] Owners named (no anonymous spec at v1).
+- [ ] Link check passes; row present in [`DASHBOARD_CATALOG.md`](../DASHBOARD_CATALOG.md).
+- [ ] Negative states use the Unified Doctrine §19 vocabulary.
+
+## 8. Open questions
+
+- [ ] **SLF-OQ-01** — Confirm the running surface (OTEL-backed vs. review-console).
+- [ ] **SLF-OQ-02** — Set per-feed cadence and latency budgets; source from descriptors.
+- [ ] **SLF-OQ-03** — Confirm `KFM-P11-FEAT-0002` implementation status against
+      mounted-repo state (card self-check: UNKNOWN).
+
+---
+
+**Related docs:** [README.md](../README.md) · [DASHBOARD_CATALOG.md](../DASHBOARD_CATALOG.md) ·
+[observability/OPENTELEMETRY_STACK.md](../observability/OPENTELEMETRY_STACK.md) ·
+[standards/TELEMETRY_MINIMUMS.md](../../standards/TELEMETRY_MINIMUMS.md)
+
+**Last updated:** 2026-05-20 · **Edition:** v0.1 (draft) · **Owners:** `<source-steward>`, `<observability-steward>` (PROPOSED)


### PR DESCRIPTION
## Goal

Establish the dashboard specification framework and governance health indicator catalog for KFM. This PR adds 11 dashboard specs across governance, operational, observability, and domain categories, plus the master indicator and dashboard catalogs that index them. These specs are PROPOSED designs that mirror Atlas v1.1 Ch. 24.11 doctrine and establish the structure for day-to-day dashboard authoring and governance posture reporting.

## Status labels

- [x] `PROPOSED` — design consistent with Atlas v1.1 Ch. 24.11 doctrine; not yet verified in running implementation.
- [x] `NEEDS VERIFICATION` — mounted-repo evidence and running-surface claims require confirmation.

## Evidence inspected

- `docs/atlases/Kansas_Frontier_Matrix_-_Domains_v1_1.md` (Atlas v1.1 Ch. 24.11 — authoritative source for all 23 indicators)
- `docs/doctrine/directory-rules.md` (placement and authority rules for `docs/dashboards/`)
- `docs/standards/` (referenced standards: EVIDENCE_BUNDLE, SENSITIVITY_RUBRIC, TELEMETRY_MINIMUMS, etc.)
- `docs/registers/` (DRIFT_REGISTER, VERIFICATION_BACKLOG references)

## Directory Rules basis

- **§6.1 (Domain roots):** `docs/dashboards/domain/air/` placed under atmosphere domain per Directory Rules §6.1; open question `PMC-OQ-04` flags whether segment should be `air/` or `atmosphere/`.
- **§2.4 (Structural moves):** `docs/dashboards/` is a new canonical root; no ADR required for initial creation, but future moves/renames will trigger ADR per §2.4.
- **§3 (Authority classes):** All specs carry `PROPOSED` authority; running implementations will move to `CONFIRMED` when mounted-repo evidence is available.

## Affected roots

- [x] `docs/`

## Affected object families

- [x] `EvidenceRef` / `EvidenceBundle` (Evidence Integrity dashboard)
- [x] `PolicyDecision` (Sensitivity / Rights dashboard)
- [x] `ValidationReport` (multiple governance dashboards)
- [x] `AIReceipt` (AI Surface Health dashboard)
- [x] `RedactionReceipt` (Sensitivity / Rights dashboard)
- [x] `ReleaseManifest` / `RollbackCard` (Release / Correction / Rollback dashboard)
- [x] `CorrectionNotice` (Release / Correction / Rollback dashboard)

## Affected lifecycle stages

- [x] None — pure doctrine/specification change (no data lifecycle impact)

## What changed

**New files added:**

1. **`docs/dashboards/README.md`** — Master README for the dashboards folder; explains the spec structure, authority model, and quickstart for authoring.

2. **`docs/dashboards/INDICATOR_CATALOG.md`** — Human-readable mirror of Atlas v1.1 Ch. 24.11 (Master Governance Health Indicators). Enumerates all 23 indicators across 5 categories with measurement, healthy posture, owning steward (PROPOSED), receipt sources, and dashboard spec links.

3. **`docs/dashboards/DASHBOARD_CATALOG.md`** — Single index of all dashboard specs under `docs/dashboards/`. Links each spec to its category, source Atlas card/section, owning steward (PROPOSED), and running location.

4. **Governance dashboards (5 specs):**
   - `docs/dashboards/governance/EVIDENCE_INTEGRITY.md` — Surfaces 5 indicators from Atlas §24.11.1 (EvidenceRef resolution, cite-or-abstain compliance, source-role drift, stale-source rate, quarantine throughput).
   - `docs/dashboards/governance/RELEASE_CORRECTION_ROLLBACK.md` — Surfaces 5 indicators from Atlas §24.11.2 (rollback-target coverage, correction lead time, derivative-invalidation coverage, rollback rehearsal rate, supersession lineage gaps).
   -

https://claude.ai/code/session_01PZh9zjo2rdZhfNev8mgDkA