### PR TITLE
Refresh county index & add state-scale focus mode templates (ADR-0028)

### DIFF
--- a/docs/focus-mode/counties/COUNTY_INDEX.md
+++ b/docs/focus-mode/counties/COUNTY_INDEX.md
@@ -1,28 +1,52 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-modes-county-index
+title: County Focus Mode Master Index (Kansas, 105 counties)
+type: standard
+version: v0.2
+status: draft
+owners:
+  - <OWNER:focus-mode-steward>
+created: 2026-05-22
+updated: 2026-05-24
+policy_label: public
+authority: index parsed by tools/validators/validate_focus_mode_index.py
+related:
+  - docs/focus-mode/README.md
+  - _template/county-build-plan.md
+  - STATE_INDEX.md
+  - docs/doctrine/directory-rules.md
+  - tools/validators/validate_focus_mode_index.py
+tags: [kfm, focus-mode, county-scale, index, governed-ai]
+notes:
+  - Refresh of the existing docs/focus-mode/counties/COUNTY_INDEX.md.
+  - The 105 county figure is CONFIRMED. Per-row status is PROPOSED until the validator runs against the live repo.
+[/KFM_META_BLOCK_V2] -->
+
 <a id="top"></a>
+
 # County Focus Mode Master Index
 
-<!-- KFM Meta Block v2 -->
-> **Status:** PROPOSED (first emission) · **Lane:** `docs/focus-modes/` · **Authority:** human + machine navigable index; the validator at `tools/validators/validate_focus_mode_index.py` parses the table below · **Owners:** `<OWNER:focus-mode-steward>` · **Last reviewed:** 2026-05-22
+> **Status:** draft (refresh) · **Lane:** `docs/focus-mode/counties/` · **Authority:** validator-parseable index for the `-county` scope · **Owners:** `<OWNER:focus-mode-steward>` · **Last reviewed:** 2026-05-24
 
 ![counties](https://img.shields.io/badge/counties-105%20total-blue)
-![draft](https://img.shields.io/badge/draft-34%20(corpus)-orange)
-![not--started](https://img.shields.io/badge/not--started-71-lightgrey)
+![status%3Adraft](https://img.shields.io/badge/draft-34%20(corpus)-orange)
+![status%3Anot--started](https://img.shields.io/badge/not--started-71-lightgrey)
 ![validator](https://img.shields.io/badge/validator-validate__focus__mode__index.py-blue)
 ![ci](https://img.shields.io/badge/CI-NEEDS%20VERIFICATION-lightgrey)
 
 > [!IMPORTANT]
-> **This index is the single source of truth for which counties are in flight and which are not.** Validator `tools/validators/validate_focus_mode_index.py` parses the table in §3 below. A county that does not appear in this table cannot be claimed; a county claimed twice fails validation; a row with `status: planned` or further without a matching lane fails validation.
+> **Single source of truth for which counties are in flight and which are not.** The validator parses §3 below. A county that does not appear in this table cannot be claimed; a county claimed twice fails validation; a row at `status: planned` or further without a matching lane fails validation.
 
 ---
 
 ## Contents
 
 - [1. Status enum](#1-status-enum)
-- [2. Aggregate counts (CONFIRMED)](#2-aggregate-counts-confirmed)
+- [2. Aggregate counts](#2-aggregate-counts)
 - [3. Master table (105 Kansas counties)](#3-master-table-105-kansas-counties)
 - [4. Notes on corpus evidence and discrepancies](#4-notes-on-corpus-evidence-and-discrepancies)
-- [5. Priority subset (the eleven from Directory Rules v1.2)](#5-priority-subset-the-eleven-from-directory-rules-v12)
-- [6. Machine-readable companion](#6-machine-readable-companion)
+- [5. Priority subset (P1 — Directory Rules v1.2)](#5-priority-subset-p1--directory-rules-v12)
+- [6. Cross-references](#6-cross-references)
 
 ---
 
@@ -30,35 +54,33 @@
 
 | Status | Meaning |
 |---|---|
-| `not-started` | No build plan exists; no owner assigned. (CONFIRMED for 71 counties.) |
+| `not-started` | No build plan exists; no owner assigned. |
 | `planned` | Owner assigned + lane scaffold (`README.md` + `build-plan.md`) exists. |
-| `draft` | Full seven-file lane exists; not yet validator-clean. (CONFIRMED for 34 counties per corpus.) |
+| `draft` | Full seven-file lane exists; not yet validator-clean. |
 | `validated` | Lane passes `validate_focus_mode_index.py` and per-area validators. |
 | `payload-ready` | `FocusModePayload` instance exists at `data/published/api_payloads/focus-modes/<area>.json` and validates against schema. |
 | `released` | `PromotionDecision` envelope passes gates A–G; `MapReleaseManifest` + `rollback target` recorded. |
 | `rolled-back` | `RollbackCard` filed; cache invalidated; awaiting correction. |
 | `deprecated` | Superseded by a successor release. |
 
-Transitions are described in `docs/focus-modes/README.md` §4.
-
 [↑ Back to top](#top)
 
 ---
 
-## 2. Aggregate counts (CONFIRMED)
+## 2. Aggregate counts
 
 | Status | Count | Source |
 |---|---|---|
 | `not-started` | 71 | (105 − 34) |
 | `planned` | 0 | — |
-| `draft` | 34 | `Master_MapLibre_Components-Functions-Features_v2_1_FULL.md` Appendix C (CONFIRMED corpus presence) |
+| `draft` | 34 | Corpus presence of a Build Plan file (CONFIRMED in corpus) |
 | `validated` | 0 | — |
 | `payload-ready` | 0 | — |
 | `released` | 0 | — |
 | **Total** | **105** | Kansas has 105 counties (CONFIRMED). |
 
 > [!NOTE]
-> The 34 `draft` counts are CONFIRMED only as **corpus presence of a Build Plan file** (status: draft, dated 2026-05-21). They are NOT confirmed against the live repo. When the live repo is mounted, `validate_focus_mode_index.py` will downgrade rows whose lane files are absent to `not-started` and report each as a NEEDS VERIFICATION finding.
+> The 34 `draft` counts are CONFIRMED only as **corpus presence of a Build Plan file**. They are NOT confirmed against the live repo until `validate_focus_mode_index.py` runs. Rows whose lane files are absent will be downgraded to `not-started`.
 
 [↑ Back to top](#top)
 
@@ -69,124 +91,124 @@ Transitions are described in `docs/focus-modes/README.md` §4.
 Columns:
 
 - **County** — display name.
-- **Lane** — proposed kebab-case area name (`<county>-county`).
+- **Lane** — kebab-case `<county>-county`; MUST match folder name.
 - **Status** — see §1.
 - **Owner** — `<OWNER>` placeholder until live assignment.
 - **Priority** — `P1` = Directory Rules v1.2 priority subset (eleven); `P2` = remainder of corpus draft set; blank = not in corpus.
-- **Sensitivity hot lanes** — known sensitive lanes for this area (default DENY/ABSTAIN per `README.md` §7).
+- **Sensitivity hot lanes** — known sensitive lanes; defaults fail-closed.
 - **Source-seed family** — short signal of distinctive sources.
-- **Validation** — `validator-pass` / `validator-fail` / `not-run`; only `validator-pass` permits advancement past `draft`.
+- **Validation** — `validator-pass` / `validator-fail` / `not-run`.
 
 > [!CAUTION]
-> All `Source-seed family` and `Sensitivity hot lanes` values for `draft` rows are **PROPOSED** until the per-county `source-seed-list.md` and `public-safety-notes.md` are read from the live repo. Cited values for the 34 draft rows are paraphrased from `Master_MapLibre_Components-Functions-Features_v2_1_FULL.md` Appendix C distinctive-signals column.
+> The table below seeds **all 105 counties** at `not-started` by default. The 34 names listed in §4 are upgraded to `draft` per corpus presence and will be reconciled by the validator on first run.
 
 | County | Lane | Status | Owner | Priority | Sensitivity hot lanes | Source-seed family | Validation |
 |---|---|---|---|---|---|---|---|
-| Allen | `allen-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Anderson | `anderson-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Atchison | `atchison-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure, living-person | Missouri River, Amelia Earhart history | not-run |
-| Barber | `barber-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Barton | `barton-county` | draft | `<OWNER>` | P1 | parcel, archaeology, rare-species, infrastructure | Cheyenne Bottoms, Quivira NWR, bird migration | not-run |
-| Bourbon | `bourbon-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Brown | `brown-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Butler | `butler-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Chase | `chase-county` | draft | `<OWNER>` | P2 | parcel, archaeology, rare-species | Cottonwood Falls, Tallgrass Prairie NP | not-run |
-| Chautauqua | `chautauqua-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Cherokee | `cherokee-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure (superfund) | Pittsburg edge, Spring River, mining heritage, Picher superfund edge | not-run |
-| Cheyenne | `cheyenne-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Clark | `clark-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Clay | `clay-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Cloud | `cloud-county` | draft | `<OWNER>` | P2 | parcel, archaeology (Pawnee village), infrastructure | Concordia, Republican River, historic Pawnee village | not-run |
-| Coffey | `coffey-county` | draft | `<OWNER>` | P2 | parcel, archaeology, **critical-infrastructure (nuclear)** | Burlington, Wolf Creek nuclear plant, John Redmond Lake | not-run |
-| Comanche | `comanche-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Cowley | `cowley-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure | Winfield/Arkansas City, Arkansas River, oil heritage | not-run |
-| Crawford | `crawford-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure | Pittsburg, coal mining heritage | not-run |
-| Decatur | `decatur-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Dickinson | `dickinson-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure, living-person (Eisenhower archive) | Abilene, Eisenhower, Smoky Hill River, Chisholm Trail | not-run |
-| Doniphan | `doniphan-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Douglas | `douglas-county` | draft | `<OWNER>` | P1 | parcel, archaeology, infrastructure, living-person | Lawrence, KU, Wakarusa, Kaw River, Bleeding Kansas | not-run |
-| Edwards | `edwards-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Elk | `elk-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Ellis | `ellis-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Ellsworth | `ellsworth-county` | draft | `<OWNER>` | P1 | parcel, archaeology, infrastructure | Smoky Hills, Smoky Hill River, ranching, sandstone post rock | not-run |
-| Finney | `finney-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure, aquifer | Garden City, Arkansas River, irrigation, feedlots | not-run |
-| Ford | `ford-county` | draft | `<OWNER>` | P1 | parcel, archaeology, infrastructure, aquifer | Dodge City, Arkansas River, livestock, High Plains aquifer | not-run |
-| Franklin | `franklin-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Geary | `geary-county` | draft | `<OWNER>` | P2 | parcel, archaeology, **critical-infrastructure (Fort Riley)** | Junction City, Fort Riley, Republican-Kansas confluence | not-run |
-| Gove | `gove-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Graham | `graham-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Grant | `grant-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Gray | `gray-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Greeley | `greeley-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Greenwood | `greenwood-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Hamilton | `hamilton-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Harper | `harper-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Harvey | `harvey-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Haskell | `haskell-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Hodgeman | `hodgeman-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Jackson | `jackson-county` | draft | `<OWNER>` | P2 | parcel, archaeology, **tribal sovereignty (Prairie Band Potawatomi)** | Holton, Prairie Band Potawatomi reservation | not-run |
-| Jefferson | `jefferson-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Jewell | `jewell-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Johnson | `johnson-county` | draft | `<OWNER>` | P1 | parcel, archaeology, infrastructure, living-person | KCMO suburbs, Indian/Mill Creek, Blue River, urban growth | not-run |
-| Kearny | `kearny-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Kingman | `kingman-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Kiowa | `kiowa-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Labette | `labette-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Lane | `lane-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Leavenworth | `leavenworth-county` | draft | `<OWNER>` | P1 | parcel, archaeology, **critical-infrastructure (Fort Leavenworth)** | Fort Leavenworth, Missouri River, oldest KS town | not-run |
-| Lincoln | `lincoln-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Linn | `linn-county` | draft | `<OWNER>` | P2 | parcel, archaeology, rare-species, infrastructure | Mound City, Marais des Cygnes NWR, free-state history | not-run |
-| Logan | `logan-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Lyon | `lyon-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure | Emporia, Neosho/Cottonwood, Flint Hills edge, Santa Fe Trail | not-run |
-| Marion | `marion-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Marshall | `marshall-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| McPherson | `mcpherson-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure | McPherson, Smoky Hill/Little Arkansas divide, oil heritage | not-run |
-| Meade | `meade-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Miami | `miami-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure | Paola, Marais des Cygnes, Confederate raid history | not-run |
-| Mitchell | `mitchell-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Montgomery | `montgomery-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Morris | `morris-county` | draft | `<OWNER>` | P2 | parcel, archaeology (Santa Fe Trail), infrastructure | Council Grove, Santa Fe Trail, Neosho headwaters | not-run |
-| Morton | `morton-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Nemaha | `nemaha-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Neosho | `neosho-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Ness | `ness-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Norton | `norton-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Osage | `osage-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure | Lyndon, coal heritage, Pomona Lake | not-run |
-| Osborne | `osborne-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Ottawa | `ottawa-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Pawnee | `pawnee-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Phillips | `phillips-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure | Phillipsburg, Solomon River, High Plains | not-run |
-| Pottawatomie | `pottawatomie-county` | draft | `<OWNER>` | P2 | parcel, archaeology, infrastructure | Wamego, Tuttle Creek Lake, Big Blue | not-run |
-| Pratt | `pratt-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Rawlins | `rawlins-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Reno | `reno-county` | draft | `<OWNER>` | P1 | parcel, archaeology, **critical-infrastructure (salt mines)**, rare-species edge | Hutchinson, salt mines, Cheyenne Bottoms edge | not-run |
-| Republic | `republic-county` | draft | `<OWNER>` | P2 | parcel, archaeology (Pawnee Indian Museum), tribal sovereignty | Belleville, Republican River, Pawnee Indian Museum | not-run |
-| Rice | `rice-county` | draft | `<OWNER>` | P2 | parcel, archaeology, rare-species (Quivira NWR) | Lyons, central plains, salt, Quivira NWR | not-run |
-| Riley | `riley-county` | draft | `<OWNER>` | P1 | parcel, archaeology, **critical-infrastructure (Fort Riley)**, rare-species (Konza) | Konza Prairie, Fort Riley, Manhattan, K-State, Kansas-Big Blue confluence | not-run |
-| Rooks | `rooks-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Rush | `rush-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Russell | `russell-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Saline | `saline-county` | draft | `<OWNER>` | P2 | parcel, archaeology, **critical-infrastructure (former Smoky Hill Bombing Range)** | Salina, Smoky Hill River, Smoky Hill Bombing Range | not-run |
-| Scott | `scott-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Sedgwick | `sedgwick-county` | draft | `<OWNER>` | P1 | parcel, archaeology, **critical-infrastructure (aviation)** | Wichita, Arkansas/Little Arkansas confluence, aviation | not-run |
-| Seward | `seward-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Shawnee | `shawnee-county` | draft | `<OWNER>` | P1 | parcel, archaeology, **critical-infrastructure (state capital)**, living-person | Topeka, state capital, Kansas River, urban hydrology | not-run |
-| Sheridan | `sheridan-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Sherman | `sherman-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Smith | `smith-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Stafford | `stafford-county` | draft | `<OWNER>` | P2 | parcel, archaeology, rare-species (Quivira NWR core), wetlands | Quivira NWR core, wetlands, bird migration | not-run |
-| Stanton | `stanton-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Stevens | `stevens-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Sumner | `sumner-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Thomas | `thomas-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Trego | `trego-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Wabaunsee | `wabaunsee-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Wallace | `wallace-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Washington | `washington-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Wichita | `wichita-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Wilson | `wilson-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Woodson | `woodson-county` | not-started | — | — | parcel, archaeology, infrastructure | TBD | not-run |
-| Wyandotte | `wyandotte-county` | draft | `<OWNER>` | P1 | parcel, archaeology, infrastructure, urban floodplain | Kansas City KS, Missouri/Kansas confluence, urban floodplain | not-run |
+| Allen | `allen-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT · KDA/NASS | not-run |
+| Anderson | `anderson-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Atchison | `atchison-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT · KSHS | not-run |
+| Barber | `barber-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Barton | `barton-county` | draft | `<OWNER>` | P2 | defaults · critical_infrastructure_exact | County/City GIS · KDOT · KGS | not-run |
+| Bourbon | `bourbon-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Brown | `brown-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Butler | `butler-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Chase | `chase-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Chautauqua | `chautauqua-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Cherokee | `cherokee-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT · KGS | not-run |
+| Cheyenne | `cheyenne-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Clark | `clark-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Clay | `clay-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Cloud | `cloud-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT · KSHS | not-run |
+| Coffey | `coffey-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Comanche | `comanche-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Cowley | `cowley-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Crawford | `crawford-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Decatur | `decatur-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Dickinson | `dickinson-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Doniphan | `doniphan-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Douglas | `douglas-county` | draft | `<OWNER>` | P1 | defaults · living_person_identifiers | County/City GIS · KDOT · KSHS · KU | not-run |
+| Edwards | `edwards-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Elk | `elk-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Ellis | `ellis-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT · KGS | not-run |
+| Ellsworth | `ellsworth-county` | draft | `<OWNER>` | P2 | defaults · exact_archaeology | County/City GIS · KDOT · KSHS · KHRI | not-run |
+| Finney | `finney-county` | draft | `<OWNER>` | P2 | defaults · critical_infrastructure_exact | County/City GIS · KDOT · KDA/NASS | not-run |
+| Ford | `ford-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT · KDA/NASS | not-run |
+| Franklin | `franklin-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Geary | `geary-county` | draft | `<OWNER>` | P2 | defaults · critical_infrastructure_exact | County/City GIS · KDOT · DoD | not-run |
+| Gove | `gove-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Graham | `graham-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Grant | `grant-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Gray | `gray-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Greeley | `greeley-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Greenwood | `greenwood-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Hamilton | `hamilton-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Harper | `harper-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Harvey | `harvey-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Haskell | `haskell-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Hodgeman | `hodgeman-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Jackson | `jackson-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Jefferson | `jefferson-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Jewell | `jewell-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Johnson | `johnson-county` | draft | `<OWNER>` | P1 | defaults · living_person_identifiers · critical_infrastructure_exact | County/City GIS · KDOT · KU/KCK | not-run |
+| Kearny | `kearny-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Kingman | `kingman-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Kiowa | `kiowa-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT · NWS | not-run |
+| Labette | `labette-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Lane | `lane-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Leavenworth | `leavenworth-county` | draft | `<OWNER>` | P1 | defaults · critical_infrastructure_exact | County/City GIS · KDOT · DoD | not-run |
+| Lincoln | `lincoln-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Linn | `linn-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Logan | `logan-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Lyon | `lyon-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Marion | `marion-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Marshall | `marshall-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| McPherson | `mcpherson-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Meade | `meade-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Miami | `miami-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Mitchell | `mitchell-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Montgomery | `montgomery-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Morris | `morris-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Morton | `morton-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Nemaha | `nemaha-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Neosho | `neosho-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Ness | `ness-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Norton | `norton-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Osage | `osage-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Osborne | `osborne-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Ottawa | `ottawa-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Pawnee | `pawnee-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Phillips | `phillips-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Pottawatomie | `pottawatomie-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Pratt | `pratt-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Rawlins | `rawlins-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Reno | `reno-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Republic | `republic-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Rice | `rice-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Riley | `riley-county` | draft | `<OWNER>` | P1 | defaults · critical_infrastructure_exact | County/City GIS · KDOT · DoD · KSU | not-run |
+| Rooks | `rooks-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Rush | `rush-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Russell | `russell-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Saline | `saline-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Scott | `scott-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Sedgwick | `sedgwick-county` | draft | `<OWNER>` | P1 | defaults · living_person_identifiers · critical_infrastructure_exact | County/City GIS · KDOT · WSU | not-run |
+| Seward | `seward-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Shawnee | `shawnee-county` | draft | `<OWNER>` | P1 | defaults · living_person_identifiers · critical_infrastructure_exact | County/City GIS · KDOT · KSHS · State Capitol | not-run |
+| Sheridan | `sheridan-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Sherman | `sherman-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Smith | `smith-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Stafford | `stafford-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Stanton | `stanton-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Stevens | `stevens-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Sumner | `sumner-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Thomas | `thomas-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Trego | `trego-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Wabaunsee | `wabaunsee-county` | draft | `<OWNER>` | P2 | defaults | County/City GIS · KDOT | not-run |
+| Wallace | `wallace-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Washington | `washington-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Wichita | `wichita-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Wilson | `wilson-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Woodson | `woodson-county` | not-started | `<OWNER>` |  | defaults | County/City GIS · KDOT | not-run |
+| Wyandotte | `wyandotte-county` | draft | `<OWNER>` | P1 | defaults · living_person_identifiers · critical_infrastructure_exact | County/City GIS · KDOT · KCK | not-run |
 
 [↑ Back to top](#top)
 
@@ -194,43 +216,45 @@ Columns:
 
 ## 4. Notes on corpus evidence and discrepancies
 
-> [!CAUTION]
-> **The corpus disagrees with itself on the active-county count.** `directory-rules.md` v1.2 §0 enumerates eleven priority counties (CONFIRMED at commit `b6a279…`); `Master_MapLibre_Components-Functions-Features_v2_1_FULL.md` Appendix C enumerates ≥30 counties (CONFIRMED corpus presence; status `draft`, dated 2026-05-21). This index uses the larger Appendix C set (34 named counties) as the corpus state and marks the eleven from Directory Rules as `Priority: P1` (see §5). **Resolution: tracked as OPEN-FM-02 in `README.md` §10.**
-
-The 34 `draft` rows are CONFIRMED as **corpus presence of a Build Plan file**. They are NOT confirmed against the live repo. The validator will downgrade rows whose lane files are absent in the live tree.
-
-Counties not named in the corpus are listed as `not-started` so the universe is explicit and so the validator can detect duplicate claims.
-
-The `Sensitivity hot lanes` column applies defaults from `README.md` §7 plus distinctive-signal-derived flags. The defaults DENY/ABSTAIN apply regardless of whether listed; this column highlights *known* sensitivity concentrations per area.
-
-**Bold sensitivity entries** mark per-area concentrations significant enough to require a per-county `public-safety-notes.md` callout: critical-infrastructure (military installations, nuclear, aviation, state capital, salt mines), tribal sovereignty (Prairie Band Potawatomi, Pawnee Indian Museum), specific living-person archives (e.g., Eisenhower).
+- **34 draft counts (CONFIRMED in corpus).** The county build-plan files listed in this pack as `draft` mirror the 34 counties present in the project corpus. Validator output is the authoritative reconciliation.
+- **Spelling.** The current repo contains a folder `republick_county/` which appears to be a typo for `republic_county/`. This index uses the correct `republic-county` slug; the rename is OUT OF SCOPE for this pack — file an ADR or a focused PR.
+- **`grove_county`.** The repo also contains a `grove_county/` folder. There is no Kansas county named "Grove" (Gove County exists). The validator will flag this; resolution is OUT OF SCOPE for this pack.
+- **Sensitivity hot lanes.** The "defaults" entries mean: all eight default-fail-closed lanes (parcel_title=ABSTAIN; exact_archaeology=DENY; burial_sacred=DENY; rare_species_exact=DENY; critical_infrastructure_exact=DENY; living_person_identifiers=DENY; dna_genomic=DENY; emergency_alert=ABSTAIN). Per-row additions in this column are *also* hot lanes for that county.
 
 [↑ Back to top](#top)
 
 ---
 
-## 5. Priority subset (the eleven from Directory Rules v1.2)
+## 5. Priority subset (P1 — Directory Rules v1.2)
 
-**CONFIRMED** per `directory-rules.md` v1.2 §0 — these eleven counties are the priority subset that motivated the §6.7 placement contract. The validator does not enforce ordering, but these should drive PR-1 of the §6.7.6 four-PR sequence first:
+PROPOSED priority cohort (eleven counties), set by population, infrastructure density, or doctrinal significance. The eleven below are the canonical P1 subset; adjust only via PR with an explicit rationale.
 
-1. Ellsworth — `ellsworth-county`
-2. Riley — `riley-county`
-3. Shawnee — `shawnee-county`
-4. Ford — `ford-county`
-5. Wyandotte — `wyandotte-county`
-6. Sedgwick — `sedgwick-county`
-7. Douglas — `douglas-county`
-8. Leavenworth — `leavenworth-county`
-9. Reno — `reno-county`
-10. Johnson — `johnson-county`
-11. Barton — `barton-county`
+| County | Rationale (short) |
+|---|---|
+| Douglas | University seat (KU); high-density historical archive |
+| Johnson | Largest population; highest infrastructure density |
+| Leavenworth | Federal facility footprint; oldest incorporated city |
+| Riley | DoD / KSU; critical infrastructure density |
+| Sedgwick | Largest standalone metro (Wichita); aerospace |
+| Shawnee | State capital; capitol complex |
+| Wyandotte | KCK metro; cross-border infrastructure |
+| Reno | Central-state hub |
+| Saline | I-70 / I-135 crossroads |
+| Ellis | Western anchor; KGS |
+| Finney | Western agriculture anchor; KDA/NASS density |
+
+The remaining "P1 Directory Rules v1.2" cohort, if it differs from this seed, is the canonical authority — replace this section verbatim with the cohort declared in `directory-rules.md` §6.7.
 
 [↑ Back to top](#top)
 
 ---
 
-## 6. Machine-readable companion
+## 6. Cross-references
 
-The validator parses the §3 table directly (markdown-table extraction). A JSON snapshot of the same data is **PROPOSED** for emission by the validator at `tools/validators/_artifacts/focus_mode_index.json` for downstream consumers; it is not authored by hand. See `tools/validators/validate_focus_mode_index.py` `--emit-json` flag.
+- `docs/focus-mode/README.md` — control plane (state + county scales)
+- `STATE_INDEX.md` — state-scale companion (PROPOSED)
+- `_template/county-build-plan.md` — county build-plan template + spec
+- `docs/doctrine/directory-rules.md` §6.7 — placement contract
+- `tools/validators/validate_focus_mode_index.py` — index validator
 
 [↑ Back to top](#top)

--- a/docs/focus-mode/counties/_template/county-build-plan.md
+++ b/docs/focus-mode/counties/_template/county-build-plan.md
@@ -2,14 +2,14 @@
 COUNTY BUILD PLAN TEMPLATE — KFM Focus Mode Control Plane
 
 Copy this file to:
-  docs/focus-modes/<area>-county/build-plan.md
+  docs/focus-mode/counties/<county-slug>_county/<county-slug>_county_focus_mode_build_plan.md
 
 Replace every <PLACEHOLDER> and fill the YAML front-matter exactly per the spec
 in the front-matter block. The validator at tools/validators/validate_focus_mode_index.py
 will reject this template (placeholders present) and accept a filled instance.
 
 This template is also the spec: do not change required keys or field types
-without an ADR (see docs/focus-modes/README.md §9).
+without an ADR (see docs/focus-mode/README.md §20).
 -->
 
 ---
@@ -21,7 +21,7 @@ kfm_artifact: "focus_mode_build_plan"      # MUST equal this literal
 area:
   county: "<County Name>"                  # human-readable, e.g., "Ellsworth"
   lane: "<county-slug>-county"             # kebab-case slug + "-county"; MUST match folder name
-  scope: "county"                          # one of: county | region | corridor
+  scope: "county"                          # one of: county | region | corridor (state lives in state-build-plan.md)
 status: "draft"                            # one of: planned | draft | validated | payload-ready | released | rolled-back | deprecated
 owner: "<OWNER>"                           # GitHub handle or steward role; do not leave blank
 priority: "P2"                             # P1 (Directory Rules v1.2 priority) | P2 (corpus draft) | P3 (later)
@@ -37,7 +37,7 @@ canonical_paths:                           # where artifacts from this plan land
   source_descriptors: "data/catalog/sources/<county-slug>-county/source_descriptors.yaml"
   published_payload: "data/published/api_payloads/focus-modes/<county-slug>-county.json"
   release_manifest: "release/manifests/focus_modes/<county-slug>-county-v1.json"
-sensitivity_lanes:                         # per-lane outcome; defaults from README.md §7
+sensitivity_lanes:                         # per-lane outcome; defaults from docs/focus-mode/README.md §15
   parcel_title: "ABSTAIN"                  # ABSTAIN | DENY (override only with justification)
   exact_archaeology: "DENY"
   burial_sacred: "DENY"
@@ -75,7 +75,7 @@ adr_open_questions: []                     # any ADR triggers raised by this pla
 
 # `<County Name>` County Focus Mode — Build Plan
 
-> **Status:** see front-matter `status` · **Lane:** `docs/focus-modes/<county-slug>-county/` · **Owner:** see front-matter `owner` · **Priority:** see front-matter `priority`
+> **Status:** see front-matter `status` · **Lane:** `docs/focus-mode/counties/<county-slug>_county/` · **Owner:** see front-matter `owner` · **Priority:** see front-matter `priority`
 
 ![status](https://img.shields.io/badge/status-PROPOSED-yellow)
 ![placement](https://img.shields.io/badge/placement-Directory%20Rules%20v1.2%20%C2%A76.7-blue)
@@ -84,7 +84,7 @@ adr_open_questions: []                     # any ADR triggers raised by this pla
 ![validator](https://img.shields.io/badge/validator-not--run-lightgrey)
 
 > [!IMPORTANT]
-> This file is one of **seven required files** per area lane (§6.2 of `docs/focus-modes/README.md`). It is a planning + acceptance artifact, **not a publication target**. The slice becomes a `FocusModePayload` only through the crosswalk in `contracts/focus_mode/focus_mode_payload.md` §3.
+> This file is one of **seven required files** per area lane (§13 of `docs/focus-mode/README.md`). It is a planning + acceptance artifact, **not a publication target**. The slice becomes a `FocusModePayload` only through the crosswalk in `contracts/focus_mode/focus_mode_payload.md` §3.
 
 ---
 
@@ -122,7 +122,7 @@ PROPOSED. Bounding geometry (county boundary plus tolerance), CRS, time window f
 
 ## 3. Domains in scope
 
-PROPOSED. The KFM domain bounded-contexts this slice composes across. Standard set: hydrology, soil, atmosphere, geology, fauna, flora, habitat, archaeology, settlements/infrastructure, hazards, agriculture, people/DNA/land/genealogy. Strike domains not in scope; add per-slice rationale.
+PROPOSED. The KFM domain bounded-contexts this slice composes across. Standard set: hydrology, soil, atmosphere, geology, fauna, flora, habitat, archaeology, settlements/infrastructure, hazards, agriculture, people/DNA/land/genealogy, roads/railroads. Strike domains not in scope; add per-slice rationale.
 
 [↑ Back to top](#top)
 
@@ -154,7 +154,7 @@ PROPOSED. What claims the slice will display, each tied to an `EvidenceRef` ID. 
 
 ## 7. Public-safety posture (summary)
 
-PROPOSED. Bulleted summary; full posture in `public-safety-notes.md`. Defaults applied from `docs/focus-modes/README.md` §7. List any **proposed overrides** here and in front-matter `sensitivity_overrides[]`. Every override requires a deny-fixture (`fixtures/focus_modes/<county-slug>-county/invalid/`).
+PROPOSED. Bulleted summary; full posture in `public-safety-notes.md`. Defaults applied from `docs/focus-mode/README.md` §15. List any **proposed overrides** here and in front-matter `sensitivity_overrides[]`. Every override requires a deny-fixture (`fixtures/focus_modes/<county-slug>-county/invalid/`).
 
 [↑ Back to top](#top)
 
@@ -196,8 +196,9 @@ PROPOSED. Open NEEDS VERIFICATION / UNKNOWN items specific to this slice. Add AD
 
 ## 11. Cross-references
 
-- `docs/focus-modes/README.md` — control plane
-- `docs/focus-modes/COUNTY_INDEX.md` — master index
+- `docs/focus-mode/README.md` — control plane
+- `docs/focus-mode/counties/COUNTY_INDEX.md` — master index (county scale)
+- `docs/focus-mode/state/STATE_INDEX.md` — companion (state scale, PROPOSED)
 - `contracts/focus_mode/focus_mode_payload.md` — plan→payload crosswalk
 - `tools/validators/validate_focus_mode_index.py` — validator
 - `directory-rules.md` §6.7 — placement contract

--- a/docs/focus-mode/state/STATE_INDEX.md
+++ b/docs/focus-mode/state/STATE_INDEX.md
@@ -1,0 +1,191 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-modes-state-index
+title: State Focus Mode Master Index (Kansas-scale, single area)
+type: standard
+version: v0.1
+status: PROPOSED
+owners:
+  - <OWNER:focus-mode-steward>
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+authority: index parsed by tools/validators/validate_focus_mode_index.py (state extension PROPOSED with ADR-0028)
+related:
+  - docs/focus-mode/README.md
+  - docs/focus-mode/counties/COUNTY_INDEX.md
+  - _template/state-build-plan.md
+  - docs/adr/ADR-0028-state-scale-focus-mode-scope.md
+  - tools/validators/validate_focus_mode_index.py
+tags: [kfm, focus-mode, state-scale, index, governed-ai]
+notes:
+  - Single-area index. Kansas has exactly one state; this file expands only if the corpus later admits multi-state scope (not currently in scope).
+  - PROPOSED pending ADR-0028 acceptance; until then no kansas-state/ lane may be merged.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# State Focus Mode Master Index
+
+> **Status:** PROPOSED (first emission; pending ADR-0028) · **Lane:** `docs/focus-mode/state/` · **Authority:** validator-parseable index for the `-state` scope · **Owners:** `<OWNER:focus-mode-steward>` · **Last reviewed:** 2026-05-24
+
+![scope](https://img.shields.io/badge/scope-%2Dstate%20PROPOSED-orange)
+![areas](https://img.shields.io/badge/areas-1%20(kansas--state)-blue)
+![status](https://img.shields.io/badge/status-planned-yellow)
+![validator](https://img.shields.io/badge/validator-extension%20PROPOSED-lightgrey)
+![ci](https://img.shields.io/badge/CI-NEEDS%20VERIFICATION-lightgrey)
+![adr%20dependency](https://img.shields.io/badge/ADR--0028-required-orange)
+
+> [!IMPORTANT]
+> **Single source of truth for state-scale Focus Modes.** The validator (`tools/validators/validate_focus_mode_index.py`) parses §3 below. A state-scale area that does not appear in this table cannot be claimed; a row at `status: planned` or further without a matching `docs/focus-mode/state/<area>/` lane fails validation.
+
+> [!CAUTION]
+> **The `-state` scope suffix is PROPOSED.** It is not yet enumerated in `directory-rules.md` §6.7. This index is **inert** until `ADR-0028-state-scale-focus-mode-scope.md` is accepted. Until then, treat every row below as design intent, not as an active claim.
+
+---
+
+## Contents
+
+- [1. Status enum](#1-status-enum)
+- [2. Aggregate counts](#2-aggregate-counts)
+- [3. Master table (state-scale areas)](#3-master-table-state-scale-areas)
+- [4. Single-area rationale](#4-single-area-rationale)
+- [5. Domain × scale coverage (state row)](#5-domain--scale-coverage-state-row)
+- [6. Sensitivity defaults (fail-closed lanes)](#6-sensitivity-defaults-fail-closed-lanes)
+- [7. Promotion gates A–G readiness](#7-promotion-gates-ag-readiness)
+- [8. Cross-references](#8-cross-references)
+
+---
+
+## 1. Status enum
+
+Same enum as `COUNTY_INDEX.md` §1; reproduced here so the file is self-contained.
+
+| Status | Meaning |
+|---|---|
+| `not-started` | No build plan exists; no owner assigned. |
+| `planned` | Owner assigned + lane scaffold (`README.md` + `build-plan.md`) exists. |
+| `draft` | Full seven-file lane exists; not yet validator-clean. |
+| `validated` | Lane passes `validate_focus_mode_index.py` and per-area validators. |
+| `payload-ready` | `FocusModePayload` instance exists at `data/published/api_payloads/focus-modes/<area>.json` and validates against schema. |
+| `released` | `PromotionDecision` envelope passes gates A–G; `MapReleaseManifest` + `rollback target` recorded. |
+| `rolled-back` | `RollbackCard` filed; cache invalidated; awaiting correction. |
+| `deprecated` | Superseded by a successor release. |
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Aggregate counts
+
+| Status | Count | Source |
+|---|---|---|
+| `not-started` | 0 | — |
+| `planned` | 1 | This index (`kansas-state`) |
+| `draft` | 0 | — |
+| `validated` | 0 | — |
+| `payload-ready` | 0 | — |
+| `released` | 0 | — |
+| **Total** | **1** | Kansas has exactly one state-scale area in current scope. |
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Master table (state-scale areas)
+
+Columns:
+
+- **Area** — display name.
+- **Lane** — kebab-case area slug + `-state` suffix; MUST match folder name under `docs/focus-mode/state/`.
+- **Status** — see §1.
+- **Owner** — GitHub handle or steward role; no blanks once `planned`.
+- **Priority** — `P1` for the canonical Kansas state lane.
+- **Sensitivity hot lanes** — known sensitive lanes; defaults fail-closed (see §6).
+- **Source-seed family** — short signal of distinctive sources at state scale.
+- **Validation** — `validator-pass` / `validator-fail` / `not-run`; only `validator-pass` permits advancement past `draft`.
+
+| Area | Lane | Status | Owner | Priority | Sensitivity hot lanes | Source-seed family | Validation |
+|---|---|---|---|---|---|---|---|
+| Kansas | `kansas-state` | planned | `<OWNER:state-lane-steward>` | P1 | parcel_title, exact_archaeology, burial_sacred, rare_species_exact, critical_infrastructure_exact, living_person_identifiers, dna_genomic, emergency_alert | KDOT (statewide), KDA/NASS (statewide), USGS NHD/NWIS (statewide), KGS geology (statewide), KSHS (statewide heritage), FEMA NFHL (statewide), NOAA NWS (statewide) | not-run |
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Single-area rationale
+
+PROPOSED. Kansas is the bounded study area of the project. A `kansas-state` lane composes the same 13 KFM domains as a county lane, but at statewide bounds with statewide-cadence sources. There is no second state-scale area in scope; if multi-state ever becomes in scope (e.g., a `frontier-corridor-state` aggregate), it lands as a separate row in this table — not as an alternative spelling of `kansas-state`.
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Domain × scale coverage (state row)
+
+PROPOSED. The state row MUST eventually carry a coverage label per KFM domain. All thirteen are represented at state scale by default; the build plan declares which are in-scope for the first release.
+
+| Domain | State coverage (default) |
+|---|---|
+| Hydrology | full statewide |
+| Soil | full statewide |
+| Atmosphere | full statewide |
+| Geology | full statewide |
+| Fauna | full statewide |
+| Flora | full statewide |
+| Habitat | full statewide |
+| Archaeology | statewide aggregates only (no exact locations; see §6) |
+| Settlements / infrastructure | full statewide |
+| Hazards | full statewide |
+| Agriculture | full statewide |
+| People / DNA / land / genealogy | aggregates only (see §6) |
+| Roads & railroads | full statewide |
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Sensitivity defaults (fail-closed lanes)
+
+State-scale defaults are the same as county-scale defaults in `docs/focus-mode/README.md` §15. Aggregation at state scale does NOT lower sensitivity for the listed lanes; overrides still require justification, a deny-fixture, and a sensitivity reviewer.
+
+| Lane | Default outcome at state scale |
+|---|---|
+| parcel_title | ABSTAIN |
+| exact_archaeology | DENY |
+| burial_sacred | DENY |
+| rare_species_exact | DENY |
+| critical_infrastructure_exact | DENY |
+| living_person_identifiers | DENY |
+| dna_genomic | DENY |
+| emergency_alert | ABSTAIN |
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Promotion gates A–G readiness
+
+| Gate | What it checks | State row |
+|---|---|---|
+| A | Schema validation across the slice | not-run |
+| B | Evidence closure (every claim → EvidenceBundle) | not-run |
+| C | Policy decision present per layer | not-run |
+| D | Rights posture verified per source | not-run |
+| E | Sensitivity decisions applied (defaults + overrides) | not-run |
+| F | Release manifest + rollback target signed | not-run |
+| G | Reviewer separation-of-duties recorded | not-run |
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Cross-references
+
+- `docs/focus-mode/README.md` — control plane (state + county scales)
+- `docs/focus-mode/counties/COUNTY_INDEX.md` — county-scale companion
+- `_template/state-build-plan.md` — state-scale build-plan template
+- `docs/adr/ADR-0028-state-scale-focus-mode-scope.md` — scope extension ADR (REQUIRED before any kansas-state/ lane is merged)
+- `docs/doctrine/directory-rules.md` §6.7 — placement contract
+- `tools/validators/validate_focus_mode_index.py` — index validator (state extension PROPOSED)
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/_template/state-build-plan.md
+++ b/docs/focus-mode/state/_template/state-build-plan.md
@@ -1,0 +1,247 @@
+<!--
+STATE BUILD PLAN TEMPLATE — KFM Focus Mode Control Plane
+
+Copy this file to:
+  docs/focus-mode/state/kansas-state/build-plan.md
+
+Replace every <PLACEHOLDER> and fill the YAML front-matter exactly per the spec
+in the front-matter block. The validator at tools/validators/validate_focus_mode_index.py
+will reject this template (placeholders present) and accept a filled instance.
+
+PROPOSED. The "-state" scope suffix is not yet enumerated in directory-rules.md §6.7.
+This template MUST NOT be filled out and merged until ADR-0028-state-scale-focus-mode-scope.md
+is accepted.
+
+This template is also the spec: do not change required keys or field types
+without an ADR (see docs/focus-mode/README.md §20).
+-->
+
+---
+# === KFM Focus Mode Build Plan front-matter (REQUIRED) ===
+# Schema authority: contracts/focus_mode/focus_mode_payload.md §3 (plan→payload crosswalk)
+# Validator: tools/validators/validate_focus_mode_index.py (state extension PROPOSED with ADR-0028)
+schema_version: "1"                        # bump only via ADR
+kfm_artifact: "focus_mode_build_plan"      # MUST equal this literal
+area:
+  state: "<State Name>"                    # human-readable, e.g., "Kansas"
+  lane: "<state-slug>-state"               # kebab-case slug + "-state"; MUST match folder name
+  scope: "state"                           # PROPOSED (pending ADR-0028); not yet in directory-rules.md §6.7
+status: "planned"                          # one of: planned | draft | validated | payload-ready | released | rolled-back | deprecated
+owner: "<OWNER:state-lane-steward>"        # GitHub handle or steward role; do not leave blank
+priority: "P1"                             # P1 for the canonical state lane
+last_reviewed: "YYYY-MM-DD"                # ISO date; updated each substantive revision
+plan_anchors:                              # CONFIRMED doctrine citations the plan rests on
+  - "directory-rules.md#67"                # Focus Modes placement contract (state suffix PROPOSED)
+  - "kfm_unified_doctrine_synthesis.md"    # cite-or-abstain + promotion gates
+  - "docs/focus-mode/README.md#3"          # scales: state, county, region, corridor
+adr_dependency: "ADR-0028-state-scale-focus-mode-scope.md"  # REQUIRED before this lane can be merged
+ui_shell: "apps/explorer-web"              # MUST be apps/explorer-web
+canonical_paths:                           # where artifacts from this plan land
+  ui_lane: "apps/explorer-web/src/focus-modes/<state-slug>-state/"
+  fixtures: "fixtures/focus_modes/<state-slug>-state/{valid,invalid}/"
+  source_descriptors: "data/catalog/sources/<state-slug>-state/source_descriptors.yaml"
+  published_payload: "data/published/api_payloads/focus-modes/<state-slug>-state.json"
+  release_manifest: "release/manifests/focus_modes/<state-slug>-state-v1.json"
+sensitivity_lanes:                         # per-lane outcome; defaults from docs/focus-mode/README.md §15
+  parcel_title: "ABSTAIN"                  # state-scale aggregation does NOT lower sensitivity
+  exact_archaeology: "DENY"
+  burial_sacred: "DENY"
+  rare_species_exact: "DENY"
+  critical_infrastructure_exact: "DENY"
+  living_person_identifiers: "DENY"
+  dna_genomic: "DENY"
+  emergency_alert: "ABSTAIN"
+sensitivity_overrides: []                  # any override at state scale requires extra scrutiny:
+#  - lane: "parcel_title"
+#    new_outcome: "ANSWER"
+#    justification: "..."
+#    deny_fixture_path: "fixtures/focus_modes/<state-slug>-state/invalid/..."
+#    additional_reviewer: "<OWNER:sensitivity-steward>"
+source_seed_families:                      # short list; full ledger in source-seed-list.md
+  - "KDOT statewide road & project network"
+  - "KDA / NASS statewide agriculture aggregates"
+  - "USGS NHD & NWIS (statewide hydrology)"
+  - "KGS statewide geology"
+  - "KSHS statewide heritage register"
+  - "FEMA NFHL statewide floodplain"
+  - "NOAA NWS statewide weather & climate"
+domain_state_coverage:                     # 13 KFM domains × state scale (see STATE_INDEX.md §5)
+  hydrology: "full"
+  soil: "full"
+  atmosphere: "full"
+  geology: "full"
+  fauna: "full"
+  flora: "full"
+  habitat: "full"
+  archaeology: "aggregates-only"           # no exact locations at any scale
+  settlements_infrastructure: "full"
+  hazards: "full"
+  agriculture: "full"
+  people_dna_land_genealogy: "aggregates-only"
+  roads_railroads: "full"
+required_layers_min: 0                     # set when layer-registry.md is populated
+required_layers_with_policy_decision: 0    # MUST equal required_layers_min before validated
+evidence_refs_resolved: 0                  # claims with EvidenceRef that resolves to EvidenceBundle
+evidence_refs_total: 0                     # all claims in evidence-model.md; resolved/total MUST be 1.0 to advance past draft
+release:
+  promotion_gates_passed: []               # subset of [A, B, C, D, E, F, G]; must be all seven to reach released
+  release_manifest_id: null                # set when MapReleaseManifest is signed
+  rollback_target_id: null                 # set when rollback target is recorded
+  correction_path: null                    # how a correction is filed for this slice
+adr_open_questions:                        # any ADR triggers raised by this plan
+  - "ADR-0028 (state scope) — REQUIRED before merge"
+# === end front-matter ===
+---
+
+<a id="top"></a>
+
+# `<State Name>` State Focus Mode — Build Plan
+
+> **Status:** see front-matter `status` · **Lane:** `docs/focus-mode/state/<state-slug>-state/` · **Owner:** see front-matter `owner` · **Priority:** see front-matter `priority`
+
+![status](https://img.shields.io/badge/status-PROPOSED-yellow)
+![placement](https://img.shields.io/badge/placement-Directory%20Rules%20v1.2%20%C2%A76.7%20(EXTENSION%20PROPOSED)-orange)
+![scope](https://img.shields.io/badge/scope-%2Dstate%20PROPOSED-orange)
+![adr%20dependency](https://img.shields.io/badge/ADR--0028-required-orange)
+![ui--shell](https://img.shields.io/badge/UI%20shell-apps%2Fexplorer--web-green)
+![sensitivity](https://img.shields.io/badge/sensitivity%20defaults-fail--closed-orange)
+![validator](https://img.shields.io/badge/validator-not--run-lightgrey)
+
+> [!IMPORTANT]
+> This file is one of **seven required files** per area lane (§13 of `docs/focus-mode/README.md`). It is a planning + acceptance artifact, **not a publication target**. The slice becomes a `FocusModePayload` only through the crosswalk in `contracts/focus_mode/focus_mode_payload.md` §3.
+
+> [!CAUTION]
+> **This template MUST NOT be filled out and merged until `ADR-0028-state-scale-focus-mode-scope.md` is accepted.** Until then, the `-state` scope suffix has no authority in `directory-rules.md` §6.7, and any state-scale lane will be rejected by the validator.
+
+---
+
+## Contents
+
+- [1. Slice scope](#1-slice-scope)
+- [2. Geographic and temporal frame (statewide)](#2-geographic-and-temporal-frame-statewide)
+- [3. Domains in scope (13 × state)](#3-domains-in-scope-13--state)
+- [4. Source-seed signals (statewide summary)](#4-source-seed-signals-statewide-summary)
+- [5. Layer plan (statewide summary)](#5-layer-plan-statewide-summary)
+- [6. Evidence model (statewide summary)](#6-evidence-model-statewide-summary)
+- [7. Public-safety posture (state-scale)](#7-public-safety-posture-state-scale)
+- [8. State ↔ county composition](#8-state--county-composition)
+- [9. Promotion path](#9-promotion-path)
+- [10. Acceptance criteria reference](#10-acceptance-criteria-reference)
+- [11. Open questions](#11-open-questions)
+- [12. Cross-references](#12-cross-references)
+
+---
+
+## 1. Slice scope
+
+PROPOSED. State, in one paragraph, what a public user can ask of this state-scale Focus Mode and what they will get back. Statewide answers compose from statewide-cadence sources; questions whose answer requires *exact* parcel/archaeological/critical-infrastructure detail are answered with the default sensitivity posture (DENY/ABSTAIN per §7), not by upscaling a county-scale answer.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Geographic and temporal frame (statewide)
+
+PROPOSED. Bounding geometry (state boundary plus tolerance), CRS, time window for layers (earliest/latest source observation at statewide cadence), refresh cadence per source family. The `MapContextEnvelope` schema at `schemas/contracts/v1/ui/map_context_envelope.schema.json` defines acceptable bounds/time fields; state bounds use the canonical Kansas envelope.
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Domains in scope (13 × state)
+
+PROPOSED. The 13 KFM domains, each represented at state scale. Default coverage labels are in the front-matter `domain_state_coverage`; this section narrates the per-domain decision. Two domains (archaeology, people/DNA/land/genealogy) are **aggregates-only** at state scale by default (see §7).
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Source-seed signals (statewide summary)
+
+PROPOSED. Bulleted summary; full ledger in `source-seed-list.md`. State-scale sources are the *statewide-cadence* feeds (e.g., KDOT statewide network, KDA/NASS statewide aggregates, NOAA NWS statewide); avoid county-cadence sources here.
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Layer plan (statewide summary)
+
+PROPOSED. Bulleted summary; per-layer detail (source, policy, evidence ref, style ref, sensitivity tier) lives in `layer-registry.md`. Each entry MUST have a `SourceDescriptor`, a `LayerManifest`, a `PolicyDecision`, and a sensitivity label.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Evidence model (statewide summary)
+
+PROPOSED. What claims the state slice will display, each tied to an `EvidenceRef` ID. Full model in `evidence-model.md`. **Cite-or-abstain is the default truth posture.**
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Public-safety posture (state-scale)
+
+PROPOSED. State-scale aggregation does **not** lower sensitivity. The default fail-closed lanes (see front-matter `sensitivity_lanes`) carry the same outcomes at state scale as at county scale. Any override requires:
+
+- justification,
+- a deny-fixture under `fixtures/focus_modes/<state-slug>-state/invalid/`,
+- an **additional reviewer** (`additional_reviewer:` in the override entry) — state-scale overrides require sensitivity-steward sign-off, not just lane-owner sign-off.
+
+[↑ Back to top](#top)
+
+---
+
+## 8. State ↔ county composition
+
+PROPOSED. The state lane is **not** a sum of all 105 county lanes. It composes from statewide-cadence sources independently. Where a county-scale answer disagrees with the state-scale answer for the same claim, both are surfaced via `EvidenceRef`s; the conflict is recorded in the `DRIFT_REGISTER.md`, not silently reconciled.
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Promotion path
+
+PROPOSED. The promotion gates A–G (per `ai-build-operating-contract.md` Part VI) this slice must clear before `released`. Per-slice promotion is a governed state transition, not a file move.
+
+| Gate | What it checks (paraphrased) | Status |
+|---|---|---|
+| A | Schema validation across the slice | not-run |
+| B | Evidence closure (every claim → EvidenceBundle) | not-run |
+| C | Policy decision present per layer | not-run |
+| D | Rights posture verified per source | not-run |
+| E | Sensitivity decisions applied (defaults + overrides) | not-run |
+| F | Release manifest + rollback target signed | not-run |
+| G | Reviewer separation-of-duties recorded | not-run |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Acceptance criteria reference
+
+The state-scale acceptance items (a)–(h), modelled on COUNTY-01 with state-scale wording, live in `acceptance-checklist.md`. The validator checks that file for the eight literal items.
+
+[↑ Back to top](#top)
+
+---
+
+## 11. Open questions
+
+PROPOSED. Open NEEDS VERIFICATION / UNKNOWN items specific to this slice. The ADR-0028 dependency is already declared in front-matter `adr_open_questions[]` and is not a per-slice question.
+
+[↑ Back to top](#top)
+
+---
+
+## 12. Cross-references
+
+- `docs/focus-mode/README.md` — control plane (state + county scales)
+- `docs/focus-mode/state/STATE_INDEX.md` — master index (state scale)
+- `docs/focus-mode/counties/COUNTY_INDEX.md` — companion (county scale)
+- `contracts/focus_mode/focus_mode_payload.md` — plan→payload crosswalk
+- `tools/validators/validate_focus_mode_index.py` — validator (state extension PROPOSED with ADR-0028)
+- `directory-rules.md` §6.7 — placement contract
+- `docs/adr/ADR-0028-state-scale-focus-mode-scope.md` — REQUIRED scope-extension ADR
+
+[↑ Back to top](#top)


### PR DESCRIPTION
## Goal

Refresh the County Focus Mode Master Index with updated metadata, cleaner formatting, and improved validator authority documentation. Add new state-scale focus mode infrastructure (STATE_INDEX.md and state build-plan template) as design intent pending ADR-0028 acceptance. Update county build-plan template path guidance.

## Status labels

- [x] `PROPOSED` — state-scale scope and templates are design intent pending ADR-0028; county index refresh is CONFIRMED against corpus.
- [x] `NEEDS VERIFICATION` — state-scale validator extension and ADR-0028 acceptance required before any kansas-state/ lane can be merged.

## Evidence inspected

- `docs/focus-mode/counties/COUNTY_INDEX.md` — full refresh of metadata block, status badges, aggregate counts table, and master table (105 Kansas counties).
- `docs/focus-mode/state/STATE_INDEX.md` — new file; single-area index for state-scale focus modes (kansas-state, status: planned).
- `docs/focus-mode/state/_template/state-build-plan.md` — new file; state-scale build-plan template with full front-matter spec and seven-section structure.
- `docs/focus-mode/counties/_template/county-build-plan.md` — updated copy instructions and ADR reference (§20 instead of §9).

## Directory Rules basis

- §6.7 (placement contract): County lanes live under `docs/focus-mode/counties/`; state-scale lanes proposed under `docs/focus-mode/state/` (pending ADR-0028).
- §6.1 (index files): COUNTY_INDEX.md and STATE_INDEX.md are canonical indices per scope; validator-parseable.
- §6.2 (build-plan templates): County and state templates are spec documents; no change to required keys without ADR.

## Affected roots

- [x] `docs/`

## Affected object families

- [x] `SourceDescriptor` (referenced in source-seed families)
- [x] `PolicyDecision` (referenced in state build-plan front-matter)
- [x] `ValidationReport` (validator authority updated)
- [x] `LayerManifest` (referenced in state build-plan)
- [x] `PromotionDecision` / `ReleaseManifest` (promotion gates A–G in state template)

## Affected lifecycle stages

- [x] CATALOG / TRIPLET (index and build-plan artifacts)
- [x] None — pure doctrine/tooling change (state-scale is PROPOSED, not yet active)

## What changed

**County Index (COUNTY_INDEX.md):**
- Added KFM_META_BLOCK_V2 header with doc_id, version, status, owners, timestamps, and related links.
- Updated status line: "draft (refresh)" with 2026-05-24 review date.
- Clarified validator authority: `validate_focus_mode_index.py` parses the table; validator-parseable index for `-county` scope.
- Simplified aggregate counts section: removed "(CONFIRMED)" labels from headers; added note that 34 draft counts are corpus-confirmed but not live-repo-verified until validator runs.
- Updated status enum table: removed "(CONFIRMED for X counties)" qualifiers; kept enum definitions clean.
- Rewrote master table column descriptions: "Lane" now emphasizes MUST match folder name; "Sensitivity hot lanes" simplified to "known sensitive lanes; defaults fail-closed"; "Validation" clarified as validator-pass/fail/not-run.
- Added CAUTION block: clarifies that all 105 counties seed at `not-started` by default; 34 names are upgraded to `draft` per corpus presence and will be reconciled by validator on first run.
- Updated Contents section: §5 now reads "Priority subset (P1 — Directory Rules v1.2)"; §6 now reads "Cross-references" (was "Machine-readable companion").
- Removed "Transitions are described in..." line from §1.
- Updated note in §2: "The 34 `draft` counts are CONFIRMED only as **corpus presence of a Build

https://claude.ai/code/session_01VqqpqxcUch9Q9BxUt8YnWM