### PR TITLE
Complete missing catalog directories and files

### DIFF
--- a/catalog/domain/agriculture/README.md
+++ b/catalog/domain/agriculture/README.md
@@ -1,0 +1,106 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/catalog-domain-agriculture-readme
+title: catalog/domain/agriculture/ - Agriculture Domain Catalog Compatibility Redirect
+type: readme
+version: v0.1
+status: draft
+owners: OWNER_TBD - Agriculture steward; Catalog steward; Registry steward; Evidence steward; Receipt steward; Proof steward; Release steward; Policy steward; Docs steward
+created: 2026-07-10
+updated: 2026-07-10
+policy_label: public
+related:
+  - ../README.md
+  - ../../README.md
+  - ../../../data/README.md
+  - ../../../data/catalog/README.md
+  - ../../../data/catalog/domain/README.md
+  - ../../../data/catalog/domain/agriculture/README.md
+  - ../../../data/registry/README.md
+  - ../../../data/receipts/README.md
+  - ../../../data/proofs/README.md
+  - ../../../data/published/README.md
+  - ../../../release/README.md
+  - ../../../docs/domains/agriculture/README.md
+  - ../../../docs/doctrine/directory-rules.md
+tags: [kfm, catalog, domain, agriculture, compatibility-root, redirect, data-catalog-domain, source-role-aware, non-authoritative, drift-fence]
+notes:
+  - Root-level catalog/domain/agriculture/ is a compatibility redirect and drift-control fence only.
+  - Canonical Agriculture catalog records belong under data/catalog/domain/agriculture/.
+  - This file does not prove migration completeness, validator coverage, source-rights closure, receipt/proof closure, release approval, publication readiness, or CI enforcement.
+[/KFM_META_BLOCK_V2] -->
+
+<a id='top'></a>
+
+# Agriculture Domain Catalog Compatibility Redirect
+
+`catalog/domain/agriculture/`
+
+This directory exists only to keep the legacy root-level `catalog/domain/` tree aligned with the repository-supported domain catalog lanes. It is not the canonical Agriculture catalog home, not a registry, not a receipt/proof store, not a release or publication surface, and not a producer output target.
+
+## Evidence Basis
+
+| Evidence | Supports | Does not prove |
+|---|---|---|
+| `catalog/domain/README.md` | Root-level `catalog/domain/` is a compatibility redirect and drift fence. | Complete migration or enforcement maturity. |
+| `data/catalog/domain/README.md` | Canonical domain catalog lanes live under `data/catalog/domain/`. | That every downstream record, schema, or validator is complete. |
+| `data/catalog/domain/agriculture/README.md` | `agriculture/` is a repository-recognized canonical Agriculture catalog lane. | Source-rights closure, proof closure, release approval, or public delivery readiness. |
+| `docs/domains/agriculture/README.md` | Domain doctrine exists outside this redirect path. | That this directory may host domain doctrine or implementation files. |
+| Existing sibling redirects in `catalog/domain/` | Child compatibility README pattern is established for root-level domain lanes. | Permission to mirror every nested canonical sublane here. |
+
+## Canonical Homes
+
+| Family | Canonical home |
+|---|---|
+| Agriculture catalog records | `data/catalog/domain/agriculture/` |
+| Parent domain catalog index | `data/catalog/domain/` |
+| Source, rights, and sensitivity registry rows | `data/registry/` |
+| Process receipts | `data/receipts/` |
+| Proof support | `data/proofs/` |
+| Release governance | `release/` |
+| Public-safe published artifacts | `data/published/` |
+
+## Allowed Contents
+
+- `README.md` files that document redirect, compatibility, migration, or drift-control posture.
+- Small migration or correction notes only when an owning repository document explicitly requires them here.
+- Empty sentinels only when an existing repository rule explicitly requires them.
+
+## Forbidden Contents
+
+- Canonical catalog records, indexes, manifests, schemas, contracts, validators, source descriptors, registry rows, receipts, proofs, release records, published artifacts, generated files, caches, credentials, or runtime outputs.
+- RAW, WORK, QUARANTINE, unpublished, canonical-internal, direct model-runtime, or policy-sensitive data.
+- AI-generated wording presented as sovereign truth instead of a downstream carrier of cited evidence.
+
+## Domain Guardrails
+- Do not treat farm, parcel, producer, or operator fields as public-safe unless registry rights, sensitivity, and release policy explicitly allow it.
+- Do not collapse soil, crop, hydrology, atmosphere, or ownership evidence into Agriculture authority when another domain owns the source role.
+- Do not publish field-level or personally identifying agricultural detail from this redirect path.
+
+## Directory Shape
+
+Expected root-level compatibility shape:
+
+```text
+catalog/domain/agriculture/
++-- README.md
+```
+
+Nested canonical sublanes should not be mirrored here unless a future repository contract explicitly requires a root-level redirect for that child path.
+
+## Change Rules
+
+1. Prefer updating the canonical `data/catalog/domain/agriculture/` lane for catalog work.
+2. Keep this directory limited to redirect and drift-control documentation.
+3. Link to owning repository documents instead of duplicating authority.
+4. Mark unknown or unverified behavior as `NEEDS VERIFICATION` instead of implying maturity.
+5. Preserve source-role separation, governed publication, receipts/proofs separation, and policy-safe public surfaces.
+
+## Open Verification Items
+
+- Actual migration completeness from any legacy root-level Agriculture catalog material: `NEEDS VERIFICATION`.
+- CI enforcement for this redirect boundary: `NEEDS VERIFICATION`.
+- Completeness of downstream schemas, examples, fixtures, validators, release manifests, and public surfaces: owned outside this directory and `NEEDS VERIFICATION` here.
+
+## Definition of Done
+
+This redirect is complete when the root-level path exists, points to the canonical Agriculture catalog lane, forbids trust-bearing content in the compatibility path, and does not duplicate authority owned by registry, receipt, proof, release, published, schema, policy, source, tool, or application directories.

