### PR TITLE
docs: update KDWP ERT compatibility README

### DIFF
--- a/connectors/kdwp_ert/README.md
+++ b/connectors/kdwp_ert/README.md
@@ -1,264 +1,477 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://doc/connectors-kdwp-ert-readme
-title: connectors/kdwp_ert/ — KDWP Ecological Review Tool Compatibility Connector Lane
+title: connectors/kdwp_ert/ — KDWP Ecological Review Tool Compatibility Lane
 type: readme
-version: v0.1
+version: v0.2
 status: draft
 owners: OWNER_TBD — Connector steward · Kansas source steward · Flora steward · Fauna steward · Habitat steward · Rights reviewer · Sensitivity reviewer · Validation steward · Docs steward
 created: 2026-06-19
-updated: 2026-06-19
-policy_label: public-doctrine; compatibility-lane; noncanonical-path; administrative-source; regulatory-source; rights-gated; sensitivity-gated; no-publication
-proposed_path: connectors/kdwp_ert/README.md
-truth_posture: CONFIRMED path exists / NONCANONICAL compatibility README / CANONICAL HOME NEEDS VERIFICATION UNDER connectors/kansas/kdwp/
+updated: 2026-07-13
+policy_label: public-doctrine; compatibility-lane; noncanonical-path; bounded-review-output; rights-gated; sensitivity-gated; no-publication
+current_path: connectors/kdwp_ert/README.md
+canonical_working_lane: connectors/kansas/kdwp_ert/
+institutional_family_lane: connectors/kansas/kdwp/
+truth_posture: CONFIRMED current path and inspected repository evidence / NONCANONICAL compatibility lane / CONFLICTED final ERT placement and SourceDescriptor role authority / UNKNOWN runtime and source-access depth
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  base_ref: main
+  base_commit: e643fd599874083f74104162ed492729fc17bc7f
+  prior_blob: a67c3bb595ae90cb1c210610a7e8a8e072de801c
 related:
   - ../README.md
   - ../kdwp/README.md
   - ../kansas/README.md
   - ../kansas/kdwp/README.md
   - ../kansas/kdwp_ert/README.md
+  - ../../CONTRIBUTING.md
+  - ../../.github/CODEOWNERS
+  - ../../docs/doctrine/directory-rules.md
   - ../../docs/sources/catalog/kansas/kdwp.md
-  - ../../docs/domains/flora/SOURCES.md
-  - ../../docs/domains/flora/README.md
-  - ../../docs/domains/fauna/README.md
-  - ../../docs/domains/habitat/README.md
   - ../../docs/sources/SOURCE_DESCRIPTOR_STANDARD.md
-  - ../../data/registry/sources/
-  - ../../data/raw/flora/
-  - ../../data/quarantine/flora/
-  - ../../data/raw/fauna/
-  - ../../data/quarantine/fauna/
-  - ../../data/raw/habitat/
-  - ../../data/quarantine/habitat/
-  - ../../fixtures/
-  - ../../schemas/contracts/v1/source/
-  - ../../schemas/contracts/v1/biodiversity/
-  - ../../policy/sensitivity/
+  - ../../docs/domains/flora/SOURCES.md
+  - ../../docs/domains/fauna/SOURCES.md
+  - ../../docs/domains/habitat/README.md
+  - ../../contracts/source/source_descriptor.md
+  - ../../schemas/contracts/v1/source/source_descriptor.schema.json
+  - ../../schemas/contracts/v1/sources/source_descriptor.schema.json
+  - ../../data/registry/sources/README.md
+  - ../../control_plane/source_authority_register.yaml
   - ../../policy/rights/
+  - ../../policy/sensitivity/
   - ../../release/
-tags: [kfm, connectors, kdwp, kdwp-ert, ecological-review-tool, kansas, flora, fauna, habitat, compatibility, administrative-source, regulatory-source, source-admission, raw, quarantine, governance]
+tags: [kfm, connectors, kdwp, kdwp-ert, ecological-review-tool, compatibility, kansas, flora, fauna, habitat, bounded-review, source-admission, rights, sensitivity, raw, quarantine, governance]
 notes:
