### PR TITLE
docs: update explorer map runtime readme

### DIFF
--- a/apps/explorer-web/src/features/map_runtime/README.md
+++ b/apps/explorer-web/src/features/map_runtime/README.md
@@ -2,11 +2,11 @@
 doc_id: kfm://app/explorer-web/src/features/map_runtime/readme
 title: Explorer Web Map Runtime Feature README
 type: app-readme
-version: v0.1
+version: v0.2
 status: draft
-owners: OWNER_TBD — Apps steward · UI steward · Map steward · MapLibre runtime steward · Governed API steward · Policy steward · Release steward · Docs steward
+owners: OWNER_TBD — Apps steward · UI steward · Map steward · MapLibre runtime steward · Governed API steward · Policy steward · Release steward · Accessibility steward · Docs steward
 created: 2026-06-16
-updated: 2026-06-16
+updated: 2026-07-09
 policy_label: public
 related:
   - ../README.md
@@ -15,6 +15,7 @@ related:
   - ../../../README.md
   - ../../../../README.md
   - ../../../../governed-api/README.md
+  - ../../../../../docs/doctrine/directory-rules.md
   - ../../../../../docs/architecture/ui/README.md
   - ../../../../../docs/architecture/ui/MAP_RUNTIME_BOUNDARY.md
   - ../../../../../docs/architecture/ui/LAYERING.md
@@ -27,11 +28,13 @@ related:
   - ../../../../../policy/decision/README.md
   - ../../../../../release/README.md
   - ../../../../../data/README.md
-tags: [kfm, apps, explorer-web, features, map-runtime, mapruntimeport, maplibreadapter, maplibre, renderer-boundary, trust-membrane]
+tags: [kfm, apps, explorer-web, features, map-runtime, mapruntimeport, maplibreadapter, maplibre, renderer-boundary, trust-membrane, click-resolution]
 notes:
   - "Replaces the greenfield Map Runtime feature stub with a governed feature README."
   - "Map Runtime UI features may compose the browser-side map port and adapter boundary, but they must not become evidence resolver, policy engine, source registry, publication authority, citation authority, AI authority, lifecycle storage, or raw/canonical data path."
   - "Feature implementation files, route wiring, tests, fixtures, MapRuntimePort contracts, MapLibreAdapter import allowlist, governed API envelopes, accessibility behavior, telemetry, and package scripts remain NEEDS VERIFICATION."
+  - "packages/maplibre/README.md exists as a bounded helper-package README; packages/maplibre-runtime/README.md was not found on main during this revision, so runtime-package specifics remain NEEDS VERIFICATION."
+  - "v0.2 refreshes the evidence basis, aligns truth posture with current GitHub evidence, adds a minimum safe implementation slice, adds runtime anti-bypass checks, and strengthens renderer-boundary, click-candidate, style-redaction, accessibility, and telemetry review gates without claiming runtime maturity."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
@@ -42,7 +45,7 @@ notes:
 
 `apps/explorer-web/src/features/map_runtime/`
 
