### PR TITLE
Add README.md to each county focus mode folder

### DIFF
--- a/docs/focus-mode/counties/atchison_county/README.md
+++ b/docs/focus-mode/counties/atchison_county/README.md
@@ -1,0 +1,21 @@
+# Atchison County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Atchison County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`atchison_county_focus_mode_build_plan.md`](./atchison_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Atchison County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/barton_county/README.md
+++ b/docs/focus-mode/counties/barton_county/README.md
@@ -1,0 +1,21 @@
+# Barton County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Barton County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`barton_county_focus_mode_build_plan.md`](./barton_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Barton County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/bourbon_county/README.md
+++ b/docs/focus-mode/counties/bourbon_county/README.md
@@ -1,0 +1,21 @@
+# Bourbon County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Bourbon County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`bourbon_county_focus_mode_build_plan.md`](./bourbon_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Bourbon County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/brown_county/README.md
+++ b/docs/focus-mode/counties/brown_county/README.md
@@ -1,0 +1,21 @@
+# Brown County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Brown County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`brown_county_focus_mode_build_plan.md`](./brown_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Brown County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/chase_county/README.md
+++ b/docs/focus-mode/counties/chase_county/README.md
@@ -1,0 +1,21 @@
+# Chase County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Chase County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`chase_county_focus_mode_build_plan.md`](./chase_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Chase County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/cherokee_county/README.md
+++ b/docs/focus-mode/counties/cherokee_county/README.md
@@ -1,0 +1,21 @@
+# Cherokee County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Cherokee County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`cherokee_county_focus_mode_build_plan.md`](./cherokee_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Cherokee County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/cloud_county/README.md
+++ b/docs/focus-mode/counties/cloud_county/README.md
@@ -1,0 +1,21 @@
+# Cloud County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Cloud County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`cloud_county_focus_mode_build_plan.md`](./cloud_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Cloud County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/coffey_county/README.md
+++ b/docs/focus-mode/counties/coffey_county/README.md
@@ -1,0 +1,21 @@
+# Coffey County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Coffey County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`coffey_county_focus_mode_build_plan.md`](./coffey_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Coffey County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/cowley_county/README.md
+++ b/docs/focus-mode/counties/cowley_county/README.md
@@ -1,0 +1,21 @@
+# Cowley County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Cowley County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`cowley_county_focus_mode_build_plan.md`](./cowley_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Cowley County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/crawford_county/README.md
+++ b/docs/focus-mode/counties/crawford_county/README.md
@@ -1,0 +1,21 @@
+# Crawford County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Crawford County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`crawford_county_focus_mode_build_plan.md`](./crawford_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Crawford County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/dickinson_county/README.md
+++ b/docs/focus-mode/counties/dickinson_county/README.md
@@ -1,0 +1,21 @@
+# Dickinson County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Dickinson County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`dickinson_county_focus_mode_build_plan.md`](./dickinson_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Dickinson County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/douglas_county/README.md
+++ b/docs/focus-mode/counties/douglas_county/README.md
@@ -1,0 +1,21 @@
+# Douglas County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Douglas County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`douglas_county_focus_mode_build_plan.md`](./douglas_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Douglas County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/ellsworth_county/README.md
+++ b/docs/focus-mode/counties/ellsworth_county/README.md
@@ -1,0 +1,21 @@
+# Ellsworth County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Ellsworth County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`ellsworth_county_focus_mode_build_plan.md`](./ellsworth_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Ellsworth County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/finney_county/README.md
+++ b/docs/focus-mode/counties/finney_county/README.md
@@ -1,0 +1,21 @@
+# Finney County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Finney County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`finney_county_focus_mode_build_plan.md`](./finney_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Finney County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/ford_county/README.md
+++ b/docs/focus-mode/counties/ford_county/README.md
@@ -1,0 +1,21 @@
+# Ford County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Ford County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`ford_county_focus_mode_build_plan.md`](./ford_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Ford County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/geary_county/README.md
+++ b/docs/focus-mode/counties/geary_county/README.md
@@ -1,0 +1,21 @@
+# Geary County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Geary County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`geary_county_focus_mode_build_plan.md`](./geary_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Geary County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/harvey_county/README.md
+++ b/docs/focus-mode/counties/harvey_county/README.md
@@ -1,0 +1,21 @@
+# Harvey County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Harvey County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`harvey_county_focus_mode_build_plan.md`](./harvey_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Harvey County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/jackson_county/README.md
+++ b/docs/focus-mode/counties/jackson_county/README.md
@@ -1,0 +1,21 @@
+# Jackson County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Jackson County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`jackson_county_focus_mode_build_plan.md`](./jackson_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Jackson County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/johnson_county/README.md
+++ b/docs/focus-mode/counties/johnson_county/README.md
@@ -1,0 +1,21 @@
+# Johnson County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Johnson County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`johnson_county_focus_mode_build_plan.md`](./johnson_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Johnson County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/leavenworth_county/README.md
+++ b/docs/focus-mode/counties/leavenworth_county/README.md
@@ -1,0 +1,21 @@
+# Leavenworth County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Leavenworth County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`leavenworth_county_focus_mode_build_plan.md`](./leavenworth_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Leavenworth County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/linn_county/README.md
+++ b/docs/focus-mode/counties/linn_county/README.md
@@ -1,0 +1,21 @@
+# Linn County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Linn County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`linn_county_focus_mode_build_plan.md`](./linn_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Linn County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/lyon_county/README.md
+++ b/docs/focus-mode/counties/lyon_county/README.md
@@ -1,0 +1,21 @@
+# Lyon County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Lyon County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`lyon_county_focus_mode_build_plan.md`](./lyon_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Lyon County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/mcpherson_county/README.md
+++ b/docs/focus-mode/counties/mcpherson_county/README.md
@@ -1,0 +1,21 @@
+# McPherson County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for McPherson County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`mcpherson_county_focus_mode_build_plan.md`](./mcpherson_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for McPherson County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/miami_county/README.md
+++ b/docs/focus-mode/counties/miami_county/README.md
@@ -1,0 +1,21 @@
+# Miami County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Miami County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`miami_county_focus_mode_build_plan.md`](./miami_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Miami County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/morris_county/README.md
+++ b/docs/focus-mode/counties/morris_county/README.md
@@ -1,0 +1,21 @@
+# Morris County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Morris County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`morris_county_focus_mode_build_plan.md`](./morris_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Morris County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/osage_county/README.md
+++ b/docs/focus-mode/counties/osage_county/README.md
@@ -1,0 +1,21 @@
+# Osage County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Osage County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`osage_county_focus_mode_build_plan.md`](./osage_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Osage County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/pottawatomie_county/README.md
+++ b/docs/focus-mode/counties/pottawatomie_county/README.md
@@ -1,0 +1,21 @@
+# Pottawatomie County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Pottawatomie County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`pottawatomie_county_focus_mode_build_plan.md`](./pottawatomie_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Pottawatomie County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/reno_county/README.md
+++ b/docs/focus-mode/counties/reno_county/README.md
@@ -1,0 +1,21 @@
+# Reno County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Reno County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`reno_county_focus_mode_build_plan.md`](./reno_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Reno County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/rice_county/README.md
+++ b/docs/focus-mode/counties/rice_county/README.md
@@ -1,0 +1,21 @@
+# Rice County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Rice County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`rice_county_focus_mode_build_plan.md`](./rice_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Rice County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/riley_county/README.md
+++ b/docs/focus-mode/counties/riley_county/README.md
@@ -1,0 +1,21 @@
+# Riley County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Riley County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`riley_county_focus_mode_build_plan.md`](./riley_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Riley County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/saline_county/README.md
+++ b/docs/focus-mode/counties/saline_county/README.md
@@ -1,0 +1,21 @@
+# Saline County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Saline County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`saline_county_focus_mode_build_plan.md`](./saline_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Saline County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/sedgwick_county/README.md
+++ b/docs/focus-mode/counties/sedgwick_county/README.md
@@ -1,0 +1,21 @@
+# Sedgwick County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Sedgwick County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`sedgwick_county_focus_mode_build_plan.md`](./sedgwick_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Sedgwick County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/shawnee_county/README.md
+++ b/docs/focus-mode/counties/shawnee_county/README.md
@@ -1,0 +1,21 @@
+# Shawnee County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Shawnee County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`shawnee_county_focus_mode_build_plan.md`](./shawnee_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Shawnee County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/stafford_county/README.md
+++ b/docs/focus-mode/counties/stafford_county/README.md
@@ -1,0 +1,21 @@
+# Stafford County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Stafford County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`stafford_county_focus_mode_build_plan.md`](./stafford_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Stafford County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview

--- a/docs/focus-mode/counties/wyandotte_county/README.md
+++ b/docs/focus-mode/counties/wyandotte_county/README.md
@@ -1,0 +1,21 @@
+# Wyandotte County — Focus Mode Build Plan
+
+This folder holds the **Focus Mode build plan** for Wyandotte County, Kansas — one
+county proof-slice in the Kansas Frontier Matrix county Focus Mode series.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [`wyandotte_county_focus_mode_build_plan.md`](./wyandotte_county_focus_mode_build_plan.md) | Full PROPOSED proof-slice build plan for Wyandotte County. |
+
+## About this plan
+
+The build plan is a **PROPOSED** county proof-slice. It follows the Kansas
+Frontier Matrix truth posture — cite-or-abstain, fail-closed, evidence-first,
+map-first, time-aware, auditable, and reversible. Repository paths referenced in
+the plan are PROPOSED and require verification before they land.
+
+## Related
+
+- [`../README.md`](../README.md) — Kansas Frontier Matrix counties Focus Mode overview


### PR DESCRIPTION
## Summary

- Adds a `README.md` to each of the 35 county folders under `docs/focus-mode/counties/`.
- Each README names the county, links to that folder's focus mode build plan in a Contents table, summarizes the plan's PROPOSED status and KFM truth posture, and links back to the parent counties README.

## Notes

- `republick_county/` was skipped — it was added to `main` separately and already has its own `README.md`.

## Test plan

- [ ] Confirm all 35 county folders contain a `README.md`
- [ ] Verify each README's relative links resolve (build plan link and `../README.md`)

https://claude.ai/code/session_01UP5wJUQnFzzSv7kSi6jf3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01UP5wJUQnFzzSv7kSi6jf3B)_