--- a/catalog/domain/archaeology/README.md
+++ b/catalog/domain/archaeology/README.md
@@ -1,0 +1,106 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/catalog-domain-archaeology-readme
+title: catalog/domain/archaeology/ - Archaeology Domain Catalog Compatibility Redirect
+type: readme
+version: v0.1
+status: draft
+owners: OWNER_TBD - Archaeology steward; Cultural review steward; Catalog steward; Registry steward; Evidence steward; Receipt steward; Proof steward; Release steward; Policy steward; Docs steward
+created: 2026-07-10
+updated: 2026-07-10
+policy_label: public
+related:
+  - ../README.md
+  - ../../README.md
+  - ../../../data/README.md
+  - ../../../data/catalog/README.md
+  - ../../../data/catalog/domain/README.md
+  - ../../../data/catalog/domain/archaeology/README.md
+  - ../../../data/registry/README.md
+  - ../../../data/receipts/README.md
+  - ../../../data/proofs/README.md
+  - ../../../data/published/README.md
+  - ../../../release/README.md
+  - ../../../docs/domains/archaeology/README.md
+  - ../../../docs/doctrine/directory-rules.md
+tags: [kfm, catalog, domain, archaeology, cultural-review, sensitive-location, compatibility-root, redirect, data-catalog-domain, non-authoritative, drift-fence]
+notes:
+  - Root-level catalog/domain/archaeology/ is a compatibility redirect and drift-control fence only.
+  - Canonical Archaeology catalog records belong under data/catalog/domain/archaeology/.
+  - This file does not prove migration completeness, validator coverage, source-rights closure, receipt/proof closure, release approval, publication readiness, or CI enforcement.
+[/KFM_META_BLOCK_V2] -->
+
+<a id='top'></a>
+
+# Archaeology Domain Catalog Compatibility Redirect
+
+`catalog/domain/archaeology/`
+
+This directory exists only to keep the legacy root-level `catalog/domain/` tree aligned with the repository-supported domain catalog lanes. It is not the canonical Archaeology catalog home, not a registry, not a receipt/proof store, not a release or publication surface, and not a producer output target.
+
+## Evidence Basis
+
+| Evidence | Supports | Does not prove |
+|---|---|---|
+| `catalog/domain/README.md` | Root-level `catalog/domain/` is a compatibility redirect and drift fence. | Complete migration or enforcement maturity. |
+| `data/catalog/domain/README.md` | Canonical domain catalog lanes live under `data/catalog/domain/`. | That every downstream record, schema, or validator is complete. |
+| `data/catalog/domain/archaeology/README.md` | `archaeology/` is a repository-recognized canonical Archaeology catalog lane. | Source-rights closure, proof closure, release approval, or public delivery readiness. |
+| `docs/domains/archaeology/README.md` | Domain doctrine exists outside this redirect path. | That this directory may host domain doctrine or implementation files. |
+| Existing sibling redirects in `catalog/domain/` | Child compatibility README pattern is established for root-level domain lanes. | Permission to mirror every nested canonical sublane here. |
+
+## Canonical Homes
+
+| Family | Canonical home |
+|---|---|
+| Archaeology catalog records | `data/catalog/domain/archaeology/` |
+| Parent domain catalog index | `data/catalog/domain/` |
+| Source, rights, and sensitivity registry rows | `data/registry/` |
+| Process receipts | `data/receipts/` |
+| Proof support | `data/proofs/` |
+| Release governance | `release/` |
+| Public-safe published artifacts | `data/published/` |
+
+## Allowed Contents
+
+- `README.md` files that document redirect, compatibility, migration, or drift-control posture.
+- Small migration or correction notes only when an owning repository document explicitly requires them here.
+- Empty sentinels only when an existing repository rule explicitly requires them.
+
+## Forbidden Contents
+
+- Canonical catalog records, indexes, manifests, schemas, contracts, validators, source descriptors, registry rows, receipts, proofs, release records, published artifacts, generated files, caches, credentials, or runtime outputs.
+- RAW, WORK, QUARANTINE, unpublished, canonical-internal, direct model-runtime, or policy-sensitive data.
+- AI-generated wording presented as sovereign truth instead of a downstream carrier of cited evidence.
+
+## Domain Guardrails
+- Do not store exact site locations, sensitive cultural-location records, candidate-site claims, or public-facing archaeology assertions here.
+- Do not bypass cultural review, rights review, sensitivity review, evidence closure, or release approval by using the legacy root catalog path.
+- Public archaeology surfaces must preserve cite-or-abstain posture and deny sensitive geometry unless governed policy explicitly permits a safe derivative.
+
+## Directory Shape
+
+Expected root-level compatibility shape:
+
+```text
+catalog/domain/archaeology/
++-- README.md
+```
+
+Nested canonical sublanes should not be mirrored here unless a future repository contract explicitly requires a root-level redirect for that child path.
+
+## Change Rules
+
+1. Prefer updating the canonical `data/catalog/domain/archaeology/` lane for catalog work.
+2. Keep this directory limited to redirect and drift-control documentation.
+3. Link to owning repository documents instead of duplicating authority.
+4. Mark unknown or unverified behavior as `NEEDS VERIFICATION` instead of implying maturity.
+5. Preserve source-role separation, governed publication, receipts/proofs separation, and policy-safe public surfaces.
+
+## Open Verification Items
+
+- Actual migration completeness from any legacy root-level Archaeology catalog material: `NEEDS VERIFICATION`.
+- CI enforcement for this redirect boundary: `NEEDS VERIFICATION`.
+- Completeness of downstream schemas, examples, fixtures, validators, release manifests, and public surfaces: owned outside this directory and `NEEDS VERIFICATION` here.
+
+## Definition of Done
+
+This redirect is complete when the root-level path exists, points to the canonical Archaeology catalog lane, forbids trust-bearing content in the compatibility path, and does not duplicate authority owned by registry, receipt, proof, release, published, schema, policy, source, tool, or application directories.

