### PR TITLE
docs(focus-mode): add state family doctrine and transition specs

### DIFF
--- a/docs/focus-mode/state/finite-outcomes.md
+++ b/docs/focus-mode/state/finite-outcomes.md
@@ -1,0 +1,278 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-finite-outcomes
+title: Focus Mode — Finite Outcome State
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/README.md §7
+  - docs/focus-mode/state/transitions/answer-to-abstain.md
+  - docs/focus-mode/state/transitions/hold-to-deny.md
+  - schemas/contracts/v1/runtime/decision_envelope.schema.json (PROPOSED)
+  - schemas/contracts/v1/runtime/ai_receipt.schema.json (PROPOSED)
+  - contracts/focus_mode/focus_mode_payload.md (PROPOSED)
+tags: [kfm, focus-mode, state, finite-outcomes, decision-envelope, ai-receipt, cite-or-abstain]
+notes:
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09 in docs/focus-mode/state/README.md §15.
+  - No mounted repo evidence; all repo-shaped claims labeled PROPOSED.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Focus Mode — Finite Outcome State
+
+> *Per-outcome semantics, required artifacts, reason-code shape, and surface mappings for the seven finite outcomes a governed Focus Mode surface MAY return.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-Focus%20Mode%20v0.2-blue)
+![truth-posture](https://img.shields.io/badge/posture-cite--or--abstain-success)
+![outcomes](https://img.shields.io/badge/outcomes-7%20enumerated-2b8a3e)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!CAUTION]
+> **Path placement diverges from Directory Rules v1.2 §6.7.2** — see [README §2.1](./README.md#21-path-divergence-must-be-resolved). Doctrine here is **CONFIRMED**; the file's location is **PROPOSED** pending OPEN-DR-09.
+
+> [!IMPORTANT]
+> **The seven outcomes are a closed enum.** Every governed Focus Mode surface, every governed API, every validator, and every policy gate MUST terminate in exactly one of: `ANSWER` · `ABSTAIN` · `DENY` · `ERROR` · `HOLD` · `PASS` · `FAIL`. Free-form text without a finite-outcome envelope is a doctrine violation. *(CONFIRMED — Atlas v1.1 §24.3.1; Doctrine Synthesis §11.)*
+
+---
+
+## Contents
+
+1. [Scope](#1-scope)
+2. [The seven outcomes](#2-the-seven-outcomes)
+3. [Per-outcome required artifacts](#3-per-outcome-required-artifacts)
+4. [Reason-code vocabularies](#4-reason-code-vocabularies)
+5. [Outcome × surface matrix](#5-outcome--surface-matrix)
+6. [Public-class vs validator-class outcomes](#6-public-class-vs-validator-class-outcomes)
+7. [Composition rules — outcomes do not chain](#7-composition-rules)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Open questions](#9-open-questions)
+10. [Cross-references](#10-cross-references)
+
+---
+
+## 1. Scope
+
+This file enumerates the **finite outcome vocabulary** used at every governed surface inside a Focus Mode and describes, per outcome:
+
+- the **trigger conditions** that justify the outcome,
+- the **required artifacts** that MUST be emitted alongside it,
+- the **reason-code shape** the outcome carries,
+- which **public-facing surfaces** are allowed to return it.
+
+It does **not** define the lifecycle stages an artifact passes through (that is `lifecycle-states.md`), nor the review state of any artifact (`review-state.md`), nor the freshness state of a payload (`payload-state.md`). Outcome state and lifecycle state are **independent vocabularies**; collapsing them is anti-pattern #1 in [README §14](./README.md#14-anti-patterns).
+
+[↑ Back to top](#top)
+
+---
+
+## 2. The seven outcomes
+
+> **CONFIRMED doctrine.** The enum is closed. Adding a new outcome requires an ADR per `directory-rules.md` §2.4.
+
+| Outcome | Class | One-line definition |
+|---|---|---|
+| **`ANSWER`** | public | Substantive response backed by released, citation-closed evidence and an allowing policy decision. |
+| **`ABSTAIN`** | public | Non-substantive response — evidence insufficient, citation closure fails, or no released alternative; **never invents**. |
+| **`DENY`** | public | Refusal because policy, rights, sensitivity, or release state forbids the answer. |
+| **`ERROR`** | public | Diagnostic refusal — governed API cannot evaluate *(malformed query, missing schema, contract violation, infra failure)*. |
+| **`HOLD`** | public | Pending steward, rights-holder, or policy review; surface remains in its prior state — **no silent rollback**. |
+| **`PASS`** | validator | Internal validator/admission terminal — input acceptable; does **not** itself emit a public answer. |
+| **`FAIL`** | validator | Internal validator/admission terminal — input unacceptable; promotion blocked; quarantine where appropriate. |
+
+> [!NOTE]
+> **`HOLD` is the only public outcome that does not produce a new claim.** It signals "no change yet" — the previously-served claim continues to render, or `ABSTAIN` if no prior claim exists. The status of the underlying review is carried by `ReviewRecord` *(see [`review-state.md`](./review-state.md))*.
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Per-outcome required artifacts
+
+> **PROPOSED contract shape.** Schemas live at `schemas/contracts/v1/runtime/` *(per directory-rules.md §6.4)*. This table is reference, not source.
+
+| Outcome | `DecisionEnvelope` | `AIReceipt` | Evidence side-car | Claim emitted? |
+|---|---|---|---|---|
+| `ANSWER` | `outcome=ANSWER`, allowing `PolicyDecision`, applicable `ReleaseManifest` ref | required; lists provider, model, hashes, context | `EvidenceDrawerPayload` *(projection of `EvidenceBundle`)*, with at least one resolved `EvidenceRef` | **yes** — substantive claim with citations |
+| `ABSTAIN` | `outcome=ABSTAIN`, reason from §4.1 | required; records why citation closure failed or evidence was insufficient | **none** — no claim, no evidence stitched | **no** |
+| `DENY` | `outcome=DENY`, `PolicyDecision=DENY`, reason from §4.2 | required; records denial provenance and policy/rights authority | **none** — denying surfaces MUST NOT leak partial evidence | **no** |
+| `ERROR` | `outcome=ERROR`, diagnostic code from §4.3, no policy/release refs | optional but RECOMMENDED *(for replay)* | **none** — claim leakage forbidden | **no** |
+| `HOLD` | `outcome=HOLD`, `PolicyDecision=HOLD`, `ReviewRecord` ref | required; records hold reason and holder identity | **none** — held content does not render | **no** (prior claim, if any, continues) |
+| `PASS` | `outcome=PASS`, validator family + check ID | n/a *(internal)* | `ValidationReport` *(PASS)* | n/a |
+| `FAIL` | `outcome=FAIL`, validator family + check ID, failure list | n/a *(internal)* | `ValidationReport` *(failure list)* | n/a |
+
+> [!IMPORTANT]
+> **Every public outcome carries a `DecisionEnvelope`.** A surface that returns a payload without an envelope — even a successful one — is doctrine-violating. The envelope is the audit hook. *(Atlas v1.1 §24.3; Doctrine Synthesis §11; CONFIRMED doctrine.)*
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Reason-code vocabularies
+
+Every non-`ANSWER` public outcome carries a reason. The reason-code namespace is enumerated per outcome and is part of the envelope contract — **not free-form**.
+
+### 4.1 `ABSTAIN` reason codes *(PROPOSED enum)*
+
+| Code | Meaning |
+|---|---|
+| `evidence_insufficient` | No `EvidenceRef` resolves to a released `EvidenceBundle` covering the query. |
+| `citation_closure_failed` | One or more cited refs do not resolve, or fail digest closure. |
+| `payload_stale` | `FocusModePayload` is stale and no released alternative was re-bound *(see [`payload-state.md`](./payload-state.md))*. |
+| `not_yet_released` | At least one referenced artifact is still `PROCESSED` or `CATALOG`. |
+| `revoked_no_alternative` | Cited evidence was revoked and no released alternative covers the query. |
+| `query_out_of_scope` | The Focus Mode area or temporal window does not include the requested subject. |
+| `confidence_below_threshold` | Available evidence does not meet the configured confidence threshold for `ANSWER`. |
+
+### 4.2 `DENY` reason codes *(PROPOSED enum)*
+
+| Code | Meaning |
+|---|---|
+| `policy_deny` | `PolicyDecision = DENY` from runtime policy bundle. |
+| `rights_deny` | Rights holder *(per `data/catalog/`)* forbids the answer at this surface/role. |
+| `sensitivity_deny` | Sensitive lane *(archaeology coordinates, rare-species exact locations, living-person, DNA, critical-infrastructure detail)* — `DENY` default applies. |
+| `release_state_deny` | Underlying artifact is not in a release state that permits public exposure. |
+| `role_deny` | Caller's role does not have access *(authenticated surfaces only)*. |
+| `geofence_deny` | Query violates a configured geofence *(e.g., burial site coordinates)*. |
+
+### 4.3 `ERROR` diagnostic codes *(PROPOSED enum)*
+
+| Code | Meaning |
+|---|---|
+| `schema_missing` | Required schema for the envelope or payload not present in `schemas/contracts/v1/`. |
+| `envelope_malformed` | `MapContextEnvelope` failed admission check — see [`map-context-state.md`](./map-context-state.md). |
+| `contract_violation` | Caller violated the published contract *(e.g., unsupported field, version mismatch)*. |
+| `resolver_failure` | Downstream evidence/layer resolver returned unhandled error. |
+| `infra_failure` | Infrastructure-level failure *(timeout, store unavailable, network)*. |
+| `internal_invariant` | A doctrinal invariant tripped *(e.g., outcome enum drift detected)*. |
+
+### 4.4 `HOLD` reason codes *(PROPOSED enum)*
+
+| Code | Meaning |
+|---|---|
+| `steward_review_pending` | Domain steward review queued. |
+| `rights_holder_review_pending` | Rights holder review queued *(sovereignty, descendant community, license review)*. |
+| `policy_review_pending` | Policy bundle revision pending; old bundle held. |
+| `correction_pending` | Correction in flight against a prior release. |
+| `release_gate_pending` | Promotion gate A–G blocked but recoverable. |
+
+> [!NOTE]
+> **Reason codes are part of the contract.** Renaming or removing one is ADR-class. Adding a new code is a minor contract revision but SHOULD be coordinated with consumers. *(directory-rules.md §2.4.)*
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Outcome × surface matrix
+
+> Restated from [README §7.1](./README.md#71-outcome--surface-mapping-confirmed-doctrine--atlas-v11-24332) with surface-level expansion.
+
+| Surface | `ANSWER` | `ABSTAIN` | `DENY` | `ERROR` | `HOLD` | `PASS`/`FAIL` |
+|---|---|---|---|---|---|---|
+| Focus Mode runtime *(`apps/explorer-web/src/focus-modes/<area>/`)* | yes | yes | yes | yes | yes | no |
+| Evidence Drawer | yes *(projection)* | yes | yes | yes | display only | no |
+| Layer manifest resolver | yes | **no** *(layers don't abstain)* | yes | yes | no | no |
+| Source-summary resolver | yes | yes | yes | yes | no | no |
+| Domain feature/detail lookup | yes | yes | yes | yes | yes | no |
+| Evidence resolver | yes | yes | yes | yes | yes | no |
+| Review queue *(role-scoped)* | `ALLOW` | n/a | yes | yes | yes | no |
+| Validator orchestrator | n/a | n/a | n/a | yes | n/a | yes |
+
+> [!CAUTION]
+> **Layer manifests do not `ABSTAIN`.** A released layer either exists *(returns `ANSWER` with `ReleaseManifest` ref)*, is denied *(returns `DENY`)*, or the resolver errors *(returns `ERROR`)*. There is no half-released layer. *(CONFIRMED — Atlas v1.1 §24.3.2.)*
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Public-class vs validator-class outcomes
+
+> **CONFIRMED separation.** `PASS` and `FAIL` are internal validator-class outcomes; they NEVER cross the trust membrane to a public surface.
+
+| Property | Public-class *(`ANSWER`, `ABSTAIN`, `DENY`, `ERROR`, `HOLD`)* | Validator-class *(`PASS`, `FAIL`)* |
+|---|---|---|
+| Where emitted | Governed APIs, Focus Mode runtime, public UI | `tools/validators/`, promotion gates, CI |
+| Carries `AIReceipt`? | yes *(except `ERROR` where optional)* | no — carries `ValidationReport` |
+| Visible to public client? | yes | no — internal only |
+| Drives lifecycle promotion? | no | yes — `FAIL` blocks promotion |
+| Reason-code namespace | §4.1–§4.4 | validator family + check ID |
+
+> [!IMPORTANT]
+> **A validator surface MUST NOT emit `ANSWER`/`ABSTAIN`/`DENY`/`ERROR`/`HOLD` as its own outcome.** A validator's job is to report `PASS` or `FAIL` on a check; the downstream surface that consumes the report then renders one of the public outcomes. Conflating the two creates a parallel decision authority. *(Anti-pattern — `state-family collapse`, [README §14](./README.md#14-anti-patterns).)*
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Composition rules
+
+Outcomes do **not** chain into a richer outcome. A surface returns **exactly one** outcome per request.
+
+| Rule | Consequence |
+|---|---|
+| **One outcome per request.** | A surface MUST NOT return `ANSWER` for part of a query and `ABSTAIN` for another part in the same envelope. Split the query or emit `ABSTAIN` for the whole. |
+| **No silent promotion.** | A surface MUST NOT upgrade a prior `ABSTAIN` to `ANSWER` without a new resolution and a new `DecisionEnvelope`. |
+| **No silent demotion.** | A previously-served `ANSWER` that becomes unservable *(stale, revoked, denied)* MUST transition publicly to `ABSTAIN`/`DENY`/`ERROR` via the documented transition — see [`transitions/answer-to-abstain.md`](./transitions/answer-to-abstain.md) and [`transitions/published-to-revoked.md`](./transitions/published-to-revoked.md). |
+| **`HOLD` preserves prior state.** | A new `HOLD` envelope does NOT alter the surface's currently-rendered claim. The prior claim continues until the hold resolves to `ANSWER`/`ABSTAIN`/`DENY`. |
+| **`ERROR` is recoverable.** | An `ERROR` envelope on one request does not poison subsequent requests; each is evaluated fresh. |
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine | Mitigation |
+|---|---|---|
+| **Free-form fallback** — surface returns prose without an envelope. | Breaks cite-or-abstain; makes audit impossible. | Every surface terminates in one finite outcome with a `DecisionEnvelope`. |
+| **Outcome enum drift** — adding `STALE`, `MAYBE`, `PARTIAL`, etc. ad hoc. | Downstream consumers join on outcome string; new strings silently bypass them. | Outcome additions are ADR-class. Folding `STALE` into `ABSTAIN` is the current convention *(see [README §15 open question](./README.md#15-open-questions-and-adr-triggers))*. |
+| **Reason-code free text** — putting a free-form string where an enum value belongs. | Defeats automated reason aggregation; consumers cannot route on free text. | Reason codes come from §4.1–§4.4; new codes are minor contract revisions. |
+| **`HOLD` rolls back the surface** — UI strips the prior claim when a `HOLD` arrives. | Hides the prior state; users see flicker; audit loses the prior claim. | `HOLD` preserves prior state. The surface shows a held badge, not a rollback. |
+| **Validator emits public outcomes** — `tools/validators/foo.py` returns `ANSWER`. | Validators are not authoritative for public claims. | Validators return `PASS`/`FAIL`; downstream surfaces map to public outcomes. |
+| **`DENY` leaks partial evidence** — denial response embeds redacted fragments. | Defeats the denial; reconstructable from the fragment. | `DENY` carries reason code + alternative *(if any)* — no payload. |
+| **`ERROR` swallowed silently** — surface returns empty `ANSWER` on infra failure. | Caller cannot distinguish "no evidence" from "infra broken". | `ERROR` is a first-class outcome; surface returns it explicitly. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Open questions
+
+| ID | Question | Class |
+|---|---|---|
+| FO-Q1 | Should `STALE` become a distinct outcome instead of folding into `ABSTAIN`? *(See [README §15](./README.md#15-open-questions-and-adr-triggers).)* | Vocabulary |
+| FO-Q2 | Is `HOLD` an outcome **and** a review state *(both currently)*, or should one collapse into the other? | Vocabulary / collision |
+| FO-Q3 | Should `DENY` carry an `obligations[]` array *(e.g., "redirect to non-restricted alternative")*? | Contract shape |
+| FO-Q4 | Are reason codes versioned independently of the envelope schema? | Contract evolution |
+| FO-Q5 | Should validator-class `PASS`/`FAIL` envelopes ride the same schema as public-class outcomes or stay separate? | Schema home |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Cross-references
+
+- [`docs/focus-mode/state/README.md`](./README.md) — state-doctrine landing.
+- [`docs/focus-mode/state/lifecycle-states.md`](./lifecycle-states.md) — RAW → PUBLISHED pipeline gates.
+- [`docs/focus-mode/state/review-state.md`](./review-state.md) — `ReviewRecord` lifecycle and `HOLD` review semantics.
+- [`docs/focus-mode/state/payload-state.md`](./payload-state.md) — `FocusModePayload` freshness states that drive `ABSTAIN` reasons.
+- [`docs/focus-mode/state/transitions/answer-to-abstain.md`](./transitions/answer-to-abstain.md) — demotion path on staleness, revocation, or closure failure.
+- [`docs/focus-mode/state/transitions/hold-to-deny.md`](./transitions/hold-to-deny.md) — `HOLD` → `DENY` transition when review resolves to refusal.
+- `schemas/contracts/v1/runtime/decision_envelope.schema.json` *(PROPOSED)*.
+- `schemas/contracts/v1/runtime/ai_receipt.schema.json` *(PROPOSED)*.
+- `contracts/focus_mode/focus_mode_payload.md` *(PROPOSED)*.
+- `kfm_unified_doctrine_synthesis.md` §11 — finite outcome envelope vocabulary.
+- `KFM_Domains_v1_1_plus_Pass23_Pass32_Consolidated_Atlas.md` §24.3 — Master Decision Outcome Envelope Reference.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/lifecycle-states.md
+++ b/docs/focus-mode/state/lifecycle-states.md
@@ -1,0 +1,250 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-lifecycle-states
+title: Focus Mode — Lifecycle State (RAW → PUBLISHED)
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/README.md §8
+  - docs/focus-mode/state/review-state.md
+  - docs/focus-mode/state/payload-state.md
+  - docs/focus-mode/state/transitions/candidate-to-hold.md
+  - docs/focus-mode/state/transitions/published-to-revoked.md
+  - directory-rules.md §9
+tags: [kfm, focus-mode, state, lifecycle, promotion-gates, default-deny, trust-membrane]
+notes:
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+  - Pipeline gates A–G are CONFIRMED doctrine; repo implementation is PROPOSED / UNKNOWN until mounted.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Focus Mode — Lifecycle State
+
+> *The five-stage default-deny promotion pipeline (`RAW → WORK/QUARANTINE → PROCESSED → CATALOG/TRIPLET → PUBLISHED`) — gate semantics, required artifacts at each transition, and the trust-membrane rule that separates internal stages from public Focus Mode surfaces.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-default--deny-blue)
+![stages](https://img.shields.io/badge/stages-5-2b8a3e)
+![gates](https://img.shields.io/badge/gates-A%E2%80%93G-2b8a3e)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **Default-deny pipeline.** Each stage holds an explicit gate. Promotion is a *governed state transition*, not a file move. An artifact that has not passed the gate stays in its current stage — silence is **not** promotion. *(CONFIRMED — Atlas v1.1 Part I.H; Doctrine Synthesis Part X; directory-rules.md §9.)*
+
+> [!CAUTION]
+> **Path placement diverges from Directory Rules v1.2 §6.7.2** — see [README §2.1](./README.md#21-path-divergence-must-be-resolved). The doctrine in this file is CONFIRMED; the file's location is PROPOSED pending OPEN-DR-09.
+
+---
+
+## Contents
+
+1. [Scope](#1-scope)
+2. [The five lifecycle stages](#2-the-five-lifecycle-stages)
+3. [Promotion gates A–G](#3-promotion-gates-ag)
+4. [Required artifacts at each stage exit](#4-required-artifacts-at-each-stage-exit)
+5. [Trust-membrane rule](#5-trust-membrane-rule)
+6. [Lifecycle state × outcome state — orthogonality](#6-lifecycle-state--outcome-state--orthogonality)
+7. [Promotion flow diagram](#7-promotion-flow-diagram)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Open questions](#9-open-questions)
+10. [Cross-references](#10-cross-references)
+
+---
+
+## 1. Scope
+
+This file defines **lifecycle state** — the stage an artifact occupies inside the KFM promotion pipeline. Each stage holds the artifact under a default-deny gate until validators, policy checks, and review records combine to authorize the next stage.
+
+Lifecycle state is **orthogonal to outcome state** *(finite outcomes — [`finite-outcomes.md`](./finite-outcomes.md))* and **orthogonal to review state** *(`ReviewRecord` lifecycle — [`review-state.md`](./review-state.md))*. An artifact can simultaneously be `PROCESSED` *(lifecycle)*, `pending` *(review)*, and contribute to an `ABSTAIN` outcome on a public surface. Collapsing the three is the canonical state-family-collapse anti-pattern.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. The five lifecycle stages
+
+> **CONFIRMED enum.** Renaming, splitting, or merging stages is ADR-class. *(directory-rules.md §2.4.)*
+
+| Stage | Handling responsibility | Public-surface visibility |
+|---|---|---|
+| **`RAW`** | Capture immutable source payload or reference *(with source role, rights, sensitivity, citation, time, hash)*. | **Never** publicly served. Focus Mode UI MUST NOT read this stage. |
+| **`WORK` / `QUARANTINE`** | Normalize schema, geometry, time, identity, evidence, rights, policy. Hold failures in `QUARANTINE` with a recorded reason. | **Never** publicly served. |
+| **`PROCESSED`** | Emit validated normalized objects, receipts, public-safe candidates. | **Never** publicly served — exists only to feed `CATALOG/TRIPLET` and promotion gates. |
+| **`CATALOG` / `TRIPLET`** | Emit catalog records, `EvidenceBundle`s, graph/triplet projections, release candidates. | **Never** publicly served — release candidate, not release. |
+| **`PUBLISHED`** | Serve released public-safe artifacts through governed APIs and manifests. | **Only** stage public surfaces *(Focus Mode runtime, Evidence Drawer, Layer manifest resolver)* MAY consume. |
+
+> [!CAUTION]
+> **There is no half-published stage.** An artifact either has a current `ReleaseManifest` *(== `PUBLISHED`)* or it does not *(== not publishable)*. Any UI flow that renders pre-release content to a public role is a trust-membrane breach.
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Promotion gates A–G
+
+> **Evidence basis:** Doctrine Synthesis Part X; CONFIRMED gate names; PROPOSED gate-by-gate implementation contract.
+
+Each gate is a governed state transition. A gate either records `PASS` *(with `ValidationReport` + `PolicyDecision`)* and advances the artifact, or records `FAIL`/`HOLD` and keeps the artifact in place.
+
+| Gate | Between | What it checks | Required artifacts to PASS |
+|---|---|---|---|
+| **A — Schema admission** | `RAW` → `WORK` | Source payload parses; mandatory fields present; identifiers well-formed. | `SourceIntakeRecord`, `ValidationReport (schema)`. |
+| **B — Rights & policy admission** | `WORK` → `WORK`* *(internal)* | Source rights compatible with intended use; sensitivity class assigned; policy bundle applies. | `PolicyDecision (admission)`, rights record. |
+| **C — Normalization** | `WORK` → `PROCESSED` | Geometry valid; time normalized; identity reconciled; digest computed. | `ValidationReport (normalization)`, digest. |
+| **D — Evidence closure** | `PROCESSED` → `CATALOG/TRIPLET` | Every claim has an `EvidenceRef`; refs resolve; hash chain closes. | `EvidenceRef`, `EvidenceBundle (candidate)`, closure report. |
+| **E — Catalog admission** | `CATALOG/TRIPLET` → release candidate | Catalog records consistent; triplet projection valid; cross-references resolve. | Catalog record, triplet projection. |
+| **F — Review & sensitivity** | release candidate → release-eligible | `ReviewRecord` resolves to `approved`; separation-of-duties enforced on sensitive lanes. | `ReviewRecord (approved)`, reviewer identity ≠ author for sensitive lanes. |
+| **G — Release & rollback** | release-eligible → `PUBLISHED` | `ReleaseManifest` issued; rollback target recorded; correction path declared. | `ReleaseManifest`, rollback target ref, `CorrectionNotice` slot. |
+
+> [!NOTE]
+> **`QUARANTINE` is a holding bay, not a gate.** An artifact lands in `QUARANTINE` when gate A, B, or C records a `FAIL` that is recoverable *(e.g., fixable schema error, pending rights clearance)*. It does not advance until the underlying issue resolves; if it never resolves, it terminates without promotion.
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Required artifacts at each stage exit
+
+Restated and expanded from [README §8](./README.md#8-lifecycle-state). The artifacts below MUST exist before the stage transition is recorded; gates that pass without them are invalid.
+
+| Stage exit | Required artifact | Where it lives *(canonical home)* |
+|---|---|---|
+| `RAW` → `WORK` | `SourceDescriptor`; `SourceIntakeRecord`; capture hash | `data/raw/<area>/` *(internal)*; `data/catalog/sources/<area>/source_descriptors.yaml` |
+| `WORK` → `PROCESSED` | `ValidationReport (schema, geometry, identity)`; `PolicyDecision (admission)`; quarantine reason *(if held)* | `data/work/<area>/`; `data/quarantine/<area>/` *(if held)*; receipts in `data/receipts/` *(PROPOSED home)* |
+| `PROCESSED` → `CATALOG/TRIPLET` | `EvidenceRef`; `EvidenceBundle (candidate)`; closure report; digest | `data/processed/<area>/`; bundle index in `data/catalog/` |
+| `CATALOG/TRIPLET` → release candidate | Catalog record; triplet projection; release-candidate dossier | `data/catalog/`; `release/candidates/<area>-focus-mode/` |
+| release candidate → `PUBLISHED` | `ReleaseManifest`; rollback target; `ReviewRecord (approved)`; correction path | `release/manifests/focus_modes/`; `data/published/layers/<area>/`; `data/published/api_payloads/focus-modes/<area>.json` |
+
+> [!IMPORTANT]
+> **Receipts are part of the contract, not nice-to-haves.** `ValidationReport`, `PolicyDecision`, `EvidenceBundle`, `ReleaseManifest`, and `RollbackCard` are not optional artifacts — they are the audit chain that lets a Focus Mode answer be replayed, challenged, or rolled back. A promotion without its receipt is a promotion that cannot be undone. *(Atlas v1.1 §24.12; CONFIRMED doctrine.)*
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Trust-membrane rule
+
+> **CONFIRMED doctrine.** Public clients *(including Focus Mode UI under `apps/explorer-web/src/focus-modes/<area>/`)* read **only** `PUBLISHED` artifacts via governed APIs. *(directory-rules.md §6.7.5, §7.1.)*
+
+| Direction | Allowed? | Notes |
+|---|---|---|
+| Focus Mode UI → `data/published/` *(via governed API)* | yes | Only path that survives review. |
+| Focus Mode UI → `data/raw/` | **no** | Trust-membrane breach. |
+| Focus Mode UI → `data/work/` | **no** | Trust-membrane breach. |
+| Focus Mode UI → `data/quarantine/` | **no** | Trust-membrane breach. |
+| Focus Mode UI → `data/processed/` | **no** | Pre-release; trust-membrane breach. |
+| Focus Mode UI → `data/catalog/` *(directly)* | **no** | Catalog records are not release artifacts; reach them via governed API. |
+| Governed API → all stages | yes *(role-scoped)* | Internal role only; public role sees only `PUBLISHED`. |
+| Validator → all stages | yes *(read-only)* | Validators audit the chain; they do not serve. |
+| AI runtime → `MapContextEnvelope` *(derived from `PUBLISHED`)* | yes | The AI never reads stages directly; it reads the envelope. |
+
+> [!CAUTION]
+> **A single read of `data/raw/` from a public client poisons the trust path.** It MUST be caught by `validate_focus_mode_payload.py` *(PROPOSED)* on every PR that touches `apps/explorer-web/src/focus-modes/`. Negative fixture `public_raw_access.invalid.json` *(see [README §18.3 in docs/focus-mode/README.md](../README.md#183-fixtures-both-directions))* is required.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Lifecycle state × outcome state — orthogonality
+
+> **CONFIRMED separation.** Collapsing lifecycle into outcome *(treating `PROCESSED` as `ANSWER`)* is the canonical anti-pattern. The two vocabularies share no values, no transitions, and no enforcement points.
+
+| Lifecycle stage | Can produce a public outcome? | If so, which? |
+|---|---|---|
+| `RAW` | **no** | Internal only. |
+| `WORK`/`QUARANTINE` | **no** | Internal only. |
+| `PROCESSED` | **no** | Pre-release; surfaces MUST treat this as `not_yet_released` → `ABSTAIN`. |
+| `CATALOG/TRIPLET` | **no** | Release candidate; surfaces MUST treat this as `not_yet_released` → `ABSTAIN`. |
+| `PUBLISHED` | **yes** | Any of `ANSWER` / `ABSTAIN` / `DENY` / `ERROR` / `HOLD` — depending on the runtime decision evaluated over the released artifact. |
+
+> [!IMPORTANT]
+> **`PUBLISHED` does not equal `ANSWER`.** Released evidence is the *precondition* for `ANSWER`, not its substitute. Policy denials, sensitivity classifications, review holds, and freshness checks can still produce `DENY` / `HOLD` / `ABSTAIN` over a fully `PUBLISHED` artifact.
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Promotion flow diagram
+
+```mermaid
+flowchart LR
+  RAW["RAW<br/><i>SourceDescriptor</i><br/><i>SourceIntakeRecord</i>"] -->|"Gate A: schema admission"| WQ["WORK<br/><i>ValidationReport (schema)</i>"]
+  WQ -->|"Gate B: rights & policy"| WQ2["WORK<br/><i>PolicyDecision (admission)</i>"]
+  WQ2 -->|"Gate C: normalization"| PROC["PROCESSED<br/><i>EvidenceRef · digest</i>"]
+  WQ -. "Gate A/B/C FAIL (recoverable)" .-> QUAR["QUARANTINE<br/><i>reason recorded</i>"]
+  QUAR -. "issue resolved" .-> WQ
+  PROC -->|"Gate D: evidence closure"| CAT["CATALOG / TRIPLET<br/><i>EvidenceBundle (candidate)</i>"]
+  CAT -->|"Gate E: catalog admission"| RC["release candidate<br/><i>dossier</i>"]
+  RC -->|"Gate F: review & sensitivity"| RE["release-eligible<br/><i>ReviewRecord (approved)</i>"]
+  RE -->|"Gate G: release & rollback"| PUB["PUBLISHED<br/><i>ReleaseManifest · rollback target</i>"]
+  PUB -. "correction" .-> CORR["CorrectionNotice"]
+  CORR -. "supersedes" .-> PUB
+  PUB -. "revocation" .-> REV["REVOKED<br/><i>see revocation-state.md</i>"]
+  classDef quarantine fill:#fff4e0,stroke:#d97706,color:#7c2d12;
+  classDef published fill:#dcfce7,stroke:#14532d,color:#000;
+  classDef revoked fill:#fee2e2,stroke:#7f1d1d,color:#000;
+  class QUAR quarantine;
+  class PUB published;
+  class REV revoked;
+```
+
+> [!NOTE]
+> Revocation and rollback live in [`revocation-state.md`](./revocation-state.md). `PUBLISHED → REVOKED` and `PUBLISHED → rolled-back` are first-class transitions, not stages within this pipeline.
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine | Mitigation |
+|---|---|---|
+| **Silent promotion** — moving a file from `data/work/` to `data/published/` without a gate decision. | Bypasses receipts; promotion cannot be replayed or rolled back. | Promotion is a state transition with a recorded `PolicyDecision`. No file moves outside the gate. |
+| **`PROCESSED` served publicly** — surface reads `data/processed/` and renders. | Pre-release content reaches public role; cite-or-abstain collapses. | Trust-membrane rule *(§5)*. Public surface reads `PUBLISHED` only. |
+| **`QUARANTINE` masked** — quarantined artifact silently absent from index. | Audit cannot tell "never existed" from "held". | `QUARANTINE` records carry a reason; index lists held items separately. |
+| **No rollback target** — `PUBLISHED` artifact without prior `ReleaseManifest` ref. | Cannot roll back when a correction is needed. | Gate G blocks promotion until rollback target is recorded. |
+| **Validator-as-promoter** — validator emits `PASS` and the artifact appears in `data/published/`. | Validators are not authoritative for release. | Validators emit `PASS`/`FAIL`; release is gated by `ReviewRecord` + `ReleaseManifest`. |
+| **State-family collapse** — treating `PROCESSED` as `ANSWER`. | Two vocabularies merged; transitions lost. | Keep the two enums separate *(§6)*; surface returns finite outcome derived from released artifact. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Open questions
+
+| ID | Question | Class |
+|---|---|---|
+| LC-Q1 | Are gate names A–G stable, or should they be renamed to schema/policy/normalization/etc.? | Vocabulary |
+| LC-Q2 | Should `CATALOG` and `TRIPLET` split into two distinct stages? | Stage shape |
+| LC-Q3 | Receipt storage — `data/receipts/` vs `data/published/receipts/` vs alongside artifact? | Storage layout |
+| LC-Q4 | Is `QUARANTINE` a side-state of `WORK` or a distinct top-level stage? *(Currently rendered as a fork off `WORK`.)* | Stage shape |
+| LC-Q5 | Should an artifact that exits `QUARANTINE` re-enter at `WORK` or carry forward its partial validation? | Promotion semantics |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Cross-references
+
+- [`docs/focus-mode/state/README.md`](./README.md) §8 — lifecycle state overview.
+- [`docs/focus-mode/state/finite-outcomes.md`](./finite-outcomes.md) — the orthogonal outcome vocabulary.
+- [`docs/focus-mode/state/review-state.md`](./review-state.md) — `ReviewRecord` lifecycle gating gate F.
+- [`docs/focus-mode/state/payload-state.md`](./payload-state.md) — payload freshness over `PUBLISHED` artifacts.
+- [`docs/focus-mode/state/revocation-state.md`](./revocation-state.md) — `PUBLISHED` → `REVOKED` / rolled-back transitions.
+- [`docs/focus-mode/state/transitions/candidate-to-hold.md`](./transitions/candidate-to-hold.md) — release-candidate → `HOLD` transition under gate F.
+- `directory-rules.md` §6.7.5, §7.1, §9 — trust-membrane rule; pipeline gates.
+- `kfm_unified_doctrine_synthesis.md` Part X — pipeline gates A–G.
+- `KFM_Domains_v1_1_plus_Pass23_Pass32_Consolidated_Atlas.md` Part I.H — lifecycle posture.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/map-context-state.md
+++ b/docs/focus-mode/state/map-context-state.md
@@ -1,0 +1,255 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-map-context-state
+title: Focus Mode — MapContextEnvelope Shape and Freshness Rules
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/README.md §10.2
+  - docs/focus-mode/state/payload-state.md
+  - docs/focus-mode/state/finite-outcomes.md §4.3 (ERROR codes)
+  - contracts/focus_mode/map_context_envelope.md (PROPOSED)
+  - schemas/contracts/v1/focus_mode/map_context_envelope.schema.json (PROPOSED)
+tags: [kfm, focus-mode, state, map-context-envelope, freshness, admission-check, viewport, maplibre]
+notes:
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+  - MapContextEnvelope shape is CONFIRMED doctrine per MapLibre v2.1 ML-O-067/068/069; implementation contract is PROPOSED.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Focus Mode — MapContextEnvelope State
+
+> *Shape, required fields, admission-check rules, and freshness semantics for the `MapContextEnvelope` — the immutable request envelope a Focus Mode runtime sees of the map (camera, layers, features, time, releases, evidence refs).*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-MapLibre%20v2.1%20ML--O--069-blue)
+![envelope](https://img.shields.io/badge/envelope-immutable-success)
+![admission](https://img.shields.io/badge/admission--check-required-success)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **The `MapContextEnvelope` is the immutable contract between the map UI and the Focus Mode runtime.** The runtime never reads the map directly; it reads the envelope. An envelope that fails admission yields `ERROR`, not a best-effort answer. *(CONFIRMED — MapLibre v2.1 ML-O-067/068/069; Atlas v1.1 §24.11.4.)*
+
+> [!CAUTION]
+> **Path placement diverges from Directory Rules v1.2 §6.7.2** — see [README §2.1](./README.md#21-path-divergence-must-be-resolved). Doctrine CONFIRMED; file location PROPOSED pending OPEN-DR-09.
+
+---
+
+## Contents
+
+1. [Scope](#1-scope)
+2. [Required fields](#2-required-fields)
+3. [Admission check](#3-admission-check)
+4. [Freshness rules](#4-freshness-rules)
+5. [Envelope state diagram](#5-envelope-state-diagram)
+6. [Viewport-pull governance](#6-viewport-pull-governance)
+7. [Envelope state vs payload state](#7-envelope-state-vs-payload-state)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Open questions](#9-open-questions)
+10. [Cross-references](#10-cross-references)
+
+---
+
+## 1. Scope
+
+This file defines the **shape, freshness, and admission state** of the `MapContextEnvelope` — the bounded, validated, immutable snapshot of map UI state that a Focus Mode runtime consumes before producing a `FocusModeResponse`.
+
+The envelope sits between two trust-membrane crossings:
+
+1. **UI → runtime** — the UI assembles the envelope from its current state and submits it; the runtime admits or rejects.
+2. **Runtime → resolvers** — the runtime resolves the envelope's refs against the governed evidence store; closure feeds payload state *(see [`payload-state.md`](./payload-state.md))*.
+
+The runtime **MUST NOT** read the live UI store, raw layer data, or any state outside the envelope. Everything the runtime knows about the map comes through this envelope.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Required fields
+
+> **CONFIRMED minimum field set per MapLibre v2.1 ML-O-069.** Additional fields may be defined per area; removing or renaming any of the below is ADR-class.
+
+| Field | Type | Purpose | Failure → outcome |
+|---|---|---|---|
+| `time_window` | `{start, end}` ISO-8601 | Temporal scope of the request. | Missing/malformed → `ERROR (envelope_malformed)` |
+| `layer_ids[]` | array of `LayerID` | Which released layers the user has visible/selected. | Includes non-`PUBLISHED` layer → `ERROR (envelope_malformed)` or `DENY (release_state_deny)` |
+| `feature_ids[]` | array of `FeatureID` | Which features the user has selected, if any. | IDs not in cited layers → `ERROR (envelope_malformed)` |
+| `spec_hash` | content hash | Hash of the layer-style + filter spec under which the layers render. | Hash mismatch with current release → `ERROR (envelope_malformed)` *(or rebind)* |
+| `release_refs[]` | array of `ReleaseManifest` refs | Which release the visible layers come from. | Ref does not resolve → `ERROR` |
+| `evidence_refs[]` | array of `EvidenceRef` | Pre-selected evidence the user requested *(e.g., from Evidence Drawer)*. | Ref does not resolve → propagated to payload; `ABSTAIN` or `ERROR` per closure step |
+| `area_scope` | area identifier + scope suffix | Which Focus Mode area the envelope addresses. | Unknown area → `ERROR (envelope_malformed)` |
+| `assembled_at` | ISO-8601 | When the UI assembled the envelope. | Older than admission TTL → `ERROR (envelope_malformed)` or re-assembly requested |
+| `spec_version` | semver | Envelope contract version. | Unsupported version → `ERROR (contract_violation)` |
+| `request_id` | UUID | Idempotency and audit. | Required; missing → `ERROR (envelope_malformed)` |
+| `caller_role` | enum | `public` / `internal` / `validator`. | Determines policy; required. |
+
+> [!NOTE]
+> **The envelope does NOT carry the user's query text.** Query text is a separate field in the `FocusModeRequest` that wraps the envelope. Keeping them separate means the envelope can be replayed against the same data without re-asking the question.
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Admission check
+
+> **Default-deny.** The runtime evaluates the admission check **before** any resolver or policy step. A failing check yields `ERROR` immediately; no partial work is attempted.
+
+| Check | Validates | On failure |
+|---|---|---|
+| **Schema admission** | Envelope parses against `schemas/contracts/v1/focus_mode/map_context_envelope.schema.json` *(PROPOSED)*. | `ERROR (schema_missing)` or `ERROR (envelope_malformed)` |
+| **Version admission** | `spec_version` is supported by this runtime. | `ERROR (contract_violation)` |
+| **Time-window sanity** | `time_window.start ≤ time_window.end`; window within configured bounds *(no future windows beyond +N days; no pre-history before configured floor)*. | `ERROR (envelope_malformed)` |
+| **Layer/release binding** | Every `layer_ids[i]` resolves to a `PUBLISHED` layer whose `release_refs[]` entry is current. | `DENY (release_state_deny)` if a layer is not `PUBLISHED`; `ERROR` if a release ref dangles. |
+| **Spec-hash match** | `spec_hash` matches the current spec for the cited layers/release. | If mismatch, runtime MAY reject or MAY rebind to a current spec and re-issue the envelope *(receipt records the rebinding)*. |
+| **Feature membership** | Every `feature_ids[i]` belongs to one of `layer_ids[]`. | `ERROR (envelope_malformed)` |
+| **Area scope match** | `area_scope` corresponds to a registered Focus Mode area *(via index — see [`docs/focus-mode/state/STATE_INDEX.md`](./STATE_INDEX.md) and `docs/focus-mode/counties/COUNTY_INDEX.md`)*. | `ERROR (envelope_malformed)` |
+| **Caller-role admission** | `caller_role` is allowed for this surface. | `DENY (role_deny)` |
+| **Citation closure** *(envelope-level)* | Every `evidence_refs[]` entry resolves; deferred closure for payload-level claims. | `ERROR` or downstream `ABSTAIN` per [`payload-state.md` §3](./payload-state.md#3-citation-closure). |
+| **TTL** | `now - assembled_at < admission_ttl` *(default: 60 seconds)*. | Re-assembly requested; `ERROR (envelope_malformed)` if persistent. |
+
+> [!IMPORTANT]
+> **A failed admission check is `ERROR`, not `ABSTAIN`.** The runtime cannot evaluate the request as posed — that is a diagnostic failure, not an evidentiary one. *(See [`finite-outcomes.md` §4.3](./finite-outcomes.md#43-error-diagnostic-codes-proposed-enum) for the diagnostic codes.)*
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Freshness rules
+
+Envelope freshness is **distinct from payload freshness**. The envelope describes the request scope at a moment; the payload describes what's citable inside that scope.
+
+| Envelope freshness state | When | Effect |
+|---|---|---|
+| `current` | `assembled_at` within TTL; `spec_hash` matches; release refs current. | Accept; proceed to payload assembly. |
+| `rebindable` | `spec_hash` mismatch but release refs still resolve; or release refs point to superseded but still-addressable manifests. | Runtime MAY rebind to current spec and re-issue the envelope; receipt records the rebinding. |
+| `stale` | `assembled_at` past TTL; or release refs no longer resolve to current. | `ERROR (envelope_malformed)`; UI MUST reassemble. |
+| `invalid` | Any admission check fails *(per §3)*. | `ERROR` with specific diagnostic code. |
+
+> [!NOTE]
+> **TTL is short on purpose.** A 60-second TTL means the envelope reflects the user's current map state within a tight window. Longer TTLs invite race conditions between the user's interaction and release changes.
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Envelope state diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> assembling : UI builds envelope
+  assembling --> schema_check : submit
+  schema_check --> invalid : schema fail
+  schema_check --> version_check : schema ok
+  version_check --> invalid : unsupported version
+  version_check --> binding_check : version ok
+  binding_check --> invalid : non-PUBLISHED layer
+  binding_check --> hash_check : layers ok
+  hash_check --> rebindable : spec_hash mismatch
+  hash_check --> ttl_check : hash ok
+  rebindable --> ttl_check : rebound
+  rebindable --> stale : rebind impossible
+  ttl_check --> stale : past TTL
+  ttl_check --> current : within TTL
+  current --> [*] : pass to runtime
+  invalid --> [*] : ERROR
+  stale --> [*] : ERROR (re-assemble)
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Viewport-pull governance
+
+> **Evidence basis:** KFM-P21-FEAT-0002 *(HUC12 viewport pulls; PROPOSED)*; MapLibre v2.1 ML-O-068/069/070.
+
+The envelope MAY include a `viewport_pull[]` field carrying scoped, on-demand fetches *(e.g., HUC12 boundaries clipped to the visible camera)*. These are **only admissible when**:
+
+| Rule | Why |
+|---|---|
+| Each pull is **scoped** *(area + time + domain)*. | Unbounded "fetch what's on screen" breaks scope governance. |
+| Each pull is **policy-aware** *(checks rights/sensitivity before serving)*. | Sensitivity defaults still apply at the viewport level. |
+| Each pull is **tied to a `SourceDescriptor`**. | The pull is not a new source; it cites an existing one. |
+| Each pull is **bounded by the envelope's `time_window`**. | A pull cannot expand the request's temporal scope. |
+| Each pull returns a **deterministic clip** *(same query → same bytes)*. | Replay and audit. |
+
+> [!CAUTION]
+> **An unbounded viewport pull is `DENY`.** A request that says "fetch every layer intersecting the viewport, regardless of scope, rights, or release state" is doctrine-violating. The runtime emits `DENY (release_state_deny)` or `ERROR (contract_violation)`. *(KFM-P21-FEAT-0002, PROPOSED.)*
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Envelope state vs payload state
+
+| Concern | Envelope state | Payload state |
+|---|---|---|
+| What it describes | The user's request scope *(at the moment of assembly)* | The released evidence available for that scope |
+| Freshness driver | Time since assembly + release-ref currency | Bundle age + revocation |
+| Failure outcome | `ERROR` *(scope undefined/invalid)* | `ABSTAIN` *(scope defined but evidence insufficient)* |
+| Authority | UI assembles; runtime admits | Runtime assembles; policy evaluates |
+| Hash binding | `spec_hash` *(layer/style/filter spec)* | bundle content hashes |
+| Replayable? | yes — same envelope + same release = same admission decision | yes — same payload hashes = same closure verdict |
+
+> [!IMPORTANT]
+> **Both must align for `ANSWER`.** A `current` envelope with a `stale` payload still produces `ABSTAIN`. An `invalid` envelope short-circuits to `ERROR` and the payload is never assembled.
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine | Mitigation |
+|---|---|---|
+| **Runtime reads live UI store** — bypasses the envelope. | Removes the trust membrane; no audit. | Runtime accepts only the envelope; UI store invisible. |
+| **Envelope mutable post-admission** — fields rewritten during evaluation. | Replay impossible; receipt no longer matches what was evaluated. | Envelope is immutable once admitted; re-assembly creates a new envelope with a new `request_id`. |
+| **Layer not `PUBLISHED`** — envelope cites `WORK`/`PROCESSED`/`CATALOG` layer. | Pre-release content reaches the runtime. | Binding check rejects; `DENY` or `ERROR`. |
+| **Unbounded viewport pull** — "give me everything on screen". | Breaks scope governance. | §6 admissibility rules. |
+| **Missing `spec_hash`** — envelope omits the hash. | Silent spec drift; layer render desync from cited bundle. | Required field; admission rejects. |
+| **Long TTL** — envelope reused for minutes/hours. | Race with release changes; envelope may cite a since-superseded release. | Short TTL *(default 60s)*; UI re-assembles. |
+| **No `request_id`** — repeated requests collapse in audit. | Cannot distinguish replays from initial requests. | Required field. |
+| **Stitched envelope** — UI assembles by joining cached fragments without re-checking release refs. | Stale release refs accepted. | UI MUST re-fetch release-ref currency on every assembly. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Open questions
+
+| ID | Question | Class |
+|---|---|---|
+| MC-Q1 | Should `viewport_pull[]` be a separate envelope sibling or a field inside the existing envelope? | Schema shape |
+| MC-Q2 | What is the canonical admission TTL — 60s, 30s, configurable per area? | Tuning |
+| MC-Q3 | Should `spec_hash` mismatch always allow rebinding, or sometimes reject outright *(e.g., when style changed materially)*? | Rebinding semantics |
+| MC-Q4 | Is `assembled_at` clock-skew-tolerant? *(UI clock can drift.)* | Time semantics |
+| MC-Q5 | Does the envelope carry user identity *(for role-scoped policy)* or only `caller_role`? | Privacy/scope |
+| MC-Q6 | Multi-layer envelopes with mixed sensitivity — single envelope-level outcome or per-layer? | Outcome shape |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Cross-references
+
+- [`docs/focus-mode/state/README.md`](./README.md) §10.2 — `MapContextEnvelope` overview.
+- [`docs/focus-mode/state/payload-state.md`](./payload-state.md) — payload freshness *(distinct from envelope freshness)*.
+- [`docs/focus-mode/state/finite-outcomes.md`](./finite-outcomes.md) §4.3 — `ERROR` diagnostic codes.
+- `contracts/focus_mode/map_context_envelope.md` *(PROPOSED)* — semantic contract.
+- `schemas/contracts/v1/focus_mode/map_context_envelope.schema.json` *(PROPOSED)* — machine schema.
+- `Master_MapLibre_Components-Functions-Features_v2_1_FULL.md` ML-O-067/068/069/070 — envelope shape doctrine.
+- `KFM_Domains_v1_1_plus_Pass23_Pass32_Consolidated_Atlas.md` §24.11.4 — AI surface health.
+- KFM-P21-FEAT-0002 *(PROPOSED)* — HUC12 viewport pulls.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/payload-state.md
+++ b/docs/focus-mode/state/payload-state.md
@@ -1,0 +1,254 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-payload-state
+title: Focus Mode — Payload State (FocusModePayload freshness and citation closure)
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/README.md §10
+  - docs/focus-mode/state/finite-outcomes.md §4.1 (ABSTAIN reason codes)
+  - docs/focus-mode/state/map-context-state.md
+  - docs/focus-mode/state/revocation-state.md
+  - docs/focus-mode/state/transitions/answer-to-abstain.md
+  - contracts/focus_mode/focus_mode_payload.md (PROPOSED)
+  - schemas/contracts/v1/focus_mode/focus_mode_payload.schema.json (PROPOSED)
+tags: [kfm, focus-mode, state, payload, freshness, citation-closure]
+notes:
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+  - Payload state is independent of the lifecycle stage of underlying artifacts; both states must align before ANSWER is allowed.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Focus Mode — Payload State
+
+> *`FocusModePayload` freshness states (`fresh` · `stale` · `not-yet-released` · `revoked-but-cached` · `unknown`), citation-closure rules, and the runtime checks that map each payload state to a finite outcome.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-payload--freshness-blue)
+![states](https://img.shields.io/badge/states-5-2b8a3e)
+![citation-closure](https://img.shields.io/badge/citation--closure-required-success)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **A `FocusModePayload` is the bounded projection of released evidence a Focus Mode answer is built from.** It carries its own freshness state independent of the underlying artifacts' lifecycle stages. A payload that resolves cleanly is necessary but not sufficient for `ANSWER` — policy decision, review state, and revocation state must also align.
+
+> [!CAUTION]
+> **Path placement diverges from Directory Rules v1.2 §6.7.2** — see [README §2.1](./README.md#21-path-divergence-must-be-resolved). Doctrine CONFIRMED; file location PROPOSED pending OPEN-DR-09.
+
+---
+
+## Contents
+
+1. [Scope](#1-scope)
+2. [The five payload states](#2-the-five-payload-states)
+3. [Citation closure — what counts as closed](#3-citation-closure)
+4. [Freshness window — what counts as fresh](#4-freshness-window)
+5. [Payload state × outcome state mapping](#5-payload-state--outcome-state-mapping)
+6. [Payload composition rules](#6-payload-composition-rules)
+7. [Lifecycle of a payload at runtime](#7-lifecycle-of-a-payload-at-runtime)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Open questions](#9-open-questions)
+10. [Cross-references](#10-cross-references)
+
+---
+
+## 1. Scope
+
+This file defines **payload state** — the freshness, closure, and resolution state of the `FocusModePayload` a Focus Mode runtime evaluates when answering a request.
+
+Payload state is **independent of**:
+
+- **Lifecycle state** *(of the underlying artifacts; see [`lifecycle-states.md`](./lifecycle-states.md))* — a payload citing only `PUBLISHED` artifacts can still be `stale` if those artifacts were superseded.
+- **Review state** *(of any single artifact; see [`review-state.md`](./review-state.md))* — a payload can resolve cleanly while a revision of one cited artifact sits at `pending`.
+- **Map context state** *(of the request envelope; see [`map-context-state.md`](./map-context-state.md))* — payload freshness is about evidence age and revocation; envelope freshness is about request-scope validity.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. The five payload states
+
+> **CONFIRMED envelope shape doctrine *(Atlas v1.1 §20.3, §24.11.4)*; PROPOSED per-state implementation contract.**
+
+| State | When | Public effect |
+|---|---|---|
+| **`fresh`** | All cited evidence is `PUBLISHED`, in-window, and not revoked. Citation closure verified. | `ANSWER` allowed *(subject to policy)*. |
+| **`stale`** | Underlying evidence has been superseded *(new `ReleaseManifest` exists)* or has aged past its freshness window. | `ABSTAIN (payload_stale)` unless a released alternative is found and re-bound. |
+| **`not-yet-released`** | At least one referenced artifact is still `PROCESSED` or `CATALOG/TRIPLET`. | `ABSTAIN (not_yet_released)` — never `ANSWER`. |
+| **`revoked-but-cached`** | Evidence has been revoked but UI still holds a cached payload locally. | `ABSTAIN (revoked_no_alternative)` and surface revocation reason — never `ANSWER`. |
+| **`unknown`** | Payload is well-formed but evidence resolution returned `ERROR`. | `ERROR` envelope — never silently `ANSWER`. |
+
+> [!NOTE]
+> **`fresh` is the only state that permits `ANSWER`.** All four other states drive the runtime to `ABSTAIN`/`ERROR`. This is the single most important invariant of payload state.
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Citation closure
+
+> **CONFIRMED doctrine — cite-or-abstain.** *(Doctrine Synthesis Part III; Atlas v1.1 §24.3.)*
+
+A payload achieves **citation closure** when every claim it carries has at least one `EvidenceRef` that:
+
+1. Resolves to a released `EvidenceBundle`.
+2. The bundle is not revoked.
+3. The bundle's content hash matches the digest in the `EvidenceRef`.
+4. The bundle's covered subject, time window, and area intersect the claim.
+
+| Closure check | Failure → payload state |
+|---|---|
+| `EvidenceRef` does not resolve | `unknown` *(→ `ERROR`)* or `stale` *(if a superseding ref exists)* |
+| Bundle revoked | `revoked-but-cached` *(→ `ABSTAIN`)* |
+| Hash mismatch | `unknown` *(→ `ERROR` — integrity break)* |
+| Subject/time/area intersection fails | `stale` or "no claim binding" — emit `ABSTAIN (evidence_insufficient)` |
+| Bundle not yet `PUBLISHED` | `not-yet-released` *(→ `ABSTAIN`)* |
+| All claims pass | closure achieved → state moves to `fresh` *(pending freshness window check)* |
+
+> [!IMPORTANT]
+> **Closure is per-claim, not per-payload.** A payload with five claims where four close and one does not is **not** `fresh` — the runtime MUST either drop the failing claim *(if the remaining four still answer the request)* or emit `ABSTAIN` for the whole. Partial citation cannot pose as full citation. *(Anti-pattern — `partial-closure`, §8.)*
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Freshness window
+
+A `fresh` payload requires every cited `EvidenceBundle` to be within its configured **freshness window**. The window is per-domain and per-evidence-type; it lives in the bundle's metadata, not the payload.
+
+| Window family *(PROPOSED defaults)* | Typical bundle | Default window |
+|---|---|---|
+| Static reference *(boundaries, geology bedrock)* | Cadastral, geological survey | 1 year *(re-check; usually still fresh)* |
+| Annual aggregate *(CDL, soils, climate normals)* | NRCS, NASS, NOAA normals | 1 year + grace period |
+| Quarterly *(some hydrology, hazard summaries)* | USGS NWIS quarterly summaries | 90 days + grace period |
+| Monthly *(some atmosphere, hazard event indexes)* | NOAA storm events, KDHE AQ | 30 days |
+| Event-time *(declarations, advisories)* | FEMA declarations, NWS advisories | event-specific; expires at declared end |
+| Real-time *(rare in KFM — generally not admissible at all)* | Live sensor feeds | not admissible without aggregation |
+
+> [!NOTE]
+> **Real-time data is generally not admissible** as Focus Mode evidence. KFM is not an alert authority. Real-time sources are admissible only after aggregation, validation, and release per the standard pipeline. *(See [`docs/focus-mode/README.md` §15](../README.md#15-sensitivity-defaults-fail-closed-lanes) — emergency-alert claims default to `ABSTAIN`.)*
+
+A payload becomes `stale` when **any** cited bundle's window expires. The runtime MUST then either:
+
+1. Re-bind to a newer released bundle covering the same subject *(payload returns to `fresh`)*, or
+2. Demote the surface from `ANSWER` to `ABSTAIN` *(see [`transitions/answer-to-abstain.md`](./transitions/answer-to-abstain.md))*.
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Payload state × outcome state mapping
+
+| Payload state | Allowed outcomes | Forbidden outcomes |
+|---|---|---|
+| `fresh` | `ANSWER` *(policy permitting)* · `DENY` *(policy denies)* · `HOLD` *(review pending)* · `ERROR` *(resolver fails on a non-payload concern)* | `ABSTAIN` solely on payload state — payload is fresh |
+| `stale` | `ABSTAIN (payload_stale)` · `DENY` *(if policy also denies)* · `ERROR` | `ANSWER` — staleness disqualifies the payload |
+| `not-yet-released` | `ABSTAIN (not_yet_released)` · `ERROR` | `ANSWER` · `DENY` *(can't deny a non-released artifact — policy never sees it)* |
+| `revoked-but-cached` | `ABSTAIN (revoked_no_alternative)` · `ERROR` | `ANSWER` — silently rendering revoked evidence is the canonical anti-pattern |
+| `unknown` | `ERROR` | `ANSWER` · `ABSTAIN` — `unknown` is not a quiet failure; the resolver errored |
+
+> [!IMPORTANT]
+> **A payload's freshness state alone never produces `DENY`.** `DENY` requires a policy/rights/sensitivity decision against the request — see [`finite-outcomes.md` §4.2](./finite-outcomes.md#42-deny-reason-codes-proposed-enum). Payload state can drive `ABSTAIN` but never substitutes for policy.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Payload composition rules
+
+| Rule | Why it matters |
+|---|---|
+| **Bounded** — payload covers exactly the area + time window of the request. | Out-of-scope evidence is not citable; including it widens the claim beyond what the request asked. |
+| **Released-only** — every cited bundle is `PUBLISHED`. | Trust-membrane rule *(see [`lifecycle-states.md` §5](./lifecycle-states.md#5-trust-membrane-rule))*. |
+| **Citation-closed** — every claim has at least one resolving `EvidenceRef` *(per §3)*. | Cite-or-abstain. |
+| **Receipt-attached** — `AIReceipt` lists every bundle the runtime touched, even those it ultimately did not cite. | Replay and audit. |
+| **Hash-bound** — payload carries the content hashes of cited bundles, not just IDs. | Detects in-flight tampering and silent revocation. |
+| **Time-snapshot** — payload records the timestamp at which it was assembled. | Replay across releases requires knowing which release the payload reflects. |
+| **No model output as evidence** — generated text or coordinates never appear in the evidence side-car. | Governed-AI rule; AI output is interpretive, not evidence. *(See [README §14](./README.md#14-anti-patterns) and `ai-build-operating-contract.md` §10.)* |
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Lifecycle of a payload at runtime
+
+```mermaid
+stateDiagram-v2
+  [*] --> assembling
+  assembling --> closure_check : refs gathered
+  closure_check --> not_yet_released : any ref pre-PUBLISHED
+  closure_check --> unknown : resolver ERROR
+  closure_check --> revoked_but_cached : any ref revoked
+  closure_check --> freshness_check : closure ok
+  freshness_check --> stale : any bundle expired
+  freshness_check --> fresh : all bundles in-window
+  fresh --> [*] : ANSWER (policy permitting)
+  stale --> rebinding : try newer bundle
+  rebinding --> fresh : newer released bundle found
+  rebinding --> [*] : ABSTAIN (payload_stale)
+  not_yet_released --> [*] : ABSTAIN (not_yet_released)
+  revoked_but_cached --> [*] : ABSTAIN (revoked_no_alternative)
+  unknown --> [*] : ERROR
+```
+
+> [!NOTE]
+> **Rebinding is allowed but governed.** If the payload finds a newer released bundle for the same subject *(area + time + domain)*, it MAY re-bind without emitting `ABSTAIN`. The receipt records the rebinding. If no newer bundle exists, the surface demotes to `ABSTAIN`. *(See [`transitions/answer-to-abstain.md`](./transitions/answer-to-abstain.md).)*
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine | Mitigation |
+|---|---|---|
+| **Partial closure** — payload renders `ANSWER` when 4 of 5 claims close and 1 does not. | Hides the uncited claim behind the cited ones. | Per-claim closure check; drop or `ABSTAIN`. |
+| **Cached-but-revoked render** — UI continues rendering after revocation. | Violates revocation; serves denied content. | `revoked-but-cached` state → `ABSTAIN`; see [`revocation-state.md`](./revocation-state.md). |
+| **Stale rendered as fresh** — payload assembled with last-known-good cache, never re-checked. | Surface diverges from current release; user sees outdated claim. | Freshness check on every request; window per bundle. |
+| **`not-yet-released` rendered as `ANSWER`** — release candidate mistaken for release. | Pre-release content reaches public surface. | `PUBLISHED` check in closure step; gate G enforces. |
+| **Model output as evidence** — generated coordinates or summaries land in the evidence side-car. | Governed-AI rule violated; AI promoted to truth source. | `AIReceipt` records model output as interpretation, not evidence; payload evidence side-car carries only released bundles. |
+| **Hash-less payload** — payload references bundle IDs but not content hashes. | Silent revocation or tamper invisible. | Hash-bound payload contract; reject on missing hash. |
+| **Receipt omitted on `ANSWER`** — `AIReceipt` not attached to a substantive answer. | Audit impossible; replay impossible. | Every `ANSWER` carries `AIReceipt` *(see [`finite-outcomes.md` §3](./finite-outcomes.md#3-per-outcome-required-artifacts))*. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Open questions
+
+| ID | Question | Class |
+|---|---|---|
+| PY-Q1 | Should the payload schema include a per-claim closure flag, or is closure an envelope-level property? | Schema shape |
+| PY-Q2 | Freshness window — encoded on the bundle or on the payload-binding metadata? | Authority placement |
+| PY-Q3 | Rebinding receipts — separate `RebindingNotice` or appended to `AIReceipt`? | Receipt shape |
+| PY-Q4 | Should `revoked-but-cached` and `stale` collapse into a single `obsolete` state with a reason field? | Vocabulary |
+| PY-Q5 | Per-claim TTL inside the payload vs per-bundle TTL — single source of truth? | Storage location |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Cross-references
+
+- [`docs/focus-mode/state/README.md`](./README.md) §10 — payload state and `MapContextEnvelope` state overview.
+- [`docs/focus-mode/state/finite-outcomes.md`](./finite-outcomes.md) §4.1 — `ABSTAIN` reason codes driven by payload state.
+- [`docs/focus-mode/state/lifecycle-states.md`](./lifecycle-states.md) §5 — trust-membrane rule (payload reads `PUBLISHED` only).
+- [`docs/focus-mode/state/map-context-state.md`](./map-context-state.md) — request envelope freshness *(distinct from payload freshness)*.
+- [`docs/focus-mode/state/revocation-state.md`](./revocation-state.md) — `revoked-but-cached` deep dive.
+- [`docs/focus-mode/state/transitions/answer-to-abstain.md`](./transitions/answer-to-abstain.md) — demotion path on staleness.
+- `contracts/focus_mode/focus_mode_payload.md` *(PROPOSED)* — semantic contract for `FocusModePayload`.
+- `schemas/contracts/v1/focus_mode/focus_mode_payload.schema.json` *(PROPOSED)* — machine schema.
+- `kfm_unified_doctrine_synthesis.md` Part III — cite-or-abstain.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/review-state.md
+++ b/docs/focus-mode/state/review-state.md
@@ -1,0 +1,281 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-review-state
+title: Focus Mode — Review State and HOLD Semantics
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/README.md §9
+  - docs/focus-mode/state/finite-outcomes.md §2 (HOLD outcome)
+  - docs/focus-mode/state/lifecycle-states.md §3 (Gate F — review & sensitivity)
+  - docs/focus-mode/state/transitions/candidate-to-hold.md
+  - docs/focus-mode/state/transitions/hold-to-deny.md
+  - schemas/contracts/v1/runtime/review_record.schema.json (PROPOSED)
+  - schemas/contracts/v1/runtime/policy_decision.schema.json (PROPOSED)
+tags: [kfm, focus-mode, state, review, hold, separation-of-duties, governance]
+notes:
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+  - HOLD currently exists as both an outcome (finite-outcomes.md) and a review state (this file); collision tracked in README §15.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Focus Mode — Review State and HOLD Semantics
+
+> *`ReviewRecord` lifecycle (`draft → pending → held / approved / rejected → superseded`), `HOLD` semantics, separation-of-duties enforcement for sensitive lanes, and the orthogonality between review state and lifecycle state.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-review--gate-blue)
+![states](https://img.shields.io/badge/states-6-2b8a3e)
+![separation-of-duties](https://img.shields.io/badge/separation--of--duties-enforced-success)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **Review state is orthogonal to lifecycle state.** A `PROCESSED` artifact *(lifecycle)* may be `pending` *(review)*, `held` *(review)*, or `approved` *(review)* simultaneously. Review state gates **gate F** of the lifecycle promotion pipeline but does not replace it. *(CONFIRMED — Atlas v1.1 §24.3, §24.11; Doctrine Synthesis §11.)*
+
+> [!CAUTION]
+> **Path placement diverges from Directory Rules v1.2 §6.7.2** — see [README §2.1](./README.md#21-path-divergence-must-be-resolved). The doctrine here is CONFIRMED; the file's location is PROPOSED pending OPEN-DR-09.
+
+---
+
+## Contents
+
+1. [Scope](#1-scope)
+2. [The six review states](#2-the-six-review-states)
+3. [Forward transitions and required artifacts](#3-forward-transitions-and-required-artifacts)
+4. [HOLD semantics — review state vs outcome](#4-hold-semantics--review-state-vs-outcome)
+5. [Separation of duties](#5-separation-of-duties)
+6. [Sensitive-lane review rules](#6-sensitive-lane-review-rules)
+7. [Review × lifecycle × outcome — the three-axis matrix](#7-review--lifecycle--outcome--the-three-axis-matrix)
+8. [Review-state diagram](#8-review-state-diagram)
+9. [Anti-patterns](#9-anti-patterns)
+10. [Open questions](#10-open-questions)
+11. [Cross-references](#11-cross-references)
+
+---
+
+## 1. Scope
+
+This file defines **review state** — the lifecycle of a `ReviewRecord` that gates whether a candidate artifact is allowed to advance through gate F of the promotion pipeline *(see [`lifecycle-states.md` §3](./lifecycle-states.md#3-promotion-gates-ag))*.
+
+Review state is **independent of lifecycle state**. A single artifact may carry:
+
+- a lifecycle stage *(`RAW` / `WORK` / ... / `PUBLISHED`)*,
+- a review state *(`draft` / `pending` / `held` / `approved` / `rejected` / `superseded`)*,
+- and produce a finite outcome *(`ANSWER` / `ABSTAIN` / `DENY` / `ERROR` / `HOLD`)* on a public surface.
+
+The three vocabularies interlock at well-defined points but never substitute for each other. See [§7](#7-review--lifecycle--outcome--the-three-axis-matrix) for the joint table.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. The six review states
+
+> **CONFIRMED enum.** Renames or additions are ADR-class. *(directory-rules.md §2.4.)*
+
+| State | Meaning | Carrier |
+|---|---|---|
+| `draft` | Authored; not yet submitted for review. | `ReviewRecord` *(state=draft)* |
+| `pending` | Submitted; awaiting reviewer decision. | `ReviewRecord` *(state=pending)* |
+| `held` | Paused by steward, rights-holder, or policy review. | `ReviewRecord` *(state=held)* + `PolicyDecision = HOLD` |
+| `approved` | Reviewer accepted; release gate may now evaluate. | `ReviewRecord` *(state=approved)* + reviewer identity |
+| `rejected` | Reviewer declined; artifact does not advance. | `ReviewRecord` *(state=rejected)* + reason |
+| `superseded` | Later approved revision exists; this one no longer current. | `ReviewRecord` *(state=superseded)* + `supersession_chain` entry |
+
+> [!NOTE]
+> **Review state is per-artifact-version, not per-area.** A new revision of the same artifact creates a new `ReviewRecord` whose `state` starts at `draft`. The prior `ReviewRecord` moves to `superseded` only after the new one reaches `approved`.
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Forward transitions and required artifacts
+
+| From | To | Trigger | Required artifact to record the transition |
+|---|---|---|---|
+| `draft` | `pending` | Author submits for review. | `ReviewRecord (pending)` with author identity, submission timestamp. |
+| `pending` | `approved` | Reviewer (≠ author for sensitive lanes) accepts. | `ReviewRecord (approved)` + reviewer identity; on sensitive lanes, separation-of-duties check recorded. |
+| `pending` | `rejected` | Reviewer declines. | `ReviewRecord (rejected)` + reason code. |
+| `pending` | `held` | Reviewer pauses pending external input *(steward, rights holder, policy)*. | `ReviewRecord (held)` + `PolicyDecision (HOLD)` + hold reason from [`finite-outcomes.md` §4.4](./finite-outcomes.md#44-hold-reason-codes-proposed-enum). |
+| `held` | `pending` | Hold reason resolves; review resumes. | `ReviewRecord (pending)` *(re-enter)* + hold-resolution note. |
+| `held` | `rejected` | Hold resolves to refusal — see [`transitions/hold-to-deny.md`](./transitions/hold-to-deny.md). | `ReviewRecord (rejected)` + `PolicyDecision (DENY)` + reason. |
+| `approved` | `superseded` | New revision reaches `approved`. | `supersession_chain` entry on the prior record; new `ReleaseManifest` *(if applicable)*. |
+| `rejected` | *(terminal)* | — | Re-authoring creates a new `ReviewRecord` at `draft`. |
+| `superseded` | *(terminal)* | — | Successor record carries forward. |
+
+> [!IMPORTANT]
+> **`approved` does NOT imply `PUBLISHED`.** Review approval satisfies gate F; gate G (release & rollback) still requires a `ReleaseManifest` with a rollback target. Conflating the two is the *review-as-release* anti-pattern. *(See [README §14](./README.md#14-anti-patterns).)*
+
+[↑ Back to top](#top)
+
+---
+
+## 4. HOLD semantics — review state vs outcome
+
+> **Open collision — tracked in [README §15](./README.md#15-open-questions-and-adr-triggers).** `HOLD` currently exists as both a **review state** *(this file)* and a **finite outcome** *(see [`finite-outcomes.md` §2](./finite-outcomes.md#2-the-seven-outcomes))*. The two senses interlock as follows:
+
+| Sense | Carrier | What it gates |
+|---|---|---|
+| **Review-state `HOLD`** | `ReviewRecord (held)` | Whether the artifact can advance through gate F *(promotion)*. |
+| **Outcome-state `HOLD`** | `DecisionEnvelope (outcome=HOLD)` | Whether a runtime request returns `ANSWER` / `ABSTAIN` / `DENY` *(decision)*. |
+
+A runtime `DecisionEnvelope (outcome=HOLD)` typically appears when:
+
+- The underlying `ReviewRecord` is in state `held`, **and**
+- The requested surface depends on the held artifact being `approved` to render an `ANSWER`.
+
+When that condition resolves, the next request may receive a different outcome — `ANSWER` if review resolves to `approved` *and* the released artifact remains fresh, or `DENY` / `ABSTAIN` otherwise.
+
+> [!CAUTION]
+> **`HOLD` preserves the prior surface state.** A `HOLD` envelope does **not** strip the previously-rendered claim. It signals "no change yet" — the prior `ANSWER` continues to render until the hold resolves to a new outcome. Silently rolling back the surface on `HOLD` is a doctrine violation. *(See [`finite-outcomes.md` §7](./finite-outcomes.md#7-composition-rules).)*
+
+### 4.1 Hold reason codes *(restated from [`finite-outcomes.md` §4.4](./finite-outcomes.md#44-hold-reason-codes-proposed-enum))*
+
+| Code | Used by review-state `HOLD`? | Used by outcome-state `HOLD`? |
+|---|---|---|
+| `steward_review_pending` | yes | yes |
+| `rights_holder_review_pending` | yes | yes |
+| `policy_review_pending` | yes | yes |
+| `correction_pending` | yes | yes |
+| `release_gate_pending` | no *(post-review)* | yes |
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Separation of duties
+
+> **CONFIRMED doctrine.** Where maturity justifies it, the author of a Focus Mode artifact and the approver of its release **MUST** be different identities. Enforced at the `pending → approved` transition for sensitive-lane content. *(Atlas v1.1 §24; Doctrine Synthesis §11.)*
+
+| Rule | Enforcement point | Validator |
+|---|---|---|
+| **Sensitive-lane author ≠ approver.** | `pending → approved` transition. | `validate_review_record.py` *(PROPOSED)* — emits `FAIL` if the same identity appears as both. |
+| **Approver role check.** | `pending → approved` transition. | `validate_review_record.py` — approver MUST hold a role in the lane's approver allowlist. |
+| **Reviewer attribution recorded.** | At every state transition. | `ReviewRecord` carries reviewer identity for every state change. |
+| **Audit chain immutable.** | Post-transition. | `ReviewRecord` revisions are append-only; a rejected record is never overwritten. |
+
+> [!IMPORTANT]
+> **Sensitive lanes** for separation-of-duties purposes include: archaeology coordinates, rare-species exact locations, burial/sacred sites, living-person identifiers, DNA/genomic data, and critical-infrastructure exact details. *(See [`docs/focus-mode/README.md` §15](../README.md#15-sensitivity-defaults-fail-closed-lanes) for the full table at both county and state scales.)*
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Sensitive-lane review rules
+
+| Lane | Required additional reviewer | Default approval threshold |
+|---|---|---|
+| Archaeology coordinates | Sovereignty reviewer + sensitivity steward | unanimous *(both required)* |
+| Burial / sacred locations | Sovereignty reviewer + sensitivity steward | unanimous |
+| Rare-species exact | Sensitivity steward + species steward *(if available)* | unanimous |
+| Critical-infrastructure detail | Sensitivity steward + infra steward | unanimous |
+| Living-person identifiers | Privacy steward | required |
+| DNA / genomic | Privacy steward + CARE/FAIR reviewer | unanimous |
+
+> [!NOTE]
+> The lane-specific reviewer requirements are tracked per-area in `docs/focus-mode/<area>/<area>-county/public-safety-notes.md` *(or `kansas-state/public-safety-notes.md`)*. Cross-cutting defaults live here; per-area overrides require policy bundle entries in `policy/sensitivity/<area>/`.
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Review × lifecycle × outcome — the three-axis matrix
+
+Joint table showing how the three vocabularies co-vary on a single artifact at a single moment.
+
+| Lifecycle | Review | Outcome on public surface |
+|---|---|---|
+| `RAW` | `draft` *(implicit — no record yet)* | n/a *(never publicly served)* |
+| `WORK` | `draft` | n/a |
+| `WORK` | `pending` | n/a *(internal review, no public surface)* |
+| `QUARANTINE` | any | n/a; held for resolution |
+| `PROCESSED` | `pending` | `ABSTAIN (not_yet_released)` if queried |
+| `PROCESSED` | `held` | `ABSTAIN (not_yet_released)` if queried; review-state `held` does not itself produce outcome-state `HOLD` *(no prior release to hold against)* |
+| `CATALOG/TRIPLET` | `pending` | `ABSTAIN (not_yet_released)` if queried |
+| `CATALOG/TRIPLET` | `approved` | `ABSTAIN (not_yet_released)` — review approval alone does not release |
+| release candidate | `approved` | `ABSTAIN (not_yet_released)` until gate G issues `ReleaseManifest` |
+| `PUBLISHED` | `approved` | `ANSWER` / `ABSTAIN` / `DENY` / `ERROR` based on runtime decision |
+| `PUBLISHED` | `held` *(revision pending review)* | `HOLD` *(outcome)* — prior claim continues to render; new revision not yet authoritative |
+| `PUBLISHED` | `superseded` | `ANSWER` redirects to successor; old version remains addressable |
+| `PUBLISHED` | `rejected` *(rare — revision rejected)* | prior `PUBLISHED` continues until revoked/rolled back |
+
+> [!IMPORTANT]
+> **Read the table as "and", not "or".** Every row is a combination that can actually occur. The orthogonality is what lets the system audit each axis independently.
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Review-state diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> draft : author creates
+  draft --> pending : submit for review
+  pending --> approved : reviewer accepts<br/>(≠ author on sensitive lanes)
+  pending --> rejected : reviewer declines
+  pending --> held : steward / rights / policy pause
+  held --> pending : hold resolves favorably
+  held --> rejected : hold resolves to refusal<br/>(see transitions/hold-to-deny.md)
+  approved --> superseded : new revision approved
+  rejected --> [*]
+  superseded --> [*]
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine | Mitigation |
+|---|---|---|
+| **Review = Release** — treating `approved` as `PUBLISHED`. | Skips gate G; release manifest, rollback target, correction path absent. | Lifecycle gate G is separate; `approved` enables release evaluation, not release itself. |
+| **Author == Approver on sensitive lanes.** | Separation-of-duties violated; audit trail compromised. | `validate_review_record.py` *(PROPOSED)* emits `FAIL`. |
+| **Held = silent rollback.** | UI strips prior claim on `HOLD`; users see flicker; audit loses prior state. | `HOLD` preserves prior surface state; new revision not authoritative until `approved` + released. |
+| **Review record overwritten** — `rejected` flipped to `approved` in place. | Audit chain destroyed; bad decision becomes invisible. | `ReviewRecord` revisions append-only; new decision creates new record. |
+| **Implicit `draft`** — artifact exists without a `ReviewRecord` entry. | Pre-submission state untracked; pipeline cannot enforce gate F. | Every artifact past `WORK` carries a `ReviewRecord`, even at `draft`. |
+| **Sensitivity reviewer skipped** — lane requires sovereignty reviewer but only steward signs. | Sensitive-lane gate bypassed; sovereignty/privacy violation possible. | Per-lane reviewer requirements *(§6)* enforced at `pending → approved`. |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Open questions
+
+| ID | Question | Class |
+|---|---|---|
+| RV-Q1 | Should `HOLD` collapse into review-state only *(removing outcome-state `HOLD`)* or vice versa? | Vocabulary collision *(tracked in README §15)* |
+| RV-Q2 | Is the approver allowlist per-lane *(in `public-safety-notes.md`)* or per-role *(in `policy/`)*? | Authority placement |
+| RV-Q3 | Should `superseded` carry the successor `ReviewRecord` reference or only a `supersession_chain` entry? | Schema shape |
+| RV-Q4 | Does a re-authored artifact after `rejected` start a new `ReviewRecord` or chain off the prior? | Audit chain |
+| RV-Q5 | Multi-reviewer threshold — explicit unanimous vs N-of-M? | Approval semantics |
+
+[↑ Back to top](#top)
+
+---
+
+## 11. Cross-references
+
+- [`docs/focus-mode/state/README.md`](./README.md) §9 — review and release state overview.
+- [`docs/focus-mode/state/finite-outcomes.md`](./finite-outcomes.md) §2, §4.4 — `HOLD` as a finite outcome, hold reason codes.
+- [`docs/focus-mode/state/lifecycle-states.md`](./lifecycle-states.md) §3 — gate F (review & sensitivity).
+- [`docs/focus-mode/state/transitions/candidate-to-hold.md`](./transitions/candidate-to-hold.md) — release-candidate → `held` transition.
+- [`docs/focus-mode/state/transitions/hold-to-deny.md`](./transitions/hold-to-deny.md) — `held` → `rejected/DENY` transition.
+- [`docs/focus-mode/README.md`](../README.md) §15 — sensitivity defaults at county and state scale.
+- `schemas/contracts/v1/runtime/review_record.schema.json` *(PROPOSED)*.
+- `schemas/contracts/v1/runtime/policy_decision.schema.json` *(PROPOSED)*.
+- `tools/validators/validate_review_record.py` *(PROPOSED)*.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/revocation-state.md
+++ b/docs/focus-mode/state/revocation-state.md
@@ -1,0 +1,321 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-revocation-state
+title: Focus Mode — Revocation and Rollback State
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/README.md §11
+  - docs/focus-mode/state/finite-outcomes.md §4.1 (revoked_no_alternative)
+  - docs/focus-mode/state/payload-state.md
+  - docs/focus-mode/state/transitions/published-to-revoked.md
+  - docs/focus-mode/state/transitions/rollback-to-prior.md
+  - schemas/contracts/v1/release/revocation_manifest.schema.json (PROPOSED)
+  - schemas/contracts/v1/release/rollback_card.schema.json (PROPOSED)
+tags: [kfm, focus-mode, state, revocation, rollback, ttl, spec-hash, KFM-P19-FEAT-0002]
+notes:
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+  - Revocation verifier KFM-P19-FEAT-0002 is PROPOSED; signed manifest + TTL + spec_hash binding are CONFIRMED doctrine pattern.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Focus Mode — Revocation and Rollback State
+
+> *Revocation manifest shape, TTL semantics, `spec_hash` binding, rollback-card contract, and the cached-but-revoked boundary that drives `revoked-but-cached` → `ABSTAIN`.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-cached--but--revoked-blue)
+![signature](https://img.shields.io/badge/manifest-signed-success)
+![ttl](https://img.shields.io/badge/TTL-required-success)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!CAUTION]
+> **Cached-but-revoked is a doctrine boundary.** If a Focus Mode UI holds a payload locally and the underlying evidence is revoked mid-session, the runtime MUST transition the answer to `ABSTAIN` with a revocation reason. Silently continuing to render the cached payload violates cite-or-abstain. *(KFM-P19-FEAT-0002, PROPOSED; CONFIRMED policy intent.)*
+
+> [!IMPORTANT]
+> **Path placement diverges from Directory Rules v1.2 §6.7.2** — see [README §2.1](./README.md#21-path-divergence-must-be-resolved). Doctrine CONFIRMED; file location PROPOSED pending OPEN-DR-09.
+
+---
+
+## Contents
+
+1. [Scope](#1-scope)
+2. [The four revocation/rollback states](#2-the-four-revocationrollback-states)
+3. [Revocation manifest contract](#3-revocation-manifest-contract)
+4. [TTL semantics](#4-ttl-semantics)
+5. [`spec_hash` binding](#5-spec_hash-binding)
+6. [Rollback card contract](#6-rollback-card-contract)
+7. [Verifier pipeline](#7-verifier-pipeline)
+8. [Cached-but-revoked enforcement](#8-cached-but-revoked-enforcement)
+9. [Anti-patterns](#9-anti-patterns)
+10. [Open questions](#10-open-questions)
+11. [Cross-references](#11-cross-references)
+
+---
+
+## 1. Scope
+
+This file defines **revocation and rollback state** — the lifecycle a `PUBLISHED` artifact follows when it is withdrawn *(revocation)* or replaced by a prior release *(rollback)*. Both transitions are first-class: they are not "delete" or "undo" operations but governed state changes with required receipts.
+
+Revocation state is **distinct from**:
+
+- **Lifecycle state** *(an artifact in `PUBLISHED` is the precondition for revocation; revocation does not move the artifact back to `PROCESSED`)*.
+- **Review state** *(revocation can happen even on `approved` artifacts when post-release evidence emerges)*.
+- **Payload state** *(payload state `revoked-but-cached` is the runtime manifestation of revocation in the UI)*.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. The four revocation/rollback states
+
+| State | Meaning | Required artifact | Required check before serving |
+|---|---|---|---|
+| `live` | Artifact is the current released form. | Current `ReleaseManifest`. | Standard release-state check. |
+| `revoked` | Issuer published a revocation; artifact MUST NOT serve. | Signed revocation manifest, TTL, `spec_hash` binding. | Revocation manifest signature + TTL freshness + `spec_hash` match + run-receipt attestations *(PROPOSED — KFM-P19-FEAT-0002)*. |
+| `rolled-back` | A prior `ReleaseManifest` has been re-promoted as current. | `RollbackCard` + prior release-manifest reference. | Rollback receipt + supersession chain. |
+| `superseded-by` | A newer release replaces this one; old version remains addressable. | `supersession_chain` entry; new `ReleaseManifest`. | Surface "superseded — see <new>" message; do not silently swap. |
+
+> [!NOTE]
+> **`revoked` and `rolled-back` are not the same.** Revocation withdraws an artifact entirely *(it cannot serve)*. Rollback re-promotes a prior release as current *(an earlier `PUBLISHED` is current again; the newer release becomes `rolled-back` or `superseded-by`)*.
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Revocation manifest contract
+
+> **CONFIRMED pattern shape** *(Atlas v1.1 §20.3)*; **PROPOSED schema home** at `schemas/contracts/v1/release/revocation_manifest.schema.json`.
+
+Required fields *(PROPOSED enum; ADR-class on any field removal)*:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `revocation_id` | UUID | Unique identifier; used by clients to dedupe. |
+| `revoked_artifact_ref` | `ReleaseManifest` ref | Which release is being revoked. |
+| `revoked_content_hash` | content hash | Hash of the artifact's content; clients verify they hold this exact form. |
+| `spec_hash` | content hash | Spec under which the artifact was released *(see §5)*. |
+| `issuer` | identity | Who issued the revocation *(role + signing identity)*. |
+| `signature` | signed-blob | Detached signature over the manifest body. |
+| `issued_at` | ISO-8601 | When the revocation was issued. |
+| `ttl_seconds` | integer | How long clients MAY cache this manifest before re-fetching *(see §4)*. |
+| `reason_code` | enum | Revocation reason *(see §3.1)*. |
+| `replaces_with` | `ReleaseManifest` ref \| `null` | Optional pointer to a successor release. If `null`, no replacement exists. |
+| `applies_to_scope` | area + time window | Which Focus Mode area + time window the revocation applies to. |
+| `run_receipt_refs[]` | receipt refs | Attestations linking the revocation to its review/audit chain. |
+
+### 3.1 Revocation reason codes *(PROPOSED enum)*
+
+| Code | Meaning |
+|---|---|
+| `evidence_invalidated` | Post-release review found the evidence does not support the claim. |
+| `rights_withdrawn` | Rights holder revoked the license to publish. |
+| `sensitivity_escalation` | New sensitivity classification forbids further publication. |
+| `legal_order` | Court order, takedown notice, regulatory action. |
+| `integrity_breach` | Hash mismatch detected post-release *(tamper or pipeline bug)*. |
+| `superseded_with_replacement` | Newer release available; see `replaces_with`. |
+| `policy_change` | Policy bundle revision forbids previously-allowed publication. |
+
+[↑ Back to top](#top)
+
+---
+
+## 4. TTL semantics
+
+> **CONFIRMED pattern; PROPOSED default values.**
+
+The revocation manifest carries a `ttl_seconds` field that controls how long clients may rely on a cached fetch before re-checking.
+
+| TTL setting | Use case | Default |
+|---|---|---|
+| `ttl_seconds: 0` | "Hard revocation" — clients MUST re-check on every serve. | Used for legal-order or rights-withdrawn cases. |
+| `ttl_seconds: 60` | Default — short-lived caching to absorb burst traffic. | **PROPOSED default** for most revocations. |
+| `ttl_seconds: 300` | Lower-urgency revocations where bandwidth concerns dominate. | Used for `superseded_with_replacement` when the replacement is announced. |
+| `ttl_seconds: > 300` | Discouraged — invites stale-revocation rendering. | Requires explicit reviewer sign-off. |
+
+### 4.1 Client TTL rules
+
+| Rule | Why |
+|---|---|
+| Client MUST re-fetch revocation manifest when TTL expires. | Prevents indefinite stale rendering. |
+| Client MUST NOT serve the revoked artifact even if TTL has not expired *(the revocation is in effect immediately)*. | TTL is a re-fetch hint, not a grace period for serving. |
+| Client MUST honor `Cache-Control: no-store` if attached. | Override for hard revocations. |
+| Client MUST surface the revocation reason in the UI when the user requests the revoked artifact. | Audit transparency. |
+
+> [!CAUTION]
+> **TTL is for re-fetch cadence, not for grace-period serving.** A revocation with `ttl_seconds: 60` means "re-check at least every 60 seconds" — it does **not** mean "you may serve the revoked artifact for 60 more seconds". Once the revocation is fetched, the revoked artifact stops serving immediately.
+
+[↑ Back to top](#top)
+
+---
+
+## 5. `spec_hash` binding
+
+> **CONFIRMED pattern.** Every release carries a `spec_hash` *(hash of the layer/style/filter spec under which the layer renders)*. Revocations bind to a specific `spec_hash` so that:
+
+| Binding case | Behavior |
+|---|---|
+| Revocation `spec_hash` == current release `spec_hash` | Revocation applies; artifact stops serving. |
+| Revocation `spec_hash` == prior release `spec_hash` | Revocation applies to that prior release only; current release continues serving unless separately revoked. |
+| Revocation `spec_hash` does not match any known release | Verifier emits `ERROR (integrity_breach)`; revocation is invalid; clients reject it. |
+
+> [!NOTE]
+> **`spec_hash` binding lets you revoke one release without nuking the family.** Without it, revoking "the hydrology layer" would be ambiguous across release versions. With it, the revocation says "the hydrology layer **as released under spec_hash X** is revoked" — a later corrected release under spec_hash Y is unaffected.
+
+A `spec_hash` mismatch between the revocation manifest and any known release is itself a **doctrine violation** — either the revocation is forged, or the release record is corrupt. Either way, the verifier emits `ERROR` and refuses to apply the revocation.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Rollback card contract
+
+> **CONFIRMED pattern shape** *(directory-rules.md §6.7; Atlas v1.1 §20.3)*; **PROPOSED schema home** at `schemas/contracts/v1/release/rollback_card.schema.json`.
+
+A `RollbackCard` is the receipt of a rollback transition. Required fields:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `rollback_id` | UUID | Unique identifier. |
+| `rolled_back_release_ref` | `ReleaseManifest` ref | The release being rolled back. |
+| `restored_release_ref` | `ReleaseManifest` ref | The prior release being re-promoted as current. |
+| `reason_code` | enum | Why rollback was performed *(see §6.1)*. |
+| `issuer` | identity | Who authorized the rollback. |
+| `signature` | signed-blob | Detached signature. |
+| `issued_at` | ISO-8601 | When rollback took effect. |
+| `applies_to_scope` | area + time window | Where the rollback applies. |
+| `correction_notice_ref` | `CorrectionNotice` ref \| `null` | Public-facing notice paired with the rollback *(usually required)*. |
+| `supersession_chain` | array of release refs | Chronological chain showing prior releases. |
+
+### 6.1 Rollback reason codes *(PROPOSED enum)*
+
+| Code | Meaning |
+|---|---|
+| `evidence_invalidated_post_release` | New release retracted; prior release more accurate. |
+| `regression` | New release broke a working behavior; revert. |
+| `policy_revert` | Policy bundle change reverted; matching release reverted. |
+| `correction_pending_rebuild` | Temporary rollback while a fix is built; expected to be re-rolled-forward later. |
+| `emergency` | Urgent rollback for safety/legal reasons; correction notice required. |
+
+> [!IMPORTANT]
+> **A `RollbackCard` does NOT delete the rolled-back release.** The rolled-back release remains addressable for replay and audit; it simply is no longer the *current* release. Clients fetching the current release receive the restored prior release.
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Verifier pipeline
+
+> **PROPOSED — KFM-P19-FEAT-0002 *(Focus Mode revocation verifier)*.**
+
+```mermaid
+flowchart LR
+  UI["Public UI<br/>(holds cached payload)"] --> CHK{"Revocation manifest<br/>present for this release?"}
+  CHK -- "no" --> SERVE["serve cached<br/><i>(payload state: fresh / stale)</i>"]
+  CHK -- "yes" --> SIG{"Signature valid?"}
+  SIG -- "no" --> ERR["ERROR<br/><i>integrity_breach</i>"]
+  SIG -- "yes" --> TTL{"TTL fresh?"}
+  TTL -- "no" --> REFETCH["re-fetch revocation manifest"]
+  REFETCH --> CHK
+  TTL -- "yes" --> HASH{"spec_hash + content_hash<br/>match cached payload?"}
+  HASH -- "no" --> SERVE
+  HASH -- "yes" --> ABSTAIN["ABSTAIN<br/><i>revoked_no_alternative</i><br/>or rebind to replaces_with"]
+```
+
+| Verifier check | Tool | On failure |
+|---|---|---|
+| Manifest signature | `validate_revocation_manifest.py` *(PROPOSED)* | `ERROR (integrity_breach)` |
+| TTL freshness | runtime check | re-fetch |
+| `spec_hash` + `content_hash` match | runtime check | If mismatch: serve cached *(revocation does not apply to this payload)*. |
+| `replaces_with` resolves to `PUBLISHED` | resolver | If `null` or unresolved: surface stays at `ABSTAIN`. If resolved: rebind and re-evaluate. |
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Cached-but-revoked enforcement
+
+> **CONFIRMED doctrine boundary.** A cached payload that becomes revoked mid-session MUST transition the answer to `ABSTAIN (revoked_no_alternative)` *(or rebind to a `replaces_with` if available)*.
+
+### 8.1 Enforcement points
+
+| Surface | Check cadence | On revocation |
+|---|---|---|
+| Focus Mode runtime | Per-request | Re-resolve revocation manifest; if revoked, payload state moves to `revoked-but-cached` → `ABSTAIN`. |
+| Evidence Drawer | Per-render | Same; drawer shows revocation reason in place of evidence. |
+| Layer manifest resolver | Per-release-ref lookup | Revoked layer returns `DENY (release_state_deny)` with revocation reason. |
+| Cached client *(offline mode)* | On reconnect | Verifier runs; revoked payloads stop rendering even though the client cached them. |
+
+### 8.2 What the user sees
+
+| State | UI surface |
+|---|---|
+| Cached payload, no revocation | Renders normally. |
+| Cached payload, revocation arrived, `replaces_with` available | UI rebinds *(possibly with a "updated to latest release" badge)*. |
+| Cached payload, revocation arrived, no replacement | UI strips the claim; shows "this evidence has been revoked: \<reason>"; the surface is at `ABSTAIN (revoked_no_alternative)`. |
+| Revocation invalid *(signature/spec_hash failure)* | UI keeps cached rendering; verifier emits `ERROR` for the revocation channel; alert raised internally. |
+
+> [!CAUTION]
+> **Silent rendering of revoked evidence is the single most damaging anti-pattern in this state family.** The verifier exists to prevent it. Negative fixture `cached_revoked_served_as_answer.invalid.json` *(PROPOSED)* MUST be present.
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine | Mitigation |
+|---|---|---|
+| **Silent revoked render** — UI keeps rendering after revocation. | Serves denied content; cite-or-abstain collapsed. | KFM-P19-FEAT-0002 verifier; negative fixture required. |
+| **Unsigned revocation accepted** — verifier skips signature check. | Anyone can forge a revocation; or no one can issue a real one. | Signature is required; bad signature → `ERROR`. |
+| **TTL as grace period** — UI serves revoked artifact "until TTL expires". | Revocation does not have a grace period; immediate effect. | §4 rules. |
+| **`spec_hash` ignored** — revocation applied to all releases of "the hydrology layer". | Over-broad revocation; collateral damage. | `spec_hash` binding; mismatch → revocation does not apply. |
+| **Rollback deletes prior release** — rolled-back release no longer addressable. | Audit chain broken; replay impossible. | Prior release remains addressable; `supersession_chain` records the order. |
+| **No `CorrectionNotice` on rollback** — rollback happens silently. | Users see content change without explanation. | `RollbackCard.correction_notice_ref` required for non-trivial rollbacks. |
+| **Revocation channel down → fail-open** — when the verifier can't reach the revocation store, it serves anyway. | Stale-revoke rendering. | Fail-closed: if revocation channel is unreachable past TTL, surface degrades to `ABSTAIN (revoked_no_alternative)` or `ERROR (resolver_failure)`. |
+| **Mixing revocation and rollback** — using `RollbackCard` to revoke or revocation manifest to rollback. | Two distinct semantics conflated. | Distinct contracts; distinct schemas; distinct verifier paths. |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Open questions
+
+| ID | Question | Class |
+|---|---|---|
+| RV-Q1 | Should revocation manifests be served from a single store *(one per Focus Mode area)* or fanned-out per release? | Storage layout |
+| RV-Q2 | Is `ttl_seconds: 0` always allowed, or is there a minimum to absorb client-side jitter? | Tuning |
+| RV-Q3 | Does a rollback automatically issue a revocation for the rolled-back release, or are they independent records? | Receipt linkage |
+| RV-Q4 | Multi-signature revocations — should sensitive lanes require multiple issuer signatures? | Authority threshold |
+| RV-Q5 | Should the revocation reason be a free-form blob or strictly enumerated? *(Current proposal: enum + optional free-form note.)* | Schema shape |
+| RV-Q6 | How does the verifier behave under network partition — fail-closed by default, but is there ever a justified fail-open? | Resilience |
+
+[↑ Back to top](#top)
+
+---
+
+## 11. Cross-references
+
+- [`docs/focus-mode/state/README.md`](./README.md) §11 — revocation and rollback overview.
+- [`docs/focus-mode/state/finite-outcomes.md`](./finite-outcomes.md) §4.1 — `revoked_no_alternative` `ABSTAIN` reason.
+- [`docs/focus-mode/state/payload-state.md`](./payload-state.md) §2 — `revoked-but-cached` payload state.
+- [`docs/focus-mode/state/transitions/published-to-revoked.md`](./transitions/published-to-revoked.md) — `PUBLISHED` → `revoked` transition.
+- [`docs/focus-mode/state/transitions/rollback-to-prior.md`](./transitions/rollback-to-prior.md) — `PUBLISHED` → `rolled-back` transition.
+- `schemas/contracts/v1/release/revocation_manifest.schema.json` *(PROPOSED)*.
+- `schemas/contracts/v1/release/rollback_card.schema.json` *(PROPOSED)*.
+- `tools/validators/validate_revocation_manifest.py` *(PROPOSED)*.
+- KFM-P19-FEAT-0002 *(PROPOSED — Focus Mode revocation verifier)*.
+- `KFM_Domains_v1_1_plus_Pass23_Pass32_Consolidated_Atlas.md` §20.3 — Correction/Rollback capability matrix.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/transitions/answer-to-abstain.md
+++ b/docs/focus-mode/state/transitions/answer-to-abstain.md
@@ -1,0 +1,181 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-transitions-answer-to-abstain
+title: Transition — ANSWER → ABSTAIN
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/finite-outcomes.md
+  - docs/focus-mode/state/payload-state.md
+  - docs/focus-mode/state/revocation-state.md
+  - docs/focus-mode/state/README.md §7, §10, §11
+tags: [kfm, focus-mode, state, transition, answer, abstain, demotion, freshness]
+notes:
+  - One of five prose transition specs under docs/focus-mode/state/transitions/.
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Transition — `ANSWER` → `ABSTAIN`
+
+> *Demotion path: a previously-served `ANSWER` becomes unservable because the underlying payload aged, was revoked, or failed re-closure. The runtime MUST publicly transition to `ABSTAIN` — silent removal is anti-pattern.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![class](https://img.shields.io/badge/class-demotion-orange)
+![preserves-prior-state](https://img.shields.io/badge/preserves--prior--state-no%20(public%20transition)-orange)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **This is a public-facing transition.** Unlike a `HOLD` *(which preserves the prior claim)*, an `ANSWER → ABSTAIN` transition strips the prior claim from the surface and surfaces the abstention reason. The user sees the change. *(See [`finite-outcomes.md` §7](../finite-outcomes.md#7-composition-rules) — composition rule "no silent demotion".)*
+
+---
+
+## Contents
+
+1. [Trigger conditions](#1-trigger-conditions)
+2. [Pre-conditions](#2-pre-conditions)
+3. [Post-conditions](#3-post-conditions)
+4. [Required receipts](#4-required-receipts)
+5. [Rollback target](#5-rollback-target)
+6. [Diagram](#6-diagram)
+7. [Anti-patterns](#7-anti-patterns)
+8. [Cross-references](#8-cross-references)
+
+---
+
+## 1. Trigger conditions
+
+Any of the following — evaluated on the next request after a prior `ANSWER` was served — drives the transition:
+
+| Trigger | Driving state | `ABSTAIN` reason code |
+|---|---|---|
+| Cited bundle's freshness window expired. | `payload state: stale` | `payload_stale` |
+| Cited bundle revoked; no `replaces_with`. | `payload state: revoked-but-cached` | `revoked_no_alternative` |
+| Cited bundle revoked; `replaces_with` resolved → rebound; rebinding failed closure. | `payload state: revoked-but-cached` then closure fail | `citation_closure_failed` |
+| Cited bundle's release ref no longer resolves *(release record deleted/moved)*. | `payload state: unknown` | `citation_closure_failed` *(or `ERROR (resolver_failure)` if non-deterministic)* |
+| Confidence threshold raised by policy update; prior `ANSWER` no longer clears. | new policy applied | `confidence_below_threshold` |
+| Scope drift — request scope changed *(new envelope `time_window` outside prior cited bundle's coverage)*. | `payload state: stale` *(scope-relative)* | `query_out_of_scope` |
+
+> [!NOTE]
+> Trigger evaluation happens **per request**. A previously-served `ANSWER` on request N may transition to `ABSTAIN` on request N+1 if any trigger fires between them.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Pre-conditions
+
+| Pre-condition | Source |
+|---|---|
+| Prior `DecisionEnvelope (outcome=ANSWER)` exists for the same `(area, time_window, query)`. | Prior `AIReceipt` log. |
+| The prior `AIReceipt` lists the bundle(s) that drove the trigger. | Replay requirement. |
+| The runtime is processing a fresh `MapContextEnvelope` *(envelope `current`, see [`map-context-state.md` §4](../map-context-state.md#4-freshness-rules))*. | Envelope admission passed. |
+| No policy/rights/sensitivity rule now applies that would drive `DENY` instead. | If `DENY` fits better, use the `DENY` transition path, not `ABSTAIN`. |
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Post-conditions
+
+| Post-condition | Carrier |
+|---|---|
+| New `DecisionEnvelope` with `outcome=ABSTAIN`, reason code per §1. | Returned to caller. |
+| New `AIReceipt` referencing the prior receipt and the trigger evidence *(stale bundle, revocation manifest, etc.)*. | Audit chain. |
+| Public surface no longer renders the prior claim; renders abstention reason instead. | UI state change. |
+| Surface-side cache invalidated for the `(area, time_window, query)` key. | Re-request would re-evaluate, not re-render. |
+| If `replaces_with` exists *(revocation case)*, surface MAY immediately re-issue a request against the replacement *(receipt records the rebinding attempt)*. | Optional follow-up. |
+
+> [!IMPORTANT]
+> **The user-visible change is part of the contract.** A surface that swaps the prior claim for "we don't know" without telling the user — same widget, no notice — fails the transition. The UI MUST indicate that the prior claim was withdrawn and why.
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Required receipts
+
+| Receipt | Required? | Notes |
+|---|---|---|
+| New `AIReceipt (outcome=ABSTAIN)` | yes | Lists trigger evidence; references prior `AIReceipt`. |
+| Reference to prior `AIReceipt` | yes | Audit chain link. |
+| Reference to trigger artifact | yes | Stale bundle ID, revocation manifest ID, policy version, or scope-drift envelope diff. |
+| `DecisionEnvelope` | yes | `outcome=ABSTAIN`, reason code from §1. |
+| `EvidenceDrawerPayload` | no | Drawer MUST NOT render the prior evidence; carries the abstention reason only. |
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Rollback target
+
+Demotions to `ABSTAIN` are themselves **reversible**: a later request MAY produce `ANSWER` again if:
+
+- The cited bundle is rebound to a fresh release, **or**
+- A new release covers the same subject and the runtime re-closes citation, **or**
+- The policy threshold returns to a state that admits the original evidence.
+
+> [!NOTE]
+> **No rollback artifact is required on the `ANSWER → ABSTAIN` transition itself.** The transition is forward; re-promotion to `ANSWER` later happens via a normal new request. Audit replay walks the `AIReceipt` chain in either direction.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Diagram
+
+```mermaid
+sequenceDiagram
+  participant UI as Public UI
+  participant RT as Focus Mode runtime
+  participant ST as Evidence + Revocation store
+  Note over UI,RT: prior request → ANSWER served
+  UI->>RT: request N+1 (same query)
+  RT->>ST: re-resolve cited bundle
+  ST-->>RT: stale | revoked | unresolved
+  RT->>RT: try rebind to newer release / replaces_with
+  alt rebind succeeds
+    RT-->>UI: ANSWER (new AIReceipt, refs new bundle)
+  else rebind fails / not attempted
+    RT-->>UI: DecisionEnvelope(outcome=ABSTAIN, reason=<from §1>)
+    Note over UI: strip prior claim; show abstention reason
+  end
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine |
+|---|---|
+| **Silent demotion** — surface stops rendering the claim without telling the user. | User believes the prior claim is current; cite-or-abstain transparency broken. |
+| **Cached `ANSWER` re-served after revocation** — runtime didn't re-check the revocation channel. | See [`revocation-state.md` §8](../revocation-state.md#8-cached-but-revoked-enforcement). |
+| **Demote to free-form prose** — surface returns "we're not sure" without a `DecisionEnvelope`. | Outcome enum bypassed; audit broken. |
+| **Demote without referencing prior receipt** — new `AIReceipt` does not link the prior. | Audit chain broken; replay impossible. |
+| **Re-promote silently** — later request returns `ANSWER` without a new evidence binding. | Skipped citation closure; AI promoted to truth. |
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Cross-references
+
+- [`docs/focus-mode/state/finite-outcomes.md`](../finite-outcomes.md) §4.1 — `ABSTAIN` reason codes.
+- [`docs/focus-mode/state/payload-state.md`](../payload-state.md) §2 — payload states that drive demotion.
+- [`docs/focus-mode/state/revocation-state.md`](../revocation-state.md) §8 — cached-but-revoked enforcement.
+- [`docs/focus-mode/state/map-context-state.md`](../map-context-state.md) §4 — envelope freshness vs payload freshness.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/transitions/candidate-to-hold.md
+++ b/docs/focus-mode/state/transitions/candidate-to-hold.md
@@ -1,0 +1,181 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-transitions-candidate-to-hold
+title: Transition — Release Candidate → HOLD
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/review-state.md
+  - docs/focus-mode/state/lifecycle-states.md §3 (Gate F)
+  - docs/focus-mode/state/finite-outcomes.md §4.4 (HOLD reason codes)
+  - docs/focus-mode/state/README.md §9
+tags: [kfm, focus-mode, state, transition, candidate, hold, review-gate, gate-F]
+notes:
+  - One of five prose transition specs under docs/focus-mode/state/transitions/.
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Transition — Release Candidate → `HOLD`
+
+> *Promotion paused: a release candidate at lifecycle stage `CATALOG/TRIPLET` (or release-eligible) is parked at review state `held` pending steward, rights-holder, or policy review. Promotion gate F does not pass while a hold is in effect.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![class](https://img.shields.io/badge/class-promotion--pause-orange)
+![gate](https://img.shields.io/badge/gate-F%20(review%20%26%20sensitivity)-orange)
+![preserves-prior-state](https://img.shields.io/badge/preserves--prior--published-yes-success)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **This transition pauses promotion, not service.** A prior `PUBLISHED` release of the same artifact continues to serve while the new candidate is held. The held candidate produces neither `ANSWER` nor `DENY` — it is suspended in review. *(CONFIRMED — Atlas v1.1 §24.3; review-state doctrine.)*
+
+---
+
+## Contents
+
+1. [Trigger conditions](#1-trigger-conditions)
+2. [Pre-conditions](#2-pre-conditions)
+3. [Post-conditions](#3-post-conditions)
+4. [Required receipts](#4-required-receipts)
+5. [Rollback target](#5-rollback-target)
+6. [Diagram](#6-diagram)
+7. [Resolution paths](#7-resolution-paths)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Cross-references](#9-cross-references)
+
+---
+
+## 1. Trigger conditions
+
+| Trigger | Driving state | `HOLD` reason code |
+|---|---|---|
+| Domain steward requested additional review before approving. | `ReviewRecord.state = pending → held` | `steward_review_pending` |
+| Rights holder *(sovereignty, descendant community, license grantor)* requested review. | `ReviewRecord.state = pending → held` | `rights_holder_review_pending` |
+| Policy bundle revision in flight; current evaluation deferred. | `PolicyDecision = HOLD` | `policy_review_pending` |
+| Correction against a prior `PUBLISHED` release in flight; new candidate paused to keep state consistent. | `ReviewRecord.state = pending → held` | `correction_pending` |
+| Gate G is blocked but recoverable *(missing rollback target, pending `CorrectionNotice` slot)*. | runtime gate signal | `release_gate_pending` |
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Pre-conditions
+
+| Pre-condition | Source |
+|---|---|
+| Candidate exists at lifecycle stage `CATALOG/TRIPLET` or release-eligible. | `data/catalog/` / `release/candidates/<area>-focus-mode/`. |
+| `ReviewRecord` for the candidate exists at state `pending`. | `ReviewRecord` carrier. |
+| The held reason is documented and falls within the `HOLD` reason-code enum *(§1)*. | `PolicyDecision (HOLD)` with reason code. |
+| Hold issuer's identity is recorded *(separation-of-duties applies: hold issuer ≠ author for sensitive lanes)*. | `ReviewRecord.held_by` field. |
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Post-conditions
+
+| Post-condition | Carrier |
+|---|---|
+| `ReviewRecord.state` set to `held`. | `ReviewRecord` revision *(append-only — see [`review-state.md` §3](../review-state.md#3-forward-transitions-and-required-artifacts))*. |
+| `PolicyDecision (outcome=HOLD)` issued referencing the held candidate and the reason code. | Receipt store. |
+| Promotion gate F evaluation is **blocked** for this candidate until the hold resolves. | Gate runtime. |
+| Prior `PUBLISHED` release of the same artifact *(if any)* continues to serve unchanged. | Public surface. |
+| Runtime requests against the area surface continue to return `ANSWER` from the prior release; the new candidate is invisible to public surfaces while held. | UI state. |
+| If a runtime evaluation depends specifically on the held candidate *(rare — e.g., a request that targets a not-yet-released revision)*, the runtime emits `DecisionEnvelope (outcome=HOLD)` with the same reason code. | Public surface. |
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Required receipts
+
+| Receipt | Required? | Notes |
+|---|---|---|
+| `ReviewRecord (held)` | yes | Carries hold reason, hold issuer, timestamp. |
+| `PolicyDecision (HOLD)` | yes | References the `ReviewRecord` and the candidate. |
+| Linked steward/rights-holder/policy ticket | yes if applicable | Provides the external reviewer reference *(e.g., sovereignty review ticket ID)*. |
+| Audit log entry | yes | Append-only entry recording the transition for replay. |
+| `DecisionEnvelope (outcome=HOLD)` for runtime queries | only if a runtime request targets the held candidate | Most queries continue against the prior `PUBLISHED` release. |
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Rollback target
+
+`HOLD` does not require a rollback target because it is **not a promotion** — the candidate has not moved into `PUBLISHED`. The rollback semantics:
+
+- If the hold resolves to `approved` and gate G passes → candidate becomes `PUBLISHED`; standard rollback semantics apply via the new `ReleaseManifest`.
+- If the hold resolves to `rejected` → candidate terminates; prior `PUBLISHED` release continues; no rollback artifact needed.
+
+> [!NOTE]
+> **`HOLD` is reversible by design.** A held candidate may return to `pending` *(hold resolved favorably)*, then to `approved`. The `ReviewRecord` records each state change as an append-only revision.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> Candidate : reaches CATALOG/TRIPLET
+  Candidate --> Pending : ReviewRecord submitted
+  Pending --> Held : steward/rights/policy/correction triggers hold
+  Held --> Pending : hold resolves favorably
+  Held --> Rejected : hold resolves to refusal<br/>(see transitions/hold-to-deny.md)
+  Pending --> Approved : reviewer accepts
+  Approved --> [*] : gate G can evaluate
+  Rejected --> [*]
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Resolution paths
+
+| Path | Condition | Next transition |
+|---|---|---|
+| `held` → `pending` | Hold reason resolved *(steward signed off, rights holder cleared, policy revision merged, correction completed)*. | Normal review continues; → `approved` or `rejected`. |
+| `held` → `rejected` | Hold resolved to refusal *(rights holder denied, policy revision forbids, correction concluded that the candidate is invalid)*. | See [`hold-to-deny.md`](./hold-to-deny.md) for the resulting `DENY` path on public surfaces. |
+| `held` → `held` *(self-loop, expected)* | Hold cycles through reviewers; `ReviewRecord` accumulates revisions with reason changes. | Continues until terminal. |
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine |
+|---|---|
+| **Hold strips prior release** — UI demotes the prior `PUBLISHED` claim when the new candidate enters `held`. | `HOLD` preserves prior surface state; the user should see no change. |
+| **Hold without `PolicyDecision`** — `ReviewRecord (held)` exists but no policy receipt issued. | Promotion gate cannot enforce the hold; audit incomplete. |
+| **Hold issuer = author on sensitive lane** — separation-of-duties bypassed. | Author can hold their own work indefinitely; review chain compromised. |
+| **Hold reason free-form** — reason text outside the enum. | Downstream consumers can't route on the reason; metrics broken. |
+| **Silent hold** — candidate disappears from the index without a held marker. | Audit cannot tell "never submitted" from "held". |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Cross-references
+
+- [`docs/focus-mode/state/review-state.md`](../review-state.md) §2–§4 — review-state lifecycle and `HOLD` semantics.
+- [`docs/focus-mode/state/lifecycle-states.md`](../lifecycle-states.md) §3 — gate F (review & sensitivity).
+- [`docs/focus-mode/state/finite-outcomes.md`](../finite-outcomes.md) §4.4 — `HOLD` reason codes.
+- [`docs/focus-mode/state/transitions/hold-to-deny.md`](./hold-to-deny.md) — `held → rejected/DENY` resolution path.
+- [`docs/focus-mode/README.md`](../../README.md) §15 — sensitivity defaults that drive most holds.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/transitions/hold-to-deny.md
+++ b/docs/focus-mode/state/transitions/hold-to-deny.md
@@ -1,0 +1,189 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-transitions-hold-to-deny
+title: Transition — HOLD → DENY
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/review-state.md
+  - docs/focus-mode/state/finite-outcomes.md §4.2 (DENY reason codes)
+  - docs/focus-mode/state/transitions/candidate-to-hold.md
+  - docs/focus-mode/state/README.md §9
+tags: [kfm, focus-mode, state, transition, hold, deny, rejected, sensitive-lane]
+notes:
+  - One of five prose transition specs under docs/focus-mode/state/transitions/.
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Transition — `HOLD` → `DENY`
+
+> *Hold resolved to refusal: a candidate in review state `held` becomes `rejected` after the holding reviewer (steward, rights holder, policy) declines. Public surface that previously rendered `HOLD` for queries against the held candidate now renders `DENY`.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![class](https://img.shields.io/badge/class-refusal-red)
+![preserves-prior-state](https://img.shields.io/badge/preserves--prior--published-yes-success)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **A `HOLD → DENY` resolution applies to the held candidate, not to the prior `PUBLISHED` release.** If a prior release of the same artifact exists, it continues to serve `ANSWER` *(subject to policy)* — the rejection is of the new revision, not the historical record. Conflating the two is the most common error in this transition.
+
+---
+
+## Contents
+
+1. [Trigger conditions](#1-trigger-conditions)
+2. [Pre-conditions](#2-pre-conditions)
+3. [Post-conditions](#3-post-conditions)
+4. [Required receipts](#4-required-receipts)
+5. [Rollback target](#5-rollback-target)
+6. [Diagram](#6-diagram)
+7. [Effect on prior `PUBLISHED` release](#7-effect-on-prior-published-release)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Cross-references](#9-cross-references)
+
+---
+
+## 1. Trigger conditions
+
+| Trigger | Hold reason that drove the prior `HOLD` | Resulting `DENY` reason code |
+|---|---|---|
+| Rights holder declined the publication. | `rights_holder_review_pending` | `rights_deny` |
+| Steward review concluded the artifact is unfit. | `steward_review_pending` | `sensitivity_deny` *(if steward is sensitivity reviewer)* or `policy_deny` |
+| New policy bundle forbids the publication; held content remains forbidden under the new bundle. | `policy_review_pending` | `policy_deny` |
+| Correction concluded the candidate is invalid. | `correction_pending` | `policy_deny` or `sensitivity_deny` per the correction's `CorrectionNotice` reasoning |
+| Gate G failure that cannot recover *(missing rollback target permanently)*. | `release_gate_pending` | `release_state_deny` |
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Pre-conditions
+
+| Pre-condition | Source |
+|---|---|
+| `ReviewRecord.state = held` exists for the candidate. | `ReviewRecord` carrier. |
+| Holding reviewer's decision is documented and signed. | Reviewer signature on the new `ReviewRecord` revision. |
+| Separation-of-duties enforced on sensitive lanes *(the reviewer issuing the refusal is not the author)*. | `validate_review_record.py` *(PROPOSED)*. |
+| If a prior `PUBLISHED` release exists, its state is verified — the refusal applies to the candidate, not the prior release. | Audit step. |
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Post-conditions
+
+| Post-condition | Carrier |
+|---|---|
+| `ReviewRecord.state` set to `rejected`; reason recorded. | `ReviewRecord` revision *(append-only)*. |
+| `PolicyDecision (outcome=DENY)` issued, referencing the rejected `ReviewRecord` and reason code per §1. | Receipt store. |
+| Candidate terminates — it is removed from the release-candidate pool and MUST NOT be promoted. | `release/candidates/<area>-focus-mode/` updated *(or candidate marked terminal)*. |
+| Public surfaces that received `HOLD` for queries against this candidate now receive `DENY` with the resolved reason code. | `DecisionEnvelope (outcome=DENY)`. |
+| Prior `PUBLISHED` release *(if any)* is **unaffected** — it continues to serve `ANSWER`. | No change. |
+| Surface MAY offer an alternative *(prior release, generalized version, related un-denied artifact)* in the `DENY` envelope's `obligations[]` field *(PROPOSED — see [`finite-outcomes.md` open question FO-Q3](../finite-outcomes.md#9-open-questions))*. | Optional. |
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Required receipts
+
+| Receipt | Required? | Notes |
+|---|---|---|
+| `ReviewRecord (rejected)` | yes | Carries refusal reason, reviewer identity, timestamp, references the prior `held` record. |
+| `PolicyDecision (DENY)` | yes | References the `ReviewRecord` and emits the reason code from §1. |
+| External reviewer ticket/record reference | yes if applicable | Sovereignty-review ID, rights-holder communication ref, policy bundle PR ref. |
+| `DecisionEnvelope (DENY)` for runtime queries that arrive after the rejection | yes | Standard public refusal envelope. |
+| `AIReceipt` for any `HOLD` envelopes that were re-evaluated after rejection | yes | Audit chain link: old `HOLD` → new `DENY` for the same query. |
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Rollback target
+
+`DENY` itself is **not rolled back** as a state transition — a future re-authoring creates a new candidate with a new `ReviewRecord` starting at `draft`. The rejected `ReviewRecord` stays in the audit chain.
+
+However, a rejection can be **revisited**:
+
+- If new evidence emerges, the author may submit a new revision; the prior `ReviewRecord (rejected)` is referenced in the new submission's history.
+- If the rights holder or steward later approves what they previously denied, that approval applies to the **new** submission, not by retroactively flipping the rejected one.
+
+> [!NOTE]
+> **A rejected `ReviewRecord` is never overwritten.** The audit chain shows that the candidate was rejected. A successor candidate is a new record. *(See [`review-state.md` §9 anti-pattern "Review record overwritten"](../review-state.md#9-anti-patterns).)*
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Diagram
+
+```mermaid
+sequenceDiagram
+  participant Author
+  participant Review as Review pipeline
+  participant Policy as Policy gate
+  participant UI as Public UI
+  Author->>Review: submit candidate (ReviewRecord pending)
+  Review->>Review: holding reviewer requests pause<br/>(state=held, PolicyDecision=HOLD)
+  Note over UI: queries against held candidate → HOLD<br/>queries against prior PUBLISHED → ANSWER
+  Review->>Policy: holding reviewer declines
+  Policy-->>Review: PolicyDecision(DENY, reason)
+  Review->>Review: ReviewRecord(state=rejected)<br/>append-only revision
+  Note over UI: queries against rejected candidate → DENY<br/>queries against prior PUBLISHED → ANSWER (unchanged)
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Effect on prior `PUBLISHED` release
+
+| Scenario | Behavior |
+|---|---|
+| No prior `PUBLISHED` release exists. | Surface returns `DENY` for queries against the area/subject. User sees the denial reason; surface offers no substantive answer. |
+| Prior `PUBLISHED` release exists and is unaffected by the rejection. | Surface continues to return `ANSWER` from the prior release. The rejection applies only to the candidate, not the historical record. |
+| Prior `PUBLISHED` release is implicated by the same rights/policy issue. | A **separate** transition — see [`published-to-revoked.md`](./published-to-revoked.md) — applies. The rejection of the candidate does not automatically revoke the prior release; that requires its own revocation manifest. |
+
+> [!CAUTION]
+> **Do not chain transitions implicitly.** A `HOLD → DENY` on a candidate does not, by itself, revoke a prior `PUBLISHED` release. If both transitions are intended, both must be issued with their own receipts. Implicit chaining is anti-pattern #1 in this file.
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine |
+|---|---|
+| **Implicit revocation of prior release** — rejecting a candidate also strips the prior `PUBLISHED` release without a revocation manifest. | Two distinct transitions conflated; audit chain broken; user sees content disappear without a documented reason. |
+| **`DENY` without reason code** — refusal envelope omits the reason code. | Reason routing broken; user cannot understand the denial; reviewer cannot answer "why was this denied?". |
+| **`ReviewRecord` overwritten** — `rejected` flipped to `approved` in place. | Audit chain destroyed; bad decision becomes invisible. |
+| **`DENY` leaks the held content** — refusal response embeds partial evidence. | Defeats the denial; reconstructable. |
+| **Reviewer == author on sensitive-lane rejection** — separation-of-duties violated. | Self-rejection bypasses the review gate. |
+| **Silent rejection** — candidate disappears with no envelope. | User waiting on `HOLD` never sees resolution. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Cross-references
+
+- [`docs/focus-mode/state/review-state.md`](../review-state.md) §3 — `held → rejected` transition.
+- [`docs/focus-mode/state/finite-outcomes.md`](../finite-outcomes.md) §4.2 — `DENY` reason codes.
+- [`docs/focus-mode/state/transitions/candidate-to-hold.md`](./candidate-to-hold.md) — entry to `held` state.
+- [`docs/focus-mode/state/transitions/published-to-revoked.md`](./published-to-revoked.md) — separate transition for the prior release if it is implicated.
+- [`docs/focus-mode/README.md`](../../README.md) §15 — sensitivity defaults.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/transitions/published-to-revoked.md
+++ b/docs/focus-mode/state/transitions/published-to-revoked.md
@@ -1,0 +1,215 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-transitions-published-to-revoked
+title: Transition — PUBLISHED → REVOKED
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/revocation-state.md
+  - docs/focus-mode/state/payload-state.md
+  - docs/focus-mode/state/finite-outcomes.md §4.1 (revoked_no_alternative)
+  - docs/focus-mode/state/transitions/rollback-to-prior.md
+  - docs/focus-mode/state/README.md §11
+tags: [kfm, focus-mode, state, transition, published, revoked, revocation-manifest, KFM-P19-FEAT-0002]
+notes:
+  - One of five prose transition specs under docs/focus-mode/state/transitions/.
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Transition — `PUBLISHED` → `REVOKED`
+
+> *Withdrawal of a released artifact: a signed revocation manifest is issued and clients (UI, governed APIs, cached payloads) stop serving the artifact. Cached-but-revoked payloads transition to `ABSTAIN (revoked_no_alternative)` or rebind to a `replaces_with` release.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![class](https://img.shields.io/badge/class-withdrawal-red)
+![signed](https://img.shields.io/badge/manifest-signed-success)
+![ttl](https://img.shields.io/badge/TTL-honored-success)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!CAUTION]
+> **A revocation takes effect immediately.** TTL governs the re-fetch cadence of the manifest, not a grace period for continued serving. The moment a client fetches a valid revocation manifest, the revoked artifact MUST stop serving. *(See [`revocation-state.md` §4](../revocation-state.md#4-ttl-semantics).)*
+
+---
+
+## Contents
+
+1. [Trigger conditions](#1-trigger-conditions)
+2. [Pre-conditions](#2-pre-conditions)
+3. [Post-conditions](#3-post-conditions)
+4. [Required receipts](#4-required-receipts)
+5. [Rollback target](#5-rollback-target)
+6. [Diagram](#6-diagram)
+7. [Replacement vs no-replacement paths](#7-replacement-vs-no-replacement-paths)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Cross-references](#9-cross-references)
+
+---
+
+## 1. Trigger conditions
+
+| Trigger | Revocation reason code *(per [`revocation-state.md` §3.1](../revocation-state.md#31-revocation-reason-codes-proposed-enum))* |
+|---|---|
+| Post-release review found evidence does not support the claim. | `evidence_invalidated` |
+| Rights holder revoked the license to publish. | `rights_withdrawn` |
+| New sensitivity classification forbids further publication. | `sensitivity_escalation` |
+| Court order, takedown notice, regulatory action. | `legal_order` |
+| Hash mismatch detected post-release *(tamper or pipeline bug)*. | `integrity_breach` |
+| Newer release available; this one stays addressable but no longer current. | `superseded_with_replacement` *(in this case, prefer `superseded-by` state — see §7)* |
+| Policy bundle revision forbids previously-allowed publication. | `policy_change` |
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Pre-conditions
+
+| Pre-condition | Source |
+|---|---|
+| Artifact is currently `PUBLISHED` *(has a current `ReleaseManifest`)*. | Release store. |
+| Issuer has authority to revoke for this lane *(role-checked)*. | Role allowlist; for sensitive lanes, multi-signature MAY be required *(see [`revocation-state.md` §10 open question RV-Q4](../revocation-state.md#10-open-questions))*. |
+| Revocation reason is within the §3.1 enum. | Manifest validation. |
+| If a replacement is intended, the replacement is itself `PUBLISHED`. | Pre-flight check. |
+| Hash of the artifact to be revoked is known *(content hash + `spec_hash`)*. | Release record. |
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Post-conditions
+
+| Post-condition | Carrier |
+|---|---|
+| Signed revocation manifest issued and published to the revocation channel. | `schemas/contracts/v1/release/revocation_manifest.schema.json` *(PROPOSED)*. |
+| Artifact's state transitions to `revoked`. | Release record updated. |
+| Governed APIs stop serving the artifact *(layer manifest resolver returns `DENY (release_state_deny)` with revocation reason)*. | Resolver behavior. |
+| Clients that fetch the revocation manifest stop rendering the artifact. | UI behavior — see [`revocation-state.md` §8](../revocation-state.md#8-cached-but-revoked-enforcement). |
+| Cached payloads that depend on the revoked evidence transition to payload state `revoked-but-cached` → `ABSTAIN (revoked_no_alternative)` *(or rebind if `replaces_with` exists)*. | Runtime behavior. |
+| `CorrectionNotice` *(public-facing)* is published referencing the revocation for non-trivial cases. | Public-facing record. |
+| Audit chain link: revocation manifest references the revoked `ReleaseManifest` and the issuer's role. | Receipt chain. |
+
+> [!IMPORTANT]
+> **The revoked artifact remains addressable for replay and audit.** Revocation withdraws *serving*, not the artifact itself. Future audits walking the chain can still read the revoked `ReleaseManifest` and the revocation manifest. *(See [`revocation-state.md` §6 note on rolled-back addressability](../revocation-state.md#6-rollback-card-contract).)*
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Required receipts
+
+| Receipt | Required? | Notes |
+|---|---|---|
+| Signed revocation manifest | yes | Full field set per [`revocation-state.md` §3](../revocation-state.md#3-revocation-manifest-contract). |
+| Issuer identity + signature | yes | Detached signature over the manifest body. |
+| `spec_hash` binding | yes | Specific spec under which the artifact was released. |
+| `content_hash` of revoked artifact | yes | So clients can verify they hold the exact form being revoked. |
+| TTL setting | yes | Default 60s; `0` for hard revocations. |
+| `replaces_with` reference *(optional but RECOMMENDED)* | conditional | Pointer to successor release if available. |
+| `CorrectionNotice` *(public-facing)* | yes for non-trivial cases | Explains the revocation to public users. |
+| Run-receipt attestations *(PROPOSED — KFM-P19-FEAT-0002)* | yes | Links the revocation to its review/audit chain. |
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Rollback target
+
+Revocation is **not a rollback**. The two are distinct:
+
+| Concern | Revocation | Rollback |
+|---|---|---|
+| What happens | Artifact stops serving. | A prior release is re-promoted as current. |
+| Successor state | `revoked` *(no current artifact unless `replaces_with` set)* | `rolled-back` on the new release; prior release becomes `live` |
+| Receipt | Revocation manifest | `RollbackCard` |
+
+A revocation MAY be paired with a rollback if appropriate — see [`rollback-to-prior.md`](./rollback-to-prior.md). The pairing is two distinct transitions with two distinct receipts; do not collapse them.
+
+> [!NOTE]
+> **Revocation does not, by itself, restore an earlier release.** If the intent is "stop serving this release **and** restore the prior one as current", issue both a revocation manifest **and** a `RollbackCard`. Each carries its own audit chain link.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Diagram
+
+```mermaid
+sequenceDiagram
+  participant Issuer
+  participant RelStore as Release store
+  participant RevChan as Revocation channel
+  participant Client as Public client (UI / governed API)
+  Issuer->>RelStore: prepare revocation (content_hash + spec_hash + reason)
+  Issuer->>Issuer: sign manifest
+  Issuer->>RevChan: publish signed revocation manifest
+  Note over Client: next request OR TTL expiry triggers re-fetch
+  Client->>RevChan: GET revocation manifest
+  RevChan-->>Client: signed manifest (TTL, reason, replaces_with?)
+  Client->>Client: verify signature + spec_hash + content_hash
+  alt verification passes, replaces_with present
+    Client->>Client: rebind to replaces_with release
+    Client-->>Client: new ANSWER (new AIReceipt, refs new bundle)
+  else verification passes, no replacement
+    Client-->>Client: ABSTAIN (revoked_no_alternative); surface revocation reason
+  else verification fails (signature/hash)
+    Client-->>Client: ERROR (integrity_breach); keep current cached state
+  end
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Replacement vs no-replacement paths
+
+| Path | Behavior |
+|---|---|
+| `replaces_with: <PUBLISHED release ref>` | Clients rebind to the replacement; surface continues with `ANSWER` from the new release; revocation receipt and rebinding receipt both recorded. |
+| `replaces_with: null` | No replacement; surface demotes to `ABSTAIN (revoked_no_alternative)`; revocation reason rendered to user. |
+| `superseded_with_replacement` reason code | Prefer modeling as `superseded-by` state instead of `revoked` — the artifact remains addressable as a historical record but is no longer current. See [`revocation-state.md` §2](../revocation-state.md#2-the-four-revocationrollback-states). |
+
+> [!CAUTION]
+> **`superseded-by` is not the same as `revoked`.** A superseded artifact is still part of the historical record and remains addressable for replay. A revoked artifact stops serving entirely *(though it remains addressable for audit)*. The distinction matters: revoking when you meant to supersede destroys the historical record's serveability without cause; superseding when you meant to revoke leaves bad content serveable as history.
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine |
+|---|---|
+| **Silent revoked render** — UI continues to render after revocation arrives. | See [`revocation-state.md` §9](../revocation-state.md#9-anti-patterns) — the canonical anti-pattern. |
+| **Unsigned revocation** — manifest published without a signature. | Anyone can forge a revocation; or no one can issue a real one. |
+| **TTL as grace period** — clients serve revoked artifact "until TTL expires". | Revocation is immediate; TTL is a re-fetch hint. |
+| **Revocation deletes the artifact** — revoked release removed from the store. | Audit replay impossible; chain broken. |
+| **Pairing implicit** — revocation issued with the assumption that a rollback will also happen, but no `RollbackCard` issued. | Implicit chaining; two distinct transitions conflated. |
+| **`spec_hash` over-broad** — revocation matches multiple unintended releases. | Collateral revocation; releases not meant to be revoked stop serving. |
+| **Revocation reason free-form** — reason text outside the enum. | Downstream consumers cannot route; metrics broken. |
+| **Revocation without `CorrectionNotice` on a user-visible case** — public user sees content disappear with no public-facing explanation. | Audit transparency broken from the user's perspective. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Cross-references
+
+- [`docs/focus-mode/state/revocation-state.md`](../revocation-state.md) — full revocation contract, TTL, `spec_hash` binding.
+- [`docs/focus-mode/state/payload-state.md`](../payload-state.md) §2 — `revoked-but-cached` payload state.
+- [`docs/focus-mode/state/finite-outcomes.md`](../finite-outcomes.md) §4.1 — `revoked_no_alternative` `ABSTAIN` reason.
+- [`docs/focus-mode/state/transitions/answer-to-abstain.md`](./answer-to-abstain.md) — the public-side demotion that pairs with this transition.
+- [`docs/focus-mode/state/transitions/rollback-to-prior.md`](./rollback-to-prior.md) — companion transition when a prior release is re-promoted.
+- KFM-P19-FEAT-0002 *(PROPOSED — Focus Mode revocation verifier)*.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)

--- a/docs/focus-mode/state/transitions/rollback-to-prior.md
+++ b/docs/focus-mode/state/transitions/rollback-to-prior.md
@@ -1,0 +1,207 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/focus-mode-state-transitions-rollback-to-prior
+title: Transition — PUBLISHED → rolled-back (prior release re-promoted)
+type: standard
+version: v0.1
+status: draft
+owners: <FOCUS-MODE-DOCTRINE-OWNER> · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - docs/focus-mode/state/revocation-state.md §6
+  - docs/focus-mode/state/transitions/published-to-revoked.md
+  - docs/focus-mode/state/lifecycle-states.md
+  - docs/focus-mode/state/README.md §11
+tags: [kfm, focus-mode, state, transition, rollback, rollback-card, supersession, correction-notice]
+notes:
+  - One of five prose transition specs under docs/focus-mode/state/transitions/.
+  - Path placement diverges from Directory Rules v1.2 §6.7.2; tracked as OPEN-DR-09.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Transition — `PUBLISHED` → `rolled-back` (prior release re-promoted)
+
+> *A prior `ReleaseManifest` is re-promoted as the current release. The new release transitions to `rolled-back`; the prior release transitions back to `live`. A `RollbackCard` and (usually) a `CorrectionNotice` are issued.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![class](https://img.shields.io/badge/class-restoration-orange)
+![rollback-card](https://img.shields.io/badge/RollbackCard-required-success)
+![supersession-chain](https://img.shields.io/badge/supersession--chain-preserved-success)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+
+**Status:** draft · **Owners:** `<FOCUS-MODE-DOCTRINE-OWNER>` *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **Rollback is a forward state transition, not an undo.** The rolled-back release remains addressable for replay; the prior release becomes current again as a new event in the audit chain. The `supersession_chain` records the order. Rollback does not delete history.
+
+---
+
+## Contents
+
+1. [Trigger conditions](#1-trigger-conditions)
+2. [Pre-conditions](#2-pre-conditions)
+3. [Post-conditions](#3-post-conditions)
+4. [Required receipts](#4-required-receipts)
+5. [Forward path after rollback](#5-forward-path-after-rollback)
+6. [Diagram](#6-diagram)
+7. [Pairing with revocation](#7-pairing-with-revocation)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Cross-references](#9-cross-references)
+
+---
+
+## 1. Trigger conditions
+
+| Trigger | Rollback reason code *(per [`revocation-state.md` §6.1](../revocation-state.md#61-rollback-reason-codes-proposed-enum))* |
+|---|---|
+| New release retracted; prior release more accurate. | `evidence_invalidated_post_release` |
+| New release broke a working behavior; revert. | `regression` |
+| Policy bundle change reverted; matching release reverted. | `policy_revert` |
+| Temporary rollback while a fix is built; expected to be re-rolled-forward later. | `correction_pending_rebuild` |
+| Urgent rollback for safety/legal reasons. | `emergency` |
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Pre-conditions
+
+| Pre-condition | Source |
+|---|---|
+| A current `PUBLISHED` release exists *(the one to be rolled back)*. | Release store. |
+| A prior `PUBLISHED` release exists for the same artifact and is addressable. | Release store; `supersession_chain`. |
+| The prior release's state has been re-validated *(its evidence still resolves; it has not itself been independently revoked)*. | Pre-flight check. |
+| Rollback issuer has authority for this lane *(role-checked; sensitive lanes may require multi-signature)*. | Role allowlist. |
+| Rollback reason is within the §6.1 enum. | `RollbackCard` validation. |
+
+> [!NOTE]
+> **Rollback requires an addressable prior release.** A rollback into "the state before anything was published" is not a rollback — it is effectively a revocation with no replacement *(see [`published-to-revoked.md`](./published-to-revoked.md))*.
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Post-conditions
+
+| Post-condition | Carrier |
+|---|---|
+| Signed `RollbackCard` issued, linking rolled-back release ↔ restored prior release. | `schemas/contracts/v1/release/rollback_card.schema.json` *(PROPOSED)*. |
+| Rolled-back release transitions to state `rolled-back`. | Release record. |
+| Prior release transitions back to `live` *(it is the current release again)*. | Release record. |
+| `supersession_chain` updated to record the new ordering. | Release index. |
+| `CorrectionNotice` *(public-facing)* issued for non-trivial rollbacks. | Public-facing record. |
+| Public surfaces re-bind to the restored prior release *(clients see the prior release's content as current)*. | UI / governed API behavior. |
+| Cached payloads referencing the rolled-back release transition to payload state `stale` and re-resolve on next request *(may produce `ANSWER` from the restored release, or `ABSTAIN` if the request scope no longer aligns)*. | Runtime behavior. |
+| Audit chain link: rollback receipt references both releases and the reason code. | Receipt chain. |
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Required receipts
+
+| Receipt | Required? | Notes |
+|---|---|---|
+| `RollbackCard` | yes | Full field set per [`revocation-state.md` §6](../revocation-state.md#6-rollback-card-contract). |
+| Issuer identity + signature | yes | Detached signature over the card body. |
+| Rolled-back release ref | yes | The release being demoted from `live`. |
+| Restored release ref | yes | The prior release being re-promoted to `live`. |
+| `supersession_chain` entry | yes | Records the chronological ordering. |
+| `CorrectionNotice` *(public-facing)* | yes for non-trivial rollbacks | Explains the rollback to public users. |
+| Reason code from §1 | yes | Routing and metrics. |
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Forward path after rollback
+
+| Scenario | Next state |
+|---|---|
+| Rollback was `emergency` or `regression`; engineering fix in flight. | New release candidate prepared; standard promotion pipeline; eventual `PUBLISHED` supersedes the restored prior release. |
+| Rollback was `policy_revert`; policy bundle revision restored. | No new release needed *(unless content also needs to change)*; prior release continues as `live`. |
+| Rollback was `correction_pending_rebuild`. | New release candidate prepared with the corrected content; standard pipeline; eventual `PUBLISHED` re-rolls-forward. |
+| Rollback was `evidence_invalidated_post_release`. | The rolled-back release may also be revoked separately *(see §7 pairing)*. |
+
+> [!NOTE]
+> **A re-roll-forward is a new transition.** A future `PUBLISHED` that supersedes the restored prior release goes through the full promotion pipeline — gate A through G. It is not a "undo the rollback" operation.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Diagram
+
+```mermaid
+sequenceDiagram
+  participant Issuer
+  participant RelStore as Release store
+  participant Idx as Supersession chain
+  participant Client as Public client
+  Note over RelStore: prior release R_n-1 exists (state: superseded-by R_n)<br/>current release R_n is live
+  Issuer->>RelStore: prepare RollbackCard<br/>(R_n → rolled-back, R_n-1 → live, reason)
+  Issuer->>Issuer: sign card
+  Issuer->>RelStore: issue RollbackCard
+  RelStore->>Idx: update supersession chain<br/>(R_n-1 restored as live)
+  RelStore->>RelStore: publish CorrectionNotice (if non-trivial)
+  Note over Client: next request triggers re-resolution
+  Client->>RelStore: GET current release for area/subject
+  RelStore-->>Client: R_n-1 (restored)
+  Client-->>Client: rebind; serve ANSWER from R_n-1
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Pairing with revocation
+
+Rollback and revocation are **distinct transitions**; either may occur without the other, or both may occur together.
+
+| Scenario | Issue rollback? | Issue revocation? |
+|---|---|---|
+| New release has a bug; prior release is fine; revert. | yes | no — the new release remains addressable as a historical mistake |
+| New release contains content that should never have been published *(rights, sensitivity, legal)*; prior release is fine. | yes *(restore prior)* | yes *(withdraw the new release entirely)* — pair the two transitions |
+| Prior release is the problem; new release is also a problem. | no — there is no good release to restore | yes for current; separate revocation for prior *(consider whether anything should be served)* |
+| Current release is fine; prior release retroactively found problematic. | no — no rollback needed | yes for the prior release; `live` state of current is unaffected |
+
+> [!IMPORTANT]
+> **If pairing, issue both receipts.** A `RollbackCard` does not implicitly revoke; a revocation manifest does not implicitly rollback. Each transition carries its own audit chain link. *(See [`published-to-revoked.md` §5](./published-to-revoked.md#5-rollback-target).)*
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Why it breaks doctrine |
+|---|---|
+| **Rollback deletes the rolled-back release** — release record removed from the store. | Audit replay impossible; chain broken. |
+| **No `CorrectionNotice` on user-visible rollback** — public users see content change without explanation. | Audit transparency broken from the user's perspective. |
+| **`supersession_chain` overwritten** — chain edited in place to hide the rolled-back release. | Audit chain destroyed. |
+| **Implicit revocation** — rollback issued with the assumption that the rolled-back release is also revoked, but no revocation manifest issued. | Two transitions conflated; rolled-back release remains technically serveable in some paths. |
+| **Rollback without prior release** — "rollback to nothing". | Not a rollback; should be modeled as revocation with no replacement. |
+| **Signature missing** — unsigned `RollbackCard` accepted. | Anyone can forge a rollback. |
+| **Rolling back to a release that is itself revoked** — restored release was independently revoked. | Pre-flight check should reject; otherwise the restored release stops serving immediately and the rollback is moot. |
+| **Reason code free-form** — rollback reason text outside the enum. | Routing broken; metrics broken. |
+| **Re-roll-forward without new pipeline pass** — restored release "promoted" to current again without going through gates A–G. | Bypasses promotion contract; new content reaches users without re-validation. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Cross-references
+
+- [`docs/focus-mode/state/revocation-state.md`](../revocation-state.md) §6 — full `RollbackCard` contract.
+- [`docs/focus-mode/state/transitions/published-to-revoked.md`](./published-to-revoked.md) — companion revocation transition.
+- [`docs/focus-mode/state/lifecycle-states.md`](../lifecycle-states.md) §3 — gate G (release & rollback).
+- [`docs/focus-mode/state/payload-state.md`](../payload-state.md) §2 — `stale` payload state on rollback.
+- [`docs/focus-mode/state/finite-outcomes.md`](../finite-outcomes.md) — outcomes after rebinding to restored release.
+
+---
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED *(OPEN-DR-09)*
+
+[↑ Back to top](#top)


### PR DESCRIPTION
## Goal

Add comprehensive Focus Mode state doctrine covering five independent state families (lifecycle, review, payload, revocation, finite outcomes) and five transition specifications. These documents establish the closed enums, required artifacts, and composition rules that govern the promotion pipeline and runtime behavior of the Focus Mode system.

## Status labels

- [x] `PROPOSED` — design consistent with Atlas v1.1 and Doctrine Synthesis; paths and implementation contracts not yet verified in mounted repo.
- [x] `NEEDS VERIFICATION` — all files marked for verification of path placement (OPEN-DR-09) and schema homes.

## Evidence inspected

- Diff of 8 new markdown files under `docs/focus-mode/state/`
- KFM_META_BLOCK_V2 headers with doc_id, status, owners, related references
- Cross-references between state family docs and transition specs
- Metadata tags and notes tracking OPEN-DR-09 path divergence

## Directory Rules basis

**Path placement:** All files placed under `docs/focus-mode/state/` per proposed structure. Per §6.7.2 of Directory Rules v1.2, this diverges from the standard directory layout. This divergence is tracked as OPEN-DR-09 and noted in each file's metadata. The doctrine itself (state enums, composition rules, required artifacts) is CONFIRMED; the file location is PROPOSED pending resolution of OPEN-DR-09.

**Schema homes:** References to PROPOSED schema locations:
- `schemas/contracts/v1/release/revocation_manifest.schema.json`
- `schemas/contracts/v1/release/rollback_card.schema.json`
- `schemas/contracts/v1/runtime/review_record.schema.json`
- `schemas/contracts/v1/runtime/policy_decision.schema.json`
- `schemas/contracts/v1/runtime/decision_envelope.schema.json`
- `schemas/contracts/v1/runtime/ai_receipt.schema.json`
- `schemas/contracts/v1/focus_mode/map_context_envelope.schema.json`
- `schemas/contracts/v1/focus_mode/focus_mode_payload.schema.json`

These schema homes are not yet mounted; all are labeled PROPOSED.

## Affected roots

- [x] `docs/`

## Affected object families

- [x] `PolicyDecision`
- [x] `ReviewRecord` (new family)
- [x] `ReleaseManifest`
- [x] `RollbackCard` (new family)
- [x] `CorrectionNotice`
- [x] `FocusModePayload` (new family)
- [x] `MapContextEnvelope` (new family)
- [x] `RevocationManifest` (new family)
- [x] `DecisionEnvelope` (new family)
- [x] `AIReceipt`

## Affected lifecycle stages

- [x] RAW
- [x] WORK / QUARANTINE
- [x] PROCESSED
- [x] CATALOG / TRIPLET
- [x] PUBLISHED

## What changed

**New state family documentation:**

1. **`lifecycle-states.md`** — Five-stage default-deny promotion pipeline (RAW → WORK/QUARANTINE → PROCESSED → CATALOG/TRIPLET → PUBLISHED). Defines gates A–G, required artifacts at each transition, and trust-membrane rule separating internal stages from public surfaces.

2. **`review-state.md`** — Six review states (draft → pending → held/approved/rejected → superseded). Establishes orthogonality between review state and lifecycle state, separation-of-duties enforcement for sensitive lanes, and the HOLD semantics that pause promotion without affecting prior PUBLISHED releases.

3. **`finite-outcomes.md`** — Seven closed-enum outcomes (ANSWER, ABSTAIN, DENY, ERROR, HOLD, PASS, FAIL). Defines per-outcome required artifacts, reason-code vocabularies, and composition rules (e.g., "no silent demotion," "outcomes do not chain").

4. **`payload-state.md`** — Five payload freshness states (fresh, stale

https://claude.ai/code/session_014W6ZU2eKxQ7ZT47jsBxve2