### PR TITLE
docs(architecture/publication): add four kebab-case companion docs

### DIFF
--- a/docs/architecture/publication/promotion-gates.md
+++ b/docs/architecture/publication/promotion-gates.md
@@ -1,0 +1,304 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/architecture-publication-promotion-gates
+title: Publication — Promotion Gates A–G
+type: standard
+version: v0.1
+status: draft
+owners: Release Manager · Docs Steward · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - README.md
+  - RELEASE_GATES.md
+  - release-state-machine.md
+  - release-objects.md
+  - rollback-and-correction.md
+  - ../governed-api/LIFECYCLE_GATES.md
+  - ../cross-domain/trust-membrane.md
+  - ../../doctrine/lifecycle-law.md
+  - kfm_unified_doctrine_synthesis.md#8
+tags: [kfm, architecture, publication, promotion, gates, doctrine]
+notes:
+  - PROPOSED. Concise companion to RELEASE_GATES.md (detailed gate matrix).
+  - Doctrine for gates A–G is CONFIRMED per kfm_unified_doctrine_synthesis.md §8.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Publication — Promotion Gates A–G
+
+> *The seven governed transitions an artifact passes before it is `PUBLISHED`. A is admission; G is release. Every gate fails closed; none can be skipped.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-CONFIRMED-blue)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+![gates](https://img.shields.io/badge/gates-A--G%20(7)-blue)
+
+**Status:** draft · **Owners:** Release Manager · Docs Steward *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **Publication is a governed state transition, not a file move** *(`README.md` §6; `lifecycle-law.md`; CONFIRMED)*. Promotion runs through gates A–G. **Skipping a gate is a doctrine violation**; each gate covers a distinct failure mode and exists because that failure has happened.
+
+> [!NOTE]
+> **This doc is the concise gate overview.** The detailed gate matrix, signers, evidence packs, and per-gate validators live in [`RELEASE_GATES.md`](RELEASE_GATES.md). The API-side request-time mapping lives in [`../governed-api/LIFECYCLE_GATES.md`](../governed-api/LIFECYCLE_GATES.md).
+
+---
+
+## Table of contents
+
+1. [Scope](#1-scope)
+2. [The seven gates — at-a-glance](#2-the-seven-gates--ataglance)
+3. [Gate A — Source admission](#3-gate-a--source-admission)
+4. [Gate B — Provenance](#4-gate-b--provenance)
+5. [Gate C — Sensitivity](#5-gate-c--sensitivity)
+6. [Gate D — Validation](#6-gate-d--validation)
+7. [Gate E — Evidence closure](#7-gate-e--evidence-closure)
+8. [Gate F — Review](#8-gate-f--review)
+9. [Gate G — Release](#9-gate-g--release)
+10. [Gate ordering and re-evaluation](#10-gate-ordering-and-reevaluation)
+11. [Anti-patterns](#11-anti-patterns)
+12. [Open questions and ADR triggers](#12-open-questions-and-adr-triggers)
+13. [Related docs](#13-related-docs)
+14. [Appendix](#14-appendix)
+
+---
+
+## 1. Scope
+
+This doc names the seven promotion gates, what each one checks, what its DENY conditions look like, and where each runs. It is the **navigation surface** for the gate matrix; for the deep matrix with evidence packs and signers, see [`RELEASE_GATES.md`](RELEASE_GATES.md).
+
+> [!TIP]
+> **When this doc binds.** Designing or auditing a pipeline step, classifying a failure to a gate, training a new reviewer, or wiring a new validator into a gate.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. The seven gates — at-a-glance
+
+> **Evidence basis:** `kfm_unified_doctrine_synthesis.md` §8 *(promotion gates A–G, CONFIRMED)*; `README.md` §7.
+
+```mermaid
+flowchart LR
+  classDef g fill:#fff4e0,stroke:#d97706;
+  classDef p fill:#c8e6c9,stroke:#1b5e20;
+  A["A · Source admission"]:::g --> B["B · Provenance"]:::g --> C["C · Sensitivity"]:::g --> D["D · Validation"]:::g --> E["E · Evidence closure"]:::g --> F["F · Review"]:::g --> G["G · Release"]:::g --> PUB["PUBLISHED"]:::p
+```
+
+| Gate | Question | DENY produces | Authority |
+|---|---|---|---|
+| **A — Source admission** | Did the source admit with role and rights known? | `ABSTAIN` `evidence/unresolved` *(API)* | Connector / Source steward |
+| **B — Provenance** | Is acquisition timestamped and traceable? | `ABSTAIN` `evidence/inconsistent-bundle` | Provenance receipt |
+| **C — Sensitivity** | Joint posture under the four cross-lane invariants? | `DENY` `policy/sensitivity` | OPA bundle; sensitivity reviewer |
+| **D — Validation** | Schema + domain validators satisfied? | `ERROR` `schema/invalid-response` | CI validators |
+| **E — Evidence closure** | Every consequential claim resolves to a bundle? | `ABSTAIN` `evidence/unresolved` | Closure validator |
+| **F — Review** | Steward review applied where required? | `ABSTAIN` / `DENY` `policy/review-required` | Steward queue |
+| **G — Release** | Manifest entry + rollback target + signatures present? | `ABSTAIN` `release/no-manifest` or fail | Release plane |
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Gate A — Source admission
+
+| Aspect | Detail |
+|---|---|
+| Question | Is the source admitted via `SourceDescriptor` with role and rights known? |
+| Inputs | `SourceDescriptor`; connector receipt; rights manifest. |
+| DENY conditions | Source role missing; rights unknown; ambiguous identity. |
+| Receipt | Connector admission receipt. |
+| Where it runs | At ingest, before `RAW` →  `WORK`. |
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Gate B — Provenance
+
+| Aspect | Detail |
+|---|---|
+| Question | Is acquisition timestamped and traceable to a canonical source? |
+| Inputs | Retrieval record; lineage chain. |
+| DENY conditions | No retrieval record; lineage gap; provenance receipt missing. |
+| Receipt | Provenance receipt referenced by `EvidenceBundle`. |
+| Where it runs | After admission, before `WORK` → `PROCESSED`. |
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Gate C — Sensitivity
+
+| Aspect | Detail |
+|---|---|
+| Question | Is the record's joint sensitivity posture correct under the four cross-lane invariants *(`cross-domain/cross-lane-relations.md`)*? |
+| Inputs | `SensitivityPolicy`; cross-lane invariant validator. |
+| DENY conditions | Joint posture downgraded; fail-closed lane exposed; aggregation used as sensitivity laundromat. |
+| Receipt | `PolicyDecision` recording `sensitivity_posture`. |
+| Where it runs | Before `PROCESSED`; re-evaluated at request time *(`governed-api/LIFECYCLE_GATES.md` §4.3)*. |
+
+> [!CAUTION]
+> **Aggregation does not lower sensitivity.** A county aggregate that includes a fail-closed class is still subject to the fail-closed posture unless the aggregation rule explicitly publishes the result *(k-anonymity, suppression, rounding)*.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Gate D — Validation
+
+| Aspect | Detail |
+|---|---|
+| Question | Does the record satisfy its schema and domain validators? |
+| Inputs | JSON Schema; per-domain validators; cross-lane validator. |
+| DENY conditions | Schema fail; validator fail; integrity mismatch. |
+| Receipt | `ValidationReport` in `data/receipts/`. |
+| Where it runs | On `PROCESSED` build; at request time for response shape. |
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Gate E — Evidence closure
+
+| Aspect | Detail |
+|---|---|
+| Question | Does every consequential claim resolve to an `EvidenceBundle`? |
+| Inputs | `EvidenceRef[]`; bundle resolver. |
+| DENY conditions | Unresolved refs; bundle inconsistency *(role mismatch, sensitivity mismatch, role-preservation violation)*. |
+| Receipt | `CitationValidationReport`. |
+| Where it runs | At promotion to `PROCESSED`; re-run at every public surface request. |
+
+> [!IMPORTANT]
+> **Closure is a runtime fact, not a build-time fact.** Pointers can fail between releases *(deleted source, schema mismatch, manifest drift)*. The runtime checks closure on every public surface, not only at build.
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Gate F — Review
+
+| Aspect | Detail |
+|---|---|
+| Question | Has steward review been applied where required? |
+| Inputs | `ReviewRecord`; steward queue. |
+| DENY conditions | Steward queue not cleared for the posture; review revoked. |
+| Receipt | `ReviewRecord`. |
+| Where it runs | Before `PROCESSED` → `PUBLISHED` for lanes requiring review *(fauna sensitive occurrences, archaeology exact location, etc.)*. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Gate G — Release
+
+| Aspect | Detail |
+|---|---|
+| Question | Is the manifest entry present with a rollback target and valid signatures? |
+| Inputs | `ReleaseManifest`; `RollbackCard`; signature receipts. |
+| DENY conditions | No manifest; no rollback; receipt authority unresolvable; signature invalid. |
+| Receipt | `ReleaseManifest` itself + `PromotionReceipt`. |
+| Where it runs | Release plane; the final transition to `PUBLISHED`. |
+
+> [!IMPORTANT]
+> **`RollbackCard` is mandatory.** A release without a pre-staged rollback target is not a public release *(see [`rollback-and-correction.md`](rollback-and-correction.md))*.
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Gate ordering and re-evaluation
+
+| Rule | Detail |
+|---|---|
+| Gates execute in order A → G | Earlier gate failure prevents later gate execution; A blocking → no B–G work. |
+| Build-time vs request-time | Build-time enforcement is necessary but not sufficient; the governed API re-evaluates relevant gates per request *(`governed-api/LIFECYCLE_GATES.md` §3)*. |
+| Re-evaluation triggers | Release event; policy bundle update; source rebind; review revocation. |
+| Skipping a gate | Doctrine violation; release fails closed. |
+| Hot-fix path | Runs through expedited Gates F/G, not around them. |
+
+[↑ Back to top](#top)
+
+---
+
+## 11. Anti-patterns
+
+| Anti-pattern | Mitigation |
+|---|---|
+| **Gate skipped under deadline pressure** | No skip; gate-skipping becomes precedent that erodes the trust path. |
+| **Build-time validation treated as sufficient** | Runtime re-evaluation required; closure check on every public surface. |
+| **Sensitivity downgraded post-Gate C via aggregation** | Aggregation does not lower sensitivity *(k-anonymity / suppression / rounding required)*. |
+| **Release without `RollbackCard`** | Gate G denies. |
+| **Steward review revoked silently** | Revocation is a release event; manifest reflects. |
+| **Gate failure papered over with retry** | Failures are first-class; retry without diagnosis is drift. |
+
+[↑ Back to top](#top)
+
+---
+
+## 12. Open questions and ADR triggers
+
+| Open item | Class | Suggested ADR title |
+|---|---|---|
+| Gate matrix consolidation — the corpus has two forms *(synthesis §8 vs PMTiles publication-gate list)*; the existing [`RELEASE_GATES.md`](RELEASE_GATES.md) flags this CONFLICTED. | Doctrine | "Promotion-gate matrix consolidation". |
+| Hot-fix path formal definition — expedited Gate F/G or new "H" gate? | Vocabulary | "Expedited promotion route". |
+| Whether Gate B and Gate E should merge *(provenance is a kind of evidence closure)*. | Doctrine | "Gate B / Gate E merger". |
+| Per-domain gate variation — should fail-closed lanes have additional gates? | Variation | "Per-lane gate extensions". |
+
+[↑ Back to top](#top)
+
+---
+
+## 13. Related docs
+
+| Reference | Role | Truth label |
+|---|---|---|
+| `README.md` *(this folder)* §7 | Landing summary of the gates | CONFIRMED doctrine |
+| `RELEASE_GATES.md` *(sibling)* | Detailed gate matrix with signers, packs, validators | CONFIRMED doctrine *(CONFLICTED on matrix form)* |
+| `release-state-machine.md` *(sibling)* | The states the gates connect | PROPOSED |
+| `release-objects.md` *(sibling)* | Objects produced and consumed by each gate | PROPOSED |
+| `rollback-and-correction.md` *(sibling)* | Gate-G `RollbackCard` requirement | PROPOSED |
+| `../governed-api/LIFECYCLE_GATES.md` | API-side request-time mapping | PROPOSED |
+| `../cross-domain/cross-lane-relations.md` | Four invariants enforced at Gates C and E | CONFIRMED doctrine |
+| `../cross-domain/trust-membrane.md` §4 | Gates as the membrane crossings | CONFIRMED doctrine |
+| `../../doctrine/lifecycle-law.md` | Parent doctrine for the invariant | CONFIRMED doctrine *(referenced)* |
+| `kfm_unified_doctrine_synthesis.md` §8 | Promotion gates A–G canonical | CONFIRMED doctrine |
+
+[↑ Back to top](#top)
+
+---
+
+## 14. Appendix
+
+<details>
+<summary><strong>14.1 Gate → outcome quick-reference</strong></summary>
+
+```text
+A — Source admission    →  ABSTAIN evidence/unresolved
+B — Provenance          →  ABSTAIN evidence/inconsistent-bundle
+C — Sensitivity         →  DENY    policy/sensitivity | fail-closed-lane
+D — Validation          →  ERROR   schema/invalid-{request,response}
+E — Evidence closure    →  ABSTAIN evidence/unresolved | ai/citation-unresolved
+F — Review              →  ABSTAIN | DENY policy/review-required
+G — Release             →  ABSTAIN release/{no-manifest,state-not-published,rollback-in-progress}
+```
+
+</details>
+
+<details>
+<summary><strong>14.2 Truth-label legend</strong></summary>
+
+- **CONFIRMED** — verified this session from attached docs.
+- **PROPOSED** — design / placement / inference not yet verified in implementation.
+- **INFERRED** — derivable from confirmed evidence but not directly stated.
+- **NEEDS VERIFICATION** — checkable, but not yet checked strongly enough to act as fact.
+
+</details>
+
+---
+
+**Related (mini)** · [`README.md`](README.md) · [`RELEASE_GATES.md`](RELEASE_GATES.md) · [`release-state-machine.md`](release-state-machine.md) · [`release-objects.md`](release-objects.md) · [`rollback-and-correction.md`](rollback-and-correction.md) · [`../governed-api/LIFECYCLE_GATES.md`](../governed-api/LIFECYCLE_GATES.md)
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED
+
+[↑ Back to top](#top)

--- a/docs/architecture/publication/release-objects.md
+++ b/docs/architecture/publication/release-objects.md
@@ -1,0 +1,385 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/architecture-publication-release-objects
+title: Publication — Release Objects
+type: standard
+version: v0.1
+status: draft
+owners: Release Manager · Docs Steward · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - README.md
+  - promotion-gates.md
+  - release-state-machine.md
+  - rollback-and-correction.md
+  - GEO_MANIFEST.md
+  - ../cross-domain/shared-kernel.md
+  - ../governed-api/ENVELOPES.md
+  - kfm_unified_doctrine_synthesis.md#10
+tags: [kfm, architecture, publication, release, manifests, receipts, doctrine]
+notes:
+  - PROPOSED. Concise catalog of object families involved in publication.
+  - Field-level schemas live in schemas/contracts/v1/release/; contract meaning in contracts/release/.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Publication — Release Objects
+
+> *The object families that compose a release: `ReleaseManifest`, `RollbackCard`, `PromotionReceipt`, `ProofPack`, `EvidenceBundle`, `RunReceipt`, `CitationValidationReport`, `CorrectionNotice`, `CatalogMatrix`, `DecisionEnvelope`, `KFMGeoManifest`.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-CONFIRMED%20(spine)-blue)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+![objects](https://img.shields.io/badge/families-11-blue)
+
+**Status:** draft · **Owners:** Release Manager · Docs Steward *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **A release is a composition of objects, not a copy of files** *(`README.md` §6, §8; `kfm_unified_doctrine_synthesis.md` §10, CONFIRMED)*. The objects below are the building blocks; the gates A–G *(see [`promotion-gates.md`](promotion-gates.md))* produce and consume them.
+
+> [!NOTE]
+> **This doc is the catalog.** Per-object semantic contracts live under `contracts/release/`, `contracts/evidence/`, `contracts/correction/`. JSON Schemas live under `schemas/contracts/v1/release/`, `schemas/contracts/v1/evidence/`, etc. *(ADR-0001)*. This doc names the family, role, and which gate emits / consumes it.
+
+---
+
+## Table of contents
+
+1. [Scope](#1-scope)
+2. [Object catalog](#2-object-catalog)
+3. [`ReleaseManifest`](#3-releasemanifest)
+4. [`RollbackCard`](#4-rollbackcard)
+5. [`PromotionReceipt`](#5-promotionreceipt)
+6. [`ProofPack`](#6-proofpack)
+7. [`EvidenceBundle` and `EvidenceRef`](#7-evidencebundle-and-evidenceref)
+8. [`RunReceipt`](#8-runreceipt)
+9. [`CitationValidationReport`](#9-citationvalidationreport)
+10. [`CorrectionNotice`](#10-correctionnotice)
+11. [`CatalogMatrix`](#11-catalogmatrix)
+12. [`DecisionEnvelope`](#12-decisionenvelope)
+13. [`KFMGeoManifest`](#13-kfmgeomanifest)
+14. [Composition through the gates](#14-composition-through-the-gates)
+15. [Anti-patterns](#15-anti-patterns)
+16. [Open questions and ADR triggers](#16-open-questions-and-adr-triggers)
+17. [Related docs](#17-related-docs)
+18. [Appendix](#18-appendix)
+
+---
+
+## 1. Scope
+
+This doc enumerates the object families involved in publication, names each one's role, identifies which gate emits or consumes it, and points to its canonical schema / contract home.
+
+> [!TIP]
+> **When this doc binds.** Designing a new pipeline step that emits an object, evolving an existing object family, mapping a release event to its receipts, or auditing a release for object completeness.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Object catalog
+
+> **Evidence basis:** `README.md` §8 *(CONFIRMED summary)*; `kfm_unified_doctrine_synthesis.md` §10 *(core object families, CONFIRMED)*.
+
+| Object | Role at publication | Schema home *(PROPOSED)* | Gate(s) |
+|---|---|---|---|
+| **`ReleaseManifest`** | Authoritative record of what is `PUBLISHED`. | `schemas/contracts/v1/release/release_manifest.schema.json` | G |
+| **`RollbackCard`** | Pre-staged rollback target for a release. | `schemas/contracts/v1/release/rollback_card.schema.json` | G |
+| **`PromotionReceipt`** | Receipt of a promotion event *(state transition)*. | `schemas/contracts/v1/release/promotion_receipt.schema.json` | A–G |
+| **`ProofPack`** | Bundle of receipts that justify a release. | `schemas/contracts/v1/release/proof_pack.schema.json` | E, G |
+| **`EvidenceBundle`** | Resolved support for the release's claims. | `schemas/contracts/v1/evidence/evidence_bundle.schema.json` | E |
+| **`RunReceipt`** | Receipt for an automated pipeline run *(connector, validator, model)*. | `schemas/contracts/v1/release/run_receipt.schema.json` | A, B, D |
+| **`CitationValidationReport`** | Proof that every cited `EvidenceRef` resolves to an admissible bundle. | `schemas/contracts/v1/focus/citation_validation_report.schema.json` | E, G |
+| **`CorrectionNotice`** | Public lineage entry that supersedes a prior release. | `schemas/contracts/v1/release/correction_notice.schema.json` | post-release |
+| **`CatalogMatrix`** | The matrix of catalog cells released as a bundle. | `schemas/contracts/v1/catalog/catalog_matrix.schema.json` | G |
+| **`DecisionEnvelope`** | Records the policy decision at release time. | `schemas/contracts/v1/runtime/decision_envelope.schema.json` | C, F, G |
+| **`KFMGeoManifest`** | Asset digest manifest for PMTiles / COG / Zarr. | `schemas/contracts/v1/release/kfm_geo_manifest.schema.json` | D, G |
+
+```mermaid
+flowchart TB
+  classDef o fill:#c8e6c9,stroke:#1b5e20;
+  RM["ReleaseManifest"]:::o
+  RC["RollbackCard"]:::o
+  PR["PromotionReceipt"]:::o
+  PP["ProofPack"]:::o
+  EB["EvidenceBundle"]:::o
+  RR["RunReceipt"]:::o
+  CVR["CitationValidationReport"]:::o
+  CN["CorrectionNotice"]:::o
+  CM["CatalogMatrix"]:::o
+  DE["DecisionEnvelope"]:::o
+  GM["KFMGeoManifest"]:::o
+
+  RR --> PP
+  EB --> PP
+  CVR --> PP
+  DE --> PP
+  PP --> RM
+  CM --> RM
+  GM --> RM
+  RM --> RC
+  RM --> PR
+  RM -. post-release .-> CN
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 3. `ReleaseManifest`
+
+| Aspect | Detail |
+|---|---|
+| Role | The authoritative inventory of what is `PUBLISHED` under a given release id. |
+| Required fields *(prose)* | `release_id`, `released_at`, member layer / artifact / scene refs, `proof_pack_ref`, `rollback_card_ref`, `policy_bundle_hash`, signature, `withdrawn`. |
+| Immutability | Manifests are immutable; corrections are new manifests. |
+| Gate | G *(release)*. |
+
+[↑ Back to top](#top)
+
+---
+
+## 4. `RollbackCard`
+
+| Aspect | Detail |
+|---|---|
+| Role | Pre-staged rollback target for a release; defines what reverting to. |
+| Required fields | `for_release_id`, `rollback_target_release_id`, trigger criteria, operational steps, expected runtime, signature. |
+| Mandatory | Every `ReleaseManifest` references a `RollbackCard`. |
+| Gate | G. |
+
+> [!IMPORTANT]
+> **Pre-staged ≠ executed.** The card is the **target** that rollback executes against; it does not retire the release on its own. See [`rollback-and-correction.md`](rollback-and-correction.md).
+
+[↑ Back to top](#top)
+
+---
+
+## 5. `PromotionReceipt`
+
+| Aspect | Detail |
+|---|---|
+| Role | Receipt of a state transition event *(e.g., `WORK` → `PROCESSED`, `PROCESSED` → `PUBLISHED`)*. |
+| Required fields | `transition`, `from_state`, `to_state`, `at`, signer, evidence refs, policy refs. |
+| Append-only | Receipts are append-only and content-addressed. |
+| Gate | A through G — every gate emits its transition receipt. |
+
+[↑ Back to top](#top)
+
+---
+
+## 6. `ProofPack`
+
+| Aspect | Detail |
+|---|---|
+| Role | Bundle of receipts that justify a release: `RunReceipt`s, `EvidenceBundle` refs, `CitationValidationReport`, `DecisionEnvelope`s, validator reports. |
+| Required fields | `release_ref`, `receipts[]`, `composition_hash`. |
+| Gate | E *(assembled)*, G *(sealed and referenced from manifest)*. |
+
+[↑ Back to top](#top)
+
+---
+
+## 7. `EvidenceBundle` and `EvidenceRef`
+
+| Aspect | Detail |
+|---|---|
+| Role | The resolved support for every consequential claim in the release. |
+| Cardinality | Multiple bundles per release; one bundle resolves multiple refs; refs are stable pointers. |
+| Gate | E *(closure)*; re-resolved at runtime per `governed-api/LIFECYCLE_GATES.md`. |
+| Cross-doc | `cross-domain/shared-kernel.md` §4. |
+
+[↑ Back to top](#top)
+
+---
+
+## 8. `RunReceipt`
+
+| Aspect | Detail |
+|---|---|
+| Role | Per-pipeline-run receipt: connector run, validator run, model run, build run. |
+| Required fields | `run_id`, `tool_id`, `inputs[]`, `outputs[]`, `spec_hash`, `started_at`, `finished_at`, signer. |
+| Gate | A *(connector)*, B *(provenance)*, D *(validator)*. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. `CitationValidationReport`
+
+| Aspect | Detail |
+|---|---|
+| Role | Confirms every cited `EvidenceRef` resolves to an admissible `EvidenceBundle`. |
+| Required fields | `claim_refs[]`, `bundle_refs[]`, `all_resolved`, per-ref resolution result. |
+| Gate | E *(promotion-time)*; runtime *(per request)*. |
+| Failure | Unresolved → `ABSTAIN`; release denied at G if closure incomplete. |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. `CorrectionNotice`
+
+| Aspect | Detail |
+|---|---|
+| Role | Public lineage entry that records a supersession event without deletion. |
+| Required fields | `corrects_release_id`, `superseded_by_release_id`, `reason_class`, `summary`, `at`, signer. |
+| Visibility | Public; drawer surfaces the chain. |
+| When | Post-release; not a gate. |
+| Cross-doc | [`rollback-and-correction.md`](rollback-and-correction.md). |
+
+[↑ Back to top](#top)
+
+---
+
+## 11. `CatalogMatrix`
+
+| Aspect | Detail |
+|---|---|
+| Role | Matrix of catalog cells released as a coherent bundle *(domain × time × space)*. |
+| Required fields | `cells[]`, per-cell evidence + source-role distribution, joint sensitivity. |
+| Gate | G *(carried in manifest)*. |
+
+[↑ Back to top](#top)
+
+---
+
+## 12. `DecisionEnvelope`
+
+| Aspect | Detail |
+|---|---|
+| Role | Records `PolicyDecision` at release time with audience class, posture, release state. |
+| Required fields | See `governed-api/ENVELOPES.md` §4. |
+| Gate | C *(sensitivity decision)*, F *(review decision)*, G *(release decision)*. |
+
+[↑ Back to top](#top)
+
+---
+
+## 13. `KFMGeoManifest`
+
+| Aspect | Detail |
+|---|---|
+| Role | Asset digest manifest for tile artifacts *(PMTiles, COG, Zarr)*; viewer-side integrity check matches against it. |
+| Required fields | Per-asset `content_digest`, signature, format, release_ref. |
+| Gate | D *(integrity)*, G *(carried in manifest)*. |
+| Cross-doc | [`GEO_MANIFEST.md`](GEO_MANIFEST.md); `map-master/TILE_ARTIFACTS.md`. |
+
+[↑ Back to top](#top)
+
+---
+
+## 14. Composition through the gates
+
+```mermaid
+flowchart LR
+  classDef g fill:#fff4e0,stroke:#d97706;
+  classDef o fill:#c8e6c9,stroke:#1b5e20;
+
+  GA["A · Source admission"]:::g --> RR1["RunReceipt"]:::o
+  GB["B · Provenance"]:::g --> RR2["RunReceipt"]:::o
+  GC["C · Sensitivity"]:::g --> DE1["DecisionEnvelope"]:::o
+  GD["D · Validation"]:::g --> RR3["RunReceipt"]:::o
+  GD --> GM["KFMGeoManifest"]:::o
+  GE["E · Evidence closure"]:::g --> EB["EvidenceBundle"]:::o
+  GE --> CVR["CitationValidationReport"]:::o
+  GF["F · Review"]:::g --> DE2["DecisionEnvelope (review)"]:::o
+  GG["G · Release"]:::g --> RM["ReleaseManifest"]:::o
+  GG --> RC["RollbackCard"]:::o
+  GG --> PP["ProofPack"]:::o
+  GG --> PR["PromotionReceipt"]:::o
+  RM -. post-release .-> CN["CorrectionNotice"]:::o
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 15. Anti-patterns
+
+| Anti-pattern | Mitigation |
+|---|---|
+| **`ReleaseManifest` edited in place** | Manifests immutable; correction is a new manifest. |
+| **`RollbackCard` omitted "for hot fixes"** | Always present; expedited path still produces one. |
+| **`ProofPack` partially assembled** | Assembly is atomic; partial pack denies release. |
+| **`CorrectionNotice` substituted for re-release** | Notice supersedes; the new content is a new manifest. |
+| **`RunReceipt` retried without new id** | Each run gets a new id; retries are new receipts. |
+| **`KFMGeoManifest` digest computed at publish time, not at build time** | Digests pinned at D; carried unchanged to G. |
+| **`EvidenceBundle` inlined into the manifest** | Bundles referenced by URI; never inlined. |
+
+[↑ Back to top](#top)
+
+---
+
+## 16. Open questions and ADR triggers
+
+| Open item | Class | Suggested ADR title |
+|---|---|---|
+| `ProofPack` composition hash — content-addressed by a Merkle tree of receipts? | Cryptography | "ProofPack composition hash". |
+| `CorrectionNotice` cardinality — one per release vs chain of notices? | Schema | "CorrectionNotice chaining". |
+| `CatalogMatrix` per-release vs per-Focus-Mode scope? | Composition | "CatalogMatrix scope". |
+| `KFMGeoManifest` and `TileArtifactManifest` unification? | Object family | "GeoManifest / TileArtifactManifest unification". |
+| Receipt schema home — `schemas/contracts/v1/receipts/` vs `schemas/contracts/v1/release/`? | Layout | "Receipt schema home". |
+
+[↑ Back to top](#top)
+
+---
+
+## 17. Related docs
+
+| Reference | Role | Truth label |
+|---|---|---|
+| `README.md` *(this folder)* §8 | Landing summary | CONFIRMED doctrine |
+| `promotion-gates.md` *(sibling)* | Which gate emits / consumes each object | PROPOSED |
+| `release-state-machine.md` *(sibling)* | The states the objects mark transitions through | PROPOSED |
+| `rollback-and-correction.md` *(sibling)* | `RollbackCard` + `CorrectionNotice` | PROPOSED |
+| `GEO_MANIFEST.md` *(sibling)* | Detailed `KFMGeoManifest` | CONFIRMED scaffold |
+| `RELEASE_GATES.md` *(sibling)* | Per-gate object detail | CONFIRMED scaffold |
+| `../cross-domain/shared-kernel.md` | Kernel object definitions | CONFIRMED doctrine |
+| `../governed-api/ENVELOPES.md` | `DecisionEnvelope` shape | PROPOSED |
+| `kfm_unified_doctrine_synthesis.md` §10 | Core object families canonical | CONFIRMED doctrine |
+| `contracts/release/` | Semantic contracts | CONFIRMED doctrine *(PROPOSED paths)* |
+
+[↑ Back to top](#top)
+
+---
+
+## 18. Appendix
+
+<details>
+<summary><strong>18.1 Object → gate quick-reference</strong></summary>
+
+```text
+ReleaseManifest             G
+RollbackCard                G
+PromotionReceipt            A-G (one per transition)
+ProofPack                   E (assembled), G (sealed)
+EvidenceBundle              E
+RunReceipt                  A, B, D
+CitationValidationReport    E (+ runtime)
+CorrectionNotice            post-release
+CatalogMatrix               G
+DecisionEnvelope            C, F, G
+KFMGeoManifest              D (computed), G (carried)
+```
+
+</details>
+
+<details>
+<summary><strong>18.2 Truth-label legend</strong></summary>
+
+- **CONFIRMED** — verified this session from attached docs.
+- **PROPOSED** — design / placement / inference not yet verified in implementation.
+- **INFERRED** — derivable from confirmed evidence but not directly stated.
+- **NEEDS VERIFICATION** — checkable, but not yet checked strongly enough to act as fact.
+
+</details>
+
+---
+
+**Related (mini)** · [`README.md`](README.md) · [`promotion-gates.md`](promotion-gates.md) · [`release-state-machine.md`](release-state-machine.md) · [`rollback-and-correction.md`](rollback-and-correction.md) · [`GEO_MANIFEST.md`](GEO_MANIFEST.md) · [`RELEASE_GATES.md`](RELEASE_GATES.md) · [`../cross-domain/shared-kernel.md`](../cross-domain/shared-kernel.md)
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED
+
+[↑ Back to top](#top)

--- a/docs/architecture/publication/release-state-machine.md
+++ b/docs/architecture/publication/release-state-machine.md
@@ -1,0 +1,346 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/architecture-publication-release-state-machine
+title: Publication — Release State Machine
+type: standard
+version: v0.1
+status: draft
+owners: Release Manager · Docs Steward · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - README.md
+  - promotion-gates.md
+  - release-objects.md
+  - rollback-and-correction.md
+  - ../governed-api/LIFECYCLE_GATES.md
+  - ../cross-domain/trust-membrane.md
+  - ../../doctrine/lifecycle-law.md
+  - kfm_unified_doctrine_synthesis.md#7
+tags: [kfm, architecture, publication, state-machine, lifecycle, doctrine]
+notes:
+  - PROPOSED. The lifecycle invariant as an explicit state machine.
+  - Doctrine for the state set is CONFIRMED (lifecycle-law.md; synthesis §7).
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Publication — Release State Machine
+
+> *The lifecycle invariant as a state machine: `RAW → WORK / QUARANTINE → PROCESSED → CATALOG / TRIPLET → PUBLISHED`, plus `WITHDRAWN` and `SUPERSEDED` as post-publication states. Every transition is governed.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-CONFIRMED%20(states)-blue)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+![states](https://img.shields.io/badge/states-7-blue)
+
+**Status:** draft · **Owners:** Release Manager · Docs Steward *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **The state set is canonical doctrine** *(`README.md` §6, "Lifecycle invariant"; CONFIRMED)*. The transitions between them are the **only** legal paths an artifact may take; promotion through Gates A–G *(see [`promotion-gates.md`](promotion-gates.md))* drives them. The trust membrane *(see `cross-domain/trust-membrane.md`)* runs along the `PUBLISHED` edge.
+
+> [!NOTE]
+> **This doc names the states, the transitions, and their irreversibility.** The deep gate matrix is in [`RELEASE_GATES.md`](RELEASE_GATES.md) and [`promotion-gates.md`](promotion-gates.md). The objects emitted at each transition are catalogued in [`release-objects.md`](release-objects.md).
+
+---
+
+## Table of contents
+
+1. [Scope](#1-scope)
+2. [The state set](#2-the-state-set)
+3. [The transition diagram](#3-the-transition-diagram)
+4. [Forward transitions](#4-forward-transitions)
+5. [Post-publication transitions](#5-postpublication-transitions)
+6. [Forbidden transitions](#6-forbidden-transitions)
+7. [Per-state visibility](#7-perstate-visibility)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Open questions and ADR triggers](#9-open-questions-and-adr-triggers)
+10. [Related docs](#10-related-docs)
+11. [Appendix](#11-appendix)
+
+---
+
+## 1. Scope
+
+This doc enumerates the states an artifact moves through, the legal transitions, the gate that authorizes each transition, the visibility class each state has, and the transitions that are explicitly forbidden.
+
+> [!TIP]
+> **When this doc binds.** Designing a new pipeline step, auditing an artifact's lifecycle path, classifying a defect to a state transition, or writing a state-machine validator.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. The state set
+
+> **Evidence basis:** `README.md` §6 *(publication invariant, CONFIRMED)*; `kfm_unified_doctrine_synthesis.md` §7 *(lifecycle states, CONFIRMED)*; `lifecycle-law.md` *(parent doctrine)*.
+
+| State | Definition | Visibility |
+|---|---|---|
+| **`RAW`** | Connector landing; untouched ingest. | Internal only |
+| **`WORK`** | Processed but not validated; staging. | Internal only |
+| **`QUARANTINE`** | Failed validation; awaiting steward. | Internal; steward-class read |
+| **`PROCESSED`** | Validated; closure pending or recorded. | Internal; steward / internal read |
+| **`CATALOG / TRIPLET`** | Catalog indexed; triplets emitted; pre-publication. | Internal |
+| **`PUBLISHED`** | Released; manifest written; rollback target pinned. | Public *(per `AUDIENCE_CLASSES`)* |
+| **`WITHDRAWN`** | Manifest marked `withdrawn = true`; rollback executed or in progress. | Public *(badge)*; auditable |
+| **`SUPERSEDED`** | A later manifest references this one as the corrected prior. | Public *(lineage)*; auditable |
+
+> [!CAUTION]
+> **`WITHDRAWN` and `SUPERSEDED` are post-publication, not pre-publication.** They are not part of the forward path; they describe what happens to a `PUBLISHED` manifest after a rollback or correction *(see [`rollback-and-correction.md`](rollback-and-correction.md))*.
+
+[↑ Back to top](#top)
+
+---
+
+## 3. The transition diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> RAW : ingest
+  RAW --> WORK : Gate A (admission)
+  RAW --> QUARANTINE : Gate A fail
+  WORK --> QUARANTINE : Gate B/C/D fail
+  WORK --> PROCESSED : Gate B + C + D pass
+  QUARANTINE --> WORK : steward release (re-process)
+  QUARANTINE --> [*] : steward reject (purge under policy)
+  PROCESSED --> CATALOG : Gate E (closure)
+  PROCESSED --> QUARANTINE : Gate E fail
+  CATALOG --> PUBLISHED : Gate F + G
+  CATALOG --> QUARANTINE : Gate F revoke
+  PUBLISHED --> WITHDRAWN : rollback initiated
+  PUBLISHED --> SUPERSEDED : correction released
+  WITHDRAWN --> PUBLISHED : forward-fix or rollback complete pointing here
+  SUPERSEDED --> SUPERSEDED : re-correction (chain grows)
+```
+
+| Transition | Authority | Receipt |
+|---|---|---|
+| `[*]` → `RAW` | Connector | Connector run receipt |
+| `RAW` → `WORK` | Gate A | `PromotionReceipt(A)` |
+| `WORK` → `PROCESSED` | Gates B + C + D | `PromotionReceipt(B,C,D)` + `RunReceipt`s |
+| `PROCESSED` → `CATALOG` | Gate E | `PromotionReceipt(E)` + `CitationValidationReport` |
+| `CATALOG` → `PUBLISHED` | Gates F + G | `PromotionReceipt(F,G)` + `ReleaseManifest` + `RollbackCard` |
+| `*` → `QUARANTINE` | Gate failure | `PromotionReceipt(<failed gate>)` |
+| `QUARANTINE` → `WORK` | Steward release | `ReviewRecord` + `PromotionReceipt` |
+| `QUARANTINE` → `[*]` | Steward reject + retention expired | Audit record |
+| `PUBLISHED` → `WITHDRAWN` | Rollback initiated | `RollbackCard` execution receipt |
+| `PUBLISHED` → `SUPERSEDED` | Correction released | `CorrectionNotice` |
+| `WITHDRAWN` → `PUBLISHED` | Rollback complete *(prior is current)* | Updated manifest pointer |
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Forward transitions
+
+### 4.1 `RAW` → `WORK`
+
+| Rule | Detail |
+|---|---|
+| Gate | A *(source admission)*. |
+| Required | `SourceDescriptor` with role + rights; connector receipt. |
+| Failure | → `QUARANTINE` with reason. |
+
+### 4.2 `WORK` → `PROCESSED`
+
+| Rule | Detail |
+|---|---|
+| Gates | B *(provenance)*, C *(sensitivity)*, D *(validation)* — all three. |
+| Required | Provenance receipt; sensitivity decision; validator reports. |
+| Failure on any | → `QUARANTINE`. |
+
+### 4.3 `PROCESSED` → `CATALOG / TRIPLET`
+
+| Rule | Detail |
+|---|---|
+| Gate | E *(evidence closure)*. |
+| Required | `EvidenceBundle` resolves; `CitationValidationReport.all_resolved = true`. |
+| Failure | → `QUARANTINE`; resolver re-run on remediation. |
+
+### 4.4 `CATALOG` → `PUBLISHED`
+
+| Rule | Detail |
+|---|---|
+| Gates | F *(review where required)* + G *(release)*. |
+| Required | `ReviewRecord` *(where applicable)*; `ReleaseManifest` + `RollbackCard` + signatures. |
+| Failure on F | `ABSTAIN` for `public`; remains `CATALOG` until cleared. |
+| Failure on G | Release plane denies; remains `CATALOG`. |
+
+[↑ Back to top](#top)
+
+---
+
+## 5. Post-publication transitions
+
+> **Detail:** [`rollback-and-correction.md`](rollback-and-correction.md).
+
+### 5.1 `PUBLISHED` → `WITHDRAWN`
+
+| Rule | Detail |
+|---|---|
+| Trigger | Operational defect *(integrity, regression, outage, security)*. |
+| Mechanism | `RollbackCard` executed; manifest `withdrawn = true`. |
+| API | `ABSTAIN release/rollback-in-progress` for affected layers / claims. |
+
+### 5.2 `PUBLISHED` → `SUPERSEDED`
+
+| Rule | Detail |
+|---|---|
+| Trigger | Editorial defect *(wrong fact / attribution / scope)*. |
+| Mechanism | New `ReleaseManifest` published + `CorrectionNotice` records `corrects_release_id`. |
+| API | Returns `ANSWER` from new manifest; lineage in `EvidenceDrawerPayload.correction_lineage`. |
+
+### 5.3 `WITHDRAWN` → `PUBLISHED`
+
+| Rule | Detail |
+|---|---|
+| Trigger | Rollback complete *(prior manifest now current)* or forward-fix released. |
+| Mechanism | Pointer updates; rollback card archives. |
+| Note | The `withdrawn` manifest still exists in storage with its marker; only the *current pointer* moved. |
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Forbidden transitions
+
+| Forbidden | Why |
+|---|---|
+| `RAW` → `PUBLISHED` | Skips every gate; trust-membrane breach. |
+| `PROCESSED` → `PUBLISHED` directly | Skips closure *(Gate E)* and review *(F)*. |
+| `WORK` ↔ `PUBLISHED` | Skips multiple gates. |
+| `PUBLISHED` → `RAW` / `WORK` / `PROCESSED` / `CATALOG` | Publication is forward-only; rollback re-points current state, it does not move the artifact backward through the lifecycle. |
+| `WITHDRAWN` → `[*]` *(delete)* | Never-delete rule *(see [`rollback-and-correction.md`](rollback-and-correction.md) §5)*. |
+| `SUPERSEDED` → `[*]` *(delete)* | Same. |
+| Manifest edits in place | Manifests immutable. |
+| `QUARANTINE` → `PUBLISHED` directly | Must re-enter via `WORK` and pass forward. |
+
+> [!IMPORTANT]
+> **Forward-only is doctrine.** Going "back" through the lifecycle silently is what creates supply-chain attacks and audit gaps. Rollback re-points; it does not regress.
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Per-state visibility
+
+> **Evidence basis:** `governed-api/AUDIENCE_CLASSES.md` §3–6; `governed-api/LIFECYCLE_GATES.md` §5.
+
+| State | `public` | `partner` | `steward` | `internal` |
+|---|---|---|---|---|
+| `RAW` | `DENY` | `DENY` | `DENY` | conditional via internal route |
+| `WORK` | `DENY` | `DENY` | `ANSWER` on review route *(lane-scoped)* | conditional |
+| `QUARANTINE` | `DENY` | `DENY` | `ANSWER` on review route *(lane-scoped)* | conditional |
+| `PROCESSED` | `ABSTAIN release/no-manifest` | same | `ANSWER` on review route | conditional |
+| `CATALOG` | `ABSTAIN` | `ABSTAIN` | `ANSWER` on review route | conditional |
+| `PUBLISHED` | `ANSWER` | `ANSWER` | `ANSWER` | `ANSWER` |
+| `WITHDRAWN` | `ABSTAIN release/rollback-in-progress` + badge | same | `ANSWER` with rollback marker | `ANSWER` |
+| `SUPERSEDED` | `ANSWER` from current manifest + lineage | same | `ANSWER` with full chain | same |
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Mitigation |
+|---|---|
+| **Pipeline writes to `data/published/` from `WORK`** | Lifecycle violation; only Gate G writes. |
+| **`QUARANTINE` artifact "promoted" by editing its state field** | State transitions require gate receipts; no field edit. |
+| **`WITHDRAWN` artifact silently deleted** | Never-delete; retention policy governs storage cleanup separately. |
+| **`SUPERSEDED` chain collapsed by deleting intermediate releases** | Chain depth grows; never collapse. |
+| **State derived from path on disk rather than from manifest** | State lives on the manifest; storage layout is incidental. |
+| **Re-ingest treated as forward-from-`PUBLISHED`** | Re-ingest is a new admission *(`RAW`)*; new release supersedes if appropriate. |
+| **Pipeline retries cross states** | Each state transition requires its own gate; retries operate within a state, not across. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Open questions and ADR triggers
+
+| Open item | Class | Suggested ADR title |
+|---|---|---|
+| `CATALOG / TRIPLET` as one state or two? | Doctrine | "Catalog vs triplet states". |
+| `WITHDRAWN` and `SUPERSEDED` formalization — distinct states or attributes on `PUBLISHED`? | Schema | "Post-publication state modeling". |
+| `QUARANTINE` retention window — fixed or policy-driven? | Operational | "Quarantine retention". |
+| Should the state machine be encoded as a machine-checkable manifest *(e.g., `STATE_MACHINE.yaml`)* in `control_plane/`? | Tooling | "Encode state machine". |
+| Per-domain state extensions — should fail-closed lanes have an extra state? | Variation | "Per-lane state extensions". |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Related docs
+
+| Reference | Role | Truth label |
+|---|---|---|
+| `README.md` *(this folder)* §6 | Landing summary | CONFIRMED doctrine |
+| `promotion-gates.md` *(sibling)* | Which gate authorizes each transition | PROPOSED |
+| `release-objects.md` *(sibling)* | Objects emitted at each transition | PROPOSED |
+| `rollback-and-correction.md` *(sibling)* | `WITHDRAWN` and `SUPERSEDED` transitions | PROPOSED |
+| `RELEASE_GATES.md` *(sibling)* | Deep gate matrix | CONFIRMED scaffold |
+| `../governed-api/LIFECYCLE_GATES.md` §5 | Release-state matrix per audience | PROPOSED |
+| `../cross-domain/trust-membrane.md` §3, §4 | Inside vs outside; gates as crossings | CONFIRMED doctrine |
+| `../../doctrine/lifecycle-law.md` | Parent doctrine | CONFIRMED doctrine *(referenced)* |
+| `kfm_unified_doctrine_synthesis.md` §7 | Lifecycle states canonical | CONFIRMED doctrine |
+
+[↑ Back to top](#top)
+
+---
+
+## 11. Appendix
+
+<details>
+<summary><strong>11.1 State machine — at-a-glance</strong></summary>
+
+```text
+[*]
+  │ ingest
+  ▼
+RAW ────A────► WORK ──B,C,D──► PROCESSED ──E──► CATALOG ──F,G──► PUBLISHED
+  │            │                │                  │              │
+  │            │                │                  │              ├── rollback ──► WITHDRAWN ──► (back to PUBLISHED via prior)
+  │            │                │                  │              │
+  │            │                │                  │              └── correction ──► SUPERSEDED (new manifest current)
+  │            │                │                  │
+  └─Gate A fail└─B/C/D fail────└─E fail────────────└─F revoke─────► QUARANTINE
+                                                                       │
+                                                                       ├── steward release ──► WORK
+                                                                       └── steward reject (+retention expired) ──► [*]
+```
+
+</details>
+
+<details>
+<summary><strong>11.2 Forbidden transitions — at-a-glance</strong></summary>
+
+```text
+NEVER:  RAW / WORK / PROCESSED / CATALOG → PUBLISHED (skip-gate)
+NEVER:  PUBLISHED → RAW / WORK / PROCESSED / CATALOG (regress)
+NEVER:  WITHDRAWN → [*]      (delete)
+NEVER:  SUPERSEDED → [*]     (delete)
+NEVER:  QUARANTINE → PUBLISHED directly
+NEVER:  in-place edit of manifest fields
+```
+
+</details>
+
+<details>
+<summary><strong>11.3 Truth-label legend</strong></summary>
+
+- **CONFIRMED** — verified this session from attached docs.
+- **PROPOSED** — design / placement / inference not yet verified in implementation.
+- **INFERRED** — derivable from confirmed evidence but not directly stated.
+- **NEEDS VERIFICATION** — checkable, but not yet checked strongly enough to act as fact.
+
+</details>
+
+---
+
+**Related (mini)** · [`README.md`](README.md) · [`promotion-gates.md`](promotion-gates.md) · [`release-objects.md`](release-objects.md) · [`rollback-and-correction.md`](rollback-and-correction.md) · [`RELEASE_GATES.md`](RELEASE_GATES.md) · [`../governed-api/LIFECYCLE_GATES.md`](../governed-api/LIFECYCLE_GATES.md) · [`../cross-domain/trust-membrane.md`](../cross-domain/trust-membrane.md)
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED
+
+[↑ Back to top](#top)

--- a/docs/architecture/publication/rollback-and-correction.md
+++ b/docs/architecture/publication/rollback-and-correction.md
@@ -1,0 +1,285 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/architecture-publication-rollback-and-correction
+title: Publication — Rollback and Correction
+type: standard
+version: v0.1
+status: draft
+owners: Release Manager · Docs Steward · NEEDS VERIFICATION
+created: 2026-05-24
+updated: 2026-05-24
+policy_label: public
+related:
+  - README.md
+  - ROLLBACK.md
+  - CORRECTION.md
+  - promotion-gates.md
+  - release-objects.md
+  - release-state-machine.md
+  - ../governed-api/LIFECYCLE_GATES.md
+  - ../map-master/LAYER_LIFECYCLE.md
+tags: [kfm, architecture, publication, rollback, correction, doctrine]
+notes:
+  - PROPOSED. Concise companion to ROLLBACK.md and CORRECTION.md (deep treatments).
+  - Never delete, always supersede. Public lineage is preserved.
+[/KFM_META_BLOCK_V2] -->
+
+<a id="top"></a>
+
+# Publication — Rollback and Correction
+
+> *Never delete, always supersede. Rollback re-points the current release state to a pre-staged target; correction publishes a new manifest that supersedes the prior one. Both preserve public lineage.*
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![doctrine](https://img.shields.io/badge/doctrine-CONFIRMED%20(spine)-blue)
+![path-status](https://img.shields.io/badge/path-PROPOSED-orange)
+![rule](https://img.shields.io/badge/rule-never%20delete%20·%20always%20supersede-success)
+
+**Status:** draft · **Owners:** Release Manager · Docs Steward *(NEEDS VERIFICATION)* · **Last updated:** 2026-05-24
+
+> [!IMPORTANT]
+> **Public lineage is preserved** *(`README.md` §11, CONFIRMED)*. A withdrawn release is **withdrawn**, not deleted. A corrected fact ships a new release that supersedes the prior; the prior remains for audit, with a `CorrectionNotice` recording the relationship.
+
+> [!NOTE]
+> **This doc is the concise overview.** The detailed rollback procedure lives in [`ROLLBACK.md`](ROLLBACK.md); the detailed correction model lives in [`CORRECTION.md`](CORRECTION.md). This doc names the rule, the contrast between the two operations, and the rules common to both.
+
+---
+
+## Table of contents
+
+1. [Scope](#1-scope)
+2. [Rollback vs correction — the contrast](#2-rollback-vs-correction--the-contrast)
+3. [Rollback](#3-rollback)
+4. [Correction](#4-correction)
+5. [The never-delete rule](#5-the-neverdelete-rule)
+6. [Drawer and renderer behavior](#6-drawer-and-renderer-behavior)
+7. [Audit posture](#7-audit-posture)
+8. [Anti-patterns](#8-anti-patterns)
+9. [Open questions and ADR triggers](#9-open-questions-and-adr-triggers)
+10. [Related docs](#10-related-docs)
+11. [Appendix](#11-appendix)
+
+---
+
+## 1. Scope
+
+This doc explains the difference between **rollback** *(operational: re-point the current release to a pre-staged prior target)* and **correction** *(editorial: publish a new manifest that supersedes the prior)*, and the rules that apply to both.
+
+> [!TIP]
+> **When this doc binds.** Triaging a release defect, choosing between rollback and correction, drafting a correction notice, or designing how the drawer surfaces lineage.
+
+[↑ Back to top](#top)
+
+---
+
+## 2. Rollback vs correction — the contrast
+
+| Dimension | Rollback | Correction |
+|---|---|---|
+| **Trigger** | Operational defect *(integrity, regression, outage)* | Editorial defect *(wrong fact, wrong attribution, withdrawn source)* |
+| **Speed** | Immediate; pre-staged | Deliberate; runs through gates |
+| **Target** | A specific prior `ReleaseManifest` *(via `RollbackCard`)* | A **new** `ReleaseManifest` |
+| **Lineage marker** | `RollbackCard` execution receipt; original release marked `withdrawn` | `CorrectionNotice` records `corrects_release_id` + `superseded_by_release_id` |
+| **Public visibility** | Drawer / renderer surface the rollback state; ABSTAIN during in-progress | Drawer surfaces the lineage chain to the user |
+| **Reversibility** | Reversible — forward-fix is a new release | Reversible — a new correction can re-correct |
+| **Doctrine** | `README.md` §11; `ROLLBACK.md` | `README.md` §11; `CORRECTION.md` |
+
+```mermaid
+flowchart LR
+  classDef op fill:#fff4e0,stroke:#d97706;
+  classDef ed fill:#bbdefb,stroke:#0d47a1;
+  classDef pub fill:#c8e6c9,stroke:#1b5e20;
+
+  R0["Release Rn (current)"]:::pub --> DEFECT{"Defect kind?"}
+  DEFECT -- "Operational" --> RB["Rollback:\nrepoint to Rn-1 via RollbackCard"]:::op
+  DEFECT -- "Editorial" --> CO["Correction:\npublish Rn+1 with CorrectionNotice"]:::ed
+  RB --> R1["Rn-1 (now current)\nRn marked withdrawn"]:::pub
+  CO --> R2["Rn+1 (now current)\nRn preserved · superseded"]:::pub
+```
+
+[↑ Back to top](#top)
+
+---
+
+## 3. Rollback
+
+| Aspect | Detail |
+|---|---|
+| **Pre-stage** | Every release ships with a `RollbackCard` referencing the prior `ReleaseManifest` *(Gate G mandatory)*. |
+| **Trigger** | Operational defect: integrity-failure, regression, outage, security incident. |
+| **Mechanism** | Release plane sets the affected manifest `withdrawn = true`; manifest resolver returns the rollback target. |
+| **API behavior during rollback** | `ABSTAIN release/rollback-in-progress` for affected layers / claims to `public` / `partner`; `steward` / `internal` see rollback marker *(`governed-api/LIFECYCLE_GATES.md` §6)*. |
+| **Renderer behavior** | Viewer-verification gate refuses `addSource` for withdrawn layers; renders rollback badge *(`map-master/VIEWER_VERIFICATION.md` §9)*. |
+| **Completion** | Prior manifest is the current `PUBLISHED` state; rollback card archived. |
+| **Forward fix** | A subsequent new manifest replaces both states; rollback card preserved. |
+
+> [!IMPORTANT]
+> **Rollback is not deletion.** The defective manifest remains, marked `withdrawn`; receipts and `EvidenceBundle`s are intact. Auditors can reconstruct the defective state if needed.
+
+[↑ Back to top](#top)
+
+---
+
+## 4. Correction
+
+| Aspect | Detail |
+|---|---|
+| **Trigger** | Editorial defect: a fact was wrong, attribution changed, a source was withdrawn upstream, scope was misstated. |
+| **Mechanism** | A new `ReleaseManifest` is built and runs through Gates A–G; a `CorrectionNotice` is emitted on release linking the new manifest to the corrected one. |
+| **`CorrectionNotice` fields** | `corrects_release_id`, `superseded_by_release_id`, `reason_class`, `summary`, `at`, signer. |
+| **API behavior** | Returns `ANSWER` from the new manifest; lineage carried via `correction_lineage` on `EvidenceDrawerPayload` *(`map-master/EVIDENCE_DRAWER.md` §7)*. |
+| **Drawer behavior** | Surfaces the supersession chain; user can navigate prior versions. |
+| **Visibility** | Public; lineage is part of the trust posture. |
+| **Re-correction** | A correction can itself be corrected; the chain grows. |
+
+> [!CAUTION]
+> **A correction does not silently overwrite.** The prior release persists with its evidence intact; readers can see the chain and reason about the change.
+
+[↑ Back to top](#top)
+
+---
+
+## 5. The never-delete rule
+
+> **Evidence basis:** `README.md` §11 *(rollback and correction, CONFIRMED)*; `lifecycle-law.md` *(parent doctrine)*.
+
+| Aspect | Rule |
+|---|---|
+| Manifests | Immutable; corrections are new manifests; withdrawn manifests persist marked `withdrawn`. |
+| Receipts | Append-only; content-addressed; never edited. |
+| `EvidenceBundle`s | Resolved bundles persist for audit; supersession recorded externally. |
+| Tile bytes | Not deleted on withdrawal; admission denied via manifest; retention follows policy. |
+| Logs | Bounded retention but not edited in place. |
+
+> [!IMPORTANT]
+> **"Delete" is an operational concept; "supersede" is a publication concept.** Publication never deletes; storage cleanup *(under operational retention policy)* may delete bytes after sufficient time has passed and audit obligations are met. The two are decoupled.
+
+[↑ Back to top](#top)
+
+---
+
+## 6. Drawer and renderer behavior
+
+| State | Drawer | Renderer |
+|---|---|---|
+| **Rollback in progress** | "Temporarily unavailable" + `release/rollback-in-progress` reason | `ABSTAIN`; layer hidden with badge |
+| **Withdrawn (post-rollback)** | "Withdrawn" + link to current rollback target | Layer hidden with withdrawal badge |
+| **Superseded by correction** | Lineage chain visible; "View current release" link | Renders **current** release; user may navigate prior |
+| **Current release after correction** | `ANSWER` + `correction_lineage` field present | Renders normally; chain link in drawer footer |
+| **Re-corrected** | Chain depth grows; drawer paginates if long | No change |
+
+[↑ Back to top](#top)
+
+---
+
+## 7. Audit posture
+
+| Aspect | Detail |
+|---|---|
+| Manifests indexed by id and digest | Audit can reach any prior state. |
+| `RollbackCard` and `CorrectionNotice` permanently retained | Lineage never expires. |
+| Receipts indexed by `request_id` and `release_ref` | Cross-event correlation possible. |
+| Steward access to withdrawn / superseded content | Lane-scoped; steward role required. |
+| Public access to lineage | Yes — the chain itself is public; the corrected facts are also public. |
+
+[↑ Back to top](#top)
+
+---
+
+## 8. Anti-patterns
+
+| Anti-pattern | Mitigation |
+|---|---|
+| **Defective manifest edited in place** | Manifests immutable; new manifest required. |
+| **Withdrawn manifest deleted from storage** | Retention policy governs storage; manifest record persists. |
+| **Correction issued without `CorrectionNotice`** | Notice mandatory; emitted at release. |
+| **Drawer hides superseded content as if it never existed** | Lineage visible; reader can navigate. |
+| **Rollback used as a "release undo button"** | Rollback for operational defects; corrections for editorial defects. |
+| **`RollbackCard` skipped "because the release is small"** | Always present; Gate G enforces. |
+| **Re-correction chain collapsed by silently removing intermediate releases** | Chain depth grows; never collapse. |
+
+[↑ Back to top](#top)
+
+---
+
+## 9. Open questions and ADR triggers
+
+| Open item | Class | Suggested ADR title |
+|---|---|---|
+| Rollback chain depth — single hop only, or chained rollbacks? | Semantics | "Rollback chain depth". |
+| Storage retention for withdrawn manifests / tile bytes — fixed window or doctrine? | Operational | "Withdrawn-content retention". |
+| Should `CorrectionNotice.reason_class` be enumerated *(controlled vocabulary)*? | Vocabulary | "CorrectionNotice reason vocabulary". |
+| Drawer chain pagination — limit depth shown or always show full chain? | UX | "Lineage chain display depth". |
+| Should rollback emit a `CorrectionNotice` too *(for cross-class lineage)*? | Object family | "Rollback emits CorrectionNotice". |
+
+[↑ Back to top](#top)
+
+---
+
+## 10. Related docs
+
+| Reference | Role | Truth label |
+|---|---|---|
+| `README.md` *(this folder)* §11 | Landing summary | CONFIRMED doctrine |
+| `ROLLBACK.md` *(sibling)* | Detailed rollback procedure | CONFIRMED scaffold |
+| `CORRECTION.md` *(sibling)* | Detailed correction model | CONFIRMED scaffold |
+| `promotion-gates.md` *(sibling)* | Gate G mandates `RollbackCard` | PROPOSED |
+| `release-objects.md` *(sibling)* | `RollbackCard` + `CorrectionNotice` object families | PROPOSED |
+| `release-state-machine.md` *(sibling)* | Transitions for withdrawal and supersession | PROPOSED |
+| `../governed-api/LIFECYCLE_GATES.md` §6 | API-side rollback behavior | PROPOSED |
+| `../map-master/LAYER_LIFECYCLE.md` §8 | Manifest-level rollback semantics | PROPOSED |
+| `../map-master/EVIDENCE_DRAWER.md` §7 | Drawer freshness / review / rollback / correction surfaces | PROPOSED |
+| `../../doctrine/lifecycle-law.md` | Parent doctrine | CONFIRMED doctrine *(referenced)* |
+
+[↑ Back to top](#top)
+
+---
+
+## 11. Appendix
+
+<details>
+<summary><strong>11.1 Rollback vs correction — at-a-glance card</strong></summary>
+
+```text
+Rollback                                Correction
+────────                                ──────────
+trigger: operational defect             trigger: editorial defect
+speed:   immediate (pre-staged)         speed:   deliberate (through gates)
+artifact: RollbackCard execution        artifact: new ReleaseManifest +
+target:   prior ReleaseManifest                    CorrectionNotice
+prior:    marked withdrawn              prior:    preserved · superseded
+drawer:   "temporarily unavailable"     drawer:   lineage chain visible
+                                                  user can navigate prior
+```
+
+</details>
+
+<details>
+<summary><strong>11.2 The never-delete rule — at-a-glance</strong></summary>
+
+```text
+Manifests          immutable · withdrawn marker only
+Receipts           append-only · content-addressed
+EvidenceBundles    persist for audit
+Tile bytes         retention policy · not deletion
+Logs               bounded retention · not edited
+```
+
+</details>
+
+<details>
+<summary><strong>11.3 Truth-label legend</strong></summary>
+
+- **CONFIRMED** — verified this session from attached docs.
+- **PROPOSED** — design / placement / inference not yet verified in implementation.
+- **INFERRED** — derivable from confirmed evidence but not directly stated.
+- **NEEDS VERIFICATION** — checkable, but not yet checked strongly enough to act as fact.
+
+</details>
+
+---
+
+**Related (mini)** · [`README.md`](README.md) · [`ROLLBACK.md`](ROLLBACK.md) · [`CORRECTION.md`](CORRECTION.md) · [`promotion-gates.md`](promotion-gates.md) · [`release-objects.md`](release-objects.md) · [`release-state-machine.md`](release-state-machine.md) · [`../map-master/EVIDENCE_DRAWER.md`](../map-master/EVIDENCE_DRAWER.md)
+
+**Last updated:** 2026-05-24 · **Doc version:** v0.1 · **Doc status:** draft · **Path status:** PROPOSED
+
+[↑ Back to top](#top)


### PR DESCRIPTION
## Summary

Adds the four lowercase-kebab files called out in the requested publication directory tree as concise companions to the existing ALL-CAPS deep treatments in the same folder (`RELEASE_GATES.md`, `ROLLBACK.md`, `CORRECTION.md`, `GEO_MANIFEST.md`).

This commit was authored on `claude/optimistic-hopper-aR0FQ` after PR #929 closed, so it needs its own PR to land on `main`.

## Files added

- `docs/architecture/publication/promotion-gates.md` (304 lines) — concise Gates A–G overview; cross-refs the detailed `RELEASE_GATES.md` matrix
- `docs/architecture/publication/release-objects.md` (385 lines) — catalog of the 11 publication object families (`ReleaseManifest`, `RollbackCard`, `PromotionReceipt`, `ProofPack`, `EvidenceBundle`, `RunReceipt`, `CitationValidationReport`, `CorrectionNotice`, `CatalogMatrix`, `DecisionEnvelope`, `KFMGeoManifest`) with per-gate mapping
- `docs/architecture/publication/rollback-and-correction.md` (285 lines) — never-delete / always-supersede model; contrast between operational rollback and editorial correction
- `docs/architecture/publication/release-state-machine.md` (346 lines) — lifecycle as an explicit state machine; post-publication `WITHDRAWN`/`SUPERSEDED` states; forbidden transitions

## Doctrine basis

Each new doc cites `kfm_unified_doctrine_synthesis.md` §§7, 8, 10 (CONFIRMED) plus the parent `docs/architecture/publication/README.md` spine, and cross-links to `docs/architecture/governed-api/LIFECYCLE_GATES.md` and `docs/architecture/cross-domain/trust-membrane.md` where relevant.

## Test plan

- [ ] Verify the four files render correctly on GitHub
- [ ] Confirm cross-links resolve (intra-folder + sibling-folder)
- [ ] Sanity-check that existing ALL-CAPS docs in `publication/` are untouched

https://claude.ai/code/session_013UxFhA5daVDeJxgQp8yYbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013UxFhA5daVDeJxgQp8yYbQ)_