--- a/catalog/domain/people-dna-land/README.md
+++ b/catalog/domain/people-dna-land/README.md
@@ -1,0 +1,106 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/catalog-domain-people-dna-land-readme
+title: catalog/domain/people-dna-land/ - People DNA Land Domain Catalog Compatibility Redirect
+type: readme
+version: v0.1
+status: draft
+owners: OWNER_TBD - People/DNA/Land steward; Consent steward; Catalog steward; Registry steward; Evidence steward; Receipt steward; Proof steward; Release steward; Policy steward; Docs steward
+created: 2026-07-10
+updated: 2026-07-10
+policy_label: public
+related:
+  - ../README.md
+  - ../../README.md
+  - ../../../data/README.md
+  - ../../../data/catalog/README.md
+  - ../../../data/catalog/domain/README.md
+  - ../../../data/catalog/domain/people-dna-land/README.md
+  - ../../../data/registry/README.md
+  - ../../../data/receipts/README.md
+  - ../../../data/proofs/README.md
+  - ../../../data/published/README.md
+  - ../../../release/README.md
+  - ../../../docs/domains/people-dna-land/README.md
+  - ../../../docs/doctrine/directory-rules.md
+tags: [kfm, catalog, domain, people-dna-land, consent, privacy, compatibility-root, redirect, data-catalog-domain, non-authoritative, drift-fence]
+notes:
+  - Root-level catalog/domain/people-dna-land/ is a compatibility redirect and drift-control fence only.
+  - Canonical People DNA Land catalog records belong under data/catalog/domain/people-dna-land/.
+  - This file does not prove migration completeness, validator coverage, source-rights closure, receipt/proof closure, release approval, publication readiness, or CI enforcement.
+[/KFM_META_BLOCK_V2] -->
+
+<a id='top'></a>
+
+# People DNA Land Domain Catalog Compatibility Redirect
+
+`catalog/domain/people-dna-land/`
+
+This directory exists only to keep the legacy root-level `catalog/domain/` tree aligned with the repository-supported domain catalog lanes. It is not the canonical People DNA Land catalog home, not a registry, not a receipt/proof store, not a release or publication surface, and not a producer output target.
+
+## Evidence Basis
+
+| Evidence | Supports | Does not prove |
+|---|---|---|
+| `catalog/domain/README.md` | Root-level `catalog/domain/` is a compatibility redirect and drift fence. | Complete migration or enforcement maturity. |
+| `data/catalog/domain/README.md` | Canonical domain catalog lanes live under `data/catalog/domain/`. | That every downstream record, schema, or validator is complete. |
+| `data/catalog/domain/people-dna-land/README.md` | `people-dna-land/` is a repository-recognized canonical People DNA Land catalog lane. | Source-rights closure, proof closure, release approval, or public delivery readiness. |
+| `docs/domains/people-dna-land/README.md` | Domain doctrine exists outside this redirect path. | That this directory may host domain doctrine or implementation files. |
+| Existing sibling redirects in `catalog/domain/` | Child compatibility README pattern is established for root-level domain lanes. | Permission to mirror every nested canonical sublane here. |
+
+## Canonical Homes
+
+| Family | Canonical home |
+|---|---|
+| People DNA Land catalog records | `data/catalog/domain/people-dna-land/` |
+| Parent domain catalog index | `data/catalog/domain/` |
+| Source, rights, and sensitivity registry rows | `data/registry/` |
+| Process receipts | `data/receipts/` |
+| Proof support | `data/proofs/` |
+| Release governance | `release/` |
+| Public-safe published artifacts | `data/published/` |
+
+## Allowed Contents
+
+- `README.md` files that document redirect, compatibility, migration, or drift-control posture.
+- Small migration or correction notes only when an owning repository document explicitly requires them here.
+- Empty sentinels only when an existing repository rule explicitly requires them.
+
+## Forbidden Contents
+
+- Canonical catalog records, indexes, manifests, schemas, contracts, validators, source descriptors, registry rows, receipts, proofs, release records, published artifacts, generated files, caches, credentials, or runtime outputs.
+- RAW, WORK, QUARANTINE, unpublished, canonical-internal, direct model-runtime, or policy-sensitive data.
+- AI-generated wording presented as sovereign truth instead of a downstream carrier of cited evidence.
+
+## Domain Guardrails
+- Do not store living-person, DNA, consent, identity graph, parcel ownership, or title-claim records in this redirect path.
+- Do not turn AI-generated language, genealogy hints, assessor data, or DNA matches into sovereign truth or public claims.
+- Consent, revocation, restricted evidence, receipts, proofs, and public-safe release derivatives must remain in their governed owning roots.
+
+## Directory Shape
+
+Expected root-level compatibility shape:
+
+```text
+catalog/domain/people-dna-land/
++-- README.md
+```
+
+Nested canonical sublanes should not be mirrored here unless a future repository contract explicitly requires a root-level redirect for that child path.
+
+## Change Rules
+
+1. Prefer updating the canonical `data/catalog/domain/people-dna-land/` lane for catalog work.
+2. Keep this directory limited to redirect and drift-control documentation.
+3. Link to owning repository documents instead of duplicating authority.
+4. Mark unknown or unverified behavior as `NEEDS VERIFICATION` instead of implying maturity.
+5. Preserve source-role separation, governed publication, receipts/proofs separation, and policy-safe public surfaces.
+
+## Open Verification Items
+
+- Actual migration completeness from any legacy root-level People DNA Land catalog material: `NEEDS VERIFICATION`.
+- CI enforcement for this redirect boundary: `NEEDS VERIFICATION`.
+- Completeness of downstream schemas, examples, fixtures, validators, release manifests, and public surfaces: owned outside this directory and `NEEDS VERIFICATION` here.
+
+## Definition of Done
+
+This redirect is complete when the root-level path exists, points to the canonical People DNA Land catalog lane, forbids trust-bearing content in the compatibility path, and does not duplicate authority owned by registry, receipt, proof, release, published, schema, policy, source, tool, or application directories.