-**App-local Explorer Web feature boundary for the map runtime seam: `MapRuntimePort`, renderer-adapter handoff, validated layer loading, camera/time synchronization, click-candidate forwarding, negative map states, accessibility-safe map controls, and trust-preserving interaction events.**
+**App-local Explorer Web feature boundary for the map runtime seam: `MapRuntimePort`, renderer-adapter handoff, validated layer loading, camera/time synchronization, click-candidate forwarding, negative map states, accessibility-safe map controls, telemetry safeguards, and trust-preserving interaction events.**
 
 ![status](https://img.shields.io/badge/status-draft-blue)
 ![owner](https://img.shields.io/badge/owner-OWNER__TBD-lightgrey)
@@ -50,7 +53,7 @@ notes:
 ![renderer](https://img.shields.io/badge/renderer-downstream__of__trust-df7e00)
 ![truth](https://img.shields.io/badge/truth-NEEDS__VERIFICATION-yellow)
 
-[Purpose](#1-purpose) · [Repo fit](#2-repo-fit) · [Boundary](#3-authority-boundary) · [Inputs](#5-inputs) · [Exclusions](#6-exclusions) · [Feature map](#7-map-runtime-feature-map) · [Definition of done](#14-definition-of-done)
+[Evidence](#0-evidence-basis-for-this-revision) · [Purpose](#1-purpose) · [Repo fit](#2-repo-fit) · [Boundary](#3-authority-boundary) · [Inputs](#5-inputs) · [Exclusions](#6-exclusions) · [Feature map](#7-map-runtime-feature-map) · [Minimum slice](#8-minimum-safe-implementation-slice) · [Definition of done](#16-definition-of-done)
 
 </div>
 
@@ -58,10 +61,11 @@ notes:
 
 > [!IMPORTANT]
 > **Status:** draft / `NEEDS VERIFICATION`  
-> **Owners:** `OWNER_TBD` — Apps steward · UI steward · Map steward · MapLibre runtime steward · Governed API steward · Policy steward · Release steward · Docs steward  
+> **Owners:** `OWNER_TBD` — Apps steward · UI steward · Map steward · MapLibre runtime steward · Governed API steward · Policy steward · Release steward · Accessibility steward · Docs steward  
 > **Path:** `apps/explorer-web/src/features/map_runtime/README.md`  
 > **Responsibility root:** `apps/` — deployable application surfaces  
-> **Truth posture:** CONFIRMED README path / CONFIRMED Map Runtime Boundary doctrine / PROPOSED feature contract / UNKNOWN implementation files, route wiring, tests, fixtures, contracts, and runtime behavior
+> **Directory Rules basis:** deployable application feature code belongs under `apps/`; Map Runtime is an app-local UI composition and renderer-port surface, not a renderer package, evidence resolver, policy home, schema home, contract home, publication authority, source registry, AI runtime, tile host, or lifecycle-data lane.  
+> **Truth posture:** CONFIRMED current GitHub README path / CONFIRMED parent feature-boundary README posture / CONFIRMED Map Runtime Boundary doc exists / CONFIRMED Layering architecture doc exists / CONFIRMED `packages/maplibre/README.md` exists as bounded helper-package README / CONFIRMED `packages/maplibre-runtime/README.md` not found on `main` in this revision / PROPOSED feature contract / UNKNOWN implementation files, route wiring, tests, fixtures, port contracts, adapter allowlist, package scripts, governed API envelopes, accessibility behavior, telemetry, and runtime behavior
 
 > [!CAUTION]
 > The map runtime is downstream of trust. Feature code must speak through a stable map-runtime seam and must not read RAW, WORK, QUARANTINE, canonical stores, graph/vector stores, object stores, model runtimes, unpublished candidates, credentials, or internal service handles. Map features and tiles can launch governed resolution; they are not proof.
@@ -70,6 +74,7 @@ notes:
 
 ## Quick jump
 
+- [0. Evidence basis for this revision](#0-evidence-basis-for-this-revision)
 - [1. Purpose](#1-purpose)
 - [2. Repo fit](#2-repo-fit)
 - [3. Authority boundary](#3-authority-boundary)
@@ -77,14 +82,34 @@ notes:
 - [5. Inputs](#5-inputs)
 - [6. Exclusions](#6-exclusions)
 - [7. Map Runtime feature map](#7-map-runtime-feature-map)
-- [8. Diagram](#8-diagram)
-- [9. Map Runtime UI obligations](#9-map-runtime-ui-obligations)
-- [10. Per-module contract](#10-per-module-contract)
-- [11. Inspection path](#11-inspection-path)
-- [12. Validation expectations](#12-validation-expectations)
-- [13. Safe change pattern](#13-safe-change-pattern)
-- [14. Definition of done](#14-definition-of-done)
-- [15. Open verification items](#15-open-verification-items)
+- [8. Minimum safe implementation slice](#8-minimum-safe-implementation-slice)
+- [9. Diagram](#9-diagram)
+- [10. Map Runtime UI obligations](#10-map-runtime-ui-obligations)
+- [11. Per-module contract](#11-per-module-contract)
+- [12. Runtime anti-bypass matrix](#12-runtime-anti-bypass-matrix)
+- [13. Inspection path](#13-inspection-path)
+- [14. Validation expectations](#14-validation-expectations)
+- [15. Safe change pattern](#15-safe-change-pattern)
+- [16. Definition of done](#16-definition-of-done)
+- [17. Open verification items](#17-open-verification-items)
+
+---
+
+## 0. Evidence basis for this revision
+
+This README is a documentation boundary, not runtime proof. The 2026-07-09 revision updates an existing README and keeps implementation maturity bounded while aligning the feature contract with current repository evidence.
+
+| Evidence item | Status | What it supports | What it does not prove |
+|---|---|---|---|
+| `apps/explorer-web/src/features/map_runtime/README.md` exists on `main`. | CONFIRMED | This is an existing README update, not a new path proposal. | It does not prove map runtime components, hooks, routes, tests, fixtures, port contracts, adapter allowlists, or runtime behavior exist. |
+| `apps/explorer-web/src/features/README.md` exists and defines feature modules as UI composition surfaces. | CONFIRMED | Map Runtime belongs under the Explorer Web feature boundary when it is app-local UI composition. | It does not prove Map Runtime is wired into routes or launch surfaces. |
+| `docs/doctrine/directory-rules.md` confirms `apps/` as the deployable-application responsibility root. | CONFIRMED | The target path is within the correct responsibility root for app-local feature code. | It does not decide whether the feature is complete or release-ready. |
+| `docs/architecture/ui/MAP_RUNTIME_BOUNDARY.md` exists and defines `MapRuntimePort` / `MapLibreAdapter` doctrine. | CONFIRMED document presence and doctrine posture | Map Runtime must keep renderer APIs isolated behind the accepted adapter and treat clicks as claim-resolution candidates. | It does not prove implementation, import allowlists, or tests. |
+| `docs/architecture/ui/LAYERING.md` exists and describes layers as derived surfaces downstream of trust. | CONFIRMED document presence and doctrine posture | Map Runtime layer loading must stay downstream of release, policy, evidence, manifest, and sensitive-geometry gates. | It does not prove implementation, schema wiring, or tests. |
+| `packages/maplibre/README.md` exists as a bounded helper-package README. | CONFIRMED README presence | Shared MapLibre helper code is distinct from app-local Map Runtime feature code. | It does not prove package source files, import namespace, tests, or runtime bindings. |
+| `packages/maplibre-runtime/README.md` was not found on `main` during this revision. | CONFIRMED absence from GitHub fetch attempt | Runtime-package references remain `NEEDS VERIFICATION`. | It does not prove no runtime package will exist, or that another accepted runtime package home is absent. |
+
+[Back to top](#top)
 
 ---
 
@@ -92,18 +117,18 @@ notes:
 
 `apps/explorer-web/src/features/map_runtime/` is the proposed app-local feature boundary for Explorer Web map runtime source modules.
 
-It may eventually hold adapter-facing view models, hooks, state bridges, finite-state renderers, runtime event handlers, import allowlist helpers, and feature orchestration for:
+It may eventually hold adapter-facing view models, hooks, state bridges, finite-state renderers, runtime event handlers, import allowlist helpers, accessibility controls, telemetry guards, and feature orchestration for:
 
 - the `MapRuntimePort` seam used by other feature surfaces;
 - validated layer loading and removal;
 - camera, bounds, zoom, pitch, bearing, and time-context synchronization;
 - renderer event conversion into governed click-candidate events;
 - forwarding feature selections to governed claim resolution without treating feature properties as claims;
-- stale, denied, abstained, conflict, invalid-payload, degraded, withdrawn, and error states;
-- map accessibility affordances, keyboard alternatives, non-map lists, and reduced-motion behavior;
+- stale, denied, abstained, conflict, invalid-payload, degraded, withdrawn, rolled-back, and error states;
+- map accessibility affordances, keyboard alternatives, non-map lists, focus management, and reduced-motion behavior;
 - safe handoffs to Layer Catalog, Evidence Drawer, Focus Panel, Compare, Export, Story, Settings, and Diagnostics.
 
-This directory is not proof that any map runtime component, port, adapter, route, hook, schema, fixture, test, package script, governed API route, import allowlist, or accessibility behavior is implemented.
+This directory is not proof that any map runtime component, port, adapter, route, hook, schema, fixture, test, package script, governed API route, import allowlist, telemetry behavior, accessibility behavior, renderer integration, or downstream handoff is implemented.
 
 [Back to top](#top)
 
@@ -120,47 +145,53 @@ This directory is not proof that any map runtime component, port, adapter, route
 | Governed API | `apps/governed-api/` | Trust membrane and normal claim-resolution/layer-manifest path |
 | Map Runtime doctrine | `docs/architecture/ui/MAP_RUNTIME_BOUNDARY.md` | MapRuntimePort / MapLibreAdapter doctrine and forbidden paths |
 | Layering doctrine | `docs/architecture/ui/LAYERING.md` | Layer descriptor, manifest, lifecycle, and trust-badge posture |
+| Evidence Drawer architecture | `docs/architecture/ui/EVIDENCE_DRAWER.md` | Proof inspection and clicked-feature support posture |
 | Shared UI components | `packages/ui/` | Reusable map controls, banners, badges, state cards, and accessibility primitives when shared |
-| Renderer wrappers | `packages/maplibre/`, `packages/maplibre-runtime/` | Renderer implementation and adapter package, if present and accepted |
+| Renderer helper package | `packages/maplibre/` | Bounded MapLibre helper code, if implementation is verified |
+| Renderer runtime package | `packages/maplibre-runtime/` | Referenced by earlier docs, but README not found on `main` in this revision; `NEEDS VERIFICATION` |
 | Layer policy | `policy/layers/` | Layer admissibility policy; current repo evidence may still be stub-level |
 | Policy gates | `policy/` | Access, sensitivity, rights, release, and decision policy |
 | Release authority | `release/` | Publication, correction, supersession, rollback control |
 | Lifecycle artifacts | `data/` | Receipts, proofs, registry, catalog, triplets, published artifacts |
+| Contracts and schemas | `contracts/`, `schemas/contracts/v1/` | Object meaning and machine shape; this feature references, not owns |
 
 ## 3. Authority boundary
 
 This feature composes the browser-side map runtime seam. It does not own MapLibre doctrine, canonical evidence, source registry records, layer publication, policy decisions, sensitivity transforms, release decisions, citation validation, schemas, contracts, lifecycle artifacts, tile hosting authority, model invocation, graph/vector indexes, telemetry truth, or AI output.
 
 ```text
-apps/explorer-web/src/features/map_runtime/ = app-local map runtime feature
-apps/explorer-web/src/features/             = feature boundary
-apps/explorer-web/src/adapters/             = adapter boundary
-apps/governed-api/                          = trust membrane and claim/layer path
+apps/explorer-web/src/features/map_runtime/  = app-local map runtime feature
+apps/explorer-web/src/features/              = feature boundary
+apps/explorer-web/src/adapters/              = adapter boundary
+apps/governed-api/                           = trust membrane and claim/layer path
 docs/architecture/ui/MAP_RUNTIME_BOUNDARY.md = map runtime doctrine
-docs/architecture/ui/LAYERING.md            = layer semantics and lifecycle doctrine
-packages/maplibre*/                         = renderer implementation/wrapper boundary, if verified
-packages/ui/                                = shared UI primitives
-policy/                                     = finite policy decisions
-data/                                       = lifecycle artifacts, receipts, proofs, registries
-release/                                    = publication, correction, rollback authority
+docs/architecture/ui/LAYERING.md             = layer semantics and lifecycle doctrine
+packages/maplibre/                           = renderer helper package, if implementation is verified
+packages/maplibre-runtime/                   = referenced runtime package, not found on main in this revision
+packages/ui/                                 = shared UI primitives
+policy/                                      = finite policy decisions
+schemas/contracts/v1/                        = machine-readable shape
+contracts/                                   = object meaning
+data/                                        = lifecycle artifacts, receipts, proofs, registries
+release/                                     = publication, correction, rollback authority
 ```
 
 ## 4. Default posture
 
 Map Runtime feature modules should fail closed, preserve the renderer boundary, and treat all map interactions as requests for governed resolution rather than proof.
 
-A map runtime path should not load or claim from a layer when any of these are unresolved:
+A map runtime path should not load, display as authoritative, or claim from a layer when any of these are unresolved:
 
 - governed API envelope and response validation;
 - `LayerDescriptor`, `LayerManifest`, `KFMGeoManifest`, or `LegendDescriptor` validation;
 - release state, release manifest, artifact digest, signature, and rollback target;
 - source role, source authority, source rights, license, and policy labels;
 - EvidenceRef resolvability and EvidenceBundle support;
-- sensitive-geometry transform, redaction, aggregation, generalization, delay, or denial state;
+- sensitive-geometry transform, redaction, aggregation, generalization, delay, suppression, or denial state;
 - review, freshness, correction, stale, degraded, withdrawn, or rollback posture;
 - MapRuntimePort contract and adapter import allowlist;
-- renderer plugin admission, 3D admission, style manifest, tile/raster asset, or protocol integrity;
-- accessibility state for keyboard controls, screen readers, non-map alternatives, and reduced motion;
+- renderer plugin admission, 3D admission, style manifest, tile/raster asset, protocol integrity, or asset URL safety;
+- accessibility state for keyboard controls, screen readers, non-map alternatives, focus behavior, and reduced motion;
 - safe telemetry posture.
 
 ## 5. Inputs
@@ -170,12 +201,13 @@ A map runtime path should not load or claim from a layer when any of these are u
 | Port inputs | camera, bounds, zoom, pitch, bearing, layer id, visible flag, screen point, time context | Runtime-validated and bounded |
 | Layer inputs | `LayerDescriptor`, `LayerManifest`, `KFMGeoManifest`, style/legend refs | Released or bounded-safe only |
 | Time inputs | valid time, observed time, source time, retrieval time, release time, correction time, freshness window | Distinct where material |
-| Click candidate | feature id, layer id, geometry, screen point, time context | Candidate only; not claim proof |
+| Click candidate | feature id, layer id, geometry, screen point, time context, query result id | Candidate only; not claim proof |
 | API envelope | claim-resolution response, `DecisionEnvelope`, `EvidenceDrawerPayload`, finite outcome | Governed API projection only |
 | Trust state | rights, sensitivity, review, release, correction, stale, degraded, denied, abstain, error | Visible and finite |
 | Renderer state | source/layer lifecycle, asset load state, style load state, plugin admission, protocol status | Adapter-owned, surfaced safely |
-| UI state | loading, ready, denied, abstained, stale, conflict, invalid, error, destroyed | Finite and tested states |
+| UI state | loading, ready, denied, abstained, stale, conflict, invalid, withdrawn, rolled-back, error, destroyed | Finite and tested states |
 | Accessibility state | keyboard map controls, focus behavior, control labels, alternative feature list, reduced motion | Required for public map UI |
+| Telemetry state | map initialized, layer loaded, click forwarded, denied state shown, adapter error | Non-secret, policy-safe, no raw evidence/restricted geometry/prompts |
 
 ## 6. Exclusions
 
@@ -190,14 +222,14 @@ A map runtime path should not load or claim from a layer when any of these are u
 | Shared reusable UI primitives | `packages/ui/` |
 | Source descriptors, catalogs, registries, and source acquisition | `data/registry/`, `data/catalog/`, `connectors/` |
 | Lifecycle artifacts, receipts, proofs, published layer artifacts | `data/` |
-| Sensitive-geometry hiding by style filters | Forbidden; use policy-backed transform/generalize/delay/redact/deny before public tile generation |
+| Sensitive-geometry hiding by style filters | Forbidden; use policy-backed transform/generalize/delay/redact/suppress/deny before public tile generation |
 | RAW, WORK, QUARANTINE, unpublished candidates, canonical stores, graph/vector stores | Forbidden from browser map runtime path |
 | Direct browser-to-model calls | Forbidden; model calls belong server-side behind governed API |
 | Secrets, credentials, tokens, private keys | Secret manager / deployment environment |
 
 ## 7. Map Runtime feature map
 
-Exact modules remain `NEEDS VERIFICATION`. Candidate modules should be introduced only with route inventory, fixtures, and tests.
+Exact modules remain `NEEDS VERIFICATION`. Candidate modules should be introduced only with route inventory, fixtures, tests, and accepted port/adapter contracts.
 
 | Candidate module | Purpose | Required safeguard | Status |
 |---|---|---|---|
@@ -209,13 +241,33 @@ Exact modules remain `NEEDS VERIFICATION`. Candidate modules should be introduce
 | `negative-state-renderer` | Surface denied, abstain, stale, conflict, invalid, error, degraded states | No silent blank map | PROPOSED |
 | `adapter-import-guard` | Guard against renderer imports outside adapter | Repo-wide import scan | PROPOSED |
 | `map-a11y-controls` | Keyboard, focus, reduced motion, non-map alternatives | Accessibility tests | PROPOSED |
-| `telemetry-safe-events` | Record non-content map runtime events | No raw evidence, prompts, restricted geometry | PROPOSED |
+| `telemetry-safe-events` | Record non-content map runtime events | No raw evidence, prompts, restricted geometry, or secret URLs | PROPOSED |
 | `mock-runtime` | No-op/static fallback for rollback/dev fixtures | Stable port retained | PROPOSED |
 
 > [!WARNING]
-> Candidate module names are not implementation proof. Do not document a Map Runtime module as runnable until files, route wiring, tests, fixtures, package scripts, governed API envelopes, port contracts, adapter import rules, and release fixtures confirm it.
+> Candidate module names are not implementation proof. Do not document a Map Runtime module as runnable until files, route wiring, tests, fixtures, package scripts, governed API envelopes, port contracts, adapter import rules, release fixtures, and accessibility checks confirm it.
 
-## 8. Diagram
+## 8. Minimum safe implementation slice
+
+A smallest useful Map Runtime slice should prove the renderer boundary before adding interaction breadth.
+
+| Slice item | Minimum requirement | Why it is required |
+|---|---|---|
+| Stable port | Feature code consumes `MapRuntimePort`, not raw MapLibre objects | Prevents renderer authority leaks |
+| Adapter import isolation | Only the accepted adapter imports MapLibre/runtime plugin APIs | Keeps renderer implementation behind one seam |
+| Validated layer loader | Load only released or bounded-safe `LayerDescriptor` / manifest-backed layers | Prevents unpublished artifact loading |
+| Envelope parser | Validate governed API envelopes and finite outcomes before rendering trust content | Prevents malformed data becoming map truth |
+| Click-candidate bridge | Convert rendered clicks into governed claim-resolution requests | Prevents feature props from becoming proof |
+| Sensitive geometry guard | Deny style-only hiding for sensitive geometry | Prevents client-side leakage |
+| Negative states | Render denied, abstained, stale, degraded, conflict, invalid, withdrawn, rolled-back, destroyed, and error states | Prevents silent blank maps |
+| Time-kind preservation | Keep valid/source/observed/retrieval/release/correction/freshness time distinct where material | Prevents temporal truth collapse |
+| Accessibility path | Keyboard controls, focus, ARIA labels, non-map alternatives, reduced-motion behavior | Makes map trust usable |
+| Telemetry guard | Emit non-secret event metadata only | Prevents logs from capturing raw evidence, restricted geometry, prompts, or secrets |
+| Lifecycle denial test | Prove browser code does not import/read lifecycle roots, canonical stores, graph stores, vector stores, or model runtimes | Preserves public-client boundary |
+
+This slice is still `PROPOSED` until files, fixtures, tests, route wiring, and accepted contracts are verified.
+
+## 9. Diagram
 
 ```mermaid
 flowchart TD
@@ -230,10 +282,14 @@ flowchart TD
     policy -->|error| error["ERROR / fail closed"]
     policy -->|answer| drawer["EvidenceDrawerPayload"]
     adapter -->|click candidate only| api
-    feature -. FORBID .-> raw["RAW / WORK / QUARANTINE / canonical stores / model runtimes / style-only sensitive hiding"]
+    drawer --> feature
+    deny --> feature
+    abstain --> feature
+    error --> feature
+    feature -. FORBID .-> raw["RAW / WORK / QUARANTINE / canonical stores / model runtimes / graph-vector stores / style-only sensitive hiding"]
 ```
 
-## 9. Map Runtime UI obligations
+## 10. Map Runtime UI obligations
 
 | Obligation | Example effect |
 |---|---|
@@ -242,17 +298,18 @@ flowchart TD
 | `released_artifacts_only` | Normal public renderer path accepts released or release-equivalent descriptors only |
 | `click_is_request_to_resolve` | Rendered feature clicks become governed claim-resolution requests, not proof |
 | `feature_props_not_truth` | Feature properties may scope a request but cannot supply claim authority |
-| `negative_states_visible` | Denied, abstain, stale, degraded, conflict, invalid, and error states are first-class |
-| `no_style_filter_redaction` | Sensitive geometry is transformed/generalized/delayed/redacted/denied before public tiles |
+| `negative_states_visible` | Denied, abstain, stale, degraded, conflict, invalid, withdrawn, rolled-back, destroyed, and error states are first-class |
+| `no_style_filter_redaction` | Sensitive geometry is transformed/generalized/delayed/redacted/suppressed/denied before public tiles |
 | `time_kind_preserved` | Valid, observed, source, retrieval, release, correction, and freshness time stay distinct where material |
-| `safe_telemetry` | Telemetry records runtime behavior only, never prompts, raw evidence, restricted geometry, or secrets |
+| `safe_telemetry` | Telemetry records runtime behavior only, never prompts, raw evidence, restricted geometry, secret URLs, or full feature payloads |
+| `accessibility_required` | Map controls and trust states are usable without mouse, motion, or color-only cues |
 | `no_authority_fork` | Feature code does not redefine evidence, citation, policy, release, renderer, schema, contract, or source authority |
 
-## 10. Per-module contract
+## 11. Per-module contract
 
 Every long-lived Map Runtime module should document or encode:
 
-- whether it is port, provider, adapter-facing, state bridge, event bridge, or UI control;
+- whether it is port, provider, adapter-facing, state bridge, event bridge, import guard, or UI control;
 - governed API envelope dependency, if any;
 - accepted layer descriptor/manifest dependencies;
 - renderer adapter dependency and import allowlist behavior;
@@ -260,21 +317,37 @@ Every long-lived Map Runtime module should document or encode:
 - click-candidate-to-claim-resolution behavior;
 - negative-state behavior;
 - sensitive-geometry, rights, release, correction, and rollback behavior;
+- time-kind preservation behavior;
 - Evidence Drawer, Layer Catalog, Focus, Compare, Export, Story, Settings, and Diagnostics handoffs;
+- telemetry behavior, if present;
 - accessibility behavior for keyboard, screen reader, focus management, reduced motion, non-map alternatives, and non-color trust badges;
 - tests and fixtures proving trust-membrane, renderer-boundary, layer-release, click-resolution, sensitive-geometry, telemetry, rollback, and accessibility constraints.
 
-## 11. Inspection path
+## 12. Runtime anti-bypass matrix
+
+| Bypass risk | Required behavior | Review signal |
+|---|---|---|
+| Feature code imports MapLibre/runtime APIs directly | Route through `MapRuntimePort` and accepted adapter only | Import scan proves renderer imports are isolated |
+| Browser reads lifecycle/canonical data directly | Deny at import/build/test review; route through governed API | No direct `data/`, canonical, graph, vector, or object-store imports/fetches |
+| Unreleased layer loads | Render `DENY`, `ABSTAIN`, or unavailable state; no map load | Fixture proves missing release refs blocks layer load |
+| Feature properties treated as proof | Use as click-candidate scope only; resolve through governed API | Click fixture proves feature props alone cannot open answer content |
+| Style filter hides sensitive geometry | Deny style-only hiding; require upstream transform/generalization/redaction/suppression | Sensitive fixture proves no raw geometry reaches public renderer path |
+| Renderer event bypasses Evidence Drawer | Click launches governed resolution and drawer payload only after allowed response | Click-to-drawer fixture exists |
+| Time kinds collapse | Preserve valid/source/observed/retrieval/release/correction/freshness distinctions | Time-state fixture keeps labels distinct |
+| Telemetry captures feature payload or geometry | Emit non-secret event metadata only | Telemetry fixture excludes raw features, restricted geometry, prompts, and secret URLs |
+| Model output changes map truth | Model output may discuss released map context only through governed Focus/AI envelopes | Map state does not depend on model text |
+
+## 13. Inspection path
 
 Map Runtime implementation files, route wiring, tests, fixtures, governed API envelopes, port contracts, adapter import allowlist, renderer package boundaries, accessibility behavior, telemetry, package scripts, and downstream handoffs remain `NEEDS VERIFICATION`.
 
 ```bash
 find apps/explorer-web/src/features/map_runtime -maxdepth 5 -type f | sort
-find apps/explorer-web/src apps/governed-api docs/architecture/ui packages/ui packages/maplibre packages/maplibre-runtime schemas contracts policy release data tests fixtures tools -maxdepth 6 -type f 2>/dev/null | grep -Ei 'map.?runtime|MapRuntimePort|MapLibreAdapter|maplibre|LayerDescriptor|LayerManifest|KFMGeoManifest|EvidenceDrawerPayload|DecisionEnvelope|claim.?resolve|release|rollback|redaction|style.?filter|a11y|accessibility|telemetry' | sort
+find apps/explorer-web/src apps/governed-api docs/architecture/ui packages/ui packages/maplibre packages/maplibre-runtime schemas contracts policy release data tests fixtures tools -maxdepth 6 -type f 2>/dev/null | grep -Ei 'map.?runtime|MapRuntimePort|MapLibreAdapter|maplibre|LayerDescriptor|LayerManifest|KFMGeoManifest|EvidenceDrawerPayload|DecisionEnvelope|claim.?resolve|release|rollback|redaction|generalization|suppression|style.?filter|telemetry|a11y|accessibility' | sort
 find data/raw data/work data/quarantine data/processed data/catalog data/triplets data/published data/receipts data/proofs -maxdepth 2 -type f 2>/dev/null | sort
 ```
 
-## 12. Validation expectations
+## 14. Validation expectations
 
 Useful validation for this feature boundary should cover:
 
@@ -286,63 +359,70 @@ Useful validation for this feature boundary should cover:
 - unreleased or missing-ReleaseManifest layers render `DENY` or `ABSTAIN` and cannot load;
 - click candidates route through governed claim resolution before Evidence Drawer content appears;
 - feature properties never substitute for EvidenceBundle resolution;
-- stale, denied, abstain, conflict, invalid payload, withdrawn, rolled-back, and degraded states remain visible;
+- stale, denied, abstain, conflict, invalid payload, withdrawn, rolled-back, destroyed, and degraded states remain visible;
 - sensitive geometry cannot be made public by style filters or client-side hiding;
-- telemetry never includes raw prompts, raw evidence, restricted geometry, secrets, or full bundle copies;
+- time-kind fields stay distinct through camera/time synchronization;
+- telemetry never includes raw prompts, raw evidence, restricted geometry, secret URLs, full feature payloads, or full bundle copies;
 - accessibility tests cover keyboard controls, focus management, screen-reader labels, reduced motion, non-color trust badges, and non-map alternatives.
 
-## 13. Safe change pattern
+## 15. Safe change pattern
 
 For Map Runtime feature changes:
 
 1. Add or update port/module inventory and per-module contract.
-2. Add fixtures for released, stale, degraded, denied, abstained, conflict, invalid payload, withdrawn, rolled-back, sensitive-generalized, sensitive-denied, loading, destroyed, and error states.
-3. Test lifecycle/canonical-data denial, no-browser-model behavior, adapter import isolation, and governed API-only claim resolution.
-4. Preserve layer refs, evidence refs, release refs, policy state, source role, rights, sensitivity, review, freshness, correction, rollback, time-kind, and legend metadata through UI state.
+2. Add fixtures for released, stale, degraded, denied, abstained, conflict, invalid payload, withdrawn, rolled-back, sensitive-generalized, sensitive-redacted, sensitive-suppressed, sensitive-denied, style-filter-denied, renderer-import-denied, telemetry-denied, loading, destroyed, and error states.
+3. Test lifecycle/canonical-data denial, no-browser-model behavior, adapter import isolation, style-redaction denial, time-kind preservation, and governed API-only claim resolution.
+4. Preserve layer refs, evidence refs, release refs, policy state, source role, rights, sensitivity, review, freshness, correction, rollback, time-kind, manifest, digest, and legend metadata through UI state.
 5. Test keyboard/screen-reader/reduced-motion paths before claiming trust-bearing map runtime usability.
-6. Update this README, parent `features/README.md`, Map Runtime Boundary docs, Layering docs, and parent app README when public behavior changes.
+6. Update this README, parent `features/README.md`, Map Runtime Boundary docs, Layering docs, Evidence Drawer docs, layer policy docs, and parent app README when public behavior changes.
 
-## 14. Definition of done
+## 16. Definition of done
 
 - [ ] Owners are confirmed and `OWNER_TBD` is replaced.
+- [ ] Evidence basis is refreshed when parent README, Map Runtime Boundary docs, Layering docs, maplibre package docs, renderer package evidence, governed API, schema, release, telemetry, or fixture evidence changes.
 - [ ] Map Runtime feature file inventory and route/module ownership are documented.
 - [ ] `MapRuntimePort` and adapter dependencies are explicit.
 - [ ] Adapter import isolation is verified.
-- [ ] `LayerDescriptor`, `LayerManifest`, and click-resolution envelope bindings are verified.
+- [ ] `LayerDescriptor`, `LayerManifest`, `KFMGeoManifest`, and click-resolution envelope bindings are verified.
 - [ ] Layer finite states and negative states are represented in UI fixtures.
 - [ ] Direct lifecycle/canonical-data import/read checks are covered.
 - [ ] Browser model-runtime denial is tested.
 - [ ] Sensitive-geometry style-filter denial is tested.
+- [ ] Time-kind preservation is tested.
+- [ ] Telemetry is tested as non-secret and policy-safe if present.
 - [ ] Evidence Drawer, Layer Catalog, Focus, Compare, Export, Story, Settings, and Diagnostics handoffs are tested for safe governed refs.
 - [ ] Accessibility behavior is tested for keyboard, focus, ARIA, reduced motion, map controls, non-map alternatives, and non-color badges.
 
-## 15. Open verification items
+## 17. Open verification items
 
 | Item | Why it matters |
 |---|---|
 | Confirm Map Runtime implementation files beyond README | Prevents overclaiming feature maturity |
 | Confirm `MapRuntimePort` and adapter implementation names | Required before port/API claims |
 | Confirm renderer adapter import allowlist | Required to protect the renderer boundary |
+| Confirm `packages/maplibre-runtime/` placement or replacement | Required before runtime-package claims |
 | Confirm governed API claim-resolution and layer-manifest endpoints | Required for trust membrane enforcement |
 | Confirm layer schemas and negative fixtures | Required before layer-load claims |
 | Confirm sensitive-geometry negative tests | Required to prevent style-filter leakage |
 | Confirm click-to-Evidence-Drawer path | Required before map-click claim-resolution claims |
 | Confirm no-browser-model tests | Required to protect governed-AI boundary |
+| Confirm time-kind preservation tests | Required to prevent temporal truth collapse |
 | Confirm accessibility tests | Required because map trust signals must be accessible |
 | Confirm telemetry is safe and non-secret | Required before diagnostics/observability claims |
 | Confirm package scripts beyond TODO | Required before build/test claims |
+| Confirm architecture-doc links and relative paths after recursive inventory | Required before treating all related paths as current implementation evidence |
 
 <details>
 <summary>Appendix A — no-loss preservation note</summary>
 
-The previous README was a greenfield stub. This replacement adds a bounded Map Runtime feature contract without claiming map runtime components, ports, adapters, hooks, fixtures, tests, package scripts, governed API envelopes, schemas, renderer integration, accessibility behavior, telemetry, click-resolution, or downstream handoffs are implemented.
+The previous README already contained a strong governed Map Runtime feature contract. This revision preserves that contract, refreshes metadata, adds a current evidence-basis section, strengthens renderer-boundary, click-candidate, style-redaction, time-kind, telemetry, accessibility, and anti-bypass safeguards, and keeps implementation claims bounded. It does not claim map runtime components, ports, adapters, hooks, fixtures, tests, package scripts, governed API envelopes, schemas, renderer integration, accessibility behavior, telemetry, click-resolution, Evidence Drawer handoff, Layer Catalog handoff, Focus handoff, Compare/Export handoff, Story handoff, Settings handoff, Diagnostics handoff, or runtime behavior are implemented.
 
 </details>
 
 ## Status summary
 
-`apps/explorer-web/src/features/map_runtime/` should contain Map Runtime feature modules only after route/module contracts, `MapRuntimePort` contracts, adapter import isolation, governed API envelopes, schema bindings, negative-state fixtures, no-browser-model tests, sensitive-geometry tests, accessibility tests, telemetry constraints, and downstream handoffs are verified.
+`apps/explorer-web/src/features/map_runtime/` should contain Map Runtime feature modules only after route/module contracts, `MapRuntimePort` contracts, adapter import isolation, governed API envelopes, schema bindings, negative-state fixtures, no-browser-model tests, sensitive-geometry tests, time-kind tests, accessibility tests, telemetry constraints, and downstream handoffs are verified.
 
-It must preserve the trust membrane and renderer boundary: Map Runtime may display released artifacts and forward bounded click candidates, but it must not become source truth, evidence resolver, policy engine, publication authority, citation authority, review authority, AI authority, lifecycle storage, raw/canonical data path, or style-only sensitive-geometry hiding mechanism.
+It must preserve the trust membrane and renderer boundary: Map Runtime may display released artifacts and forward bounded click candidates, but it must not become source truth, evidence resolver, policy engine, publication authority, citation authority, review authority, AI authority, lifecycle storage, raw/canonical data path, style-only sensitive-geometry hiding mechanism, or telemetry leakage path.
 
 <p align="right"><a href="#top">Back to top</a></p>


### PR DESCRIPTION
## Summary

- updates `apps/explorer-web/src/features/map_runtime/README.md`
- refreshes metadata to v0.2 / 2026-07-09
- adds a current evidence-basis section for the README path, parent feature boundary, Directory Rules placement, Map Runtime Boundary docs, Layering docs, `packages/maplibre/README.md`, and missing `packages/maplibre-runtime/README.md`
- tightens the Map Runtime truth posture so it remains an app-local renderer-port surface, not a renderer package, evidence resolver, policy engine, publication authority, source registry, AI runtime, tile host, lifecycle store, or raw/canonical data path
- adds a minimum safe implementation slice, runtime anti-bypass matrix, renderer import isolation, click-candidate safeguards, style-redaction denial posture, time-kind preservation, telemetry safeguards, and refreshed definition-of-done items

## Evidence checked

- existing target README at `apps/explorer-web/src/features/map_runtime/README.md`
- parent feature boundary at `apps/explorer-web/src/features/README.md`
- Directory Rules placement doctrine at `docs/doctrine/directory-rules.md`
- Map Runtime Boundary doc at `docs/architecture/ui/MAP_RUNTIME_BOUNDARY.md`
- Layering architecture doc at `docs/architecture/ui/LAYERING.md`
- `packages/maplibre/README.md` exists as a bounded helper-package README
- `packages/maplibre-runtime/README.md` was not found on `main` during this revision

## Validation

- GitHub connector fetch verified the updated branch copy.
- GitHub compare reports one modified file, 145 additions, 65 deletions, branch ahead of `main` by one commit.

## Boundary

Docs-only change. No Map Runtime component, port, adapter, hook, route wiring, governed API envelope, schema binding, fixture, test, package script, renderer integration, accessibility behavior, telemetry behavior, click-resolution path, Evidence Drawer handoff, Layer Catalog handoff, Focus handoff, Compare/Export handoff, Story handoff, Settings handoff, Diagnostics handoff, or runtime behavior is claimed as implemented.