-  - "This README fills a blank top-level KDWP ERT connector path."
-  - "The KDWP source profile confirms canonical KDWP work belongs under `connectors/kansas/kdwp/`; this top-level snake_case path is a compatibility lane unless an ADR says otherwise."
-  - "The flora source registry names KDWP Ecological Review Tool / stewardship outputs as administrative and regulatory source material with rights and sensitivity gates."
-  - "This path must not become a public review service, policy authority, release surface, or direct publication path."
-  - "Connector output may enter RAW or QUARANTINE handoff only; downstream validation, EvidenceBundle closure, rights/sensitivity review, catalog/triplet projection, release review, publication, correction, and rollback remain outside this folder."
+  - "This top-level path is retained as a compatibility and migration surface. It must not evolve as a second canonical KDWP ERT implementation."
+  - "The current implementation-bearing documentation lane is `connectors/kansas/kdwp_ert/`; final sibling-versus-child placement under the institutional `connectors/kansas/kdwp/` family remains CONFLICTED / NEEDS VERIFICATION."
+  - "ERT and stewardship outputs are bounded review evidence. Preserve request scope, review status, inputs, output version, expiry, limitations, correction, withdrawal, and supersession context; do not reinterpret them as legal clearance, reusable site truth, a public occurrence layer, or a KFM release decision."
+  - "SourceDescriptor authority remains conflicted across narrative doctrine, the singular-path schema, the plural-path scaffold, and source-role vocabulary. This compatibility lane must not resolve that conflict."
+  - "Only this README is changed. No connector code, descriptor, fixture, policy, schema, workflow, receipt, release object, source activation, path move, or public artifact is created."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-# KDWP Ecological Review Tool Compatibility Connector Lane
-
-> Compatibility README for the existing top-level `connectors/kdwp_ert/` path. This path is **not** a canonical connector home; KDWP Ecological Review Tool / stewardship-output work should converge under the canonical Kansas/KDWP connector lane unless a later ADR or migration decision says otherwise.
-
-<p>
-  <img alt="Status: compatibility" src="https://img.shields.io/badge/status-compatibility-yellow">
-  <img alt="Canonicality: noncanonical path" src="https://img.shields.io/badge/canonicality-noncanonical__path-orange">
-  <img alt="Canonical lane: connectors/kansas/kdwp" src="https://img.shields.io/badge/canonical__lane-connectors%2Fkansas%2Fkdwp-success">
-  <img alt="Source roles: administrative plus regulatory" src="https://img.shields.io/badge/source__roles-administrative%20%2B%20regulatory-blue">
-  <img alt="Lifecycle: RAW or QUARANTINE only" src="https://img.shields.io/badge/lifecycle-RAW%20%7C%20QUARANTINE%20only-orange">
-</p>
+# KDWP Ecological Review Tool Compatibility Lane
 
 > [!IMPORTANT]
-> **Status:** compatibility / noncanonical-path README · **Owner:** `OWNER_TBD`  
-> **Path:** `connectors/kdwp_ert/README.md`  
-> **Truth posture:** `CONFIRMED` file exists · `NONCANONICAL` compatibility path · `NEEDS VERIFICATION` exact canonical ERT subpath  
-> **Boundary:** source-admission compatibility only; no public review service, no policy decision authority, no direct publication, no rights/sensitivity bypass.
+> **Document lifecycle:** `draft`  
+> **Component maturity:** compatibility and migration contract; runtime `UNKNOWN`  
+> **Owner:** `OWNER_TBD`  
+> **Canonicality:** `NONCANONICAL` top-level path  
+> **Working lane:** [`connectors/kansas/kdwp_ert/`](../kansas/kdwp_ert/)  
+> **Boundary:** no source activation, public review service, legal clearance, sensitivity decision, map publication, or release authority.
 