--- a/catalog/domain/roads-rail-trade/README.md
+++ b/catalog/domain/roads-rail-trade/README.md
@@ -1,0 +1,106 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/catalog-domain-roads-rail-trade-readme
+title: catalog/domain/roads-rail-trade/ - Roads Rail Trade Domain Catalog Compatibility Redirect
+type: readme
+version: v0.1
+status: draft
+owners: OWNER_TBD - Roads/Rail/Trade steward; Catalog steward; Registry steward; Evidence steward; Receipt steward; Proof steward; Release steward; Policy steward; Docs steward
+created: 2026-07-10
+updated: 2026-07-10
+policy_label: public
+related:
+  - ../README.md
+  - ../../README.md
+  - ../../../data/README.md
+  - ../../../data/catalog/README.md
+  - ../../../data/catalog/domain/README.md
+  - ../../../data/catalog/domain/roads-rail-trade/README.md
+  - ../../../data/registry/README.md
+  - ../../../data/receipts/README.md
+  - ../../../data/proofs/README.md
+  - ../../../data/published/README.md
+  - ../../../release/README.md
+  - ../../../docs/domains/roads-rail-trade/README.md
+  - ../../../docs/doctrine/directory-rules.md
+tags: [kfm, catalog, domain, roads-rail-trade, transportation, trade, compatibility-root, redirect, data-catalog-domain, non-authoritative, drift-fence]
+notes:
+  - Root-level catalog/domain/roads-rail-trade/ is a compatibility redirect and drift-control fence only.
+  - Canonical Roads Rail Trade catalog records belong under data/catalog/domain/roads-rail-trade/.
+  - This file does not prove migration completeness, validator coverage, source-rights closure, receipt/proof closure, release approval, publication readiness, or CI enforcement.
+[/KFM_META_BLOCK_V2] -->
+
+<a id='top'></a>
+
+# Roads Rail Trade Domain Catalog Compatibility Redirect
+
+`catalog/domain/roads-rail-trade/`
+
+This directory exists only to keep the legacy root-level `catalog/domain/` tree aligned with the repository-supported domain catalog lanes. It is not the canonical Roads Rail Trade catalog home, not a registry, not a receipt/proof store, not a release or publication surface, and not a producer output target.
+
+## Evidence Basis
+
+| Evidence | Supports | Does not prove |
+|---|---|---|
+| `catalog/domain/README.md` | Root-level `catalog/domain/` is a compatibility redirect and drift fence. | Complete migration or enforcement maturity. |
+| `data/catalog/domain/README.md` | Canonical domain catalog lanes live under `data/catalog/domain/`. | That every downstream record, schema, or validator is complete. |
+| `data/catalog/domain/roads-rail-trade/README.md` | `roads-rail-trade/` is a repository-recognized canonical Roads Rail Trade catalog lane. | Source-rights closure, proof closure, release approval, or public delivery readiness. |
+| `docs/domains/roads-rail-trade/README.md` | Domain doctrine exists outside this redirect path. | That this directory may host domain doctrine or implementation files. |
+| Existing sibling redirects in `catalog/domain/` | Child compatibility README pattern is established for root-level domain lanes. | Permission to mirror every nested canonical sublane here. |
+
+## Canonical Homes
+
+| Family | Canonical home |
+|---|---|
+| Roads Rail Trade catalog records | `data/catalog/domain/roads-rail-trade/` |
+| Parent domain catalog index | `data/catalog/domain/` |
+| Source, rights, and sensitivity registry rows | `data/registry/` |
+| Process receipts | `data/receipts/` |
+| Proof support | `data/proofs/` |
+| Release governance | `release/` |
+| Public-safe published artifacts | `data/published/` |
+
+## Allowed Contents
+
+- `README.md` files that document redirect, compatibility, migration, or drift-control posture.
+- Small migration or correction notes only when an owning repository document explicitly requires them here.
+- Empty sentinels only when an existing repository rule explicitly requires them.
+
+## Forbidden Contents
+
+- Canonical catalog records, indexes, manifests, schemas, contracts, validators, source descriptors, registry rows, receipts, proofs, release records, published artifacts, generated files, caches, credentials, or runtime outputs.
+- RAW, WORK, QUARANTINE, unpublished, canonical-internal, direct model-runtime, or policy-sensitive data.
+- AI-generated wording presented as sovereign truth instead of a downstream carrier of cited evidence.
+
+## Domain Guardrails
+- Do not make this path a route, facility, story-node, legal-status, or trade-network authority.
+- Do not publish unresolved historical precision, active infrastructure risk, or legal-status claims without evidence closure and governed release.
+- Cross-domain joins with hydrology, settlements, hazards, or people/land evidence must keep source roles separate.
+
+## Directory Shape
+
+Expected root-level compatibility shape:
+
+```text
+catalog/domain/roads-rail-trade/
++-- README.md
+```
+
+Nested canonical sublanes should not be mirrored here unless a future repository contract explicitly requires a root-level redirect for that child path.
+
+## Change Rules
+
+1. Prefer updating the canonical `data/catalog/domain/roads-rail-trade/` lane for catalog work.
+2. Keep this directory limited to redirect and drift-control documentation.
+3. Link to owning repository documents instead of duplicating authority.
+4. Mark unknown or unverified behavior as `NEEDS VERIFICATION` instead of implying maturity.
+5. Preserve source-role separation, governed publication, receipts/proofs separation, and policy-safe public surfaces.
+
+## Open Verification Items
+
+- Actual migration completeness from any legacy root-level Roads Rail Trade catalog material: `NEEDS VERIFICATION`.
+- CI enforcement for this redirect boundary: `NEEDS VERIFICATION`.
+- Completeness of downstream schemas, examples, fixtures, validators, release manifests, and public surfaces: owned outside this directory and `NEEDS VERIFICATION` here.
+
+## Definition of Done
+
+This redirect is complete when the root-level path exists, points to the canonical Roads Rail Trade catalog lane, forbids trust-bearing content in the compatibility path, and does not duplicate authority owned by registry, receipt, proof, release, published, schema, policy, source, tool, or application directories.

