### PR TITLE
Add 13 per-domain dashboard specifications (Atlas §24.11 instances)

### DIFF
--- a/docs/dashboards/DASHBOARD_CATALOG.md
+++ b/docs/dashboards/DASHBOARD_CATALOG.md
@@ -29,7 +29,7 @@ notes:
 ![Status](https://img.shields.io/badge/status-draft-lightgrey)
 ![Truth posture](https://img.shields.io/badge/truth-cite--or--abstain-blue)
 ![Policy label](https://img.shields.io/badge/policy-public-brightgreen)
-![Specs](https://img.shields.io/badge/specs-11%20proposed-yellow)
+![Specs](https://img.shields.io/badge/specs-24%20proposed-yellow)
 
 **Status:** draft · **Owners:** `<dashboards-stewards>` (PROPOSED) · **Last reviewed:** 2026-05-20
 
@@ -105,6 +105,19 @@ match a Directory Rules §6.1 `docs/domains/` name.
 
 | Spec file | Documents | Source | Owner (PROPOSED) | Runs on (PROPOSED) | Status |
 |---|---|---|---|---|---|
+| [`domain/hydrology.md`](domain/hydrology.md) | Per-domain instance of §24.11 for hydrology: EvidenceRef resolution, rollback coverage, correction lead time, derivative invalidation, documentation drift. | Atlas v1.1 §24.11.1 / §24.11.2 / §24.11.5 | Hydrology domain steward | `apps/review-console/` | PROPOSED |
+| [`domain/soil.md`](domain/soil.md) | Per-domain instance of §24.11 for soil: evidence resolution, source-role drift, taxonomy-edition skew, MUKEY stability. | Atlas v1.1 §24.11.1 / §24.11.5 | Soil domain steward | `apps/review-console/` | PROPOSED |
+| [`domain/habitat.md`](domain/habitat.md) | Per-domain instance of §24.11 for habitat: evidence integrity plus sensitive-lane gating on habitat × sensitive-species intersection. | Atlas v1.1 §24.11.1 / §24.11.3 | Habitat domain steward · Sensitivity reviewer | `apps/review-console/` | PROPOSED |
+| [`domain/fauna.md`](domain/fauna.md) | Per-domain instance of §24.11 for fauna (T4 defaults): fail-closed rate, redaction coverage, rights-change response, side-channel audit. | Atlas v1.1 §24.11.3 / §24.11.1 | Fauna domain steward · Sensitivity reviewer · Rights-holder rep | `apps/review-console/` | PROPOSED |
+| [`domain/flora.md`](domain/flora.md) | Per-domain instance of §24.11 for flora (T4 defaults for poaching-vulnerable taxa): fail-closed, voucher coverage, poaching-pattern audit. | Atlas v1.1 §24.11.3 / §24.11.1 | Flora domain steward · Sensitivity reviewer · Rights-holder rep | `apps/review-console/` | PROPOSED |
+| [`domain/agriculture.md`](domain/agriculture.md) | Per-domain instance of §24.11 for agriculture: evidence resolution, NASS suppression-rule compliance, CDL taxonomy skew, irrigation classification confidence. | Atlas v1.1 §24.11.1 / §24.11.5 | Agriculture domain steward | `apps/review-console/` | PROPOSED |
+| [`domain/geology.md`](domain/geology.md) | Per-domain instance of §24.11 for geology / natural resources: source breadth, stratigraphic canonicalization, well-record identifiability gate. | Atlas v1.1 §24.11.1 | Geology domain steward | `apps/review-console/` | PROPOSED |
+| [`domain/atmosphere.md`](domain/atmosphere.md) | Per-domain instance of §24.11 for atmosphere / air: source posture plus AI-surface forecasting cite-or-abstain, ABSTAIN by template, synthetic-claim incidence. | Atlas v1.1 §24.11.1 / §24.11.4 | Atmosphere domain steward · AI-surface steward | `apps/review-console/` | PROPOSED |
+| [`domain/hazards.md`](domain/hazards.md) | Per-domain instance of §24.11 for hazards: rollback coverage, correction lead time, alert-authority DENY rate, derivative invalidation cascade. | Atlas v1.1 §24.11.2 / §24.11.1 | Hazards domain steward · Release steward | `apps/review-console/` | PROPOSED |
+| [`domain/roads-rail-trade.md`](domain/roads-rail-trade.md) | Per-domain instance of §24.11 for roads / rail / trade routes: source breadth, functional-class canonicalization, historical-corpus edition pinning; rolls up transit SLOs. | Atlas v1.1 §24.11.1 / §24.11.5 | Roads-rail-trade domain steward · Source steward | `apps/review-console/` | PROPOSED |
+| [`domain/settlements-infrastructure.md`](domain/settlements-infrastructure.md) | Per-domain instance of §24.11 for settlements / infrastructure (critical-asset T4): fail-closed gate, redaction coverage, rollback coverage, service-area cascade. | Atlas v1.1 §24.11.3 / §24.11.2 | Settlements-infrastructure domain steward · Sensitivity reviewer | `apps/review-console/` | PROPOSED |
+| [`domain/archaeology.md`](domain/archaeology.md) | Per-domain instance of §24.11 for archaeology / cultural heritage (T4 defaults, sovereignty): sovereignty review presence, NAGPRA-flag completeness, side-channel audit. | Atlas v1.1 §24.11.3 / §24.11.1 | Archaeology domain steward · Sensitivity reviewer · Sovereignty rep | `apps/review-console/` | PROPOSED |
+| [`domain/people-dna-land.md`](domain/people-dna-land.md) | Per-domain instance of §24.11 for people / genealogy / DNA / land ownership (living-person T4, DNA T4): fail-closed, rights-change response time, AIReceipt presence, synthetic-claim incidence (target zero). | Atlas v1.1 §24.11.3 / §24.11.4 / §24.11.1 | People-DNA-land domain steward · Sensitivity reviewer · AI-surface steward · Rights-holder rep | `apps/review-console/` | PROPOSED |
 | [`domain/air/PM_SENSOR_CALIBRATION_REVIEW.md`](domain/air/PM_SENSOR_CALIBRATION_REVIEW.md) | PM-sensor trust scores, meteorology features, co-location windows, low-concentration safeguards. | `KFM-P30-FEAT-0001` | Atmosphere domain steward | `apps/review-console/` | PROPOSED |
 
 [↑ back to top](#dashboard-catalog--docsdashboardsdashboard_catalogmd)

--- a/docs/dashboards/domain/README.md
+++ b/docs/dashboards/domain/README.md
@@ -34,7 +34,7 @@ notes:
   <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
   <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
   <img alt="Scope: specifications only" src="https://img.shields.io/badge/scope-specifications%20only-informational">
-  <img alt="Domains: 0 of 13" src="https://img.shields.io/badge/domains-0%20of%2013-yellow">
+  <img alt="Domains: 13 of 13" src="https://img.shields.io/badge/domains-13%20of%2013-yellowgreen">
   <img alt="Master indicators: Atlas §24.11" src="https://img.shields.io/badge/master%20indicators-Atlas%20%C2%A724.11-purple">
   <img alt="ADR: OPEN-DASH-01" src="https://img.shields.io/badge/ADR-OPEN--DASH--01-yellow">
   <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
@@ -179,19 +179,19 @@ Domain naming follows `docs/domains/<domain>/` convention from Directory Rules �
 
 | Atlas Ch. | Domain | File | Status | Indicator categories that primarily apply |
 |:---:|:---|:---|:---:|:---|
-| 4 | Hydrology | `hydrology.md` | ⏳ | Evidence-and-source; Release-correction-rollback; Documentation-and-drift |
-| 5 | Soil | `soil.md` | ⏳ | Evidence-and-source; Documentation-and-drift |
-| 6 | Habitat | `habitat.md` | ⏳ | Evidence-and-source; Sensitivity-and-rights |
-| 7 | Fauna | `fauna.md` | ⏳ | **Sensitivity-and-rights** *(T4 defaults)*; Evidence-and-source |
-| 8 | Flora | `flora.md` | ⏳ | **Sensitivity-and-rights** *(T4 defaults)*; Evidence-and-source |
-| 9 | Agriculture | `agriculture.md` | ⏳ | Evidence-and-source; Documentation-and-drift |
-| 10 | Geology / Natural Resources | `geology.md` | ⏳ | Evidence-and-source |
-| 11 | Atmosphere / Air | `atmosphere.md` | ⏳ | Evidence-and-source; **AI-surface-health** *(forecasting cite-or-abstain)* |
-| 12 | Hazards | `hazards.md` | ⏳ | **Release-correction-rollback** *(alert-authority denial)*; Evidence-and-source |
-| 13 | Roads / Rail / Trade Routes | `roads-rail-trade.md` | ⏳ | Evidence-and-source; Documentation-and-drift |
-| 14 | Settlements / Infrastructure | `settlements-infrastructure.md` | ⏳ | **Sensitivity-and-rights** *(critical-asset T4)*; Release-correction-rollback |
-| 15 | Archaeology / Cultural Heritage | `archaeology.md` | ⏳ | **Sensitivity-and-rights** *(T4 defaults, sovereignty)*; Evidence-and-source |
-| 16 | People / Genealogy / DNA / Land Ownership | `people-dna-land.md` | ⏳ | **Sensitivity-and-rights** *(living-person T4, DNA T4)*; AI-surface-health |
+| 4 | Hydrology | [`hydrology.md`](hydrology.md) | ✅ | Evidence-and-source; Release-correction-rollback; Documentation-and-drift |
+| 5 | Soil | [`soil.md`](soil.md) | ✅ | Evidence-and-source; Documentation-and-drift |
+| 6 | Habitat | [`habitat.md`](habitat.md) | ✅ | Evidence-and-source; Sensitivity-and-rights |
+| 7 | Fauna | [`fauna.md`](fauna.md) | ✅ | **Sensitivity-and-rights** *(T4 defaults)*; Evidence-and-source |
+| 8 | Flora | [`flora.md`](flora.md) | ✅ | **Sensitivity-and-rights** *(T4 defaults)*; Evidence-and-source |
+| 9 | Agriculture | [`agriculture.md`](agriculture.md) | ✅ | Evidence-and-source; Documentation-and-drift |
+| 10 | Geology / Natural Resources | [`geology.md`](geology.md) | ✅ | Evidence-and-source |
+| 11 | Atmosphere / Air | [`atmosphere.md`](atmosphere.md) | ✅ | Evidence-and-source; **AI-surface-health** *(forecasting cite-or-abstain)* |
+| 12 | Hazards | [`hazards.md`](hazards.md) | ✅ | **Release-correction-rollback** *(alert-authority denial)*; Evidence-and-source |
+| 13 | Roads / Rail / Trade Routes | [`roads-rail-trade.md`](roads-rail-trade.md) | ✅ | Evidence-and-source; Documentation-and-drift |
+| 14 | Settlements / Infrastructure | [`settlements-infrastructure.md`](settlements-infrastructure.md) | ✅ | **Sensitivity-and-rights** *(critical-asset T4)*; Release-correction-rollback |
+| 15 | Archaeology / Cultural Heritage | [`archaeology.md`](archaeology.md) | ✅ | **Sensitivity-and-rights** *(T4 defaults, sovereignty)*; Evidence-and-source |
+| 16 | People / Genealogy / DNA / Land Ownership | [`people-dna-land.md`](people-dna-land.md) | ✅ | **Sensitivity-and-rights** *(living-person T4, DNA T4)*; AI-surface-health |
 
 > [!NOTE]
 > **Cross-domain systems** (Atlas Ch. 17 Frontier Matrix, Ch. 18 Planetary/3D, Ch. 19 Cross-Domain Systems) are **not** in this inventory — they belong in `docs/dashboards/cross-domain/` (PROPOSED sibling). Spatial Foundation (Ch. 3) is foundational, not a domain; its instrumentation rolls up into every domain's dashboard.

--- a/docs/dashboards/domain/agriculture.md
+++ b/docs/dashboards/domain/agriculture.md
@@ -1,0 +1,146 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-agriculture
+title: Agriculture Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: agriculture-domain steward + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-agriculture-dossier                    # CONFIRMED dossier home: docs/domains/agriculture/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, agriculture, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Atlas §24.11 wins on indicator conflicts; agriculture dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Agriculture Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-agriculture] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Agriculture** (Atlas v1.0 Ch. 9). Cropland data layer (CDL), Census of Agriculture, NASS QuickStats, irrigation, and farm-level claims; **operator-identifiability** is the recurrent sensitivity exposure.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 9" src="https://img.shields.io/badge/atlas-Ch.%209-purple">
+  <img alt="Indicator emphasis: 24.11.1 / 24.11.5" src="https://img.shields.io/badge/emphasis-24.11.1%20%C2%B7%2024.11.5-informational">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicators PROPOSED; instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+> [!CAUTION]
+> **Operator identifiability.** NASS suppression rules (n<3 cell suppression, complementary suppression) are a sensitivity gate, not a styling preference. The dashboard surfaces compliance posture; the gate enforces the suppression itself.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 9 (Agriculture).
+- **Default sensitivity tier(s):** T1–T2 for state/county aggregates within NASS suppression rules; **T3** where parcel-level cropping pattern + irrigation type makes operator identification plausible.
+- **Pipeline shape:** Standard intake → validation → derive → publish, with NASS-suppression validator on every aggregation.
+- **Dossier:** `docs/domains/agriculture/` — `K.` validators (CDL class taxonomy, NASS suppression), `M.` correction posture for CDL re-releases.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Evidence-and-source · Documentation-and-drift**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across CDL / NASS QuickStats / Census of Agriculture / KDA cites; per-source rate visible. | `ValidationReport`, EvidenceBundle index |
+| Source-role distribution drift | 24.11.1 | CDL remains the canonical cover-class role; NASS reported-vs-modeled mix tracked. | Source descriptors |
+| Stale source rate | 24.11.1 | CDL annual epoch + NASS QuickStats refresh tracked; Census of Agriculture quinquennial alignment dispositioned. | Source descriptors, freshness cadence metadata |
+| Quarantine throughput | 24.11.1 | Cause distribution visible (suppression-rule violation, CDL class drift); no sustained backlog. | `ValidationReport`, quarantine ledger |
+| ADR completeness | 24.11.5 | Open agriculture ADRs (CDL class canonicalization, irrigation classification) tracked to a state. | ADR index |
+| Drift register size | 24.11.5 | Agriculture-derivative drift surfaced; trend not regressing across crop years. | `docs/registers/DRIFT_REGISTER.md` |
+| Per-root README presence | 24.11.5 | `docs/domains/agriculture/README.md` exists and is current. | Directory-rules linter output |
+| Atlas / supplement lineage clarity | 24.11.5 | Each crop-year supplement carries forward/back links. | Supersession entries |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why agriculture-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| NASS suppression-rule compliance | % of published aggregates that pass NASS n<3 + complementary suppression checks. | §24.11.3 (sensitivity variant) |
+| CDL class taxonomy version skew | Cross-year aggregates silently mixing CDL class definitions. | §24.11.5 |
+| Irrigation-classification confidence | Distribution of irrigation classification confidence (remote-sensed vs. WIMAS-derived). | §24.11.1 |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (agriculture dossier owner).
+- **Governance-health steward:** OWNER_TBD (source steward + docs steward).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/validation/`, `schemas/contracts/v1/source/`.
+- **Policy bundles emitting signals:** `policy/sources/`, `policy/documentation/`, `policy/sensitivity/` (suppression).
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** CDL annual release; NASS QuickStats schema change; Census of Agriculture quinquennial publication; agriculture dossier edition.
+- **Default cadence:** annual (post-CDL release); semi-annual review of suppression-rule compliance.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-AG-01** — Confirm NASS suppression-rule compliance home (§24.11.3 vs. agriculture-local).
+- [ ] **OPEN-DASH-AG-02** — Define irrigation-classification confidence indicator scope (vs. hydrology spec).
+- [ ] **OPEN-DASH-AG-03** — Decide whether parcel-level T3 lift triggers fauna/flora-style sensitivity-reviewer gating.
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.1 / §24.11.5 | CONFIRMED (manuscript) | §2 indicator subset. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 9 (Agriculture dossier) | CONFIRMED (manuscript) | §1 scope; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis; template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain agriculture dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/agriculture/`.** NASS suppression rules are enforced at the gate; the dashboard reports compliance posture.</sub>

--- a/docs/dashboards/domain/archaeology.md
+++ b/docs/dashboards/domain/archaeology.md
@@ -1,0 +1,153 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-archaeology
+title: Archaeology / Cultural Heritage Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: archaeology-domain steward + sensitivity reviewer + sovereignty representative + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-archaeology-dossier                    # CONFIRMED dossier home: docs/domains/archaeology/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, archaeology, cultural-heritage, sovereignty, t4, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Default T4 — archaeological site coordinates and culturally affiliated material are sovereignty-governed by default.
+  - The dashboard reports posture; sovereignty is held by the affiliated nation, not by KFM.
+  - Atlas §24.11 wins on indicator conflicts; archaeology dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Archaeology / Cultural Heritage Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-archaeology] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Archaeology / Cultural Heritage** (Atlas v1.0 Ch. 15). Site locations, culturally affiliated material, NAGPRA-class records. **T4 by default; sovereignty-governed.**
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 15" src="https://img.shields.io/badge/atlas-Ch.%2015-purple">
+  <img alt="Indicator emphasis: 24.11.3 (T4 defaults, sovereignty) / 24.11.1" src="https://img.shields.io/badge/emphasis-24.11.3%20%C2%B7%2024.11.1-informational">
+  <img alt="Default tier: T4 / sovereignty" src="https://img.shields.io/badge/default--tier-T4%20%C2%B7%20sovereignty-red">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicators PROPOSED; instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+> [!CAUTION]
+> **Sovereignty.** Tribal sovereignty over culturally affiliated archaeological material is not a permission KFM grants — it is held by the affiliated nation. The dashboard reports KFM's compliance posture against sovereignty rules; it does not enumerate or expose the underlying records.
+
+> [!WARNING]
+> **Authoring control.** Per OPEN-DASH-08, this spec **requires** a sensitivity reviewer **and** a sovereignty representative on the PR. Authoring without both is a process defect.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 15 (Archaeology / Cultural Heritage).
+- **Default sensitivity tier(s):** **T4** for site coordinates and culturally affiliated material; **T1–T2** for de-identified, sovereignty-cleared aggregate reporting.
+- **Pipeline shape:** Standard intake → validation → derive → publish, with **sensitive-lane fail-closed gate** before any public-surface emission and **sovereignty review** as a SoD-named role.
+- **Dossier:** `docs/domains/archaeology/` — `I.` sovereignty + sensitivity rules, `K.` validators (site-type vocabulary, NAGPRA flags), `M.` correction posture, `N.` verification backlog.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Sensitivity-and-rights (T4 defaults, sovereignty) · Evidence-and-source**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| **Sensitive-lane fail-closed rate** | 24.11.3 | **100% at the first gate** for any T4 archaeology emission. | `PolicyDecision` DENY counts |
+| RedactionReceipt coverage | 24.11.3 | 100% on public-safe derivatives (de-identified summaries, generalized regions). | `RedactionReceipt` |
+| **Sovereignty review presence** | 24.11.3 | 100% — every claim involving culturally affiliated material carries a sovereignty `ReviewRecord`. | `ReviewRecord` (sovereignty-typed) |
+| Review-aged-out incidence | 24.11.3 | Sensitive-lane / sovereignty claims past review cadence dispositioned within tolerance. | `ReviewRecord` |
+| Rights-change response time | 24.11.3 | Median time from sovereignty-rule change (nation request, NAGPRA decision) to tier reassignment within tolerance. | Source descriptors, `ReviewRecord` |
+| Sensitive-content side-channel audit | 24.11.3 | Periodic audit for label / popup / vertex-density / AI-text leaks of site location or affiliation. | Audit logs, `RepresentationReceipt` |
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across KSHS / NPS / state archaeological-survey / scholarly cites; per-source rate visible (counting only metadata, not site coordinates). | `ValidationReport`, EvidenceBundle index |
+| Quarantine throughput | 24.11.1 | Cause distribution visible (site-type vocabulary, NAGPRA flag, geometry precision); no sustained backlog. | `ValidationReport`, quarantine ledger |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why archaeology-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Sovereignty-decision lineage coverage | % of culturally affiliated claims with a resolvable sovereignty-decision lineage. | §24.11.3 |
+| NAGPRA-flag completeness | % of records carrying a NAGPRA classification flag where applicable. | §24.11.3 |
+| Cultural-affiliation vocabulary drift | Shift in cultural-affiliation vocabulary without an ADR or sovereignty-record amendment. | §24.11.5 |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (archaeology dossier owner).
+- **Governance-health steward:** OWNER_TBD (**sensitivity reviewer** + **sovereignty representative** + rights-holder representative; **all three** required).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/sensitivity/`, `runtime/observability/sovereignty/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/sensitivity/`, `schemas/contracts/v1/redaction/`, `schemas/contracts/v1/review/` (sovereignty-typed), `schemas/contracts/v1/correction/`.
+- **Policy bundles emitting signals:** `policy/sensitivity/sovereignty/`, `policy/sources/`, `policy/correction/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** sovereignty-rule change (nation request, NAGPRA decision, scholar consultation); archaeology dossier edition; Atlas §24.11 amendment.
+- **Default cadence:** quarterly; **immediate** review on any sovereignty-related correction or denial pattern shift.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-ARCH-01** — Confirm sovereignty `ReviewRecord` schema (is it a typed variant, or a separate receipt family?).
+- [ ] **OPEN-DASH-ARCH-02** — Define NAGPRA-flag completeness scope (which record families are in scope).
+- [ ] **OPEN-DASH-ARCH-03** — Confirm sensitivity-reviewer + sovereignty-representative dual-gate per OPEN-DASH-08.
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.3 / §24.11.1 | CONFIRMED (manuscript) | §2 indicator subset; sovereignty emphasis. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 15 (Archaeology dossier) | CONFIRMED (manuscript) | §1 scope, T4-default + sovereignty; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| Atlas v1.1 §24.5 / §24.7 | CONFIRMED authored sibling | T4 default; sovereignty representative as SoD-named role. | Tier table + role matrix PROPOSED. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis (Sensitivity-and-rights, T4 defaults, sovereignty); template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain archaeology / cultural heritage dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/archaeology/`.** Sovereignty is held by the affiliated nation; the dashboard reports KFM's compliance posture only.</sub>

--- a/docs/dashboards/domain/atmosphere.md
+++ b/docs/dashboards/domain/atmosphere.md
@@ -1,0 +1,153 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-atmosphere
+title: Atmosphere / Air Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: atmosphere-domain steward + AI-surface steward + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-atmosphere-dossier                     # CONFIRMED dossier home: docs/domains/atmosphere/
+  - kfm://doc/dashboards-domain-air-pm-sensor-calibration    # CONFIRMED sibling: domain/air/PM_SENSOR_CALIBRATION_REVIEW.md
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, atmosphere, air, ai-surface, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Atmosphere is the home for AI-surface forecasting (cite-or-abstain emphasis); air-quality sub-surfaces live under domain/air/.
+  - Atlas §24.11 wins on indicator conflicts; atmosphere dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Atmosphere / Air Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-atmosphere] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Atmosphere / Air** (Atlas v1.0 Ch. 11). Weather observations, climate normals, forecasts, air-quality, drought indices. Carries an **AI-surface forecasting cite-or-abstain emphasis** beyond the standard evidence indicators.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 11" src="https://img.shields.io/badge/atlas-Ch.%2011-purple">
+  <img alt="Indicator emphasis: 24.11.1 / 24.11.4" src="https://img.shields.io/badge/emphasis-24.11.1%20%C2%B7%2024.11.4-informational">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicators PROPOSED; instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+> [!CAUTION]
+> **Forecast vs. observation.** Atmospheric forecasts are **derived AI/numerical claims**. They must cite the model run + boundary conditions or abstain. The dashboard's AI-surface-health indicators apply specifically to forecasting and downscaled-model emissions.
+
+> [!NOTE]
+> **Sub-surfaces.** Air-quality / PM-sensor sub-dashboards live under `domain/air/` (currently: [`domain/air/PM_SENSOR_CALIBRATION_REVIEW.md`](./air/PM_SENSOR_CALIBRATION_REVIEW.md)). The relationship between this domain-scoped spec and the per-card sub-surfaces is OPEN-DASH-ATMOS-03.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 11 (Atmosphere / Air).
+- **Default sensitivity tier(s):** T1 (public weather / air-quality observations and forecasts).
+- **Pipeline shape:** Standard intake → validation → derive → publish; forecast emissions carry an **AI-surface gate** requiring `AIReceipt` with model-run, boundary conditions, and cite-or-abstain.
+- **Dossier:** `docs/domains/atmosphere/` — `K.` validators (station QC, calibration, forecast verification), `M.` correction posture for re-analysis revisions.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Evidence-and-source · AI-surface-health (forecasting cite-or-abstain)**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across NOAA / ASOS / Mesonet / EPA AQS / KS Mesonet cites; per-source rate visible. | `ValidationReport`, EvidenceBundle index |
+| Source-role distribution drift | 24.11.1 | Observation-vs-model role split tracked; downscaled-product role explicit, never silent. | Source descriptors |
+| Stale source rate | 24.11.1 | Sub-hourly cadence sources monitored; outage dispositioned within tolerance. | Source descriptors, freshness cadence metadata |
+| Quarantine throughput | 24.11.1 | Cause distribution visible (sensor flag, range check, derived-product schema); no sustained backlog. | `ValidationReport`, quarantine ledger |
+| **AIReceipt presence rate** | 24.11.4 | **100%** on every forecast / downscaled-model emission to a public surface. | `AIReceipt` |
+| **ABSTAIN rate by template** | 24.11.4 | Tracked per forecast horizon and per-variable; no template silently drops abstain. | `AIReceipt`, prompt registry |
+| DENY reason distribution | 24.11.4 | Forecast denials surface model-run-stale / boundary-mismatch causes; trend tracked. | `PolicyDecision` |
+| Synthetic-claim incidence | 24.11.4 | Zero unverified forecast claims (e.g., AI text inventing a heat-index value not in the model output). | `AIReceipt`, audit logs |
+| Cite-or-abstain compliance | 24.11.1 / 24.11.4 | 100% on all AI-derived atmospheric text (forecast summaries, drought commentary). | `AIReceipt` |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why atmosphere-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Forecast skill calibration drift | Verification-score drift per model / horizon; signals model decay. | §24.11.4 |
+| Boundary-condition lineage completeness | % of forecast `AIReceipt`s naming model run + boundary conditions resolvable to source. | §24.11.4 |
+| Air-quality calibration-residual roll-up | Aggregate roll-up of `domain/air/PM_SENSOR_CALIBRATION_REVIEW.md` residuals. | §24.11.1 (coverage variant) |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (atmosphere dossier owner).
+- **Governance-health steward:** OWNER_TBD (**AI-surface steward** + source steward; mandatory pair).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/ai-surface/`, `runtime/observability/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/ai-receipt/`, `schemas/contracts/v1/validation/`, `schemas/contracts/v1/source/`.
+- **Policy bundles emitting signals:** `policy/ai-surface/`, `policy/sources/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** model upgrade (NWM/HRRR/RAP/global model migration); air-quality re-analysis; atmosphere dossier edition; Atlas §24.11 amendment.
+- **Default cadence:** quarterly; **immediate** review on AI-surface DENY-pattern shift or synthetic-claim incident.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-ATMOS-01** — Define the precise forecast-horizon partition for ABSTAIN-rate tracking.
+- [ ] **OPEN-DASH-ATMOS-02** — Confirm boundary-condition lineage completeness scope (single model run vs. ensemble member).
+- [ ] **OPEN-DASH-ATMOS-03** — Resolve relationship between this domain-scoped spec and per-card sub-surfaces under `domain/air/` (parent vs sibling).
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.1 / §24.11.4 | CONFIRMED (manuscript) | §2 indicator subset; AI-surface emphasis. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 11 (Atmosphere dossier) | CONFIRMED (manuscript) | §1 scope; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| `docs/dashboards/domain/air/PM_SENSOR_CALIBRATION_REVIEW.md` | CONFIRMED (this folder) | §2 air-quality roll-up; §7 OPEN-DASH-ATMOS-03 parent/sub-surface relationship. | PM-sensor calibration is a single Pass-30 card; broader air-quality coverage NEEDS VERIFICATION. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis (Evidence-and-source · AI-surface-health); template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain atmosphere dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/atmosphere/`.** AI-surface forecasting cite-or-abstain is enforced at the policy gate; the dashboard reports posture.</sub>

--- a/docs/dashboards/domain/fauna.md
+++ b/docs/dashboards/domain/fauna.md
@@ -1,0 +1,153 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-fauna
+title: Fauna Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: fauna-domain steward + sensitivity reviewer + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-fauna-dossier                          # CONFIRMED dossier home: docs/domains/fauna/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, fauna, sensitivity, t4, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Default sensitivity tier is T4 (sensitive-species localities, listed-species range, observation lineage).
+  - Atlas §24.11 wins on indicator-definition conflicts; the fauna dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Fauna Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-fauna] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Fauna** (Atlas v1.0 Ch. 7). A **T4-default sensitive domain** — the dashboard's primary job is reporting fail-closed posture, redaction coverage, and side-channel audit cadence.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 7" src="https://img.shields.io/badge/atlas-Ch.%207-purple">
+  <img alt="Indicator emphasis: 24.11.3 (T4 defaults) / 24.11.1" src="https://img.shields.io/badge/emphasis-24.11.3%20%C2%B7%2024.11.1-informational">
+  <img alt="Default tier: T4" src="https://img.shields.io/badge/default--tier-T4-red">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Atlas §24.11 catalog PROPOSED; per-domain instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+> [!CAUTION]
+> **T4 default.** Fauna observations of listed, sensitive, or vulnerable species are T4 by default. The dashboard reports posture; **the gate enforces**. Any apparent "false-positive DENY" must be diagnosed at the policy/, not by tuning this dashboard.
+
+> [!WARNING]
+> **Authoring control.** Per OPEN-DASH-08, sensitive-domain specs should require a sensitivity reviewer on the PR. Treat that as a soft gate until the ADR resolves.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 7 (Fauna).
+- **Default sensitivity tier(s):** **T4** for listed-species localities, nest/den sites, observation lineage; T2–T3 for non-sensitive aggregate counts.
+- **Pipeline shape:** Standard intake → validation → derive → publish, with **sensitive-lane fail-closed gate** before any public-surface emission; redaction receipts required on public-safe derivatives.
+- **Dossier:** `docs/domains/fauna/` — `I.` sensitivity rules (KDWP / USFWS / state listings), `K.` validators, `M.` correction posture for misidentification rollback.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Sensitivity-and-rights (T4 defaults) · Evidence-and-source**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| **Sensitive-lane fail-closed rate** | 24.11.3 | **100% at the first gate.** Any DENY-leakage below the gate is a critical defect. | `PolicyDecision` DENY counts |
+| RedactionReceipt coverage | 24.11.3 | 100% on every public-safe derivative of a T4 fauna record. | `RedactionReceipt` |
+| Review-aged-out incidence | 24.11.3 | Sensitive-lane claims past review cadence dispositioned within tolerance; trend tracked. | `ReviewRecord` |
+| Rights-change response time | 24.11.3 | Median time from rights-change detection (e.g., new state listing) to tier reassignment within stated tolerance. | Source descriptors, `ReviewRecord` |
+| Sensitive-content side-channel audit | 24.11.3 | Periodic automated checks for label / map-popup / AI-text leaks; documented. | Audit logs, `RepresentationReceipt` |
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across iNaturalist / KDWP / GBIF / KU Biodiversity Institute cites; per-source rate visible. | `ValidationReport`, EvidenceBundle index |
+| Source-role distribution drift | 24.11.1 | Observation roles (museum specimen / citizen science / regulatory) tracked; no silent shift. | Source descriptors |
+| Quarantine throughput | 24.11.1 | Cause distribution visible (misidentification, locality precision); no sustained backlog. | `ValidationReport`, quarantine ledger |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why fauna-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Locality-precision DENY pattern | DENYs triggered specifically by locality coarseness below threshold — a fauna-recurrent signal. | §24.11.3 |
+| Citizen-science role drift | Shift in observation-role mix toward citizen science without an ADR — affects identification confidence. | §24.11.1 |
+| Listing-change lag | Time between a state/federal listing change and the corresponding tier reassignment on local records. | §24.11.3 (rights-change variant) |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (fauna dossier owner — resolve against Atlas §24.7).
+- **Governance-health steward:** OWNER_TBD (**sensitivity reviewer** + rights-holder representative; mandatory pair per Atlas §24.7).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/sensitivity/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/sensitivity/`, `schemas/contracts/v1/redaction/`, `schemas/contracts/v1/review/`.
+- **Policy bundles emitting signals:** `policy/sensitivity/`, `policy/sources/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** state/federal listing change; fauna dossier edition; Atlas §24.11 amendment; **any** unexplained drop in DENY rate.
+- **Default cadence:** quarterly; **immediate** review on side-channel audit failure.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-FAUNA-01** — Define locality-precision threshold per taxon group (mammals / birds / herps).
+- [ ] **OPEN-DASH-FAUNA-02** — Confirm `RedactionReceipt` schema covers vertex-density side-channels (cross-reference habitat spec).
+- [ ] **OPEN-DASH-FAUNA-03** — Confirm sensitivity-reviewer-on-PR gate per OPEN-DASH-08.
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.3 / §24.11.1 | CONFIRMED (manuscript) | §2 indicator subset. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 7 (Fauna dossier) | CONFIRMED (manuscript) | §1 scope, T4 default; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| Atlas v1.1 §24.5 (Sensitivity tier reference) | CONFIRMED authored sibling | T4 default justification. | Tier table PROPOSED. |
+| Atlas v1.1 §24.10 (Risk register) | CONFIRMED (manuscript) | Sensitive-lane risk severities. | PROPOSED severities. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis (Sensitivity-and-rights, T4 defaults); template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain fauna dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/fauna/`.** Default tier T4: the dashboard reports posture, the gate enforces, the receipts back the trust.</sub>

--- a/docs/dashboards/domain/flora.md
+++ b/docs/dashboards/domain/flora.md
@@ -1,0 +1,152 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-flora
+title: Flora Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: flora-domain steward + sensitivity reviewer + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-flora-dossier                          # CONFIRMED dossier home: docs/domains/flora/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, flora, sensitivity, t4, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Default sensitivity tier T4 for poaching-vulnerable taxa, T1–T2 for non-sensitive flora.
+  - Atlas §24.11 wins on indicator conflicts; flora dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Flora Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-flora] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Flora** (Atlas v1.0 Ch. 8). A **T4-default sensitive domain** for poaching-vulnerable taxa (rare orchids, cacti, etc.); the dashboard's primary job is reporting fail-closed and redaction posture.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 8" src="https://img.shields.io/badge/atlas-Ch.%208-purple">
+  <img alt="Indicator emphasis: 24.11.3 (T4 defaults) / 24.11.1" src="https://img.shields.io/badge/emphasis-24.11.3%20%C2%B7%2024.11.1-informational">
+  <img alt="Default tier: T4" src="https://img.shields.io/badge/default--tier-T4-red">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicators PROPOSED; instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+> [!CAUTION]
+> **T4 default for poaching-vulnerable taxa.** The poaching risk model — not the science — drives T4 on rare orchids, cacti, and certain medicinals. Aggregate ecological reporting (Kansas grassland composition) remains T1–T2.
+
+> [!WARNING]
+> **Authoring control.** Per OPEN-DASH-08, sensitive-domain specs should require a sensitivity reviewer on the PR.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 8 (Flora).
+- **Default sensitivity tier(s):** **T4** for poaching-vulnerable taxa and identified rare-plant localities; T1–T2 for aggregate cover, composition, and common-species range.
+- **Pipeline shape:** Standard intake → validation → derive → publish, with sensitive-lane fail-closed gate on T4 emissions; redaction receipts required on public-safe derivatives.
+- **Dossier:** `docs/domains/flora/` — `I.` sensitivity rules (KDWP / USFWS / KS state listings / herbarium policy), `K.` validators (taxonomy version, voucher requirement), `M.` correction posture.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Sensitivity-and-rights (T4 defaults) · Evidence-and-source**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| **Sensitive-lane fail-closed rate** | 24.11.3 | **100% at the first gate** for any T4 locality emission. | `PolicyDecision` DENY counts |
+| RedactionReceipt coverage | 24.11.3 | 100% on public-safe derivatives of T4 records. | `RedactionReceipt` |
+| Review-aged-out incidence | 24.11.3 | Sensitive-lane claims past review cadence dispositioned within tolerance. | `ReviewRecord` |
+| Rights-change response time | 24.11.3 | Median time from listing change to tier reassignment within tolerance. | Source descriptors, `ReviewRecord` |
+| Sensitive-content side-channel audit | 24.11.3 | Periodic checks for label / map-popup / AI-text leakage of T4 localities. | Audit logs, `RepresentationReceipt` |
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across herbarium / iNaturalist / Kansas Native Plant Society / KBS cites. | `ValidationReport`, EvidenceBundle index |
+| Source-role distribution drift | 24.11.1 | Voucher-specimen vs photo-observation mix tracked; no silent shift. | Source descriptors |
+| Quarantine throughput | 24.11.1 | Cause distribution visible (taxonomy version, locality precision); no sustained backlog. | `ValidationReport`, quarantine ledger |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why flora-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Voucher-specimen coverage | % of identified rare-plant claims backed by a voucher specimen vs photo-only. | §24.11.1 |
+| Taxonomy edition skew | Mixed APG / Flora of the Great Plains editions in a single derivative. | §24.11.5 |
+| Poaching-pattern audit | Periodic check for repeat-pattern queries against the same T4 locality (defensive analytics). | §24.11.3 |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (flora dossier owner).
+- **Governance-health steward:** OWNER_TBD (**sensitivity reviewer** + rights-holder representative).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/sensitivity/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/sensitivity/`, `schemas/contracts/v1/redaction/`, `schemas/contracts/v1/review/`.
+- **Policy bundles emitting signals:** `policy/sensitivity/`, `policy/sources/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** state/federal listing change; flora dossier edition; Atlas §24.11 amendment; side-channel audit alert.
+- **Default cadence:** quarterly; **immediate** on poaching-pattern audit alert.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-FLORA-01** — Confirm the voucher-specimen coverage threshold per taxon class.
+- [ ] **OPEN-DASH-FLORA-02** — Define the poaching-pattern audit query shape — is it a §24.11.3 indicator or a separate defensive-analytics surface?
+- [ ] **OPEN-DASH-FLORA-03** — Confirm sensitivity-reviewer-on-PR gate per OPEN-DASH-08.
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.3 / §24.11.1 | CONFIRMED (manuscript) | §2 indicator subset. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 8 (Flora dossier) | CONFIRMED (manuscript) | §1 scope, T4 default; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| Atlas v1.1 §24.5 (Sensitivity tier reference) | CONFIRMED authored sibling | T4 default for poaching-vulnerable taxa. | Tier table PROPOSED. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis; template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain flora dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/flora/`.** T4 default for poaching-vulnerable taxa: dashboard reports, gate enforces, receipts back the trust.</sub>

--- a/docs/dashboards/domain/geology.md
+++ b/docs/dashboards/domain/geology.md
@@ -1,0 +1,140 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-geology
+title: Geology / Natural Resources Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: geology-domain steward + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-geology-dossier                        # CONFIRMED dossier home: docs/domains/geology/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, geology, natural-resources, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Operator/well-owner identifiability lifts T from T1–T2 to T3 on certain well-record products.
+  - Atlas §24.11 wins on indicator conflicts; geology dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Geology / Natural Resources Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-geology] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Geology / Natural Resources** (Atlas v1.0 Ch. 10). Bedrock/surficial geology, mineral resources, oil & gas, well records, geophysics. Source coverage breadth is the dominant signal.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 10" src="https://img.shields.io/badge/atlas-Ch.%2010-purple">
+  <img alt="Indicator emphasis: 24.11.1" src="https://img.shields.io/badge/emphasis-24.11.1-informational">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicators PROPOSED; instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 10 (Geology / Natural Resources).
+- **Default sensitivity tier(s):** T1 for bedrock/surficial geology and aggregate resources; **T3** where well-record granularity reveals operator/owner identity.
+- **Pipeline shape:** Standard intake → validation → derive → publish; well-record products carry an additional operator-identifiability gate.
+- **Dossier:** `docs/domains/geology/` — `K.` validators (lithology, stratigraphy, KGS WIZARD schema), `M.` correction posture for re-interpreted units.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Evidence-and-source**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across KGS / USGS / KDHE cites; per-source rate visible. | `ValidationReport`, EvidenceBundle index |
+| Cite-or-abstain compliance | 24.11.1 | 100% — any AI-generated lithology / age claim must cite or abstain. | `AIReceipt` |
+| Source-role distribution drift | 24.11.1 | KGS canonical for bedrock map units; USGS for stratigraphy. No silent role shift. | Source descriptors |
+| Stale source rate | 24.11.1 | KGS WIZARD / well-record refresh tracked; lag dispositioned. | Source descriptors, freshness cadence metadata |
+| Quarantine throughput | 24.11.1 | Cause distribution visible (stratigraphic-unit drift, datum, lithology vocabulary); no sustained backlog. | `ValidationReport`, quarantine ledger |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why geology-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Stratigraphic-unit canonicalization coverage | % of map units mapped to a canonical KGS stratigraphic ID. | §24.11.1 |
+| Well-record operator-identifiability gate compliance | % of published well-record derivatives that passed the operator-identifiability gate. | §24.11.3 |
+| Lithology vocabulary version skew | Cross-product use of differing lithology vocabularies (BGS / USGS-NGD / KGS). | §24.11.5 |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (geology dossier owner).
+- **Governance-health steward:** OWNER_TBD (source steward; sensitivity reviewer for well-record products).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/validation/`, `schemas/contracts/v1/source/`, `schemas/contracts/v1/sensitivity/` (well records).
+- **Policy bundles emitting signals:** `policy/sources/`, `policy/sensitivity/` (well-record gate).
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** KGS publication cycle; well-record schema change; geology dossier edition.
+- **Default cadence:** annual; semi-annual for well-record products.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-GEO-01** — Confirm operator-identifiability gate scope (which well-record fields trigger).
+- [ ] **OPEN-DASH-GEO-02** — Reconcile stratigraphic vocabulary canonicalization with USGS NGD adoption.
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.1 | CONFIRMED (manuscript) | §2 indicator subset. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 10 (Geology dossier) | CONFIRMED (manuscript) | §1 scope; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis; template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain geology dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/geology/`.** Well-record products carry an additional identifiability gate; the dashboard reports gate-compliance posture.</sub>

--- a/docs/dashboards/domain/habitat.md
+++ b/docs/dashboards/domain/habitat.md
@@ -1,0 +1,146 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-habitat
+title: Habitat Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: habitat-domain steward + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-habitat-dossier                        # CONFIRMED dossier home: docs/domains/habitat/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, habitat, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of the master indicator catalog (Atlas v1.1 §24.11). Specification only; not an implementation.
+  - Habitat carries sensitivity exposure where polygons touch sensitive-species range; T-tier per dossier §I.
+  - Atlas §24.11 wins on indicator-definition conflicts; the habitat dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Habitat Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-habitat] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Habitat** (Atlas v1.0 Ch. 6). Instances the Atlas §24.11 governance health indicators at the habitat scale; surfaces sensitivity-and-rights posture wherever habitat polygons intersect sensitive-species range.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 6" src="https://img.shields.io/badge/atlas-Ch.%206-purple">
+  <img alt="Indicator emphasis: 24.11.1 / 24.11.3" src="https://img.shields.io/badge/emphasis-24.11.1%20%C2%B7%2024.11.3-informational">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicator catalog from Atlas §24.11 is PROPOSED. Per-domain instances PROPOSED. Lane PROPOSED per OPEN-DASH-01. Implementation status NEEDS VERIFICATION.
+
+> [!CAUTION]
+> **Sensitivity coupling.** Habitat polygons are not themselves sensitive, but their intersection with fauna/flora T4 range can leak species locations. This dashboard surfaces the **fail-closed rate** at that intersection; the dashboard does not, itself, decide redaction.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 6 (Habitat).
+- **Default sensitivity tier(s):** T1–T2 baseline; **escalates to T3/T4** by intersection with fauna/flora sensitive-species range.
+- **Pipeline shape:** Standard intake → validation → derive → publish, with sensitive-lane fail-closed gate on cross-domain join with fauna/flora.
+- **Dossier:** `docs/domains/habitat/` — `K.` validators (cover-class taxonomy, ecoregion membership), `I.` sensitivity coupling rules.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Evidence-and-source · Sensitivity-and-rights**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across NLCD/LANDFIRE/KBS habitat cites; per-source rate visible. | `ValidationReport`, EvidenceBundle index |
+| Source-role distribution drift | 24.11.1 | NLCD remains the canonical cover-class role; LANDFIRE / Kansas Biological Survey roles tracked separately. | Source descriptors |
+| Stale source rate | 24.11.1 | NLCD epoch refresh tracked; lag dispositioned, not silent. | Source descriptors, freshness cadence metadata |
+| Quarantine throughput | 24.11.1 | Cause distribution visible (cover-class taxonomy drift, projection); no sustained backlog. | `ValidationReport`, quarantine ledger |
+| **Sensitive-lane fail-closed rate** | 24.11.3 | **100% at the first gate** for any habitat × sensitive-species join. | `PolicyDecision` DENY counts |
+| RedactionReceipt coverage | 24.11.3 | 100% on habitat layers public-safe-derived from sensitive-species joins. | `RedactionReceipt` |
+| Review-aged-out incidence | 24.11.3 | Habitat-as-proxy claims past review cadence dispositioned within tolerance. | `ReviewRecord` |
+| Sensitive-content side-channel audit | 24.11.3 | Periodic audit for habitat-polygon vertex density that could re-identify sensitive nest / den sites. | Audit logs, `RepresentationReceipt` |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why habitat-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Cover-class taxonomy version skew | Mixed NLCD epochs / LANDFIRE versions across a single map sheet is a recurrent defect. | §24.11.5 |
+| Vertex-density side-channel exposure | Habitat polygons with abnormally tight vertex density at sensitive-species range edges. | §24.11.3 |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (habitat dossier owner).
+- **Governance-health steward:** OWNER_TBD (sensitivity reviewer + source steward).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/validation/`, `schemas/contracts/v1/sensitivity/`, `schemas/contracts/v1/redaction/`.
+- **Policy bundles emitting signals:** `policy/sensitivity/`, `policy/sources/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** NLCD/LANDFIRE epoch bump; fauna/flora dossier edition (sensitivity coupling); Atlas §24.11 amendment.
+- **Default cadence:** quarterly; **immediate** review on any sensitive-lane denial pattern change.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-HABITAT-01** — Define the vertex-density side-channel threshold (per cover class? per ecoregion?).
+- [ ] **OPEN-DASH-HABITAT-02** — Reconcile NLCD-epoch skew detection between this spec and the soil spec (cross-domain).
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.1 / §24.11.3 | CONFIRMED (manuscript) | §2 indicator subset. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 6 (Habitat dossier) | CONFIRMED (manuscript) | §1 scope; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| Atlas v1.1 §24.10 (Risk register) | CONFIRMED (manuscript) | §2 sensitive-lane emphasis (habitat × T4 species). | Risk severities PROPOSED. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | §2 emphasis (Evidence-and-source · Sensitivity-and-rights); template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain habitat dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/habitat/`.** Habitat sensitivity escalates via intersection with fauna/flora; the gate enforces, the dashboard reports.</sub>

--- a/docs/dashboards/domain/hazards.md
+++ b/docs/dashboards/domain/hazards.md
@@ -1,0 +1,153 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-hazards
+title: Hazards Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: hazards-domain steward + release steward + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-hazards-dossier                        # CONFIRMED dossier home: docs/domains/hazards/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, hazards, alerts, release-correction-rollback, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Hazards carries an alert-authority gate — KFM does not issue official alerts; the dashboard reports DENY-by-authority posture.
+  - Atlas §24.11 wins on indicator conflicts; hazards dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Hazards Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-hazards] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Hazards** (Atlas v1.0 Ch. 12). Flood, wildfire, severe-weather, tornado, drought, seismicity. **Release-correction-rollback** is the central indicator family: hazards corrections must invalidate downstream derivatives quickly.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 12" src="https://img.shields.io/badge/atlas-Ch.%2012-purple">
+  <img alt="Indicator emphasis: 24.11.2 / 24.11.1" src="https://img.shields.io/badge/emphasis-24.11.2%20%C2%B7%2024.11.1-informational">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicators PROPOSED; instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+> [!CAUTION]
+> **KFM is not an alerting authority.** Anything that resembles an official warning (NWS, USGS, KDEM) must be DENIED with `ALERT_AUTHORITY` reason and routed to the authoritative source. The dashboard reports the DENY-by-authority rate; the gate enforces it.
+
+> [!WARNING]
+> **Time pressure.** Hazards posture is consequential within minutes-to-hours. Indicator latencies here matter more than in slower domains.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 12 (Hazards).
+- **Default sensitivity tier(s):** T1–T2 (public hazard event records, historical extents); T3 where individual loss/property impact is identifiable.
+- **Pipeline shape:** Standard intake → validation → derive → publish, with **alert-authority gate** on any emission that resembles an active warning; rollback is mandatory for all hazard layers.
+- **Dossier:** `docs/domains/hazards/` — `K.` validators (event-type vocabulary, severity scales), `M.` rollback + correction posture, `N.` verification backlog.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Release-correction-rollback (alert-authority denial) · Evidence-and-source**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| Release with rollback target | 24.11.2 | **100%** — every published hazard layer (flood-extent, fire-perimeter, severe-weather track) names a valid rollback target. | `ReleaseManifest`, `RollbackCard` |
+| Correction lead time | 24.11.2 | **Median ≤ stated hazards-domain tolerance** (faster than slower domains; trend tracked). | `CorrectionNotice` |
+| Derivative-invalidation coverage | 24.11.2 | Approaches 100% — corrections to event extents cascade-invalidate downstream impact / loss derivatives. | `CorrectionNotice`, lineage graph |
+| Rollback rehearsal rate | 24.11.2 | Non-zero per release window; rehearsals exercise the alert-resembling-content path. | `RollbackCard` |
+| Supersession lineage gap | 24.11.2 / 24.11.5 | Zero — every superseded hazard product carries a forward link. | `ReleaseManifest`, supersession entries |
+| **`ALERT_AUTHORITY` DENY rate** | 24.11.2 / 24.11.4 | **Tracked, visible, expected to be non-zero.** Any silent zero with active hazard sources is a defect (gate not firing). | `PolicyDecision`, `AIReceipt` |
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across NWS / USGS / KDEM / KS Mesonet cites; per-source rate visible. | `ValidationReport`, EvidenceBundle index |
+| Stale source rate | 24.11.1 | Real-time hazard feeds monitored against freshness cadence; outage dispositioned. | Source descriptors, freshness cadence metadata |
+| Quarantine throughput | 24.11.1 | Cause distribution visible (event-type vocabulary, severity, geometry); no sustained backlog. | `ValidationReport`, quarantine ledger |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why hazards-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Active-hazard rollback latency | Time from hazard correction emission to last derivative invalidation — minutes-grade target. | §24.11.2 |
+| Authority routing coverage | % of `ALERT_AUTHORITY` DENYs that surface a routing link to the canonical source. | §24.11.2 |
+| Event-type vocabulary drift | Drift in event-type vocabulary across years / sources (NWS storm-event database). | §24.11.5 |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (hazards dossier owner).
+- **Governance-health steward:** OWNER_TBD (**release steward** + correction reviewer; mandatory pair).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/release/`, `runtime/observability/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/release/`, `schemas/contracts/v1/correction/`, `schemas/contracts/v1/policy-decision/`.
+- **Policy bundles emitting signals:** `policy/release/`, `policy/correction/`, `policy/alert-authority/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** any hazard correction issued; NWS / USGS schema bump; hazards dossier edition.
+- **Default cadence:** monthly during active-hazard season (spring severe weather, summer fire, winter ice); **immediate** review on any silent-zero in `ALERT_AUTHORITY` DENY rate.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-HAZ-01** — Define active-hazard rollback latency target (minutes vs hour-grade).
+- [ ] **OPEN-DASH-HAZ-02** — Confirm `ALERT_AUTHORITY` is a single denial reason or a family (per-authority sub-reasons).
+- [ ] **OPEN-DASH-HAZ-03** — Reconcile hazards spec's rollback-rehearsal cadence with the governance `RELEASE_CORRECTION_ROLLBACK` master spec.
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.2 / §24.11.1 | CONFIRMED (manuscript) | §2 indicator subset. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 12 (Hazards dossier) | CONFIRMED (manuscript) | §1 scope; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| Atlas v1.1 §24.10 (Risk register) | CONFIRMED (manuscript) | §2 release-correction emphasis. | Risk severities PROPOSED. |
+| `docs/dashboards/governance/RELEASE_CORRECTION_ROLLBACK.md` | CONFIRMED (this folder) | §2 cross-reference for master rollback indicators. | Master spec is itself PROPOSED. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis; template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain hazards dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/hazards/`.** KFM is not an alerting authority: the gate denies, the dashboard reports the denial rate, the receipts back the trust.</sub>

--- a/docs/dashboards/domain/hydrology.md
+++ b/docs/dashboards/domain/hydrology.md
@@ -1,0 +1,156 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-hydrology
+title: Hydrology Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: hydrology-domain steward + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme                       # CONFIRMED authored sibling
+  - kfm://doc/atlas-v1-1                                     # PROPOSED: docs/atlases/KFM_Domains_Culmination_Atlas_v1_1.pdf §24.11
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference   # CONFIRMED authored sibling
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference      # CONFIRMED authored sibling
+  - kfm://doc/domains-hydrology-dossier                      # CONFIRMED dossier home: docs/domains/hydrology/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, hydrology, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of the master indicator catalog (Atlas v1.1 §24.11). Specification only; not an implementation.
+  - Atlas §24.11 wins on indicator-definition conflicts; the hydrology dossier wins on context conflicts.
+  - Mounted-repo implementation status is NEEDS VERIFICATION.
+[/KFM_META_BLOCK_V2] -->
+
+# Hydrology Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-hydrology] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Hydrology** (Atlas v1.0 Ch. 4). Instances the Atlas §24.11 governance health indicators at the hydrology scale; does **not** redefine them.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 4" src="https://img.shields.io/badge/atlas-Ch.%204-purple">
+  <img alt="Indicator emphasis: 24.11.1 / 24.11.2 / 24.11.5" src="https://img.shields.io/badge/emphasis-24.11.1%20%C2%B7%2024.11.2%20%C2%B7%2024.11.5-informational">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicator catalog from Atlas §24.11 is PROPOSED. Per-domain instances in this file are PROPOSED. The lane (`docs/dashboards/`) is PROPOSED per OPEN-DASH-01. Implementation status is NEEDS VERIFICATION.
+
+> [!NOTE]
+> **Anti-collapse rule.** This spec **reports** posture; it does not enforce it. Hydrology decisions rest on the receipts, evidence bundles, and validators this spec points to. *(Atlas v1.1 §24.11, CONFIRMED.)*
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 4 (Hydrology).
+- **Default sensitivity tier(s):** T1–T2 (public hydrography; well-record privacy escalates to T3 on identifiability). *(See `docs/atlases/chapters/24-5-sensitivity-tier-reference.md`.)*
+- **Pipeline shape:** Standard intake → validation → derive → publish, with rollback-target requirement on every published gauge/derived layer. *(See `docs/atlases/chapters/24-6-pipeline-gate-reference.md`.)*
+- **Dossier:** `docs/domains/hydrology/` — the dossier's `K.` validators, `M.` publication/correction/rollback, and `N.` verification backlog supply the *why* behind every healthy-posture value below. **Dossier wins on context conflicts.**
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+The hydrology dashboard surfaces the §24.11 indicators below. Emphasis follows README §5.1: **Evidence-and-source · Release-correction-rollback · Documentation-and-drift**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% over trailing release window (matches master); per-source rate visible for USGS NWIS, KGS WIZARD, NOAA NWM, KDA WIMAS. | `ValidationReport`, EvidenceBundle index |
+| Source-role distribution drift | 24.11.1 | No silent shift in observed-vs-modeled mix without an ADR or steward note. | Source descriptors, `ValidationReport` |
+| Stale source rate | 24.11.1 | All NWIS/WIMAS feeds within freshness cadence; stewards dispositioned within tolerance. | Source descriptors, freshness cadence metadata |
+| Quarantine throughput | 24.11.1 | Quarantine cause distribution visible (units, projection, gauge-state); no sustained backlog. | `ValidationReport`, quarantine ledger |
+| Release with rollback target | 24.11.2 | 100% — every published flow-network / floodplain / drought layer names a valid rollback target. | `ReleaseManifest`, `RollbackCard` |
+| Correction lead time | 24.11.2 | Median lead time tracked; trend not regressing across drought / flood seasons. | `CorrectionNotice` |
+| Derivative-invalidation coverage | 24.11.2 | Corrections to upstream hydrography cascade-invalidate downstream flood-extent / water-budget derivatives. | `CorrectionNotice`, lineage graph |
+| Supersession lineage gap | 24.11.5 | Zero — every superseded hydrography product carries a forward link. | `ReleaseManifest`, supersession entries |
+| ADR completeness | 24.11.5 | Open hydrography ADRs (CRS choice, gauge-canonicalization rule) tracked to a state. | ADR index |
+| Per-root README presence | 24.11.5 | `docs/domains/hydrology/README.md` exists and is current. | Directory-rules linter output |
+
+> [!TIP]
+> Indicators not listed above are not silenced — they still roll up at the system scale via the cross-domain dashboard. They are simply not the **defining** signals for hydrology posture.
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+Candidates surfaced from the hydrology dossier (`docs/domains/hydrology/` §K / §N). Each is a **candidate §24.11 amendment**, not a local redefinition. Escalate via ADR per README §4.
+
+| PROPOSED indicator | Why hydrology-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Gauge-state coverage | Operational gauges per HUC-8 vs declared baseline; flags silent gauge dropouts. | §24.11.1 (source-coverage variant) |
+| Datum / CRS drift | Mixed-datum publication is a hydrology-recurrent defect (NAVD88 vs NGVD29). | §24.11.5 (documentation drift) |
+| Hydrologic-year alignment | Year-on-year comparisons silently using calendar year instead of water year. | §24.11.5 (documentation drift) |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (hydrology dossier owner — resolve against Atlas v1.1 §24.7).
+- **Governance-health steward:** OWNER_TBD (release steward + source steward — see Atlas §24.7 matrix).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team, pending OPEN-DASH-03).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED, pending OPEN-DASH-03) — `UNKNOWN` until mounted-repo evidence confirms.
+- **Telemetry:** `runtime/observability/` (PROPOSED) — `UNKNOWN` until confirmed.
+- **Schemas read:** `schemas/contracts/v1/validation/`, `schemas/contracts/v1/release/`, `schemas/contracts/v1/correction/`.
+- **Policy bundles emitting signals:** `policy/release/`, `policy/correction/`, `policy/sources/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** edition bump in `docs/domains/hydrology/`; Atlas §24.11 amendment; new `KFM-P*-FEAT-*` card naming a hydrology dashboard.
+- **Default cadence:** quarterly review by docs steward + hydrology domain steward + governance-health steward.
+- **Drift watch:** if `apps/` implementation diverges from this spec, log the divergence in `docs/registers/DRIFT_REGISTER.md` rather than silently reconciling.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-HYDRO-01** — Confirm dashboard app path (`apps/review-console/` vs a future `apps/dashboards/`) per OPEN-DASH-03.
+- [ ] **OPEN-DASH-HYDRO-02** — Resolve gauge-state coverage as either a hydrology-local indicator or a candidate §24.11.1 amendment.
+- [ ] **OPEN-DASH-HYDRO-03** — Define the "hydrologic year" alignment check — flag, denial, or steward-note only?
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.1 / §24.11.2 / §24.11.5 | CONFIRMED (manuscript) | §2 indicator subset rows. | Indicators labeled PROPOSED in source; VB-11-08 open. |
+| Atlas v1.0 Ch. 4 (Hydrology dossier) | CONFIRMED (manuscript) | §1 domain scope; §3 candidate hydrology-specific indicators. | Mounted dossier presence NEEDS VERIFICATION. |
+| `docs/dashboards/domain/README.md` §5.1, §6 template | CONFIRMED (this folder) | Skeleton used by this file; indicator emphasis (Evidence-and-source · Release-correction-rollback · Documentation-and-drift). | This folder is the PROPOSED lane (OPEN-DASH-01). |
+| `docs/dashboards/INDICATOR_CATALOG.md` | CONFIRMED (this folder) | §2 indicator names and master healthy postures. | Mirror of Atlas; Atlas wins on conflicts. |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain hydrology dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/hydrology/`.** Atlas v1.1 §24.11 wins on indicator conflicts; the hydrology dossier wins on context conflicts.</sub>

