### PR TITLE
docs(connectors): update EPA source root README

### DIFF
--- a/connectors/epa/src/README.md
+++ b/connectors/epa/src/README.md
@@ -2,278 +2,358 @@
 doc_id: kfm://doc/connectors-epa-src-readme
 title: connectors/epa/src/ — EPA Connector Source Root
 type: readme
-version: v0.1
+version: v0.2
 status: draft
 owners: OWNER_TBD — Source steward · Connector steward · Data steward · Validation steward · Docs steward
 created: 2026-06-18
-updated: 2026-06-18
+updated: 2026-07-11
 policy_label: public
 proposed_path: connectors/epa/src/README.md
-truth_posture: CONFIRMED path exists / PROPOSED source-root contract / UNKNOWN implementation depth
+truth_posture: CONFIRMED repository inventory / PROPOSED source-root contract / UNKNOWN runtime and CI maturity
 related:
   - ../README.md
   - epa/README.md
   - ../tests/README.md
-  - ../../../docs/sources/catalog/epa.md
+  - ../../../docs/sources/catalog/epa/
   - ../../../data/registry/sources/
   - ../../../data/raw/
   - ../../../data/quarantine/
-  - ../../../fixtures/
   - ../../../schemas/contracts/v1/source/
-  - ../../../policy/sensitivity/
+  - ../../../policy/
   - ../../../release/
-tags: [kfm, connectors, epa, source-root, python, source-admission, raw, quarantine, governance]
+tags: [kfm, connectors, epa, source-root, source-admission, raw, quarantine, governance]
 notes:
   - "This README documents the connector source-code root, not EPA source truth or publication authority."
-  - "The implementation package below this root may prepare source material for RAW or QUARANTINE admission only."
-  - "Concrete package metadata, modules, imports, source descriptors, endpoint coverage, tests, fixtures, and CI wiring remain NEEDS VERIFICATION until inspected in the mounted repo."
+  - "The current package contains README.md, fetch.py, admit.py, and descriptor.yaml; the Python modules and descriptor are greenfield placeholders at the inspected commit."
+  - "The connector may prepare material for RAW or QUARANTINE admission only; downstream validation, evidence closure, policy, review, release, correction, and rollback remain outside this root."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
 # EPA Connector Source Root
 
-> Source-code root for the EPA connector implementation under `connectors/epa/`.
+> Source-code boundary for EPA fetch and admission helpers under `connectors/epa/`.
 
-<p>
-  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
-  <img alt="Owner: OWNER_TBD" src="https://img.shields.io/badge/owner-OWNER__TBD-lightgrey">
-  <img alt="Scope: connector source root" src="https://img.shields.io/badge/scope-connector__source__root-blue">
-  <img alt="Lifecycle: raw or quarantine only" src="https://img.shields.io/badge/lifecycle-raw%20%7C%20quarantine%20only-orange">
-  <img alt="Publication: not publisher" src="https://img.shields.io/badge/publication-not__publisher-critical">
-</p>
+> [!IMPORTANT]
+> **Document lifecycle:** draft  
+> **Component maturity:** experimental scaffold  
+> **Owner:** `OWNER_TBD`  
+> **Truth posture:** repository inventory confirmed at base commit `30d2c71`; runtime behavior, package wiring, tests, and CI remain unverified.
 
 `connectors/epa/src/`
 
-## Quick jumps
+## Quick navigation
 