--- a/catalog/domain/settlements-infrastructure/README.md
+++ b/catalog/domain/settlements-infrastructure/README.md
@@ -1,0 +1,106 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/catalog-domain-settlements-infrastructure-readme
+title: catalog/domain/settlements-infrastructure/ - Settlements Infrastructure Domain Catalog Compatibility Redirect
+type: readme
+version: v0.1
+status: draft
+owners: OWNER_TBD - Settlements/Infrastructure steward; Catalog steward; Registry steward; Evidence steward; Receipt steward; Proof steward; Release steward; Policy steward; Docs steward
+created: 2026-07-10
+updated: 2026-07-10
+policy_label: public
+related:
+  - ../README.md
+  - ../../README.md
+  - ../../../data/README.md
+  - ../../../data/catalog/README.md
+  - ../../../data/catalog/domain/README.md
+  - ../../../data/catalog/domain/settlements-infrastructure/README.md
+  - ../../../data/registry/README.md
+  - ../../../data/receipts/README.md
+  - ../../../data/proofs/README.md
+  - ../../../data/published/README.md
+  - ../../../release/README.md
+  - ../../../docs/domains/settlements-infrastructure/README.md
+  - ../../../docs/doctrine/directory-rules.md
+tags: [kfm, catalog, domain, settlements-infrastructure, settlements, infrastructure, compatibility-root, redirect, data-catalog-domain, non-authoritative, drift-fence]
+notes:
+  - Root-level catalog/domain/settlements-infrastructure/ is a compatibility redirect and drift-control fence only.
+  - Canonical Settlements Infrastructure catalog records belong under data/catalog/domain/settlements-infrastructure/.
+  - This file does not prove migration completeness, validator coverage, source-rights closure, receipt/proof closure, release approval, publication readiness, or CI enforcement.
+[/KFM_META_BLOCK_V2] -->
+
+<a id='top'></a>
+
+# Settlements Infrastructure Domain Catalog Compatibility Redirect
+
+`catalog/domain/settlements-infrastructure/`
+
+This directory exists only to keep the legacy root-level `catalog/domain/` tree aligned with the repository-supported domain catalog lanes. It is not the canonical Settlements Infrastructure catalog home, not a registry, not a receipt/proof store, not a release or publication surface, and not a producer output target.
+
+## Evidence Basis
+
+| Evidence | Supports | Does not prove |
+|---|---|---|
+| `catalog/domain/README.md` | Root-level `catalog/domain/` is a compatibility redirect and drift fence. | Complete migration or enforcement maturity. |
+| `data/catalog/domain/README.md` | Canonical domain catalog lanes live under `data/catalog/domain/`. | That every downstream record, schema, or validator is complete. |
+| `data/catalog/domain/settlements-infrastructure/README.md` | `settlements-infrastructure/` is a repository-recognized canonical Settlements Infrastructure catalog lane. | Source-rights closure, proof closure, release approval, or public delivery readiness. |
+| `docs/domains/settlements-infrastructure/README.md` | Domain doctrine exists outside this redirect path. | That this directory may host domain doctrine or implementation files. |
+| Existing sibling redirects in `catalog/domain/` | Child compatibility README pattern is established for root-level domain lanes. | Permission to mirror every nested canonical sublane here. |
+
+## Canonical Homes
+
+| Family | Canonical home |
+|---|---|
+| Settlements Infrastructure catalog records | `data/catalog/domain/settlements-infrastructure/` |
+| Parent domain catalog index | `data/catalog/domain/` |
+| Source, rights, and sensitivity registry rows | `data/registry/` |
+| Process receipts | `data/receipts/` |
+| Proof support | `data/proofs/` |
+| Release governance | `release/` |
+| Public-safe published artifacts | `data/published/` |
+
+## Allowed Contents
+
+- `README.md` files that document redirect, compatibility, migration, or drift-control posture.
+- Small migration or correction notes only when an owning repository document explicitly requires them here.
+- Empty sentinels only when an existing repository rule explicitly requires them.
+
+## Forbidden Contents
+
+- Canonical catalog records, indexes, manifests, schemas, contracts, validators, source descriptors, registry rows, receipts, proofs, release records, published artifacts, generated files, caches, credentials, or runtime outputs.
+- RAW, WORK, QUARANTINE, unpublished, canonical-internal, direct model-runtime, or policy-sensitive data.
+- AI-generated wording presented as sovereign truth instead of a downstream carrier of cited evidence.
+
+## Domain Guardrails
+- Do not make this path a settlement gazetteer, infrastructure inventory, address authority, facility authority, or public map source.
+- Do not publish sensitive facility, critical infrastructure, private-property, or uncertain historical-place detail from this redirect path.
+- Settlement identity, source descriptors, receipts, proofs, release records, and public-safe derivatives must remain in their governed owning roots.
+
+## Directory Shape
+
+Expected root-level compatibility shape:
+
+```text
+catalog/domain/settlements-infrastructure/
++-- README.md
+```
+
+Nested canonical sublanes should not be mirrored here unless a future repository contract explicitly requires a root-level redirect for that child path.
+
+## Change Rules
+
+1. Prefer updating the canonical `data/catalog/domain/settlements-infrastructure/` lane for catalog work.
+2. Keep this directory limited to redirect and drift-control documentation.
+3. Link to owning repository documents instead of duplicating authority.
+4. Mark unknown or unverified behavior as `NEEDS VERIFICATION` instead of implying maturity.
+5. Preserve source-role separation, governed publication, receipts/proofs separation, and policy-safe public surfaces.
+
+## Open Verification Items
+
+- Actual migration completeness from any legacy root-level Settlements Infrastructure catalog material: `NEEDS VERIFICATION`.
+- CI enforcement for this redirect boundary: `NEEDS VERIFICATION`.
+- Completeness of downstream schemas, examples, fixtures, validators, release manifests, and public surfaces: owned outside this directory and `NEEDS VERIFICATION` here.
+
+## Definition of Done
+
+This redirect is complete when the root-level path exists, points to the canonical Settlements Infrastructure catalog lane, forbids trust-bearing content in the compatibility path, and does not duplicate authority owned by registry, receipt, proof, release, published, schema, policy, source, tool, or application directories.