--- a/docs/dashboards/domain/people-dna-land.md
+++ b/docs/dashboards/domain/people-dna-land.md
@@ -1,0 +1,164 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-people-dna-land
+title: People / Genealogy / DNA / Land Ownership Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: people-dna-land-domain steward + sensitivity reviewer + AI-surface steward + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-people-dna-land-dossier                # CONFIRMED dossier home: docs/domains/people-dna-land/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, people, genealogy, dna, land-ownership, t4, ai-surface, sensitivity, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Living-person records and DNA evidence default to T4; AI-surface posture is critical because synthetic genealogical claims are the recurrent risk.
+  - The strictest single domain in KFM — three reviewer roles, two gates, and the lowest tolerance for synthetic-claim incidents.
+  - Atlas §24.11 wins on indicator conflicts; people-dna-land dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# People / Genealogy / DNA / Land Ownership Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-people-dna-land] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **People / Genealogy / DNA / Land Ownership** (Atlas v1.0 Ch. 16). Living-person records, DNA evidence, genealogical reasoning, land-ownership chains. The **strictest** domain in the project: T4 by default, AI-surface posture in the critical band, three reviewer roles.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 16" src="https://img.shields.io/badge/atlas-Ch.%2016-purple">
+  <img alt="Indicator emphasis: 24.11.3 (living-person T4, DNA T4) / 24.11.4" src="https://img.shields.io/badge/emphasis-24.11.3%20%C2%B7%2024.11.4-informational">
+  <img alt="Default tier: T4" src="https://img.shields.io/badge/default--tier-T4-red">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicators PROPOSED; instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+> [!CAUTION]
+> **Living-person T4 + DNA T4.** Records of living people, DNA evidence at any resolution, and identifiable land-ownership chains touching living owners default to T4. Deceased-person records de-escalate per dossier rules; DNA never de-escalates by age alone.
+
+> [!CAUTION]
+> **AI-surface critical band.** Genealogical reasoning is a natural attractor for AI synthesis (relationship inference, surname/locality bridging). Synthetic-claim incidence in this domain must be **zero**; any non-zero count is a defect that pauses publication.
+
+> [!WARNING]
+> **Authoring control.** Per OPEN-DASH-08, this spec **requires** sensitivity reviewer **and** AI-surface steward **and** rights-holder representative on the PR. Authoring without all three is a process defect.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 16 (People / Genealogy / DNA / Land Ownership).
+- **Default sensitivity tier(s):** **T4** for living-person, DNA, and identifiable land-ownership chains touching living owners; **T3** for recently deceased with surviving identifiable kin; **T1–T2** for historical (well past life-of-natural-person thresholds) records.
+- **Pipeline shape:** Standard intake → validation → derive → publish, with **sensitive-lane fail-closed gate** before any public-surface emission, **AI-surface gate** on any genealogical-reasoning emission, and **rollback** required on every release.
+- **Dossier:** `docs/domains/people-dna-land/` — `I.` sensitivity + sovereignty rules (DNA, GDPR-analog, NAGPRA), `K.` validators (relationship-graph, source-strength, locality bridging), `M.` correction + rollback posture for genealogical defects.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Sensitivity-and-rights (living-person T4, DNA T4) · AI-surface-health**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| **Sensitive-lane fail-closed rate** | 24.11.3 | **100% at the first gate** for any T4 emission (living person, DNA, identifiable owner). | `PolicyDecision` DENY counts |
+| RedactionReceipt coverage | 24.11.3 | 100% on every public-safe derivative of T4 records. | `RedactionReceipt` |
+| Review-aged-out incidence | 24.11.3 | Sensitive-lane claims past review cadence dispositioned within tolerance; trend tracked. | `ReviewRecord` |
+| Rights-change response time | 24.11.3 | Median time from rights-change event (death, court order, takedown) to tier reassignment within stated (short) tolerance. | Source descriptors, `ReviewRecord` |
+| Sensitive-content side-channel audit | 24.11.3 | Periodic checks for label / popup / map-marker / AI-text leakage of living-person identifiers. | Audit logs, `RepresentationReceipt` |
+| **AIReceipt presence rate** | 24.11.4 | **100%** on every genealogical-reasoning or land-chain-inference emission. | `AIReceipt` |
+| **ABSTAIN rate by template** | 24.11.4 | Tracked per template (relationship inference, locality bridging, surname disambiguation); no template silently drops abstain. | `AIReceipt`, prompt registry |
+| **DENY reason distribution** | 24.11.4 | Genealogical DENYs surface source-strength / contradiction / privacy reasons; trend tracked. | `PolicyDecision` |
+| **Synthetic-claim incidence** | 24.11.4 | **Zero.** Any non-zero count pauses publication and triggers incident review. | `AIReceipt`, audit logs |
+| Cite-or-abstain compliance | 24.11.1 / 24.11.4 | 100% on every AI-derived genealogical or land-ownership claim. | `AIReceipt` |
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across vital records / census / probate / DNA-source cites; per-source rate visible. | `ValidationReport`, EvidenceBundle index |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why this-domain-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Source-strength distribution | Distribution of cited source-strengths (primary / secondary / tertiary) per genealogical claim; surfaces lineage built on weak chains. | §24.11.1 |
+| Living-person screen-out rate | % of intake records that screen out living-person at admission vs. later in the pipeline. | §24.11.3 |
+| DNA-evidence handling chain completeness | % of DNA-based claims with a resolvable handling-chain back to the source repository's release. | §24.11.1 + §24.11.3 |
+| Genealogical contradiction surfacing | Cases of contradicting evidence that produce DENY/ABSTAIN rather than silent merge. | §24.11.4 |
+| Land-chain identifiable-owner gate compliance | % of land-chain claims that hit the identifiable-owner gate before emission. | §24.11.3 |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (people-dna-land dossier owner).
+- **Governance-health steward:** OWNER_TBD (**sensitivity reviewer** + **AI-surface steward** + **rights-holder representative**; all three required).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/sensitivity/`, `runtime/observability/ai-surface/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/sensitivity/`, `schemas/contracts/v1/redaction/`, `schemas/contracts/v1/review/`, `schemas/contracts/v1/ai-receipt/`, `schemas/contracts/v1/correction/`.
+- **Policy bundles emitting signals:** `policy/sensitivity/living-person/`, `policy/sensitivity/dna/`, `policy/ai-surface/`, `policy/sources/`, `policy/correction/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** rights-change event (death notification, court order, takedown request); DNA-source repository policy change; people-dna-land dossier edition; any synthetic-claim incident.
+- **Default cadence:** quarterly; **immediate** review on any synthetic-claim count, side-channel audit failure, or rights-change response-time miss.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-PDL-01** — Define rights-change response-time tolerance per event class (death vs court order vs takedown).
+- [ ] **OPEN-DASH-PDL-02** — Confirm source-strength taxonomy alignment between this spec and the genealogy dossier `K.` validators.
+- [ ] **OPEN-DASH-PDL-03** — Define the "pause publication" trigger for synthetic-claim incidents (single count? rate?).
+- [ ] **OPEN-DASH-PDL-04** — Confirm three-reviewer authoring gate per OPEN-DASH-08.
+- [ ] **OPEN-DASH-PDL-05** — Reconcile DNA-evidence handling-chain indicator with any cross-domain biometric data policy (if surfaced separately).
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.3 / §24.11.4 / §24.11.1 | CONFIRMED (manuscript) | §2 indicator subset; T4 + AI-surface emphasis. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 16 (People / Genealogy / DNA / Land Ownership dossier) | CONFIRMED (manuscript) | §1 scope, T4-default; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| Atlas v1.1 §24.5 / §24.7 / §24.10 | CONFIRMED authored sibling | T4 default (living person, DNA); reviewer role matrix; threat model. | All PROPOSED. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis (Sensitivity-and-rights, living-person T4, DNA T4 · AI-surface-health); template. | Lane PROPOSED (OPEN-DASH-01). |
+| `docs/dashboards/governance/SENSITIVITY_RIGHTS.md`, `…/AI_SURFACE_HEALTH.md` | CONFIRMED (this folder) | Cross-references for master indicator catalogs; this spec does not redefine them. | Master specs PROPOSED. |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain people / genealogy / DNA / land ownership dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/people-dna-land/`.** Living-person T4 + DNA T4 + AI-surface critical band: the dashboard reports posture, the gate enforces, the receipts back the trust, and synthetic-claim incidence must be zero.</sub>

--- a/docs/dashboards/domain/roads-rail-trade.md
+++ b/docs/dashboards/domain/roads-rail-trade.md
@@ -1,0 +1,147 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-roads-rail-trade
+title: Roads / Rail / Trade Routes Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: roads-rail-trade-domain steward + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-roads-rail-trade-dossier               # CONFIRMED dossier home: docs/domains/roads-rail-trade/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, roads, rail, trade, transit, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Historical trade-route corpora (Santa Fe / Chisholm / Oregon-California Trail) carry edition lineage; modern transit feeds carry SLO emphasis.
+  - Atlas §24.11 wins on indicator conflicts; roads-rail-trade dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Roads / Rail / Trade Routes Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-roads-rail-trade] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Roads / Rail / Trade Routes** (Atlas v1.0 Ch. 13). Modern road & rail networks, transit feeds, historical trade-route corpora.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 13" src="https://img.shields.io/badge/atlas-Ch.%2013-purple">
+  <img alt="Indicator emphasis: 24.11.1 / 24.11.5" src="https://img.shields.io/badge/emphasis-24.11.1%20%C2%B7%2024.11.5-informational">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicators PROPOSED; instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+> [!NOTE]
+> **Real-time transit.** SLO posture for live transit feeds is already surfaced by [`operational/SLO_LIVE_FEEDS.md`](../operational/SLO_LIVE_FEEDS.md) and [`operational/REALTIME_FEED_FRESHNESS.md`](../operational/REALTIME_FEED_FRESHNESS.md). This per-domain spec roll-ups domain coverage; it does not duplicate operational SLOs.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 13 (Roads / Rail / Trade Routes).
+- **Default sensitivity tier(s):** T1 (public road/rail networks, transit schedules, historical trade routes).
+- **Pipeline shape:** Standard intake → validation → derive → publish; live transit feeds emit additional SLO signals (see operational dashboards).
+- **Dossier:** `docs/domains/roads-rail-trade/` — `K.` validators (functional-class taxonomy, GTFS schema, trade-route corpus version), `M.` correction posture for re-routed or re-classified segments.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Evidence-and-source · Documentation-and-drift**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across KDOT / OSM / GTFS / historical-trade-corpus cites. | `ValidationReport`, EvidenceBundle index |
+| Source-role distribution drift | 24.11.1 | KDOT canonical for state highway functional class; OSM auxiliary; historical-trade routes carry corpus-edition pinning. | Source descriptors |
+| Stale source rate | 24.11.1 | KDOT base, GTFS feed cadence, OSM diff cadence all monitored. | Source descriptors, freshness cadence metadata |
+| Quarantine throughput | 24.11.1 | Cause distribution visible (functional-class drift, GTFS validation, geometry); no sustained backlog. | `ValidationReport`, quarantine ledger |
+| ADR completeness | 24.11.5 | Open ADRs (route-segment canonicalization, historical-corpus edition pinning) tracked. | ADR index |
+| Drift register size | 24.11.5 | Route-network derivative drift surfaced; trend tracked. | `docs/registers/DRIFT_REGISTER.md` |
+| Per-root README presence | 24.11.5 | `docs/domains/roads-rail-trade/README.md` exists and is current. | Directory-rules linter output |
+| Atlas / supplement lineage clarity | 24.11.5 | Each historical trade-route corpus supplement carries forward/back links; no orphan supplements. | Supersession entries |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why this-domain-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Functional-class canonicalization coverage | % of road segments mapped to a canonical functional class (FHWA / KDOT / OSM). | §24.11.1 |
+| Historical-corpus edition pinning | % of trade-route derivative claims pinned to a specific corpus edition. | §24.11.5 |
+| Live-transit SLO coverage roll-up | Roll-up of `SLO_LIVE_FEEDS` posture per agency (RideKC, Topeka Metro, KSL services). | §24.11.1 (coverage variant) |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (roads-rail-trade dossier owner).
+- **Governance-health steward:** OWNER_TBD (source steward + docs steward; observability steward for transit SLOs).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/validation/`, `schemas/contracts/v1/source/`, `schemas/contracts/v1/release/`.
+- **Policy bundles emitting signals:** `policy/sources/`, `policy/documentation/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** KDOT major-network update; GTFS feed agency change; trade-route corpus edition bump; roads-rail-trade dossier edition.
+- **Default cadence:** semi-annual.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-RRT-01** — Reconcile live-transit SLO roll-up here vs. authoritative home in `operational/SLO_LIVE_FEEDS.md`.
+- [ ] **OPEN-DASH-RRT-02** — Confirm historical-trade-corpus edition-pinning surface (per-route or per-derivative).
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.1 / §24.11.5 | CONFIRMED (manuscript) | §2 indicator subset. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 13 (Roads / Rail / Trade Routes dossier) | CONFIRMED (manuscript) | §1 scope; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| `docs/dashboards/operational/SLO_LIVE_FEEDS.md`, `…/REALTIME_FEED_FRESHNESS.md` | CONFIRMED (this folder) | Live-transit SLO authority; this spec rolls up rather than duplicates. | Operational specs are PROPOSED. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis; template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain roads / rail / trade routes dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/roads-rail-trade/`.** Live-transit SLOs live in the operational dashboards; this spec only rolls them up.</sub>