-[Scope](#scope) · [Repository fit](#repository-fit) · [Authority boundary](#authority-boundary) · [Expected contents](#expected-contents) · [Import and packaging posture](#import-and-packaging-posture) · [Lifecycle handoff](#lifecycle-handoff) · [Testing relationship](#testing-relationship) · [Definition of done](#definition-of-done) · [Verification backlog](#verification-backlog)
+- [Scope](#scope)
+- [Repository fit](#repository-fit)
+- [Confirmed inventory](#confirmed-inventory)
+- [Authority boundary](#authority-boundary)
+- [Lifecycle handoff](#lifecycle-handoff)
+- [File contracts](#file-contracts)
+- [Safety and runtime posture](#safety-and-runtime-posture)
+- [Testing relationship](#testing-relationship)
+- [Definition of done](#definition-of-done)
+- [Verification backlog](#verification-backlog)
 
 ---
 
 ## Scope
 
-`connectors/epa/src/` is the implementation source root for the EPA connector lane.
+`connectors/epa/src/` owns the source-code boundary for EPA-specific fetching and admission preparation.
 
-This folder may contain importable connector code that supports EPA source intake, parsing, normalization into source-admission envelopes, and safe handoff toward RAW or QUARANTINE lifecycle states.
+This root may contain code and connector-local metadata that:
 
-It must not contain:
+- contacts a steward-approved EPA source when explicitly enabled;
+- preserves source identity, retrieval context, timestamps, and digests;
+- prepares material for RAW admission;
+- routes malformed, incomplete, rights-unclear, sensitive, or drifted material toward QUARANTINE;
+- returns bounded, reviewable failure outcomes;
+- supports deterministic no-network tests.
 
-- EPA source truth;
-- source registry authority;
-- policy authority;
-- schema authority;
+This root does **not** own:
+
+- EPA source truth or environmental-domain truth;
+- canonical source registry records;
+- contract or schema authority;
+- policy decisions;
 - processed domain records;
-- published records;
-- release decisions;
-- proof packs;
-- credentials;
-- large copied source payloads;
-- UI-facing claim text.
+- catalog or triplet records;
+- EvidenceBundle authority;
+- proof, receipt, promotion, or release authority;
+- published artifacts;
+- UI-facing claims or generated explanations.
 
-> [!IMPORTANT]
-> This root is for connector implementation code. It does not replace `connectors/epa/README.md`, `connectors/epa/tests/README.md`, source catalog documentation, source descriptors, contracts, schemas, policy files, release records, or downstream pipeline documentation.
+The connector is an admission-edge adapter. It is not a publisher.
 
 ---
 
 ## Repository fit
 
+Directory Rules place source-specific fetchers and admitters under `connectors/`. EPA remains a source-family lane inside that responsibility root rather than becoming a domain or root-level authority.
+
 ```text
 connectors/
 └── epa/
-    ├── README.md                  # connector-lane overview, if present
+    ├── README.md
     ├── src/
     │   ├── README.md              # this file
     │   └── epa/
-    │       └── README.md          # implementation-package boundary
+    │       ├── README.md
+    │       ├── fetch.py
+    │       ├── admit.py
+    │       └── descriptor.yaml
     └── tests/
-        └── README.md              # connector-local tests
+        └── README.md
 ```
 
 Related responsibility roots:
 
-```text
-connectors/                         # source-specific fetch and admission code
-docs/sources/catalog/epa.md          # EPA source-family documentation
-data/registry/sources/               # source descriptors and activation state
-data/raw/                            # raw staged source outputs
-data/quarantine/                     # held material requiring review
-fixtures/                            # shared test fixtures, when promoted out of connector-local scope
-schemas/contracts/v1/source/         # source/admission schemas, subject to ADR/schema-home convention
-policy/sensitivity/                  # sensitivity and release policy
-release/                             # release decisions, rollback, and correction state
-```
+| Responsibility | Canonical or expected home |
+|---|---|
+| Source-family documentation | `docs/sources/catalog/epa/` |
+| Canonical source descriptors and activation state | `data/registry/sources/` |
+| Raw admitted material | `data/raw/` |
+| Held or unsafe material | `data/quarantine/` |
+| Contract meaning | `contracts/` |
+| Machine-checkable shapes | `schemas/contracts/v1/` |
+| Policy and sensitivity decisions | `policy/` |
+| Downstream normalization and domain processing | `pipelines/` and domain packages |
+| Release, correction, and rollback decisions | `release/` |
+
+> [!NOTE]
+> The path is consistent with the Directory Rules responsibility-root model: `connectors/` owns source-specific fetch and admission behavior. Topic-specific truth, schemas, policy, lifecycle data, and release records remain in their own authority roots.
+
+---
+
+## Confirmed inventory
+
+The following inventory was verified at base commit `30d2c71ad48ae932f068969cfc0b51676c5c23f3`.
+
+| Path | Status | Confirmed content | What it does not prove |
+|---|---:|---|---|
+| `connectors/epa/src/README.md` | **CONFIRMED** | Source-root documentation existed as v0.1. | Does not prove connector execution. |
+| `connectors/epa/src/epa/README.md` | **CONFIRMED** | Package-boundary documentation exists. | Does not prove the proposed package contract is implemented. |
+| `connectors/epa/src/epa/fetch.py` | **CONFIRMED scaffold** | Contains a one-line greenfield placeholder for an EPA fetcher. | No endpoint, network, parsing, retry, or receipt behavior is implemented. |
+| `connectors/epa/src/epa/admit.py` | **CONFIRMED scaffold** | Contains a one-line greenfield placeholder for an admission gate. | No RAW/QUARANTINE routing or policy enforcement is implemented. |
+| `connectors/epa/src/epa/descriptor.yaml` | **CONFIRMED placeholder** | Declares `name: epa`, with `role: TBD`, `rights: TBD`, and `sensitivity_floor: public`. | Does not establish a reviewed canonical source descriptor, rights decision, or activation state. |
+| `connectors/epa/tests/README.md` | **CONFIRMED** | Connector-local test guidance exists. | Does not prove test files, passing tests, or CI wiring. |
+
+### Current maturity determination
+
+The directory is a documented scaffold, not a verified working connector.
+
+- **CONFIRMED:** the source root and four package entries exist.
+- **CONFIRMED:** `fetch.py` and `admit.py` are placeholders.
+- **CONFIRMED:** `descriptor.yaml` contains unresolved `TBD` values.
+- **PROPOSED:** future fetch and admit implementations should preserve the boundary defined here.
+- **UNKNOWN:** import path, package metadata, runtime behavior, endpoint coverage, tests, CI, emitted receipts, and downstream integration.
 
 ---
 
 ## Authority boundary
 
 ```text
-THIS SOURCE ROOT MAY CONTAIN:
-  connector implementation code
-  parser helpers
-  bounded client helpers
-  envelope builders
-  connector-local error classes
-  small package-local constants
-  package README files
+THIS SOURCE ROOT MAY:
+  implement bounded EPA fetch behavior
+  prepare source-admission candidates
+  preserve source identity and retrieval metadata
+  compute deterministic digests
+  return finite connector outcomes
+  target RAW or QUARANTINE handoff
 
-THIS SOURCE ROOT MUST NOT CONTAIN:
-  source descriptors as authority records
-  policy decisions
-  schemas as authority records
-  release manifests
-  publication outputs
-  raw source dumps
-  credentials or private endpoint material
-  generated truth claims
+THIS SOURCE ROOT MUST NOT:
+  declare EPA-derived facts true
+  act as the canonical source registry
+  decide rights or sensitivity by itself
+  own schemas, contracts, policy, evidence, proofs, or releases
+  write directly to PROCESSED, CATALOG, TRIPLET, or PUBLISHED
+  expose credentials or private endpoint material
+  silently repair missing source facts
+  turn generated language into evidence
 ```
 
-The EPA connector source root participates at the admission edge only:
-
-```text
-EPA source material
-  -> connectors/epa/src/
-  -> data/raw/ or data/quarantine/
-  -> downstream governed processing, validation, evidence closure, policy, review, release
-```
-
-It must not short-circuit the KFM lifecycle:
-
-```text
-RAW -> WORK / QUARANTINE -> PROCESSED -> CATALOG / TRIPLET -> PUBLISHED
-```
-
----
-
-## Expected contents
-
-The exact implementation inventory is **NEEDS VERIFICATION**. A minimal source-root structure may look like this:
-
-```text
-connectors/epa/src/
-├── README.md
-└── epa/
-    ├── README.md
-    ├── __init__.py
-    ├── config.py
-    ├── client.py
-    ├── parser.py
-    ├── envelope.py
-    └── errors.py
-```
-
-Recommended separation:
-
-| Area | Responsibility |
-|---|---|
-| `epa/config.py` | Configuration parsing, feature flags, no-network defaults, endpoint keys. |
-| `epa/client.py` | Bounded request helpers; no live access unless explicitly enabled. |
-| `epa/parser.py` | Payload parsing from fixtures or live responses without asserting truth. |
-| `epa/envelope.py` | Source-admission envelope construction with metadata and digest support. |
-| `epa/errors.py` | Finite connector errors safe for logs and review. |
-| `epa/__init__.py` | Small import surface that does not trigger network behavior. |
-
-Avoid adding shared utilities here until more than one connector needs them. Shared connector patterns should move to a governed shared package or tool home after review.
-
----
-
-## Import and packaging posture
-
-Expected posture:
-
-- importing the package should not make network calls;
-- importing the package should not require credentials;
-- package-level code should avoid reading live environment secrets at import time;
-- optional live behavior should be invoked explicitly;
-- parser functions should operate on supplied payloads or fixtures;
-- connector outputs should be deterministic for the same input payload and connector configuration;
-- source descriptors, schema validation, and policy checks should remain explicit dependencies, not hidden side effects.
-
-Likely import shape, subject to repo verification:
-
-```python
-from epa.parser import parse_payload
-from epa.envelope import build_source_admission_envelope
-```
-
-Do not treat this example as implementation proof until the mounted repo confirms module names and packaging configuration.
+The local `descriptor.yaml` is connector-adjacent scaffolding. Because its role and rights fields remain unresolved, it must not be treated as an activated or authoritative source descriptor. A reviewed registry record and the applicable policy decision must govern live source use.
 
 ---
 
 ## Lifecycle handoff
 
-Connector source code may prepare data for lifecycle handoff, but it does not own the later lifecycle phases.
+The EPA connector participates only at the source edge of the KFM lifecycle:
 
-| Phase | Connector source-root role |
+```text
+EPA source
+  -> fetch candidate
+  -> admit or quarantine decision
+  -> RAW or QUARANTINE
+  -> WORK
+  -> PROCESSED
+  -> CATALOG / TRIPLET
+  -> PUBLISHED
+```
+
+| Lifecycle stage | Source-root responsibility |
 |---|---|
-| Pre-RAW / source contact | May prepare bounded source requests when authorized. |
-| RAW | May write or prepare raw-admission payloads only if the repo’s intake convention allows it. |
-| QUARANTINE | May route incomplete, rights-unclear, malformed, or sensitive material to quarantine-safe output. |
-| WORK / PROCESSED | Out of scope unless a downstream pipeline imports connector helpers explicitly. |
-| CATALOG / TRIPLET | Out of scope. |
-| PUBLISHED | Out of scope. |
-| RELEASE / ROLLBACK | Out of scope. |
+| Pre-RAW | Prepare a bounded request and preserve source context when live access is authorized. |
+| RAW | Produce or hand off immutable source material with retrieval metadata and digest support. |
+| QUARANTINE | Route unresolved, malformed, sensitive, rights-unclear, or drifted material for review. |
+| WORK | No ownership; downstream pipelines may consume admitted material. |
+| PROCESSED | No ownership. |
+| CATALOG / TRIPLET | No ownership. |
+| PUBLISHED | No ownership. |
+| RELEASE / CORRECTION / ROLLBACK | No ownership. |
 
-When in doubt, route uncertain material toward quarantine or explicit abstention rather than guessing.
+Promotion remains a governed state transition. A successful fetch or admission helper call is not publication evidence.
+
+---
+
+## File contracts
+
+### `epa/fetch.py`
+
+**Current state:** one-line greenfield placeholder.
+
+Future implementation should:
+
+- require explicit configuration rather than hidden import-time behavior;
+- make network access deliberate and bounded;
+- use finite timeouts and retries;
+- preserve the source endpoint key, retrieval time, response status, and safe diagnostic context;
+- avoid logging credentials or unrestricted response bodies;
+- return a typed or otherwise contract-bound result suitable for admission review;
+- avoid writing directly to downstream lifecycle stores.
+
+It should not claim that a successful HTTP response is valid, admissible, authoritative, or publishable.
+
+### `epa/admit.py`
+
+**Current state:** one-line greenfield placeholder.
+
+Future implementation should:
+
+- accept a fetched or fixture-backed source candidate;
+- verify the required source descriptor reference and activation state;
+- preserve source role, rights, sensitivity, freshness, and retrieval metadata;
+- select only RAW, QUARANTINE, ABSTAIN, DENY, or ERROR-style bounded outcomes as the surrounding contract permits;
+- emit reviewable reasons for quarantine or refusal;
+- avoid normalizing EPA material into domain truth inside the connector.
+
+It should not bypass contracts, schemas, policy, validation, evidence closure, or release review.
+
+### `epa/descriptor.yaml`
+
+**Current state:** placeholder with unresolved role and rights.
+
+```yaml
+name: epa
+role: TBD
+rights: TBD
+sensitivity_floor: public
+```
+
+Required hardening before live activation:
+
+- replace `TBD` values through source-steward review;
+- bind the local file to the canonical source-registry identity or remove duplication if repo convention does not allow a connector-local descriptor;
+- record source program or endpoint scope rather than treating all EPA systems as one undifferentiated source;
+- record rights, citation, access, cadence, freshness, sensitivity, and failure posture;
+- validate the descriptor against the accepted source schema;
+- document whether this file is canonical, generated, mirrored, or connector-local configuration.
+
+Until those questions are resolved, live activation remains **DENY by default**.
+
+### `epa/README.md`
+
+The package README documents the intended package boundary. It should be updated alongside implementation so that its module inventory reflects the repository rather than a proposed `config.py` / `client.py` / `parser.py` layout that does not currently exist.
+
+---
+
+## Safety and runtime posture
+
+| Concern | Required posture |
+|---|---|
+| Import behavior | Importing connector code must not perform network I/O. |
+| Credentials | Never required for reading documentation or running no-network tests; never committed. |
+| Live access | Explicit opt-in, source-descriptor-backed, rate-limited, and steward-reviewable. |
+| Retries | Finite and observable; no uncontrolled polling. |
+| Logging | Safe metadata only; no secrets or excessive source payload copying. |
+| Determinism | The same fixture, configuration, and code version should produce the same normalized admission candidate and digest. |
+| Unknown rights or role | Quarantine, deny, or abstain; do not guess. |
+| Schema drift | Surface a reviewable drift outcome; do not silently coerce. |
+| Publication | Forbidden from this package. |
+
+> [!CAUTION]
+> EPA is an umbrella source family with many programs and endpoints. A single connector label must not flatten distinct source roles, terms, update cadences, spatial supports, or evidentiary limits.
 
 ---
 
 ## Testing relationship
 
-Connector-local tests live outside this source root:
+Connector-local test guidance lives at `connectors/epa/tests/README.md`.
 
-```text
-connectors/epa/tests/
-```
+Tests for this source root should be no-network by default and should verify at least:
 
-The source root should be easy to test with no-network fixtures:
+- importing modules causes no network activity;
+- live behavior cannot run without explicit enablement and a reviewed source reference;
+- fetch timeout, forbidden, rate-limit, empty-response, malformed-response, and schema-drift cases are finite and reviewable;
+- admission results target RAW or QUARANTINE only;
+- unresolved rights, role, sensitivity, or source drift fails closed;
+- deterministic fixtures produce stable metadata and digests;
+- no connector-local test writes to processed, catalog, triplet, published, proof, receipt, or release stores.
 
-- parser tests should pass with static payloads;
-- client tests should mock all HTTP behavior by default;
-- envelope tests should check metadata, source references, lifecycle target, and digest fields;
-- error tests should cover timeout, forbidden, rate-limited, empty, malformed, and schema-drift cases;
-- live smoke tests, if any, should be opt-in and isolated from default CI.
-
-Likely local command, subject to repo verification:
-
-```bash
-python -m pytest connectors/epa/tests
-```
+The exact test command and CI integration remain **NEEDS VERIFICATION**. Do not claim `pytest` coverage or passing CI until actual test files and workflow results are inspected.
 
 ---
 
 ## Definition of done
 
-This source root is ready for first review when:
+This source root is ready to move beyond scaffold status when:
 
-- [ ] `connectors/epa/src/README.md` explains the source-root boundary.
-- [ ] `connectors/epa/src/epa/README.md` explains the package boundary.
-- [ ] Importing package modules does not perform network I/O.
-- [ ] No credentials or private endpoint material are committed.
-- [ ] Connector output is limited to RAW or QUARANTINE handoff.
-- [ ] Parser behavior is fixture-testable without live EPA calls.
-- [ ] Errors are finite, actionable, and safe to log.
-- [ ] Live source activation requires source-descriptor and steward review.
-- [ ] The connector does not write directly to processed, catalog, triplet, published, proof, receipt, or release stores.
-- [ ] Test and CI wiring is documented once verified.
+- [ ] `fetch.py` contains bounded, testable implementation rather than a placeholder.
+- [ ] `admit.py` contains contract-bound RAW/QUARANTINE admission logic rather than a placeholder.
+- [ ] The source descriptor role, rights, sensitivity, citation, cadence, and activation state are reviewed and schema-valid.
+- [ ] Canonical versus connector-local descriptor ownership is documented without creating parallel authority.
+- [ ] Imports do not perform network I/O or read secrets as a side effect.
+- [ ] Live access is opt-in, bounded, and steward-approved.
+- [ ] No-network fixtures cover success and negative cases.
+- [ ] Errors and drift outcomes are finite, actionable, and safe to log.
+- [ ] Outputs preserve source identity, retrieval metadata, time, and digest support.
+- [ ] Outputs are limited to RAW or QUARANTINE handoff.
+- [ ] Tests and CI wiring are present and verified.
+- [ ] Package and source-root READMEs match the implemented modules.
+- [ ] No code in this root bypasses evidence, policy, review, release, correction, or rollback controls.
 
 ---
 
 ## Verification backlog
 
-| Item | Status | Needed evidence |
+| Item | Status | Evidence needed |
 |---|---:|---|
-| Confirm actual files below `connectors/epa/src/`. | **NEEDS VERIFICATION** | Mounted repo tree or GitHub file listing. |
-| Confirm whether `src/` is packaged by `pyproject.toml`, workspace config, or connector-specific metadata. | **NEEDS VERIFICATION** | Packaging files and CI. |
-| Confirm package import name is `epa`. | **NEEDS VERIFICATION** | Python package metadata and import tests. |
-| Confirm shared connector helper home, if any. | **NEEDS VERIFICATION** | Repo tree and ADRs. |
-| Confirm source-admission envelope schema. | **NEEDS VERIFICATION** | Contracts and schemas under the accepted schema home. |
-| Confirm source descriptor location and EPA source-family coverage. | **NEEDS VERIFICATION** | Source registry and source catalog docs. |
-| Confirm default no-network test behavior. | **NEEDS VERIFICATION** | Test config and CI workflows. |
+| Determine whether `descriptor.yaml` is canonical, generated, mirrored, or connector-local configuration. | **NEEDS VERIFICATION** | Source registry convention, schema, ADRs, and adjacent connector examples. |
+| Resolve `role: TBD` and `rights: TBD`. | **BLOCKING / NEEDS VERIFICATION** | Source-steward and rights review for each EPA program or endpoint. |
+| Confirm package import name and packaging metadata. | **UNKNOWN** | `pyproject.toml`, workspace configuration, import tests, or build metadata. |
+| Confirm the accepted fetch and admission contracts. | **UNKNOWN** | Contract docs and schemas at the accepted authority homes. |
+| Confirm actual EPA programs and endpoints in scope. | **UNKNOWN** | Source catalog, registry records, and approved implementation issue or ADR. |
+| Confirm test files and default no-network behavior. | **UNKNOWN** | Repository test inventory and test execution. |
+| Confirm CI coverage and required checks. | **UNKNOWN** | Workflow configuration and run results. |
+| Confirm RAW and QUARANTINE write interfaces. | **UNKNOWN** | Pipeline or intake contracts and integration tests. |
+| Confirm emitted receipt or event-envelope requirements. | **UNKNOWN** | Current schemas, validators, and proof-bearing fixture run. |
+
+---
+
+## Maintenance and rollback
+
+When implementation changes:
+
+1. update this inventory and the package README in the same documentation change;
+2. keep source-role, rights, sensitivity, and lifecycle boundaries visible;
+3. add or update no-network negative tests;
+4. avoid broad connector cleanup unrelated to the EPA lane;
+5. revert the documentation commit if the revised contract proves inconsistent with the implemented branch, then prepare a narrower correction.
+
+A Git commit or pull request changes repository documentation only. It does not activate an EPA source, admit data, or make any EPA-derived material KFM-published.
 
 ---
 
 ## Maintainer note
 
-Keep `connectors/epa/src/` boring and narrow. It should make EPA source material easier to admit safely, inspect, test, quarantine, and review. It should not become a hidden pipeline, a source registry, a policy engine, or a publication path.
+Keep `connectors/epa/src/` narrow, explicit, and boring. Its job is to make EPA source material safer to fetch, inspect, admit, quarantine, and hand off. Evidence, policy, validation, review, publication, correction, and rollback remain downstream governance responsibilities.


### PR DESCRIPTION
## Summary

Updates `connectors/epa/src/README.md` from a mostly proposed source-root description to a repository-grounded v0.2 contract.

## Changed path

- `connectors/epa/src/README.md` — revised

## Evidence basis

- Base branch: `main`
- Pinned base commit: `30d2c71ad48ae932f068969cfc0b51676c5c23f3`
- Confirmed package inventory at that commit:
  - `connectors/epa/src/epa/README.md`
  - `connectors/epa/src/epa/fetch.py`
  - `connectors/epa/src/epa/admit.py`
  - `connectors/epa/src/epa/descriptor.yaml`
- Confirmed `fetch.py` and `admit.py` are one-line greenfield placeholders.
- Confirmed `descriptor.yaml` retains unresolved `role: TBD` and `rights: TBD` fields.
- Placement follows Directory Rules: source-specific fetch and admission code belongs under `connectors/`; canonical registry, schema, policy, lifecycle, and release authority remain elsewhere.

## Material status labels

- **CONFIRMED:** source-root path and current file inventory.
- **CONFIRMED scaffold:** fetch and admit modules exist but do not implement operational behavior.
- **PROPOSED:** future file contracts and hardening requirements.
- **UNKNOWN:** package wiring, runtime behavior, endpoints, tests, CI, emitted receipts, and downstream integration.
- **NEEDS VERIFICATION:** canonical versus connector-local descriptor ownership, EPA program scope, source rights, and activation state.

## No-loss assessment

The revision preserves the existing trust-membrane boundary, RAW/QUARANTINE output limit, no-publication posture, no-network testing expectation, and maintainer guidance. It replaces inaccurate proposed module examples with the actual repository inventory and adds explicit scaffold, descriptor, validation, and rollback guidance.

## Validation

- PASS — remote read-back of the updated README.
- PASS — base-to-head comparison contains exactly one changed path.
- PASS — commit is one fast-forward commit ahead of the pinned base.
- NOT RUN — Markdown lint, link checker, tests, and CI were not executed by the connector.
- UNKNOWN — GitHub Actions results until workflows run on this pull request.

## Risk and sensitivity

Documentation-only change. No source activation, endpoint access, data ingestion, schema, policy, release, or publication state is changed. The README explicitly keeps unresolved EPA role and rights fields fail-closed.

## Rollback

Before merge, close this draft pull request and abandon the scoped branch. After merge, create a transparent revert of commit `ed0944728bd31b1d2f5aff21a968036c529af271` and re-run documentation validation.

<!-- kfm-task:connectors-epa-src-readme-v0.2 -->