-**Quick jumps:** [Scope](#scope) · [Repo fit](#repo-fit) · [Accepted inputs](#accepted-inputs) · [Exclusions](#exclusions) · [Evidence ledger](#evidence-ledger) · [Lifecycle diagram](#lifecycle-diagram) · [Admission posture](#admission-posture) · [Anti-collapse rules](#anti-collapse-rules) · [Validation](#validation) · [Rollback](#rollback) · [Verification backlog](#verification-backlog)
+This folder exists to keep older references to `connectors/kdwp_ert/` understandable and safely redirected. New implementation work should not be added here unless an accepted ADR or explicit migration plan requires a narrowly bounded compatibility adapter.
 
----
-
-## Scope
-
-`connectors/kdwp_ert/` is retained here only as a compatibility lane because the path already exists.
-
-KDWP’s canonical connector family is under `connectors/kansas/kdwp/`. The exact canonical home for Ecological Review Tool or stewardship-output implementation remains **NEEDS VERIFICATION**: it may remain as a KDWP sublane, a documented compatibility path, or a migrated child path under `connectors/kansas/kdwp/` depending on ADR and repo convention.
-
-This path must not become a public ecological review product, policy authority, source registry, release surface, or canonical connector root without governance evidence.
-
-[Back to top ↑](#top)
+**Quick links:** [Purpose](#purpose) · [Authority and status](#authority-and-status) · [Routing](#routing) · [What belongs here](#what-belongs-here) · [What does not belong here](#what-does-not-belong-here) · [ERT meaning boundaries](#ert-record-and-meaning-boundaries) · [Lifecycle](#lifecycle-boundary) · [Validation](#validation) · [Review burden](#review-burden) · [Evidence basis](#evidence-basis) · [Definition of done](#definition-of-done) · [Rollback](#rollback) · [Verification backlog](#verification-backlog)
 
 ---
 
-## Repo fit
+## Purpose
 
-| Surface | Role | Status |
-|---|---|---:|
-| `connectors/kdwp_ert/` | Existing top-level compatibility path. | **CONFIRMED path / NONCANONICAL** |
-| `connectors/kansas/kdwp/` | Canonical KDWP connector lane. | **CONFIRMED README path** |
-| `connectors/kansas/kdwp_ert/` | Existing Kansas-lane ERT compatibility or sublane. | **CONFIRMED README path / PLACEMENT NEEDS VERIFICATION** |
-| `connectors/kdwp/` | Top-level KDWP compatibility path. | **CONFIRMED README path / NONCANONICAL** |
-| `docs/sources/catalog/kansas/kdwp.md` | Human-facing KDWP source catalog entry. | **CONFIRMED** |
-| `docs/domains/flora/SOURCES.md` | Flora source registry naming KDWP ERT / stewardship outputs. | **CONFIRMED** |
-| `data/registry/sources/` | SourceDescriptor authority. | **Outside connector / NEEDS VERIFICATION for entries** |
-| `data/raw/flora/`, `data/raw/fauna/`, `data/raw/habitat/` | Candidate RAW handoff targets. | **PROPOSED / NEEDS VERIFICATION** |
-| `data/quarantine/flora/`, `data/quarantine/fauna/`, `data/quarantine/habitat/` | Candidate quarantine handoff targets. | **PROPOSED / NEEDS VERIFICATION** |
-| `release/` | Release and publication controls. | **Out of scope for this compatibility lane** |
+`connectors/kdwp_ert/` is a compatibility lane for historical or external references that still point to the top-level KDWP Ecological Review Tool path.
 
-[Back to top ↑](#top)
+Its responsibilities are deliberately narrow:
 
----
+1. redirect maintainers to the current Kansas-family ERT documentation lane;
+2. record that this path is noncanonical;
+3. preserve migration and rollback context;
+4. prevent parallel connector, schema, registry, policy, or publication authority from forming here;
+5. fail closed when ERT product identity, rights, sensitivity, source role, review scope, or access posture is unresolved.
 
-## Accepted inputs
+The current implementation-bearing documentation lane is:
 
-Accepted content for this noncanonical compatibility path:
+```text
+connectors/kansas/kdwp_ert/
+```
 
-- README-level migration and compatibility notes;
-- links to the canonical KDWP connector lane;
-- notes that prevent this path from becoming a parallel authority;
-- temporary fixture or test notes only if explicitly migration-bound;
-- adapter notes for KDWP ERT or stewardship-output metadata only if retained here by ADR or migration note;
-- quarantine criteria for unresolved rights, source role, review status, taxon identity, geometry, sensitivity status, access method, or source-shape issues.
+The institutional KDWP family lane is:
 
-New implementation code should prefer the canonical Kansas/KDWP lane once exact placement is verified.
+```text
+connectors/kansas/kdwp/
+```
+
+Whether ERT should remain a Kansas-family sibling, become a child of `kdwp/`, or be represented only by this redirect remains **CONFLICTED / NEEDS VERIFICATION**. This README records that conflict; it does not settle it.
+
+[Back to top](#top)
 
 ---
 
-## Exclusions
+## Authority and status
 
-This folder must not contain or imply authority over:
+| Concern | Status | Evidence-bounded determination |
+|---|---:|---|
+| Responsibility root | **CONFIRMED** | Source-specific retrieval and parsing belong under `connectors/`. |
+| This top-level path | **CONFIRMED / NONCANONICAL** | The file exists, but the path is a compatibility surface rather than a second implementation authority. |
+| Kansas connector family | **CONFIRMED** | KDWP connector work belongs under `connectors/kansas/`. |
+| Current ERT working lane | **CONFIRMED** | `connectors/kansas/kdwp_ert/README.md` contains the current detailed admission contract. |
+| Final ERT product placement | **CONFLICTED / NEEDS VERIFICATION** | No accepted path-specific ADR was verified that resolves sibling versus institutional-child placement. |
+| Connector runtime | **UNKNOWN** | No live client, parser execution, fixture run, emitted receipt, source endpoint, or runtime log was verified for this top-level path. |
+| Source activation | **NONE** | A README or folder cannot activate an external source. |
+| Registry, schema, and policy authority | **NONE** | Those responsibilities belong to their governing roots. |
+| Publication and legal-clearance authority | **NONE** | Connector output cannot authorize public release or represent legal clearance. |
 
-- canonical connector-family status;
-- public ecological review decisions;
-- public release decisions;
-- direct writes to `PROCESSED`, `CATALOG`, `TRIPLET`, `PUBLISHED`, proof, receipt, or release stores;
-- SourceDescriptor authority records;
-- policy or schema authority;
-- generated summaries presented as regulatory, ecological, occurrence, habitat, or review truth;
-- source activation without SourceDescriptor, rights, sensitivity, source-role, taxonomy, geometry, provenance, and review checks.
+> [!CAUTION]
+> Repository presence is not canonicality. A compatibility path must not become a parallel authority merely because references to it still exist.
 
-Redirect implementation and source-family authority to the canonical KDWP connector lane once verified.
-
-[Back to top ↑](#top)
-
----
-
-## Evidence ledger
-
-| Source | Status | Supports | Limits |
-|---|---:|---|---|
-| `connectors/kdwp_ert/README.md` | **CONFIRMED** | Target file exists and was blank before this update. | Does not prove implementation files, tests, or CI. |
-| `docs/sources/catalog/kansas/kdwp.md` | **CONFIRMED** | KDWP source profile identifies the canonical KDWP connector path under `connectors/kansas/kdwp/` and requires KDWP source-role separation. | Does not prove exact ERT subpath or implementation. |
-| `docs/domains/flora/SOURCES.md` | **CONFIRMED** | Flora registry names KDWP ERT / stewardship outputs as administrative and regulatory source material with rights and sensitivity gates. | Does not prove endpoint availability, fixture safety, or implementation. |
-| `connectors/kansas/kdwp_ert/README.md` | **CONFIRMED** | Kansas-lane ERT README exists. | Placement and final migration status remain NEEDS VERIFICATION. |
+[Back to top](#top)
 
 ---
 
-## Lifecycle diagram
+## Routing
+
+Use the following routing rules:
+
+| Need | Go to |
+|---|---|
+| Detailed ERT admission contract | [`connectors/kansas/kdwp_ert/`](../kansas/kdwp_ert/) |
+| KDWP institutional connector family | [`connectors/kansas/kdwp/`](../kansas/kdwp/) |
+| Kansas connector-family rules | [`connectors/kansas/`](../kansas/) |
+| Top-level KDWP compatibility notes | [`connectors/kdwp/`](../kdwp/) |
+| Human-readable KDWP source profile | [`docs/sources/catalog/kansas/kdwp.md`](../../docs/sources/catalog/kansas/kdwp.md) |
+| Source descriptor standard | [`docs/sources/SOURCE_DESCRIPTOR_STANDARD.md`](../../docs/sources/SOURCE_DESCRIPTOR_STANDARD.md) |
+| Machine source registry | [`data/registry/sources/`](../../data/registry/sources/) |
+| Source authority decisions | [`control_plane/source_authority_register.yaml`](../../control_plane/source_authority_register.yaml) |
+| Rights controls | [`policy/rights/`](../../policy/rights/) |
+| Sensitivity controls | [`policy/sensitivity/`](../../policy/sensitivity/) |
+| Release controls | [`release/`](../../release/) |
+
+Do not duplicate the detailed ERT contract in this path. The compatibility lane should remain small enough that migration intent and authority boundaries are unmistakable.
+
+[Back to top](#top)
+
+---
+
+## What belongs here
+
+Permitted content is limited to:
+
+- this redirect and compatibility README;
+- explicit migration notes with an owner, target path, validation step, and rollback target;
+- deprecation notices for historical imports or links;
+- narrowly bounded adapters required to preserve compatibility during an approved migration;
+- tests proving that compatibility behavior forwards, warns, or fails closed as designed;
+- sunset criteria and removal evidence for any temporary compatibility code.
+
+Any compatibility implementation must:
+
+- avoid independent source activation;
+- delegate to the accepted implementation lane rather than fork behavior;
+- preserve source identity and request scope;
+- emit no public artifact;
+- avoid storing credentials, private requests, or sensitive payloads;
+- have an explicit removal condition.
+
+No item in this list proves that corresponding code already exists.
+
+[Back to top](#top)
+
+---
+
+## What does not belong here
+
+This folder must not own or imply authority over:
+
+- a second KDWP ERT client, parser, fetcher, or product implementation;
+- a public Ecological Review Tool or public review workflow;
+- legal clearance, permitting, consultation, or release decisions;
+- reusable site-level truth detached from the bounded source request;
+- `SourceDescriptor` instances or source-authority registry entries;
+- canonical contracts, schemas, source-role vocabularies, policies, or release rules;
+- rights, sensitivity, redaction, access, or public-precision decisions;
+- taxonomic-backbone or conservation-status tie-breakers;
+- public occurrence points, range truth, habitat occupancy, or sensitive-location products inferred from review output;
+- requester contact details, private-project material, credentials, tokens, cookies, private URLs, or private correspondence;
+- direct writes to `WORK`, `PROCESSED`, `CATALOG`, `TRIPLET`, `PUBLISHED`, proof, or release stores;
+- `EvidenceBundle`, proof-pack, catalog, release-manifest, correction, withdrawal, or rollback authority;
+- public APIs, map layers, tiles, dashboards, summaries, exports, or AI answers;
+- generated language presented as regulatory, ecological, occurrence, habitat, sensitivity, legal, or release truth.
+
+A retrieved review result is not an admitted source. An admitted source is not validated evidence. Validated evidence is not legal clearance or a released public claim.
+
+[Back to top](#top)
+
+---
+
+## ERT record and meaning boundaries
+
+ERT or stewardship-review material must remain bounded to the source-issued request, review, result, package, and limitations.
+
+Preserve, when the source provides them:
+
+| Record dimension | Required treatment |
+|---|---|
+| Product identity | Identify the exact issuing program, product, and version; agency name alone is insufficient. |
+| Request scope | Keep the source-defined spatial, temporal, taxonomic, project, and purpose boundary. |
+| Review identifier | Preserve the source-native request, review, result, or package identifier. |
+| Review status | Preserve preliminary, complete, expired, withdrawn, corrected, superseded, or other source-native state. |
+| Inputs | Preserve references to screening layers, submitted geometry, taxon lists, or other source inputs when disclosure is permitted. |
+| Output limitations | Preserve caveats, expiry, reuse restrictions, required follow-up, and non-clearance language. |
+| Temporal context | Preserve source, review, effective, expiry, retrieval, correction, withdrawal, and supersession time where material. |
+| Geometry | Preserve original-versus-public intent, precision, coordinate uncertainty, withholding, generalization, and sensitivity state. |
+| Rights | Preserve access, attribution, redistribution, downstream-use, and retention limits. Unknown rights fail closed. |
+| Source role | Use the accepted machine vocabulary. Until authority is resolved, preserve human meaning and quarantine ambiguous mixed-role records. |
+| Provenance | Preserve source URI or controlled reference, source head, checksum or equivalent identity signal, retrieval context, and transform lineage. |
+
+Do not reinterpret a bounded review output as:
+
+- statewide occurrence truth;
+- current range or occupancy truth;
+- a taxonomic authority;
+- a sensitivity policy decision;
+- a legal clearance;
+- a guarantee that no protected resource is present;
+- a reusable answer for another site, time, project, or purpose;
+- a KFM release decision.
+
+[Back to top](#top)
+
+---
+
+## SourceDescriptor authority conflict
+
+The repository currently exposes competing or incomplete `SourceDescriptor` authority signals:
+
+- narrative doctrine and source catalog material;
+- `contracts/source/source_descriptor.md`;
+- `schemas/contracts/v1/source/source_descriptor.schema.json`;
+- `schemas/contracts/v1/sources/source_descriptor.schema.json`;
+- `data/registry/sources/README.md`;
+- `control_plane/source_authority_register.yaml`.
+
+The inspected Kansas-lane ERT README records the singular-path schema as legacy and the plural-path schema as an empty scaffold. Source-role descriptions also vary across narrative surfaces.
+
+Therefore:
+
+1. this compatibility README must not declare one schema home or role vocabulary canonical;
+2. an ERT source must not be activated without an accepted product-level descriptor and authority decision;
+3. ambiguous role mappings route to `QUARANTINE` or `ABSTAIN`;
+4. resolving the schema-home or vocabulary conflict belongs to an accepted ADR or governing authority update, not this folder.
+
+[Back to top](#top)
+
+---
+
+## Lifecycle boundary
 
 ```mermaid
 flowchart LR
-  A[KDWP ERT / stewardship-output source material] --> B[SourceDescriptor gate]
-  B --> C{Admission decision}
-  C -->|allowed with limits| D[RAW handoff]
-  C -->|needs review| Q[QUARANTINE handoff]
-  C -->|denied| X[No connector activation]
-  D --> E[Source-role and sensitivity validation]
-  Q --> E
-  E --> F[Rights and review-state checks]
-  F --> G[EvidenceBundle and policy review]
-  G --> H[Catalog or triplet projection]
-  H --> I[Release review]
-  I --> P[Published public-safe artifact]
+  A[Historical caller or import] --> C[connectors/kdwp_ert compatibility surface]
+  C --> D{Approved compatibility behavior?}
+  D -->|redirect or delegate| K[connectors/kansas/kdwp_ert]
+  D -->|unclear or unsafe| X[DENY / ABSTAIN]
+  K --> S[Product-level SourceDescriptor and activation gate]
+  S --> G{Admission decision}
+  G -->|allowed with limits| R[Caller-owned RAW handoff]
+  G -->|needs review| Q[Caller-owned QUARANTINE handoff]
+  G -->|denied| X
+  R --> V[Downstream validation, policy, evidence, and review]
+  Q --> V
+  V --> P[Governed promotion and release process]
 ```
 
-[Back to top ↑](#top)
+This compatibility path may redirect or delegate. It must not independently advance source material through the lifecycle.
 
----
+The KFM lifecycle remains:
 
-## Admission posture
+```text
+RAW -> WORK / QUARANTINE -> PROCESSED -> CATALOG / TRIPLET -> PUBLISHED
+```
 
-Expected behavior for KDWP ERT / stewardship-output source-admission work:
+Promotion is a governed state transition, not a connector write, file move, commit, pull request, or generated summary.
 
-- no live source access unless explicitly enabled and reviewed;
-- no source fetch without an accepted SourceDescriptor and activation decision;
-- no implicit publication from retrieved source material;
-- no conversion of review output into public occurrence, range, habitat, regulatory, or review truth without downstream review;
-- no collapse of ERT/stewardship outputs into generic KDWP observation data;
-- no loss of source ID, source URI, surface identity, source role, review status, taxon context, geometry/uncertainty, date/vintage, license/rights, sensitivity state, review, or release-class metadata;
-- unclear rights, source role, review status, taxon context, geometry, sensitivity state, access endpoint, freshness, or schema drift routes to quarantine or abstention.
-
----
-
-## Anti-collapse rules
-
-The ERT source lane must preserve the following controls:
-
-1. `connectors/kdwp_ert/` is compatibility-only unless an ADR says otherwise.
-2. Canonical KDWP work belongs under the Kansas connector family.
-3. ERT/stewardship outputs are administrative/regulatory source material, not automatically observed occurrence truth.
-4. Review outputs are source evidence, not public release approval.
-5. Public release is a governed state transition, not a connector output.
-6. Derived summaries, maps, tiles, joins, and AI explanations are downstream carriers, not sovereign truth.
+[Back to top](#top)
 
 ---
 
 ## Validation
 
-Compatibility-lane validation should check that:
+A compatibility change is acceptable only when validation shows that:
 
-- this path is not treated as canonical without ADR/migration evidence;
-- source metadata is preserved;
-- SourceDescriptor references are required for activation;
-- source role is explicit and not collapsed;
-- rights and sensitivity states are explicit before promotion-track use;
-- surface identity, review status, taxon context, source URI, geometry/uncertainty, date/vintage, access method, review, and release-class fields are explicit where available;
-- malformed or incomplete records fail closed;
-- records with unresolved rights, sensitivity state, source role, review status, taxon context, geometry, or access method route to quarantine;
-- connector output is limited to RAW or QUARANTINE handoff;
-- no connector run writes directly to processed, catalog, triplet, published, proof, receipt, or release stores.
+- the top-level path is visibly marked noncanonical;
+- normal documentation navigation points to `connectors/kansas/kdwp_ert/`;
+- no implementation fork is introduced;
+- any adapter delegates to the accepted implementation lane;
+- source metadata and bounded review scope are preserved;
+- live access still requires an accepted product-level descriptor and activation decision;
+- unresolved rights, sensitivity, source role, taxonomy, geometry, review status, product identity, or access method fail closed;
+- no sensitive or private fixture data is committed;
+- outputs remain limited to redirect behavior or caller-owned `RAW` / `QUARANTINE` handoff through the canonical lane;
+- no direct writes target `WORK`, `PROCESSED`, `CATALOG`, `TRIPLET`, `PUBLISHED`, proof, receipt, or release stores;
+- Markdown links and anchors resolve;
+- the compatibility path has a documented rollback target and sunset decision.
 
-Root-level validation, policy-as-code, EvidenceBundle closure, release review, public caveats, and rollback remain outside this compatibility lane.
+Documentation-only validation for this change should include:
 
-[Back to top ↑](#top)
+```bash
+git diff --check
+markdownlint connectors/kdwp_ert/README.md
+```
+
+The exact repository-supported Markdown command remains **NEEDS VERIFICATION** against current workflow and tool configuration.
+
+[Back to top](#top)
+
+---
+
+## Review burden
+
+At minimum, a material change to this lane should receive review from:
+
+- connector steward;
+- Kansas source steward;
+- relevant flora, fauna, or habitat steward;
+- rights reviewer;
+- sensitivity reviewer;
+- validation steward;
+- docs steward.
+
+Additional review is required when a change affects:
+
+- source activation;
+- schema or contract authority;
+- source-role vocabulary;
+- exact or sensitive geometry;
+- rights or redistribution;
+- public API, map, export, or AI behavior;
+- release, correction, withdrawal, or rollback.
+
+`CODEOWNERS` routing is useful operational evidence, but it does not by itself prove semantic ownership or approval.
+
+[Back to top](#top)
+
+---
+
+## Evidence basis
+
+| Evidence | Status | Supports | Does not prove |
+|---|---:|---|---|
+| `connectors/kdwp_ert/README.md` at base commit | **CONFIRMED** | Existing top-level compatibility documentation and prior blob for rollback. | Canonicality, runtime, or source activation. |
+| `connectors/kansas/kdwp_ert/README.md` | **CONFIRMED** | Current detailed ERT admission contract, product meaning boundaries, descriptor conflict, and current working path. | Final sibling-versus-child placement or implementation maturity. |
+| `connectors/kansas/kdwp/README.md` | **CONFIRMED** | Institutional KDWP family responsibilities and anti-collapse posture. | Product-specific ERT access or implementation. |
+| `docs/sources/catalog/kansas/kdwp.md` | **CONFIRMED** | Human-facing KDWP source profile and Kansas-family placement. | Current official endpoint, rights, cadence, or activation. |
+| `docs/doctrine/directory-rules.md` | **CONFIRMED doctrine** | Responsibility-root placement, no parallel authority, lifecycle and migration discipline. | Exact current implementation below uninspected paths. |
+| Source descriptor and authority surfaces listed above | **CONFIRMED paths referenced by current lane** | Existence of multiple authority signals and the need for resolution. | An accepted canonical schema home or role vocabulary. |
+| Current repository snapshot | **CONFIRMED at pinned commit** | Base commit and prior blob used for this revision. | CI success, branch protection, runtime behavior, or deployed state. |
+
+### Evidence limits
+
+This update does not claim that:
+
+- a KDWP ERT connector runtime exists;
+- a live endpoint is available or approved;
+- current official terms or redistribution rights are known;
+- an accepted ERT `SourceDescriptor` exists;
+- source-role or schema-home conflicts are resolved;
+- fixtures, tests, receipts, proofs, releases, or public artifacts exist;
+- this compatibility path should be deleted or retained permanently.
+
+[Back to top](#top)
+
+---
+
+## ADRs
+
+No accepted path-specific ADR was verified that authorizes this top-level folder as a canonical ERT implementation home.
+
+An ADR or equivalent accepted migration decision is required before:
+
+- making this path canonical;
+- moving ERT from its current Kansas-family sibling position;
+- creating a second implementation;
+- changing schema-home authority;
+- establishing a new source-role vocabulary;
+- creating a parallel registry, policy, receipt, proof, or release home.
+
+A future placement decision should record:
+
+1. current and target paths;
+2. responsibility owner;
+3. compatibility period;
+4. import and documentation migration;
+5. validation and no-duplicate-authority checks;
+6. rollback target;
+7. deletion or retention criteria.
+
+[Back to top](#top)
 
 ---
 
 ## Definition of done
 
-This compatibility README is ready for first review when:
+This compatibility lane is ready for review when:
 
-- [ ] KDWP source profile and Flora source registry are linked and current enough for review.
-- [ ] A migration or ADR decision resolves whether to remove this top-level path, keep it as a redirect, or migrate implementation under the canonical KDWP lane.
-- [ ] Canonical ERT implementation home is verified.
-- [ ] SourceDescriptor homes and ERT source IDs are verified.
-- [ ] Rights terms, access methods, cadence, fixture strategy, source-role strategy, and sensitivity checks are verified by source steward review.
-- [ ] Live source access is disabled by default for connector code.
-- [ ] Source-role, review-state, taxonomy, rights, sensitivity, geometry, and anti-collapse checks are represented in tests.
-- [ ] Connector output is limited to RAW or QUARANTINE handoff.
-- [ ] No public ecological review, occurrence, range, habitat, or regulatory claims are created by connector code.
+- [x] The top-level path is explicitly marked noncanonical.
+- [x] The current Kansas-family ERT lane is linked.
+- [x] ERT review output is bounded and not represented as legal clearance or reusable site truth.
+- [x] Source activation, registry, schema, policy, and publication authority are excluded.
+- [x] The current base commit and prior blob are recorded for rollback.
+- [ ] An accepted placement decision resolves sibling, child, redirect-only, or removal status.
+- [ ] Canonical `SourceDescriptor` schema and source-role authority are resolved.
+- [ ] Product-level ERT descriptor, rights, sensitivity, access, cadence, and fixture posture are verified.
+- [ ] Any compatibility code has tests, a removal condition, and no independent source behavior.
+- [ ] Repository-supported Markdown and link checks pass in CI.
+- [ ] Owners and required reviewers are assigned.
+
+[Back to top](#top)
 
 ---
 
 ## Rollback
 
-Rollback is required if this README is used to justify canonical-family status, direct publication, source activation, source-role collapse, rights/sensitivity bypass, public review claims, or direct writes beyond RAW/QUARANTINE handoff.
-
-Rollback target:
+**Rollback target**
 
 ```text
-commit prior to this update: SHA_TBD_AFTER_GIT_HISTORY_CHECK
+base commit: e643fd599874083f74104162ed492729fc17bc7f
+prior blob: a67c3bb595ae90cb1c210610a7e8a8e072de801c
+path: connectors/kdwp_ert/README.md
 ```
 
-Because the file was blank before this update, a safe rollback is to restore the blank placeholder or replace this document with a shorter redirect-only README until canonical placement is resolved.
+Rollback is appropriate if this revision:
+
+- breaks repository navigation;
+- incorrectly identifies the working lane;
+- conflicts with an accepted ADR or newer migration decision;
+- obscures rather than clarifies the compatibility boundary;
+- is used to justify source activation, legal clearance, direct publication, or parallel authority.
+
+A rollback restores the prior blob at the recorded base. It does not decide the long-term fate of the path.
+
+[Back to top](#top)
 
 ---
 
 ## Verification backlog
 
-| Item | Status | Needed evidence |
+| Item | Status | Evidence needed |
 |---|---:|---|
-| Confirm canonical KDWP ERT implementation home. | **NEEDS VERIFICATION** | Directory Rules, ADR, migration note, or repo tree. |
-| Confirm whether this top-level path should remain. | **NEEDS VERIFICATION** | ADR or migration decision. |
-| Confirm SourceDescriptor homes and ERT source IDs. | **NEEDS VERIFICATION** | Source registry entries and accepted schemas. |
-| Confirm current access methods, cadence, and terms. | **NEEDS VERIFICATION** | Source steward review and current source documentation. |
-| Confirm rights and sensitivity handling. | **NEEDS VERIFICATION** | Rights review, sensitivity review, and policy references. |
-| Confirm fixture strategy and CI wiring. | **NEEDS VERIFICATION** | Fixture registry, workflow files, and test logs. |
+| Resolve final ERT placement: Kansas-family sibling, child under `kdwp/`, redirect-only path, or removal. | **CONFLICTED / NEEDS VERIFICATION** | Accepted ADR, migration decision, and repository-wide reference scan. |
+| Confirm the current authoritative `SourceDescriptor` schema home. | **CONFLICTED** | Accepted schema-home ADR and populated canonical schema. |
+| Confirm the accepted source-role vocabulary for bounded review outputs. | **CONFLICTED** | Machine contract, registry rule, policy mapping, and fixtures. |
+| Verify an ERT product-level descriptor and source authority record. | **NOT VERIFIED** | Registry entry and accepted activation decision. |
+| Verify official product identity, fields, access method, cadence, and source-head signal. | **NEEDS VERIFICATION** | Current official source documentation and source-steward review. |
+| Verify rights, attribution, redistribution, retention, and account requirements. | **NEEDS VERIFICATION** | Rights review and recorded terms snapshot. |
+| Verify sensitivity, geometry, private-project, rare-taxon, cultural, and facility controls. | **NEEDS VERIFICATION** | Policy review, redaction/generalization tests, and safe fixtures. |
+| Scan repository references to `connectors/kdwp_ert/`. | **NEEDS VERIFICATION** | Complete code and documentation search at the migration commit. |
+| Confirm whether compatibility code exists below this path. | **UNKNOWN** | Recursive tree inspection and tests. |
+| Assign semantic owners and reviewers. | **UNKNOWN** | Steward decision plus CODEOWNERS or governance update. |
+| Confirm Markdown lint and link-check commands. | **NEEDS VERIFICATION** | Current workflow and tool configuration. |
+| Define removal or long-term retention criteria. | **PROPOSED** | Migration plan with validation and rollback evidence. |
+
+[Back to top](#top)
 
 ---
 
-## Maintainer note
+## Maintainer summary
 
-Do not build new authority here. This existing top-level path should either stay a clear compatibility pointer or be removed after migration. Implementation should converge under the canonical KDWP connector lane unless an ADR says otherwise.
+Treat `connectors/kdwp_ert/` as a signpost, not a second connector.
 
-[Back to top ↑](#top)
+```text
+historical reference
+  -> compatibility redirect
+  -> connectors/kansas/kdwp_ert/
+  -> product-level source admission
+  -> RAW or QUARANTINE handoff
+  -> downstream evidence, policy, validation, release, correction, and rollback
+```
+
+When evidence is incomplete, preserve the bounded source meaning and choose `QUARANTINE`, `DENY`, or `ABSTAIN` rather than inventing authority.


### PR DESCRIPTION
## What changed

- updates `connectors/kdwp_ert/README.md` from v0.1 to v0.2
- makes the top-level path an explicit noncanonical compatibility and migration surface
- routes detailed ERT work to `connectors/kansas/kdwp_ert/`
- records the unresolved sibling-versus-child placement question without inventing an ADR decision
- adds bounded-review meaning rules so ERT output is not treated as legal clearance, reusable site truth, occurrence truth, or release authority
- carries forward the `SourceDescriptor` schema and role-vocabulary conflict from the current Kansas-lane README
- replaces the stale blank-file claim and rollback placeholder with the pinned base commit and prior blob
- documents lifecycle, validation, review burden, evidence limits, ADR triggers, rollback, and verification backlog

## Why

The existing top-level README lagged behind the newer Kansas-family ERT contract. It still described the file as formerly blank, did not include the current descriptor-authority conflict, and could be read as a duplicated implementation specification rather than a narrow compatibility signpost.

## Scope

Documentation only. No connector code, source descriptor, fixture, schema, policy, workflow, source activation, path move, release object, or public artifact is changed.

## Validation

- verified the branch contains exactly one changed file
- verified the branch is one commit ahead of `main` and not behind
- re-fetched the updated file from GitHub and confirmed the v0.2 metadata, current evidence snapshot, working-lane routing, and noncanonical boundary
- repository-supported Markdown lint and link-check execution remain to CI/reviewer verification

## Rollback

Restore blob `a67c3bb595ae90cb1c210610a7e8a8e072de801c` at base commit `e643fd599874083f74104162ed492729fc17bc7f`.