--- a/docs/dashboards/domain/settlements-infrastructure.md
+++ b/docs/dashboards/domain/settlements-infrastructure.md
@@ -1,0 +1,153 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-settlements-infrastructure
+title: Settlements / Infrastructure Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: settlements-infrastructure-domain steward + sensitivity reviewer + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-settlements-infrastructure-dossier     # CONFIRMED dossier home: docs/domains/settlements-infrastructure/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, settlements, infrastructure, critical-asset, t4, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of Atlas v1.1 §24.11. Specification only; not an implementation.
+  - Critical-asset infrastructure (water, power, wastewater, hospitals, emergency services) defaults to T4.
+  - Atlas §24.11 wins on indicator conflicts; settlements-infrastructure dossier wins on context conflicts.
+[/KFM_META_BLOCK_V2] -->
+
+# Settlements / Infrastructure Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-settlements-infrastructure] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Settlements / Infrastructure** (Atlas v1.0 Ch. 14). Cities, towns, places, plus the **critical-asset** infrastructure that supports them (water, power, wastewater, hospitals, emergency services).
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 14" src="https://img.shields.io/badge/atlas-Ch.%2014-purple">
+  <img alt="Indicator emphasis: 24.11.3 (critical-asset T4) / 24.11.2" src="https://img.shields.io/badge/emphasis-24.11.3%20%C2%B7%2024.11.2-informational">
+  <img alt="Critical-asset tier: T4" src="https://img.shields.io/badge/critical--asset-T4-red">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicators PROPOSED; instances PROPOSED; lane PROPOSED (OPEN-DASH-01); implementation NEEDS VERIFICATION.
+
+> [!CAUTION]
+> **Critical-asset T4.** Settlements themselves are public (T1); **critical-asset infrastructure** (water treatment, power substations, wastewater, hospital MEP, EOC siting) defaults to T4 under a threat-model assumption that fine-grained location aids targeting. The dashboard reports the fail-closed gate; the gate enforces.
+
+> [!WARNING]
+> **Authoring control.** Per OPEN-DASH-08, sensitive-domain specs should require a sensitivity reviewer on the PR. Treat this spec accordingly.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 14 (Settlements / Infrastructure).
+- **Default sensitivity tier(s):** **T1** for settlements (places, populations, boundaries); **T4** for critical-asset infrastructure components.
+- **Pipeline shape:** Standard intake → validation → derive → publish, with **sensitive-lane fail-closed gate** before any critical-asset emission and **rollback** required on every release.
+- **Dossier:** `docs/domains/settlements-infrastructure/` — `I.` sensitivity rules (critical-asset taxonomy), `K.` validators, `M.` rollback & correction posture.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Sensitivity-and-rights (critical-asset T4) · Release-correction-rollback**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| **Sensitive-lane fail-closed rate** | 24.11.3 | **100% at the first gate** for any critical-asset infrastructure emission. | `PolicyDecision` DENY counts |
+| RedactionReceipt coverage | 24.11.3 | 100% on public-safe derivatives of critical-asset data. | `RedactionReceipt` |
+| Review-aged-out incidence | 24.11.3 | Critical-asset claims past review cadence dispositioned within tolerance. | `ReviewRecord` |
+| Sensitive-content side-channel audit | 24.11.3 | Periodic audit for vertex-density / labeling / popup leakage at critical-asset locations. | Audit logs, `RepresentationReceipt` |
+| Release with rollback target | 24.11.2 | 100% — every published settlement / infrastructure layer names a valid rollback target. | `ReleaseManifest`, `RollbackCard` |
+| Correction lead time | 24.11.2 | Median tracked; faster cadence for critical-asset corrections (within stated tolerance). | `CorrectionNotice` |
+| Derivative-invalidation coverage | 24.11.2 | Approaches 100% — corrections cascade-invalidate downstream service-area / accessibility derivatives. | `CorrectionNotice`, lineage graph |
+| Rollback rehearsal rate | 24.11.2 | Non-zero per release window; rehearsals exercise critical-asset redaction path. | `RollbackCard` |
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across Census / KDHE / KCC / utility-commission / hospital-licensing cites. | `ValidationReport`, EvidenceBundle index |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why this-domain-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Critical-asset taxonomy completeness | % of asset records mapped to a canonical critical-asset class. | §24.11.5 |
+| Vertex-density side-channel exposure (critical-asset) | Polygon vertex density at critical-asset boundaries that could re-identify exact siting. | §24.11.3 |
+| Service-area derivative correction cascade | Time from critical-asset correction to all service-area / accessibility derivatives invalidated. | §24.11.2 |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (settlements-infrastructure dossier owner).
+- **Governance-health steward:** OWNER_TBD (**sensitivity reviewer** + release steward; mandatory pair).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/sensitivity/`, `runtime/observability/release/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/sensitivity/`, `schemas/contracts/v1/redaction/`, `schemas/contracts/v1/release/`, `schemas/contracts/v1/correction/`.
+- **Policy bundles emitting signals:** `policy/sensitivity/critical-asset/`, `policy/release/`, `policy/correction/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** critical-asset taxonomy bump; utility / hospital licensing schema change; settlements-infrastructure dossier edition.
+- **Default cadence:** quarterly; **immediate** review on side-channel audit failure or critical-asset correction emission.
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-SI-01** — Confirm critical-asset taxonomy completeness threshold (per asset class).
+- [ ] **OPEN-DASH-SI-02** — Define service-area cascade target latency (minutes vs hours).
+- [ ] **OPEN-DASH-SI-03** — Confirm sensitivity-reviewer-on-PR gate per OPEN-DASH-08.
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.3 / §24.11.2 | CONFIRMED (manuscript) | §2 indicator subset. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 14 (Settlements / Infrastructure dossier) | CONFIRMED (manuscript) | §1 scope, critical-asset T4 default; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| Atlas v1.1 §24.5 / §24.10 | CONFIRMED authored sibling | Critical-asset T4 justification; threat model. | Tier table + risk severities PROPOSED. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | Emphasis (Sensitivity-and-rights, critical-asset T4 · Release-correction-rollback); template. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain settlements / infrastructure dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/settlements-infrastructure/`.** Critical-asset T4 default: the dashboard reports posture, the gate enforces redaction, the receipts back the trust.</sub>

--- a/docs/dashboards/domain/soil.md
+++ b/docs/dashboards/domain/soil.md
@@ -1,0 +1,146 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/dashboards-domain-soil
+title: Soil Dashboard Specification (PROPOSED lane; per-domain instance of Atlas §24.11)
+type: standard
+version: v0.1
+status: draft
+owners: OWNER_TBD  # NEEDS VERIFICATION: soil-domain steward + governance-health steward
+created: 2026-05-26
+updated: 2026-05-26
+policy_label: public
+related:
+  - kfm://doc/dashboards-domain-readme
+  - kfm://doc/atlas-v1-1
+  - kfm://doc/atlas-v1-1-ch24-5-sensitivity-tier-reference
+  - kfm://doc/atlas-v1-1-ch24-6-pipeline-gate-reference
+  - kfm://doc/domains-soil-dossier                           # CONFIRMED dossier home: docs/domains/soil/
+  - kfm://adr/dashboards-lane-existence                      # PROPOSED candidate: OPEN-DASH-01
+tags: [kfm, dashboards, domain, soil, indicators, governance-health, specification]
+notes:
+  - Per-domain instance of the master indicator catalog (Atlas v1.1 §24.11). Specification only; not an implementation.
+  - Atlas §24.11 wins on indicator-definition conflicts; the soil dossier wins on context conflicts.
+  - Mounted-repo implementation status is NEEDS VERIFICATION.
+[/KFM_META_BLOCK_V2] -->
+
+# Soil Dashboard Specification
+
+<!-- [doc: kfm://doc/dashboards-domain-soil] -->
+<a id="top"></a>
+
+> Per-domain dashboard specification for **Soil** (Atlas v1.0 Ch. 5). Instances the Atlas §24.11 governance health indicators at the soil scale; does **not** redefine them.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-blue">
+  <img alt="Lane: PROPOSED" src="https://img.shields.io/badge/lane-PROPOSED-orange">
+  <img alt="Atlas chapter: Ch. 5" src="https://img.shields.io/badge/atlas-Ch.%205-purple">
+  <img alt="Indicator emphasis: 24.11.1 / 24.11.5" src="https://img.shields.io/badge/emphasis-24.11.1%20%C2%B7%2024.11.5-informational">
+  <img alt="Policy label: public" src="https://img.shields.io/badge/policy--label-public-lightgrey">
+</p>
+
+> [!IMPORTANT]
+> **Truth posture.** Indicator catalog from Atlas §24.11 is PROPOSED. Per-domain instances in this file are PROPOSED. The lane is PROPOSED per OPEN-DASH-01. Implementation status is NEEDS VERIFICATION.
+
+> [!NOTE]
+> **Anti-collapse rule.** A soil dashboard reports posture; soil **decisions** rest on SSURGO/STATSGO receipts, KGS profile records, and the validators this spec points to.
+
+---
+
+## 1. Domain scope
+
+- **Atlas chapter:** v1.0 Ch. 5 (Soil).
+- **Default sensitivity tier(s):** T1 (public soil survey products); T2 where parcel-level resolution invites re-identification.
+- **Pipeline shape:** Standard intake → validation → derive → publish; long-stable upstream sources (SSURGO) emphasize **documentation-and-drift** posture over release cadence.
+- **Dossier:** `docs/domains/soil/` — `K.` validators (texture / classification / map-unit), `M.` correction posture for survey re-issues, `N.` verification backlog.
+
+[↑ back to top](#top)
+
+---
+
+## 2. Indicator subset
+
+Emphasis per README §5.1: **Evidence-and-source · Documentation-and-drift**.
+
+| Indicator | §24.11 cat. | Domain-scale healthy posture | Receipt / signal source |
+|:---|:---|:---|:---|
+| EvidenceRef resolution rate | 24.11.1 | > 99.9% across SSURGO/STATSGO/KGS profile cites; per-source rate visible. | `ValidationReport`, EvidenceBundle index |
+| Source-role distribution drift | 24.11.1 | SSURGO remains the canonical map-unit role; auxiliary roles (KGS, USDA-NRCS interpretations) tracked separately. | Source descriptors |
+| Stale source rate | 24.11.1 | Survey-area refresh aligns with NRCS publication cadence; lag is dispositioned, not silent. | Source descriptors, freshness cadence metadata |
+| Quarantine throughput | 24.11.1 | Quarantine causes visible (map-unit-key mismatch, attribute-domain violation); no sustained backlog. | `ValidationReport`, quarantine ledger |
+| ADR completeness | 24.11.5 | Open soil ADRs (taxonomy version, map-unit canonicalization) tracked to a state. | ADR index |
+| Drift register size | 24.11.5 | Hydric-soil and prime-farmland derivative drift surfaced; trend not regressing. | `docs/registers/DRIFT_REGISTER.md` |
+| Per-root README presence | 24.11.5 | `docs/domains/soil/README.md` exists and is current. | Directory-rules linter output |
+| Atlas / supplement lineage clarity | 24.11.5 | Each soil-supplement carries forward/back links; no orphan supplements. | Supersession entries |
+
+[↑ back to top](#top)
+
+---
+
+## 3. Domain-specific indicators (PROPOSED)
+
+| PROPOSED indicator | Why soil-specific | Candidate §24.11 home |
+|:---|:---|:---|
+| Map-unit-key stability | SSURGO MUKEY changes across survey areas / years are a recurrent silent-drift source. | §24.11.5 |
+| Soil-taxonomy edition skew | Mixing Keys-to-Soil-Taxonomy editions across map sheets is a documentation drift. | §24.11.5 |
+| Hydric-soil derivative coverage | Coverage of hydric-soil derivative against the publication baseline. | §24.11.1 (coverage variant) |
+
+[↑ back to top](#top)
+
+---
+
+## 4. Ownership
+
+- **Domain steward:** OWNER_TBD (soil dossier owner).
+- **Governance-health steward:** OWNER_TBD (source steward + docs steward per Atlas §24.7).
+- **Implementation owner:** OWNER_TBD (`apps/review-console/` team).
+
+[↑ back to top](#top)
+
+---
+
+## 5. Implementation pointer
+
+- **Dashboard app:** `apps/review-console/` (PROPOSED) — `UNKNOWN` until verified.
+- **Telemetry:** `runtime/observability/` (PROPOSED) — `UNKNOWN`.
+- **Schemas read:** `schemas/contracts/v1/validation/`, `schemas/contracts/v1/source/`.
+- **Policy bundles emitting signals:** `policy/sources/`, `policy/documentation/`.
+
+[↑ back to top](#top)
+
+---
+
+## 6. Review cadence
+
+- **Trigger events:** SSURGO/STATSGO publication-window bump; soil dossier edition; Atlas §24.11 amendment.
+- **Default cadence:** semi-annual review (soil sources change slowly).
+
+[↑ back to top](#top)
+
+---
+
+## 7. Open questions
+
+- [ ] **OPEN-DASH-SOIL-01** — Confirm MUKEY-stability indicator scope (across survey years vs. across upstream re-issues).
+- [ ] **OPEN-DASH-SOIL-02** — Decide whether the hydric-soil coverage indicator belongs here or in habitat (cross-domain dependency).
+
+[↑ back to top](#top)
+
+---
+
+## 8. Evidence basis & citations
+
+<details>
+<summary><strong>Source ledger</strong></summary>
+
+| Source | Status | Supports | Limits |
+|:---|:---|:---|:---|
+| Atlas v1.1 §24.11.1 / §24.11.5 | CONFIRMED (manuscript) | §2 indicator subset. | Indicators PROPOSED at source. |
+| Atlas v1.0 Ch. 5 (Soil dossier) | CONFIRMED (manuscript) | §1 scope; §3 candidates. | Mounted dossier presence NEEDS VERIFICATION. |
+| `docs/dashboards/domain/README.md` §5.1, §6 | CONFIRMED | §2 emphasis; this file's skeleton. | Lane PROPOSED (OPEN-DASH-01). |
+
+</details>
+
+[↑ back to top](#top)
+
+---
+
+<sub>Per-domain soil dashboard specification. **Specification only — implementations live in `apps/`; indicator definitions live in Atlas §24.11; domain context lives in `docs/domains/soil/`.**</sub>


### PR DESCRIPTION
## Goal

Complete the per-domain dashboard specification suite by adding 13 domain-scoped governance-health indicator specifications, one for each Atlas v1.0 chapter (Ch. 4–16). These specifications instance the master indicator catalog (Atlas §24.11) at domain scale and establish healthy-posture targets, sensitivity rules, and pipeline gates for each domain.

## Status labels

- [x] `PROPOSED` — specifications authored per Atlas §24.11 doctrine; implementation status NEEDS VERIFICATION across all domains.
- [x] `NEEDS VERIFICATION` — indicator instances and healthy-posture values are checkable but not yet validated against mounted-repo implementations.

## Evidence inspected

- `docs/dashboards/domain/README.md` (modified) — updated domain count badge from 0/13 to 13/13.
- `docs/dashboards/DASHBOARD_CATALOG.md` (modified) — updated spec count badge.
- 13 new domain specification files:
  - `docs/dashboards/domain/hydrology.md` (Ch. 4)
  - `docs/dashboards/domain/soil.md` (Ch. 5)
  - `docs/dashboards/domain/habitat.md` (Ch. 6)
  - `docs/dashboards/domain/fauna.md` (Ch. 7)
  - `docs/dashboards/domain/flora.md` (Ch. 8)
  - `docs/dashboards/domain/agriculture.md` (Ch. 9)
  - `docs/dashboards/domain/geology.md` (Ch. 10)
  - `docs/dashboards/domain/atmosphere.md` (Ch. 11)
  - `docs/dashboards/domain/hazards.md` (Ch. 12)
  - `docs/dashboards/domain/roads-rail-trade.md` (Ch. 13)
  - `docs/dashboards/domain/settlements-infrastructure.md` (Ch. 14)
  - `docs/dashboards/domain/archaeology.md` (Ch. 15)
  - `docs/dashboards/domain/people-dna-land.md` (Ch. 16)

## Directory Rules basis

§11: All new files are placed under `docs/dashboards/domain/`, which is the canonical home for per-domain dashboard specifications per the README and DASHBOARD_CATALOG structure. No paths are moved or renamed.

## Affected roots

- [x] `docs/`

## Affected object families

- [x] `SourceDescriptor` (referenced in indicator tables)
- [x] `EvidenceRef` / `EvidenceBundle` (evidence-and-source indicators)
- [x] `PolicyDecision` (sensitivity-and-rights indicators)
- [x] `ValidationReport` (validation posture)
- [x] `AIReceipt` (AI-surface indicators in atmosphere, people-dna-land)
- [x] `RedactionReceipt` (sensitivity-gated domains: fauna, flora, archaeology, settlements-infrastructure)

## Affected lifecycle stages

- [x] PROCESSED (validation, derive)
- [x] PUBLISHED (release, rollback)

## What changed

**Added 13 per-domain dashboard specifications:**

Each specification follows a consistent structure:
1. **KFM_META_BLOCK_V2** header with doc_id, status (draft), version (v0.1), owners (OWNER_TBD / NEEDS VERIFICATION), and related references.
2. **Domain scope** section naming the Atlas chapter, default sensitivity tier(s), pipeline shape, and dossier home.
3. **Indicator subset** table mapping §24.11 indicator categories to domain-scale healthy-posture targets and receipt sources.
4. **Domain-specific emphasis** per README §5.1 (Evidence-and-source, Sensitivity-and-rights, Release-correction-rollback, AI-surface-health, Documentation-and-drift).

**Domain-specific highlights:**

- **Hydrology, Soil, Habitat, Geology, Roads-Rail-Trade, Agriculture:** Evidence-and-source emphasis; T1–T2 baseline; standard pipeline gates.
-

https://claude.ai/code/session_014wWcBjX2T6eygEUXZKUaAu