### PR TITLE
docs(archive): establish deprecated and exploratory subdirectories with governance

### DIFF
--- a/docs/archive/deprecated/.gitkeep
+++ b/docs/archive/deprecated/.gitkeep
@@ -1,0 +1,3 @@
+# deprecated/ — sunset-dated subtrees go here (PROPOSED, currently empty)
+# Each scheduled removal gets its own <YYYY-MM-DD>-<short-slug>/ subtree per
+# docs/archive/deprecated/README.md §5. No files until a sunset is scheduled.

--- a/docs/archive/deprecated/README.md
+++ b/docs/archive/deprecated/README.md
@@ -1,0 +1,309 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<TODO-uuid>
+title: Archived Deprecated Material
+type: standard
+version: v1
+status: draft
+owners: <TODO: Docs Steward + Release Authority>
+created: 2026-05-25
+updated: 2026-05-25
+policy_label: public
+related:
+  - docs/archive/README.md
+  - docs/archive/lineage/README.md
+  - docs/archive/exploratory/README.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/corrections-first-class.md
+  - docs/governance/deprecation-process.md
+  - docs/governance/DECISION_LOG.md
+  - docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md
+  - control_plane/deprecation_register.yaml
+tags: [kfm, archive, deprecated, sunset, governance, removal]
+notes:
+  - "Directory purpose is derived from docs/archive/README.md §6 and §10; NEEDS VERIFICATION against the live repository."
+  - "Hand-off mechanism between control_plane/deprecation_register.yaml and this folder is PROPOSED."
+[/KFM_META_BLOCK_V2] -->
+
+# 🗑 Archived Deprecated Material
+
+> A short-stay holding area for documents **scheduled for removal** — visible while the migration runs, on a clock pegged to `control_plane/deprecation_register.yaml`.
+
+![status](https://img.shields.io/badge/status-draft-orange)
+![type](https://img.shields.io/badge/type-archive-1F3A66)
+![bucket](https://img.shields.io/badge/bucket-deprecated-b91c1c)
+![policy](https://img.shields.io/badge/policy_label-public-2E7D32)
+![invariant](https://img.shields.io/badge/sunset_date-required-critical)
+![scope](https://img.shields.io/badge/scope-documentation-4A6FA5)
+![updated](https://img.shields.io/badge/updated-2026--05--25-lightgrey)
+
+**Status:** `draft` · **Owners:** `TODO — Docs Steward + Release Authority` <sub>NEEDS VERIFICATION</sub> · **Last updated:** `2026-05-25`
+
+> [!CAUTION]
+> `deprecated/` is **not** a synonym for "old." Old-but-current content stays in its canonical home. Material lands here only when a deprecation-register entry (or ADR) has **scheduled** its removal with a sunset date.
+
+---
+
+## 📑 Contents
+
+1. [Scope](#1-scope)
+2. [Repo fit](#2-repo-fit)
+3. [Inputs — what belongs here](#3-inputs--what-belongs-here)
+4. [Exclusions — what does not](#4-exclusions--what-does-not)
+5. [Directory layout](#5-directory-layout)
+6. [Lifecycle (REGISTER → DEPRECATED → SUNSET)](#6-lifecycle-register--deprecated--sunset)
+7. [The sunset clock](#7-the-sunset-clock)
+8. [Conventions](#8-conventions)
+9. [Authoring workflow](#9-authoring-workflow)
+10. [Validation](#10-validation)
+11. [FAQ](#11-faq)
+12. [Related docs](#12-related-docs)
+13. [Last reviewed](#13-last-reviewed)
+
+---
+
+## 1. Scope
+
+`docs/archive/deprecated/` is the canonical short-stay holding area for **documentation surfaces slated for removal**. Each file here is on a clock — a `sunset_date` recorded in `control_plane/deprecation_register.yaml` (or a doctrine-level retirement ADR) pegs when the file is reevaluated for either:
+
+- **Move to `lineage/`** if the file retains continuing reference value after sunset, or
+- **Removal in a reviewed PR** if it does not.
+
+The folder exists so that scheduled removals are **visible and auditable** while migration paths complete — anchors keep resolving, downstream callers keep finding the surface, and the migration is not a silent drop.
+
+> [!NOTE]
+> Directory presence and exact contents are **PROPOSED** per `docs/archive/README.md` §7. The hand-off mechanism between `control_plane/deprecation_register.yaml` sunset events and placement here is **PROPOSED** per `docs/archive/README.md` §10.
+
+[⬆ Back to top](#-archived-deprecated-material)
+
+---
+
+## 2. Repo fit
+
+| Direction  | Surface                                              | Relationship                                                                            | Status                  |
+|------------|------------------------------------------------------|-----------------------------------------------------------------------------------------|-------------------------|
+| Upstream   | `control_plane/deprecation_register.yaml`            | Operational tracker — entries with a sunset date eventually land affected docs here.    | **PROPOSED**            |
+| Upstream   | `docs/governance/deprecation-process.md`             | Defines `DeprecationNotice` and `SunsetRecord` shapes.                                  | **NEEDS VERIFICATION**  |
+| Upstream   | `docs/adr/`                                          | Retirement ADRs that schedule removal link here.                                        | **NEEDS VERIFICATION**  |
+| Sibling    | `docs/archive/lineage/`                              | Destination for post-sunset files that retain reference value.                          | **CONFIRMED**           |
+| Sibling    | `docs/archive/exploratory/`                          | Holds **unpromoted** ideas, not scheduled removals.                                     | **CONFIRMED — distinct**|
+| Downstream | `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md`    | Classifies entries here while they are in the deprecation window.                       | **PROPOSED**            |
+| Downstream | `(deletion)`                                         | Reviewed PR removes the file after sunset if no continuing reference value.             | **PROPOSED**            |
+
+> [!WARNING]
+> This folder is **not** a parking lot for content that "feels old." If the file still informs a current decision, it is not deprecated — it is canon. Mark it current and review it, or open a deprecation register entry.
+
+[⬆ Back to top](#-archived-deprecated-material)
+
+---
+
+## 3. Inputs — what belongs here
+
+A file belongs in `deprecated/` when **all** of the following are true:
+
+1. The subject is a **documentation surface** (doctrine doc, ADR, schema doc, API/route description, runbook, governance artifact, brand asset page, etc.).
+2. A **scheduled removal** has been recorded in `control_plane/deprecation_register.yaml` (or a retirement ADR) with a `sunset_date`.
+3. A **migration plan** exists for callers/readers (where applicable) — successor link, replacement instructions, or `no_successor_rationale`.
+4. The file is **not** still informing a current decision in any current doc (drift check).
+
+Typical contents:
+
+- Pages tied to retired roots, retired schemas, retired policies, or retired tooling.
+- Doc surfaces whose canonical home is being collapsed or relocated.
+- Retired runbooks for sunset operational paths.
+
+---
+
+## 4. Exclusions — what does not
+
+| Do not place here                              | Where it goes instead                                       | Why                                                  |
+|------------------------------------------------|-------------------------------------------------------------|------------------------------------------------------|
+| Predecessors of *current* canon                | `docs/archive/lineage/`                                     | Those are supersession trails, not scheduled removals. |
+| Closed idea packets / withdrawn drafts         | `docs/archive/exploratory/`                                 | Those never reached canon.                           |
+| Files without a `sunset_date`                  | Their canonical home, with a deprecation register entry first | A clock is required.                              |
+| Schemas / contracts                            | `schemas/contracts/v1/...` with `superseded_by` header      | Schema lineage stays in the schema home.             |
+| Policy files                                   | `policy/` with `superseded_by` link                         | Policy lineage stays in the policy home.             |
+| Receipts, proofs, manifests, release artifacts | `data/receipts/`, `data/proofs/`, `release/`                | Trust artifacts never live in `docs/`.               |
+| Generated reports                              | `docs/reports/`                                             | Reports are current outputs, not deprecated.         |
+
+> [!IMPORTANT]
+> A file with **no sunset_date** does **not** belong here. If the file is genuinely going away but no removal has been scheduled, open a deprecation register entry first; only then move the file.
+
+[⬆ Back to top](#-archived-deprecated-material)
+
+---
+
+## 5. Directory layout
+
+> [!WARNING]
+> The tree below is **PROPOSED** per `docs/archive/README.md` §7. Path presence is `NEEDS VERIFICATION` until inspected on disk.
+
+```text
+docs/archive/deprecated/
+├── README.md                          # this file
+└── <sunset-dated subtrees>/           # one subtree per scheduled removal (PROPOSED)
+    └── …                              # the deprecated files, with metadata
+```
+
+Subtree naming convention: `<YYYY-MM-DD>-<short-slug>/` where `YYYY-MM-DD` is the `sunset_date` and `<short-slug>` is a stable kebab-case identifier (e.g., `2026-09-30-retired-runbook-roots/`). This keeps sunsets sortable on disk.
+
+---
+
+## 6. Lifecycle (REGISTER → DEPRECATED → SUNSET)
+
+```mermaid
+flowchart LR
+    R["control_plane/<br/>deprecation_register.yaml"]
+    A["Current doc surface<br/>(any docs/ subtree)"]
+    D["docs/archive/deprecated/<br/>&lt;YYYY-MM-DD-slug&gt;/"]
+    L["docs/archive/lineage/"]
+    X["(deletion)"]
+
+    R -->|"schedule sunset"| A
+    A -->|"git mv at deprecation"| D
+    D -->|"sunset reached:<br/>retain as lineage"| L
+    D -->|"sunset reached:<br/>remove (reviewed PR)"| X
+
+    REG["docs/registers/<br/>CANONICAL_LINEAGE_EXPLORATORY.md"]
+    D --> REG
+    L --> REG
+
+    classDef cur fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20;
+    classDef arc fill:#ede7f6,stroke:#5e35b1,color:#311b92;
+    classDef reg fill:#e3f2fd,stroke:#1565c0,color:#0d47a1;
+    classDef del fill:#ffebee,stroke:#c62828,color:#b71c1c;
+    class R,A cur;
+    class D,L arc;
+    class REG reg;
+    class X del;
+```
+
+> [!NOTE]
+> The dashed transitions in `docs/archive/README.md` §10 correspond to the two post-sunset branches above (`→ lineage/` vs `→ deletion`). The precise gating mechanism is **NEEDS VERIFICATION** — a PROPOSED ADR is expected to formalize it.
+
+---
+
+## 7. The sunset clock
+
+Every file in `deprecated/` carries a `sunset_date`. The clock has three observable states:
+
+| State                | Condition                                  | Action                                                          |
+|----------------------|--------------------------------------------|-----------------------------------------------------------------|
+| **Active sunset**    | `today < sunset_date`                      | File remains here; migration callers can still find it.         |
+| **At sunset**        | `today == sunset_date`                     | Docs steward + subsystem owner decide: lineage or deletion.     |
+| **Past sunset**      | `today > sunset_date` and file still here  | **Drift event.** Open a drift register entry; resolve in next PR.|
+
+> [!CAUTION]
+> A file lingering past its sunset is a governance failure, not a free extension. Either reaffirm the sunset (extend the date with a reviewed PR) or execute the lineage/deletion transition.
+
+[⬆ Back to top](#-archived-deprecated-material)
+
+---
+
+## 8. Conventions
+
+Every file in `docs/archive/deprecated/` MUST carry a front-matter block with these fields:
+
+```text
+archived_on:      YYYY-MM-DD
+archived_by:      <reviewer or team>
+predecessor_of:   <relative path to successor, or "none — deprecated">
+supersession:     retirement
+adr_ref:          <ADR id, if structural>
+register_ref:     <line/anchor in docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md>
+reason:           <one or two sentences>
+sunset_date:      YYYY-MM-DD
+deprecation_register_ref: <key/anchor in control_plane/deprecation_register.yaml>
+migration_plan:   <one or two sentences, or link to migration doc>
+```
+
+Additional rules:
+
+- **Subtrees are named by sunset date.** `<YYYY-MM-DD>-<short-slug>/` — see [§5](#5-directory-layout).
+- **Filenames are not renamed** on archival.
+- **Files are not edited in place**, except to add or correct the metadata block above, or to extend `sunset_date` (which is itself a reviewed change).
+- **Every `deprecated/` file MUST have a matching entry** in `control_plane/deprecation_register.yaml` referenced by `deprecation_register_ref`.
+
+---
+
+## 9. Authoring workflow
+
+1. A deprecation is scheduled by adding (or updating) an entry in `control_plane/deprecation_register.yaml` with a `sunset_date` and `migration_plan`.
+2. The affected file(s) are moved here with `git mv` into a `<YYYY-MM-DD>-<short-slug>/` subtree.
+3. The front-matter block (per [§8](#8-conventions)) is added in the same PR.
+4. An entry is added to `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md` classifying the file as `deprecated`.
+5. Reviewers: docs steward + subsystem owner whose surface is being retired.
+6. At sunset: a follow-up PR either moves the file to `lineage/` (retain) or removes it (delete) — both require docs steward review.
+
+[⬆ Back to top](#-archived-deprecated-material)
+
+---
+
+## 10. Validation
+
+| Check                                                                                  | Where it runs                                  | Failure mode                                                |
+|----------------------------------------------------------------------------------------|------------------------------------------------|-------------------------------------------------------------|
+| Every file under `deprecated/` has a `sunset_date` and a `deprecation_register_ref`.   | `tools/validators/docs/archive_metadata/` *(PROPOSED)* | PR blocked; reviewer must add metadata.              |
+| Every `deprecation_register_ref` resolves to an existing entry in the YAML register.   | same validator                                  | PR blocked.                                                 |
+| No file with `today > sunset_date` lingers in `deprecated/`.                           | scheduled drift scan *(PROPOSED)*               | Drift register entry opened.                                |
+| No current doc cites a `deprecated/` file as the authority for a current decision.     | docs link-check workflow *(PROPOSED)*           | Drift register entry opened.                                |
+
+> [!NOTE]
+> All validator paths above are **PROPOSED**. Per Directory Rules §7.5, validator homes live under `tools/validators/<area>/`; specific names and exit codes are `NEEDS VERIFICATION` until a validator PR lands.
+
+---
+
+## 11. FAQ
+
+<details>
+<summary><strong>What is the difference between <code>deprecated/</code> and <code>lineage/</code>?</strong></summary>
+
+`deprecated/` is a **short-stay** holding area for files **scheduled for removal**. `lineage/` is the **long-term home** for **predecessors of current canon**. A file may transit `deprecated/` → `lineage/` at sunset if it retains continuing reference value; or it may exit via deletion. The two are distinct stages of a single lifecycle.
+
+</details>
+
+<details>
+<summary><strong>What is the difference between <code>deprecated/</code> and the deprecation register?</strong></summary>
+
+`control_plane/deprecation_register.yaml` is the **operational tracker** — machine-readable sunset dates, migration plans, owners. `deprecated/` is **where the affected docs physically sit** during the deprecation window. The register schedules; this folder holds.
+
+</details>
+
+<details>
+<summary><strong>A file's sunset arrived. Do I delete it or move it to <code>lineage/</code>?</strong></summary>
+
+Ask: does the file have continuing reference value? If a current doc cites it as historical context, or a downstream caller still needs to discover the supersession trail, move to `lineage/`. If no caller needs it and it adds noise, delete it in a reviewed PR. When in doubt, prefer `lineage/` — retention is cheap; lost lineage is not.
+
+</details>
+
+<details>
+<summary><strong>Can I extend a sunset date?</strong></summary>
+
+Yes — but it is a reviewed change. Update the `sunset_date` field in both this folder's front matter and `control_plane/deprecation_register.yaml` in the same PR. Reviewers: docs steward + subsystem owner.
+
+</details>
+
+---
+
+## 12. Related docs
+
+- [`../README.md`](../README.md) — parent archive README and supersession rule
+- [`../lineage/README.md`](../lineage/README.md) — long-term home for predecessors of canon
+- [`../exploratory/README.md`](../exploratory/README.md) — unpromoted-ideas bucket
+- [`../../doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — governs the deprecation transition
+- [`../../doctrine/corrections-first-class.md`](../../doctrine/corrections-first-class.md) — corrections produce supersession trails
+- [`../../governance/deprecation-process.md`](../../governance/deprecation-process.md) — `DeprecationNotice` and `SunsetRecord` shapes
+- [`../../governance/DECISION_LOG.md`](../../governance/DECISION_LOG.md) — indexes scheduling decisions
+- [`../../registers/CANONICAL_LINEAGE_EXPLORATORY.md`](../../registers/CANONICAL_LINEAGE_EXPLORATORY.md) — classification register
+- [`../../../control_plane/deprecation_register.yaml`](../../../control_plane/deprecation_register.yaml) — operational tracker
+
+---
+
+## 13. Last reviewed
+
+| Field          | Value        |
+|----------------|--------------|
+| Last reviewed  | 2026-05-25   |
+| Next review    | TODO         |
+| Reviewer       | TODO — Docs Steward |
+
+[⬆ Back to top](#-archived-deprecated-material)

--- a/docs/archive/exploratory/README.md
+++ b/docs/archive/exploratory/README.md
@@ -1,0 +1,296 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/<TODO-uuid>
+title: Archived Exploratory Material
+type: standard
+version: v1
+status: draft
+owners: <TODO: Docs Steward + Intake Owner>
+created: 2026-05-25
+updated: 2026-05-25
+policy_label: public
+related:
+  - docs/archive/README.md
+  - docs/archive/lineage/README.md
+  - docs/archive/deprecated/README.md
+  - docs/doctrine/lifecycle-law.md
+  - docs/doctrine/authority-ladder.md
+  - docs/doctrine/truth-posture.md
+  - docs/intake/IDEA_INTAKE.md
+  - docs/intake/NEW_IDEAS_INDEX.md
+  - docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md
+tags: [kfm, archive, exploratory, intake, drafts, withdrawn-adrs, governance]
+notes:
+  - "Directory purpose is derived from docs/archive/README.md §6 and §8; NEEDS VERIFICATION against the live repository."
+  - "All paths below the directory tree are PROPOSED until inspected on disk."
+[/KFM_META_BLOCK_V2] -->
+
+# 🧪 Archived Exploratory Material
+
+> The graveyard of **unpromoted ideas** — closed intake packets, never-promoted drafts, and withdrawn proposed-ADRs that did not pass KFM's promotion gates and are therefore not canon.
+
+![status](https://img.shields.io/badge/status-draft-orange)
+![type](https://img.shields.io/badge/type-archive-1F3A66)
+![bucket](https://img.shields.io/badge/bucket-exploratory-7c4a8d)
+![policy](https://img.shields.io/badge/policy_label-public-2E7D32)
+![invariant](https://img.shields.io/badge/closed-state-critical)
+![scope](https://img.shields.io/badge/scope-documentation-4A6FA5)
+![updated](https://img.shields.io/badge/updated-2026--05--25-lightgrey)
+
+**Status:** `draft` · **Owners:** `TODO — Docs Steward + Intake Owner` <sub>NEEDS VERIFICATION</sub> · **Last updated:** `2026-05-25`
+
+> [!IMPORTANT]
+> Presence of an idea here is **not** evidence that the idea is wrong — only that it did not pass KFM's promotion gates and is therefore not current canon. Re-promotion requires a **new** intake entry, not direct edits here.
+
+---
+
+## 📑 Contents
+
+1. [Scope](#1-scope)
+2. [Repo fit](#2-repo-fit)
+3. [Inputs — what belongs here](#3-inputs--what-belongs-here)
+4. [Exclusions — what does not](#4-exclusions--what-does-not)
+5. [Directory layout](#5-directory-layout)
+6. [Lifecycle (INTAKE → EXPLORATORY)](#6-lifecycle-intake--exploratory)
+7. [Immutability invariant](#7-immutability-invariant)
+8. [Subfolders](#8-subfolders)
+9. [Conventions](#9-conventions)
+10. [Authoring workflow](#10-authoring-workflow)
+11. [FAQ](#11-faq)
+12. [Related docs](#12-related-docs)
+13. [Last reviewed](#13-last-reviewed)
+
+---
+
+## 1. Scope
+
+`docs/archive/exploratory/` is the canonical home for **closed exploratory material** in the KFM documentation tree. It exists so that ideas that never reached canon remain inspectable as lineage — the project can answer "did we ever consider X?" without exhuming git history.
+
+Three categories of artifact land here:
+
+1. **Closed idea packets** — entries from `docs/intake/IDEA_INTAKE.md` (and `docs/intake/NEW_IDEAS_INDEX.md`) that were closed without promotion.
+2. **Never-promoted drafts** — architecture sketches, speculative dossiers, design experiments authored outside the intake pipeline but never adopted.
+3. **Withdrawn proposed-ADRs** — ADR drafts that reached proposed state but were withdrawn before acceptance.
+
+> [!NOTE]
+> Directory presence and exact contents are **PROPOSED** per `docs/archive/README.md` §7. Treat every claim below as `NEEDS VERIFICATION` until inspected on disk.
+
+[⬆ Back to top](#-archived-exploratory-material)
+
+---
+
+## 2. Repo fit
+
+| Direction  | Surface                                                                  | Relationship                                                              | Status                 |
+|------------|--------------------------------------------------------------------------|---------------------------------------------------------------------------|------------------------|
+| Upstream   | `docs/intake/IDEA_INTAKE.md`                                             | Packets closed `not-promoted` land here.                                  | **PROPOSED**           |
+| Upstream   | `docs/intake/NEW_IDEAS_INDEX.md`                                         | The index records the closure decision; the body moves here.              | **PROPOSED**           |
+| Upstream   | `docs/adr/`                                                              | Proposed ADRs withdrawn before acceptance move to `withdrawn-adrs/`.      | **PROPOSED**           |
+| Sibling    | `docs/archive/lineage/`                                                  | Holds **predecessors of canon**, not unpromoted ideas. No cross-moves.    | **CONFIRMED — distinct** |
+| Sibling    | `docs/archive/deprecated/`                                               | Holds **sunset-dated** removals, not unpromoted ideas.                    | **CONFIRMED — distinct** |
+| Downstream | `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md`                        | Classifies entries here as `exploratory` by relative path.                | **PROPOSED**           |
+
+> [!WARNING]
+> Do **not** treat this folder as a parking lot for "looks half-baked." Open packets stay in `docs/intake/`. Drafts of *current* canonical docs stay in their canonical home with PR review. Only **closed** states land here.
+
+[⬆ Back to top](#-archived-exploratory-material)
+
+---
+
+## 3. Inputs — what belongs here
+
+A file belongs in `exploratory/` when **all** of the following are true:
+
+1. The subject is **not current canon** and was never promoted to canon.
+2. The intake decision (or the author's withdrawal) is **closed** — the packet, draft, or proposed-ADR is in a terminal state.
+3. A reason for non-promotion is recorded in front matter (`reason:` field) — rejected, deferred indefinitely, merged into a different concept, or author-withdrawn.
+4. The file has been classified in `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md` as `exploratory`.
+
+| Artifact                                | Destination subfolder      | Trigger                                       |
+|-----------------------------------------|----------------------------|-----------------------------------------------|
+| Closed `IDEA_INTAKE` packet             | `idea-packets/`            | Index records closure without merge.          |
+| Never-promoted architecture sketch      | `drafts/`                  | Author or steward marks `closed-no-promote`.  |
+| Speculative dossier (not adopted)       | `drafts/`                  | Same as above.                                |
+| Withdrawn proposed-ADR                  | `withdrawn-adrs/`          | ADR transitions `proposed → withdrawn`.       |
+
+---
+
+## 4. Exclusions — what does not
+
+| Do not place here                             | Where it goes instead                                          | Why                                                       |
+|-----------------------------------------------|----------------------------------------------------------------|-----------------------------------------------------------|
+| Open / in-progress idea packets               | `docs/intake/`                                                 | Open packets are part of the intake pipeline.             |
+| Predecessors of current canon                 | `docs/archive/lineage/`                                        | Those are supersession trails, not unpromoted ideas.      |
+| Docs scheduled for removal with sunset date   | `docs/archive/deprecated/`                                     | Deprecation is operational, not exploratory.              |
+| Drafts of *current* canonical docs            | Author in place under PR review                                | Drafts of canon are canon-in-progress, not exploratory.   |
+| Accepted ADRs                                 | `docs/adr/`                                                    | Only **withdrawn** proposed-ADRs land here.               |
+| Generated reports                             | `docs/reports/`                                                | Reports are current outputs, not exploratory.             |
+
+> [!CAUTION]
+> A "good idea we might revisit" still belongs here once its packet is **closed**. Re-opening is done by a **new** intake entry that may reference the archived packet; do not edit the archived packet to "reopen" it.
+
+[⬆ Back to top](#-archived-exploratory-material)
+
+---
+
+## 5. Directory layout
+
+> [!WARNING]
+> The tree below is **PROPOSED** per `docs/archive/README.md` §7. Path presence is `NEEDS VERIFICATION` until inspected on disk.
+
+```text
+docs/archive/exploratory/
+├── README.md           # this file
+├── idea-packets/       # closed IDEA_INTAKE packets (PROPOSED)
+├── drafts/             # never-promoted drafts (PROPOSED)
+└── withdrawn-adrs/     # proposed-but-withdrawn ADRs (PROPOSED)
+```
+
+---
+
+## 6. Lifecycle (INTAKE → EXPLORATORY)
+
+```mermaid
+flowchart LR
+    A["Open packet<br/>docs/intake/IDEA_INTAKE.md"]
+    B["Draft (sketch, dossier)<br/>any author location"]
+    C["Proposed ADR<br/>docs/adr/"]
+
+    A -->|"closed: not promoted"| EP["exploratory/idea-packets/"]
+    B -->|"closed: no promotion"| ED["exploratory/drafts/"]
+    C -->|"withdrawn"| EW["exploratory/withdrawn-adrs/"]
+
+    EP --> R["docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md<br/>classifies entry"]
+    ED --> R
+    EW --> R
+
+    classDef src fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20;
+    classDef arc fill:#ede7f6,stroke:#5e35b1,color:#311b92;
+    classDef reg fill:#e3f2fd,stroke:#1565c0,color:#0d47a1;
+    class A,B,C src;
+    class EP,ED,EW arc;
+    class R reg;
+```
+
+> [!NOTE]
+> The trigger for `drafts/` placement is **NEEDS VERIFICATION** — the exact lifecycle gate for non-intake drafts is not formally specified. Until then, the docs steward determines closure.
+
+---
+
+## 7. Immutability invariant
+
+Files in `exploratory/` are **append-only by closure** and **immutable in content**. The only edits permitted post-archival are:
+
+- Adding or correcting the front-matter metadata block (per [§9](#9-conventions)).
+- Adding a back-link in metadata when a **new** intake entry references the closed packet.
+
+Content edits — rewriting the body, "improving" the idea, removing claims — are **drift events** and require revert. If an exploratory artifact's body needs change, it is no longer archived: a new intake entry must be opened.
+
+---
+
+## 8. Subfolders
+
+### `idea-packets/`
+
+Closed entries from `docs/intake/IDEA_INTAKE.md` (and the `NEW_IDEAS_INDEX`). Each packet retains its original filename; the index records the closure decision and points here.
+
+### `drafts/`
+
+Never-promoted drafts authored outside the intake pipeline — architecture sketches, speculative dossiers, design experiments. Closure is recorded in front matter; there is no central index, so the docs steward owns enumeration.
+
+### `withdrawn-adrs/`
+
+ADR drafts that reached `proposed` state but were withdrawn before acceptance. Files retain their ADR number (e.g., `ADR-0042-...withdrawn.md`); the canonical `docs/adr/` index links here from the withdrawn entry.
+
+[⬆ Back to top](#-archived-exploratory-material)
+
+---
+
+## 9. Conventions
+
+Every file in `docs/archive/exploratory/` MUST carry a front-matter block with these fields:
+
+```text
+archived_on:      YYYY-MM-DD
+archived_by:      <reviewer or team>
+predecessor_of:   "none — exploratory closure"
+supersession:     retirement
+adr_ref:          <ADR id, if structural>
+register_ref:     <line/anchor in docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md>
+reason:           <one or two sentences — rejected | deferred | merged-into-other | withdrawn>
+intake_ref:       <line/anchor in docs/intake/NEW_IDEAS_INDEX.md, if applicable>
+```
+
+Additional rules:
+
+- **Filenames are not renamed** on archival, except to add a trailing `.withdrawn.md` for withdrawn ADRs to preserve the original ADR number.
+- **No cross-archive moves.** An idea here does not migrate to `lineage/` if later revived — a **new** intake entry must produce a **new** canon doc; the original packet stays here as the original closure.
+- **Two-level depth max** under any subfolder without an ADR.
+
+---
+
+## 10. Authoring workflow
+
+1. The intake owner (or ADR author) records the closure decision in the appropriate source surface (`NEW_IDEAS_INDEX.md` or the ADR index).
+2. The packet/draft/ADR is moved here with `git mv` — filename preserved.
+3. The front-matter block (per [§9](#9-conventions)) is added in the same PR.
+4. An entry is added to `docs/registers/CANONICAL_LINEAGE_EXPLORATORY.md` classifying the file as `exploratory`.
+5. A docs steward reviews the closure metadata and merges.
+
+[⬆ Back to top](#-archived-exploratory-material)
+
+---
+
+## 11. FAQ
+
+<details>
+<summary><strong>An idea I archived here turned out to be relevant. Can I "promote" it?</strong></summary>
+
+No — not by editing the archived file. Open a **new** intake entry, reference the archived packet by path, and let the new entry go through the normal promotion gates. The archived packet stays in place as the original closure record.
+
+</details>
+
+<details>
+<summary><strong>What is the difference between <code>exploratory/</code> and <code>lineage/</code>?</strong></summary>
+
+`lineage/` holds **predecessors of current canon** — material that *was* canon and was superseded. `exploratory/` holds material that **never reached canon** — closed packets, withdrawn proposals, unpromoted drafts. They never cross-move.
+
+</details>
+
+<details>
+<summary><strong>Where do <em>open</em> idea packets live?</strong></summary>
+
+In `docs/intake/`. Only **closed** packets land here.
+
+</details>
+
+<details>
+<summary><strong>Can I edit a withdrawn ADR to "fix a typo"?</strong></summary>
+
+Only inside the metadata block (per [§9](#9-conventions)). Body edits are drift events. If the ADR's content needs to change, it is no longer withdrawn — author a new proposed ADR.
+
+</details>
+
+---
+
+## 12. Related docs
+
+- [`../README.md`](../README.md) — parent archive README and supersession rule
+- [`../lineage/README.md`](../lineage/README.md) — predecessors of canon
+- [`../deprecated/README.md`](../deprecated/README.md) — sunset-dated removals
+- [`../../intake/IDEA_INTAKE.md`](../../intake/IDEA_INTAKE.md) — source of `idea-packets/`
+- [`../../intake/NEW_IDEAS_INDEX.md`](../../intake/NEW_IDEAS_INDEX.md) — closure index
+- [`../../registers/CANONICAL_LINEAGE_EXPLORATORY.md`](../../registers/CANONICAL_LINEAGE_EXPLORATORY.md) — classification register
+- [`../../doctrine/lifecycle-law.md`](../../doctrine/lifecycle-law.md) — governs closure transitions
+- [`../../doctrine/authority-ladder.md`](../../doctrine/authority-ladder.md) — why exploratory ≠ authoritative
+
+---
+
+## 13. Last reviewed
+
+| Field          | Value        |
+|----------------|--------------|
+| Last reviewed  | 2026-05-25   |
+| Next review    | TODO         |
+| Reviewer       | TODO — Docs Steward |
+
+[⬆ Back to top](#-archived-exploratory-material)

--- a/docs/archive/exploratory/drafts/.gitkeep
+++ b/docs/archive/exploratory/drafts/.gitkeep
@@ -1,0 +1,2 @@
+# exploratory/drafts/ — never-promoted drafts (PROPOSED, currently empty)
+# Architecture sketches and speculative dossiers that never reached canon land here on closure.

--- a/docs/archive/exploratory/idea-packets/.gitkeep
+++ b/docs/archive/exploratory/idea-packets/.gitkeep
@@ -1,0 +1,2 @@
+# exploratory/idea-packets/ — closed IDEA_INTAKE packets (PROPOSED, currently empty)
+# Packets land here when docs/intake/NEW_IDEAS_INDEX.md records closure without promotion.

--- a/docs/archive/exploratory/withdrawn-adrs/.gitkeep
+++ b/docs/archive/exploratory/withdrawn-adrs/.gitkeep
@@ -1,0 +1,2 @@
+# exploratory/withdrawn-adrs/ — proposed-but-withdrawn ADRs (PROPOSED, currently empty)
+# ADR drafts that reached `proposed` state but were withdrawn before acceptance land here.

--- a/docs/archive/lineage/adr/.gitkeep
+++ b/docs/archive/lineage/adr/.gitkeep
@@ -1,0 +1,2 @@
+# lineage/adr/ — superseded ADRs (PROPOSED, currently empty)
+# ADRs land here when their replacement is accepted, with `superseded_by` in metadata.

--- a/docs/archive/lineage/architecture/.gitkeep
+++ b/docs/archive/lineage/architecture/.gitkeep
@@ -1,0 +1,2 @@
+# lineage/architecture/ — prior editions of docs/architecture/* (PROPOSED, currently empty)
+# Files land here per docs/archive/lineage/README.md when a successor edition is accepted.

--- a/docs/archive/lineage/atlases/.gitkeep
+++ b/docs/archive/lineage/atlases/.gitkeep
@@ -1,0 +1,2 @@
+# lineage/atlases/ — Atlas predecessor editions (PROPOSED, currently empty)
+# Only used if a future edition replaces v1.0 entirely (replacement, not extension).

--- a/docs/archive/lineage/doctrine/.gitkeep
+++ b/docs/archive/lineage/doctrine/.gitkeep
@@ -1,0 +1,2 @@
+# lineage/doctrine/ — prior editions of docs/doctrine/* (PROPOSED, currently empty)
+# Files land here per docs/archive/lineage/README.md when a successor edition is accepted.

--- a/docs/archive/lineage/domains/.gitkeep
+++ b/docs/archive/lineage/domains/.gitkeep
@@ -1,0 +1,2 @@
+# lineage/domains/ — domain dossier predecessors (PROPOSED, currently empty)
+# Files land here when a successor domain dossier is accepted.

--- a/docs/archive/lineage/runbooks/.gitkeep
+++ b/docs/archive/lineage/runbooks/.gitkeep
@@ -1,0 +1,2 @@
+# lineage/runbooks/ — superseded runbooks (PROPOSED, currently empty)
+# Files land here when a successor runbook is accepted.

--- a/docs/archive/lineage/standards/.gitkeep
+++ b/docs/archive/lineage/standards/.gitkeep
@@ -1,0 +1,2 @@
+# lineage/standards/ — prior standards conformance briefs (PROPOSED, currently empty)
+# Files land here when a successor standards brief is accepted.


### PR DESCRIPTION
## Goal

Establish the `docs/archive/deprecated/` and `docs/archive/exploratory/` subdirectories with comprehensive governance documentation, lifecycle rules, and validation conventions. These directories formalize the handling of sunset-dated removals and unpromoted ideas respectively, anchoring them to the deprecation register and intake pipeline.

## Status labels

- [x] `PROPOSED` — design and paths consistent with `docs/archive/README.md` §6–10; directory structure and governance rules are proposed pending verification against live repository state.
- [x] `NEEDS VERIFICATION` — exact validator homes, ADR references, and cross-references to `control_plane/deprecation_register.yaml` and `docs/intake/` require inspection on disk.

## Evidence inspected

- `docs/archive/deprecated/README.md` — 309 lines; governance, lifecycle, conventions, validation rules for sunset-dated removals.
- `docs/archive/exploratory/README.md` — 296 lines; governance, lifecycle, conventions, validation rules for unpromoted ideas.
- `.gitkeep` files establishing subdirectory structure under both `deprecated/` and `exploratory/`.
- Metadata block templates and front-matter conventions for both archives.

## Directory Rules basis

**§11 — New paths:**

- `docs/archive/deprecated/` — short-stay holding area for files scheduled for removal (per `docs/archive/README.md` §6, §10).
- `docs/archive/deprecated/README.md` — governance document for the deprecated archive.
- `docs/archive/deprecated/<YYYY-MM-DD>-<slug>/` — subtree naming convention for sunset-dated removals (PROPOSED).
- `docs/archive/exploratory/` — long-term home for unpromoted ideas (per `docs/archive/README.md` §6, §8).
- `docs/archive/exploratory/README.md` — governance document for the exploratory archive.
- `docs/archive/exploratory/idea-packets/` — closed intake packets.
- `docs/archive/exploratory/drafts/` — never-promoted drafts.
- `docs/archive/exploratory/withdrawn-adrs/` — proposed-but-withdrawn ADRs.
- `docs/archive/lineage/<category>/.gitkeep` — placeholder structure for lineage subfolders (adr, architecture, atlases, doctrine, domains, runbooks, standards).

All paths are consistent with `docs/archive/README.md` §5–7 and the archive supersession rule.

## Affected roots

- [x] `docs/`

## Affected object families

- [ ] None — pure governance and directory structure.

## Affected lifecycle stages

- [ ] None — documentation governance only.

## What changed

1. **`docs/archive/deprecated/README.md`** (309 lines)
   - Defines scope: short-stay holding area for files with scheduled removal dates.
   - Establishes lifecycle: `REGISTER → DEPRECATED → SUNSET → (LINEAGE | DELETION)`.
   - Specifies front-matter conventions: `archived_on`, `sunset_date`, `deprecation_register_ref`, `migration_plan`, etc.
   - Documents validation rules (PROPOSED): metadata presence, register resolution, drift detection.
   - Provides authoring workflow and FAQ.

2. **`docs/archive/exploratory/README.md`** (296 lines)
   - Defines scope: graveyard of unpromoted ideas (closed intake packets, never-promoted drafts, withdrawn ADRs).
   - Establishes immutability invariant: append-only by closure, no content edits post-archival.
   - Specifies front-matter conventions: `archived_on`, `reason`, `intake_ref`, etc.
   - Documents three subfolders: `idea-packets/`, `drafts/`, `withdrawn-adrs/`.
   - Provides authoring workflow and FAQ.

3. **`.gitkeep` files** (8 files)
   - `docs/archive/deprecated/.gitkeep` — marks deprecated/ as ready for subtrees.
   - `docs/archive/exploratory/{drafts,idea-packets,withdrawn-adrs

https://claude.ai/code/session_01EVDn1iUhSN1iA1rEnE6Uka