--- a/catalog/domain/soil/README.md
+++ b/catalog/domain/soil/README.md
@@ -1,0 +1,106 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/catalog-domain-soil-readme
+title: catalog/domain/soil/ - Soil Domain Catalog Compatibility Redirect
+type: readme
+version: v0.1
+status: draft
+owners: OWNER_TBD - Soil steward; Catalog steward; Registry steward; Evidence steward; Receipt steward; Proof steward; Release steward; Policy steward; Docs steward
+created: 2026-07-10
+updated: 2026-07-10
+policy_label: public
+related:
+  - ../README.md
+  - ../../README.md
+  - ../../../data/README.md
+  - ../../../data/catalog/README.md
+  - ../../../data/catalog/domain/README.md
+  - ../../../data/catalog/domain/soil/README.md
+  - ../../../data/registry/README.md
+  - ../../../data/receipts/README.md
+  - ../../../data/proofs/README.md
+  - ../../../data/published/README.md
+  - ../../../release/README.md
+  - ../../../docs/domains/soil/README.md
+  - ../../../docs/doctrine/directory-rules.md
+tags: [kfm, catalog, domain, soil, ssurgo, gssurgo, compatibility-root, redirect, data-catalog-domain, non-authoritative, drift-fence]
+notes:
+  - Root-level catalog/domain/soil/ is a compatibility redirect and drift-control fence only.
+  - Canonical Soil catalog records belong under data/catalog/domain/soil/.
+  - This file does not prove migration completeness, validator coverage, source-rights closure, receipt/proof closure, release approval, publication readiness, or CI enforcement.
+[/KFM_META_BLOCK_V2] -->
+
+<a id='top'></a>
+
+# Soil Domain Catalog Compatibility Redirect
+
+`catalog/domain/soil/`
+
+This directory exists only to keep the legacy root-level `catalog/domain/` tree aligned with the repository-supported domain catalog lanes. It is not the canonical Soil catalog home, not a registry, not a receipt/proof store, not a release or publication surface, and not a producer output target.
+
+## Evidence Basis
+
+| Evidence | Supports | Does not prove |
+|---|---|---|
+| `catalog/domain/README.md` | Root-level `catalog/domain/` is a compatibility redirect and drift fence. | Complete migration or enforcement maturity. |
+| `data/catalog/domain/README.md` | Canonical domain catalog lanes live under `data/catalog/domain/`. | That every downstream record, schema, or validator is complete. |
+| `data/catalog/domain/soil/README.md` | `soil/` is a repository-recognized canonical Soil catalog lane. | Source-rights closure, proof closure, release approval, or public delivery readiness. |
+| `docs/domains/soil/README.md` | Domain doctrine exists outside this redirect path. | That this directory may host domain doctrine or implementation files. |
+| Existing sibling redirects in `catalog/domain/` | Child compatibility README pattern is established for root-level domain lanes. | Permission to mirror every nested canonical sublane here. |
+
+## Canonical Homes
+
+| Family | Canonical home |
+|---|---|
+| Soil catalog records | `data/catalog/domain/soil/` |
+| Parent domain catalog index | `data/catalog/domain/` |
+| Source, rights, and sensitivity registry rows | `data/registry/` |
+| Process receipts | `data/receipts/` |
+| Proof support | `data/proofs/` |
+| Release governance | `release/` |
+| Public-safe published artifacts | `data/published/` |
+
+## Allowed Contents
+
+- `README.md` files that document redirect, compatibility, migration, or drift-control posture.
+- Small migration or correction notes only when an owning repository document explicitly requires them here.
+- Empty sentinels only when an existing repository rule explicitly requires them.
+
+## Forbidden Contents
+
+- Canonical catalog records, indexes, manifests, schemas, contracts, validators, source descriptors, registry rows, receipts, proofs, release records, published artifacts, generated files, caches, credentials, or runtime outputs.
+- RAW, WORK, QUARANTINE, unpublished, canonical-internal, direct model-runtime, or policy-sensitive data.
+- AI-generated wording presented as sovereign truth instead of a downstream carrier of cited evidence.
+
+## Domain Guardrails
+- Do not make this path a soil survey data store, horizon-table authority, suitability result store, or generated raster/vector output location.
+- Do not collapse soil source roles into agriculture, hydrology, habitat, or geology without explicit cross-domain evidence and release policy.
+- Soil catalog records, source descriptors, receipts, proofs, schemas, validators, and public-safe outputs belong in their owning roots.
+
+## Directory Shape
+
+Expected root-level compatibility shape:
+
+```text
+catalog/domain/soil/
++-- README.md
+```
+
+Nested canonical sublanes should not be mirrored here unless a future repository contract explicitly requires a root-level redirect for that child path.
+
+## Change Rules
+
+1. Prefer updating the canonical `data/catalog/domain/soil/` lane for catalog work.
+2. Keep this directory limited to redirect and drift-control documentation.
+3. Link to owning repository documents instead of duplicating authority.
+4. Mark unknown or unverified behavior as `NEEDS VERIFICATION` instead of implying maturity.
+5. Preserve source-role separation, governed publication, receipts/proofs separation, and policy-safe public surfaces.
+
+## Open Verification Items
+
+- Actual migration completeness from any legacy root-level Soil catalog material: `NEEDS VERIFICATION`.
+- CI enforcement for this redirect boundary: `NEEDS VERIFICATION`.
+- Completeness of downstream schemas, examples, fixtures, validators, release manifests, and public surfaces: owned outside this directory and `NEEDS VERIFICATION` here.
+
+## Definition of Done
+
+This redirect is complete when the root-level path exists, points to the canonical Soil catalog lane, forbids trust-bearing content in the compatibility path, and does not duplicate authority owned by registry, receipt, proof, release, published, schema, policy, source, tool, or application directories.


### PR DESCRIPTION
## Summary

* audited `catalog/` and all nested directories
* reviewed existing README files as directory contracts
* created repository-supported missing directories and files
* made only minimal index or link updates where required

No existing files were modified. The PR adds root-level `catalog/domain/` compatibility redirect READMEs for canonical domain lanes that already exist under `data/catalog/domain/` but were missing from the root-level compatibility tree.

## Evidence used

* `catalog/README.md` and all existing `catalog/**/README.md` files: established root-level `catalog/` as compatibility / redirect / drift-control documentation, not canonical catalog authority.
* `catalog/domain/README.md`: established `catalog/domain/` as a root-level domain compatibility redirect, with canonical domain catalog records under `data/catalog/domain/`.
* Existing sibling root redirects under `catalog/domain/{atmosphere,fauna,flora,geology,habitat,hazards,hydrology}/README.md`: established the child README redirect pattern.
* `data/catalog/domain/README.md`: listed the known canonical domain lanes.
* `data/catalog/domain/{agriculture,archaeology,people-dna-land,roads-rail-trade,settlements-infrastructure,soil}/README.md`: confirmed the canonical homes for the added root redirect paths.
* `docs/domains/{agriculture,archaeology,people-dna-land,roads-rail-trade,settlements-infrastructure,soil}/README.md`: confirmed domain doctrine lives outside the root redirect paths.
* `data/registry/README.md`, `data/receipts/README.md`, `data/proofs/README.md`, `data/published/README.md`, and `release/README.md`: confirmed registry, receipt, proof, release, and publication family separation.
* `docs/doctrine/directory-rules.md`: confirmed directory placement carries ownership, governance, and lifecycle meaning.
* Git history for `catalog/domain/` and `data/catalog/domain/`: confirmed the root-level compatibility tree lagged the canonical domain lane inventory.
* Searches across repository docs, workflows, tools, tests, manifests, and configuration for catalog references and missing-path language.

## Added paths

* `catalog/domain/agriculture/`
* `catalog/domain/agriculture/README.md`
* `catalog/domain/archaeology/`
* `catalog/domain/archaeology/README.md`
* `catalog/domain/people-dna-land/`
* `catalog/domain/people-dna-land/README.md`
* `catalog/domain/roads-rail-trade/`
* `catalog/domain/roads-rail-trade/README.md`
* `catalog/domain/settlements-infrastructure/`
* `catalog/domain/settlements-infrastructure/README.md`
* `catalog/domain/soil/`
* `catalog/domain/soil/README.md`

## Modified existing files

None.

## Validation

* `git fetch origin main` - refreshed the base branch to `e3b0e9b413bd1a1fef72593f61e65c020128cab5` before creating the final branch commit.
* `git ls-tree -d --name-only origin/main:catalog/domain` - confirmed the root compatibility tree had only `atmosphere`, `fauna`, `flora`, `geology`, `habitat`, `hazards`, and `hydrology` before these additions.
* `git ls-tree -d --name-only origin/main:data/catalog/domain` - confirmed the canonical domain tree includes the six added lanes.
* Custom Python link/metadata check over the six new READMEs - passed: all files exist; no encoding artifacts, trailing whitespace, or broken Markdown/related links; final newlines present.
* Final catalog tree print from `origin/main` plus the new paths - passed, total catalog files after additions: 43.
* `git diff --name-status origin/main codex/complete-catalog-structure -- catalog` - passed: exactly six added README files.
* `git diff --check origin/main codex/complete-catalog-structure -- catalog` - passed with no whitespace errors.
* GitHub compare `main...codex/complete-catalog-structure` - passed: branch is ahead by 1, behind by 0, with exactly six added files.
* `python -m pytest tests/schemas tests/contracts -q` using the bundled Python runtime - not run successfully: environment is missing `pytest` (`No module named pytest`).

Environment note: a normal full Windows checkout/index workflow is blocked by an existing repository path containing a literal backslash (`docs/focus-mode/counties/edwards_county\README.md`). Local Git object operations and GitHub Git Data API were used to preserve the current tree and publish the branch safely.

## Unresolved or uncertain items

* `data/catalog/domain/people/` and `data/catalog/domain/settlement/` are present as proposed/conflicted aliases in the canonical inventory; root-level redirect paths were not created for those aliases to avoid amplifying the conflict.
* Nested canonical sublanes, such as fauna public/restricted, habitat ecoregions, people-dna-land land-ownership, and roads-rail-trade story-nodes, were not mirrored under root `catalog/domain/` because existing root-level sibling redirects do not mirror nested sublanes.
* Broad historical or planned references to other root-level `catalog/...` paths remain in repository text, but the current root `catalog/` README contracts define the root as compatibility/redirect space and did not provide sufficient evidence to create those paths in this PR.
* Full repository tests were not run because this environment lacks `pytest` and cannot complete a normal Windows checkout due the pre-existing invalid path noted above.

## Scope protection

* no unrelated directories were redesigned
* no existing authority was duplicated
* no unsupported implementation claims were introduced
* no existing files were overwritten without necessity
* no generated caches, credentials, build outputs, or local-environment files were included