### PR TITLE
docs(policy): strengthen access policy root

### DIFF
--- a/policy/access/README.md
+++ b/policy/access/README.md
@@ -2,368 +2,716 @@
 doc_id: kfm://policy/access
 title: Access Policy README
 type: policy-readme
-version: v0.1
+version: v0.2
 status: draft
-owners: OWNER_TBD — Access steward · Policy steward · Security steward · Docs steward
+owners: OWNER_TBD — Access steward · Policy steward · Security steward · Identity steward · Audit steward · Release steward · Docs steward
 created: 2026-06-15
-updated: 2026-06-15
+updated: 2026-07-14
 policy_label: restricted
+supersedes: v0.1 (2026-06-15)
 related:
   - ../README.md
   - flora-steward/README.md
-  - ../../docs/doctrine/trust-membrane.md
+  - ../../contracts/policy/policy_input_bundle.md
+  - ../../contracts/policy/policy_decision.md
+  - ../../schemas/contracts/v1/policy/policy_input_bundle.schema.json
+  - ../../schemas/contracts/v1/policy/policy_decision.schema.json
   - ../../docs/doctrine/directory-rules.md
+  - ../../docs/architecture/trust-membrane.md
   - ../../docs/security/DATA_CLASSIFICATION.md
   - ../../apps/governed-api/README.md
+  - ../../apps/review-console/README.md
   - ../../packages/policy-runtime/README.md
-tags: [kfm, policy, access, authorization, roles, least-privilege, audit, deny-by-default]
+tags: [kfm, policy, access, authorization, capability, least-privilege, separation-of-duties, audit, revocation, deny-by-default]
 notes:
-  - "Initial README for the policy/access root."
-  - "This directory is for access-policy documentation and policy modules; it is not a credential store or deployment secret home."
-  - "Runtime enforcement, identity-provider mappings, policy bundle shape, tests, fixtures, and audit schemas remain NEEDS VERIFICATION."
+  - "v0.2 aligns the access-policy root with the repository PolicyInputBundle and PolicyDecision contracts."
+  - "Runtime-facing access decisions use ANSWER | ABSTAIN | DENY | ERROR with policy_family=access."
+  - "This README defines the access-policy boundary; it is not a credential store, access grant, identity provider, sensitivity decision, rights clearance, evidence authority, or release approval."
+  - "Runtime enforcement, identity mappings, bundles, audit sinks, fixtures, tests, revocation propagation, and deployed review surfaces remain NEEDS VERIFICATION."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
-
-<div align="center">
 
 # Access Policy Root
 
 `policy/access/`
 
-**Access-control policy lane for KFM roles, steward capabilities, review surfaces, least-privilege gates, and auditable allow / deny / abstain decisions.**
+**Canonical access-policy lane for deciding who may perform a specific, bounded KFM capability on a governed object, for a stated purpose, through an auditable interface.**
 
 ![status](https://img.shields.io/badge/status-draft-blue)
+![version](https://img.shields.io/badge/version-v0.2-1f6feb)
 ![owner](https://img.shields.io/badge/owner-OWNER__TBD-lightgrey)
-![policy](https://img.shields.io/badge/policy-access__control-0a7ea4)
-![truth](https://img.shields.io/badge/truth-NEEDS__VERIFICATION-yellow)
-![default](https://img.shields.io/badge/default-deny__closed-d62728)
-
-[Scope](#1-scope) · [Repo fit](#2-repo-fit) · [Inputs](#5-inputs) · [Exclusions](#6-exclusions) · [Access lanes](#7-access-lanes) · [Diagram](#8-diagram) · [Definition of done](#14-definition-of-done)
-
-</div>
-
----
+![outcomes](https://img.shields.io/badge/outcomes-ANSWER%20%7C%20ABSTAIN%20%7C%20DENY%20%7C%20ERROR-2ea44f)
+![default](https://img.shields.io/badge/default-fail__closed-d62728)
+![publication](https://img.shields.io/badge/publication-not__authorized-critical)
 
 > [!IMPORTANT]
-> **Status:** draft / `NEEDS VERIFICATION`  
-> **Owners:** `OWNER_TBD` — Access steward · Policy steward · Security steward · Docs steward  
 > **Path:** `policy/access/README.md`  
-> **Responsibility root:** `policy/` — policy-as-code and policy documentation  
-> **Truth posture:** CONFIRMED file path / PROPOSED access-root contract / UNKNOWN runtime enforcement
+> **Responsibility root:** `policy/` — admissibility and access-control policy  
+> **Truth posture:** CONFIRMED repository relationships · PROPOSED access-root contract · UNKNOWN deployed enforcement
 
 > [!CAUTION]
-> Access policy is not publication authority. An access decision can permit a bounded user action inside a governed review surface, but it must not publish claims, downgrade sensitivity, bypass rights review, or expose lifecycle data directly to public clients.
-
----
+> **Access authority is not truth, sensitivity, rights, evidence, or release authority.** An access decision may permit one bounded action inside a governed surface. It must not publish a claim, downgrade sensitivity, clear rights, manufacture evidence, expose internal lifecycle stores, or grant a broad “see everything” role.
 
 ## Quick jump
 
-- [1. Scope](#1-scope)
-- [2. Repo fit](#2-repo-fit)
-- [3. Root boundary](#3-root-boundary)
-- [4. Default posture](#4-default-posture)
-- [5. Inputs](#5-inputs)
-- [6. Exclusions](#6-exclusions)
-- [7. Access lanes](#7-access-lanes)
-- [8. Diagram](#8-diagram)
-- [9. Decision outcomes](#9-decision-outcomes)
-- [10. Role and capability rules](#10-role-and-capability-rules)
-- [11. Audit expectations](#11-audit-expectations)
-- [12. Inspection path](#12-inspection-path)
-- [13. Validation expectations](#13-validation-expectations)
-- [14. Definition of done](#14-definition-of-done)
-- [15. Open verification items](#15-open-verification-items)
+[Scope](#1-scope) · [Authority](#3-authority-boundary) · [Capabilities](#6-capability-model) · [Child lanes](#7-child-access-lane-contract) · [Decision contract](#10-decision-contract) · [Audit](#14-audit-and-data-minimization) · [Validation](#18-validation-and-acceptance-matrix) · [Definition of done](#21-definition-of-done)
 
 ---
 
 ## 1. Scope
 
-`policy/access/` is the KFM policy lane for access-control posture.
+`policy/access/` owns the policy conditions under which an authenticated subject may perform a named capability on a governed object, for an explicit purpose, within a bounded scope and authorization window.
 
-It should hold access-policy documentation and, when implemented, policy modules or bundle material that decide who may use bounded KFM capabilities: reviewer actions, steward review, admin-only correction flows, restricted surfaces, and other role-gated operations.
+### In scope
 
-In scope:
+- capability-specific authorization;
+- role-to-capability mappings;
+- least-privilege, purpose-bound, time-bound, and object-bound access;
+- reviewer, steward, operator, service, and restricted-surface access;
+- finite decisions, reason codes, and obligations;
+- audit, revocation, freshness, and cache-invalidation expectations;
+- separation of duties and break-glass constraints;
+- child access-lane requirements;
+- deterministic negative-path fixtures and tests.
 
-- role and capability policy boundaries
-- least-privilege access posture
-- allow / deny / abstain decision vocabulary
-- fail-closed behavior for missing identity, role, purpose, object, or audit context
-- review-console and governed-API access posture
-- domain steward access lanes such as Flora steward review
-- audit and validation expectations for access decisions
+### Out of scope
 
-Out of scope:
-
-- credentials, secrets, tokens, keys, or deployment environment variables
-- schema authority
-- release approval
-- source acquisition
-- public app routing
-- direct data lifecycle access for public clients
-- domain truth decisions
-- sensitivity downgrades without sensitivity policy and review records
-
-[Back to top](#top)
+- credentials, tokens, private keys, or deployment secrets;
+- identity-provider implementation;
+- contracts and JSON Schemas;
+- source authority or evidence truth;
+- rights clearance or sensitivity downgrade;
+- release, correction, withdrawal, or rollback approval;
+- application routes and UI implementation;
+- direct public access to RAW, WORK, QUARANTINE, or canonical stores;
+- AI-generated authorization.
 
 ---
 
-## 2. Repo fit
+## 2. Evidence basis and verification boundary
 
-| Concern | Owning root | Expected relationship |
-|---|---|---|
-| Access policy | `policy/access/` | This README and child access-policy lanes |
-| General policy root | `policy/` | Singular policy authority root for allow / deny / restrict / abstain / redaction / release posture |
-| Runtime policy evaluation | `packages/policy-runtime/` or governed API policy runtime | Implementation home remains `NEEDS VERIFICATION` |
-| Public API boundary | `apps/governed-api/` | Normal public and reviewer access should route through governed interfaces |
-| Security classification | `docs/security/` | Human-facing security and exposure guidance, if present and current |
-| Tests and fixtures | `tests/policy/`, `fixtures/policy/`, or verified equivalents | Required before promoting beyond draft |
-| Receipts and audit records | `data/`, `schemas/contracts/v1/receipts/`, or verified homes | Exact homes remain `NEEDS VERIFICATION` |
+### CONFIRMED
 
-> [!NOTE]
-> The repository root `policy/` README identifies the singular policy home and lists access-related policy concerns. This `access/` README narrows that root contract to role and capability gates.
+- `policy/` is the singular policy responsibility root.
+- This README and `flora-steward/README.md` exist.
+- `PolicyInputBundle` and `PolicyDecision` contracts exist under `contracts/policy/`.
+- paired policy schemas exist under `schemas/contracts/v1/policy/`.
+- `packages/policy-runtime/README.md` defines reusable evaluator-helper boundaries.
+- `apps/governed-api/README.md` defines the intended trust-membrane boundary.
+- Directory Rules separate policy, contracts, schemas, packages, apps, data, and release authority.
 
-## 3. Root boundary
+### PROPOSED
 
-This root may define who may use a capability. It must not decide whether a claim is true, whether a source has rights clearance, whether a sensitive location can be public, or whether a release is approved.
+- this access-root contract;
+- capability naming and scoping;
+- access reason codes and obligations;
+- evaluation order;
+- revocation, cache, break-glass, and child-lane requirements.
 
-Short rule:
+### UNKNOWN / NEEDS VERIFICATION
+
+- identity provider and claim names;
+- executable policy language and bundle packaging;
+- runtime wiring and enforcement coverage;
+- audit-event schema and sink;
+- revocation propagation and decision caching;
+- review-console routes;
+- fixtures, tests, CI results, and production behavior.
+
+This README is not implementation proof.
+
+---
+
+## 3. Authority boundary
+
+The access root answers:
+
+> **May this authenticated subject perform this specific operation on this bounded object, for this purpose, through this governed interface, at this time, under these obligations?**
+
+It does not decide claim truth, source authority, evidence closure, rights, sensitivity tier, release, correction, or rollback.
 
 ```text
-policy/access/       = who may use a bounded KFM capability
-policy/sensitivity/  = whether sensitivity permits exposure or requires transform
-policy/domains/      = domain policy and rights posture when present
-contracts/           = object meaning
-schemas/contracts/v1/ = machine-readable shape
-release/             = publication, correction, rollback control
-data/                = lifecycle state, proofs, receipts, artifacts
+policy/access/            = who may perform a bounded capability
+policy/sensitivity/       = what sensitivity permits or transforms
+policy/domains/           = domain admissibility and rights posture
+contracts/                = object meaning
+schemas/contracts/v1/     = machine shape
+packages/policy-runtime/  = reusable evaluation helpers
+apps/                     = governed executable surfaces
+data/                     = lifecycle state, receipts, proofs, audit artifacts
+release/                  = publication, correction, withdrawal, rollback
 ```
 
-## 4. Default posture
+A child lane may narrow access for one capability, but it must not redefine shared contracts, sensitivity tiers, rights statuses, release gates, or lifecycle law.
 
-Access policy should fail closed.
+---
 
-A request should return `DENY` or `ABSTAIN` when any required input is absent, stale, ambiguous, or unsupported:
+## 4. Operating invariants
 
-- authenticated subject
-- role or capability binding
-- active authorization window
-- target object reference
-- requested action
-- purpose of access
-- policy context
-- sensitivity context where relevant
-- rights context where relevant
-- release or review state where relevant
-- audit target
+1. Missing, stale, ambiguous, unsupported, or invalid context never becomes implicit permission.
+2. Decisions name the capability; broad role labels are insufficient.
+3. Object, purpose, audience, interface, scope, and time window are explicit.
+4. Access is not publication.
+5. Obligations are mandatory; inability to enforce them fails closed.
+6. Access policy consumes evidence, rights, sensitivity, review, and release state; it does not create them.
+7. Sensitive details are minimized in responses and logs.
+8. Revocation and expiry override cached permission.
+9. Public clients use governed interfaces, not lifecycle or canonical stores.
+10. Decisions are auditable, immutable, and supersedable.
+11. AI-generated text cannot create identity or authorization.
+12. Break-glass access is isolated, short-lived, audited, and independently reviewed.
 
-## 5. Inputs
+---
 
-| Input family | Examples | Required posture |
-|---|---|---|
-| Subject | user ID, service ID, role claims, steward assignment | Verified by identity and access layer |
-| Action | review, inspect, propose transform, recommend rollback, administer fixture | Explicit, finite, auditable |
-| Object | claim, candidate, layer, source descriptor, review task, release artifact | Governed object reference, not raw public shortcut |
-| Context | purpose, request channel, ticket, steward note, tenant or project scope | Present before consequential access |
-| Policy state | sensitivity tier, rights state, release state, review state | Resolved or explicitly unknown |
-| Evidence state | EvidenceRef, EvidenceBundle summary, citation state | Present for consequential review or display |
-| Runtime metadata | policy version, request time, audit correlation ID | Recorded when runtime exists |
+## 5. Default posture
 
-## 6. Exclusions
-
-| Does not belong here | Correct home |
+| Condition | Default outcome |
 |---|---|
-| Credentials, secrets, private keys, tokens | Secret manager / deployment configuration, not repo docs |
-| Deployable application code | `apps/` |
-| Reusable runtime implementation | `packages/policy-runtime/` or verified runtime package |
-| Contract meaning | `contracts/` |
-| Machine-readable schemas | `schemas/contracts/v1/` |
-| Release approval and rollback authority | `release/` |
-| Lifecycle data and artifacts | `data/` |
-| Source acquisition jobs | `connectors/` or verified ingestion home |
-| Human-only domain guidance | `docs/domains/` |
-| Sensitivity exposure decisions | `policy/sensitivity/` plus domain policy lanes |
+| Unauthenticated subject | `DENY` |
+| Capability absent, expired, inactive, or revoked | `DENY` |
+| Missing operation, object, purpose, or audit context | `ABSTAIN` |
+| Invalid input, stale bundle, evaluator failure, or revocation-check failure | `ERROR` |
+| Public exposure with unresolved rights or sensitivity | `DENY` or `ABSTAIN` per accepted policy |
+| Authorized restricted review to resolve an unresolved state | `ANSWER` with restrictive obligations |
+| Caller cannot enforce a mandatory obligation | `DENY` or `ERROR` |
 
-## 7. Access lanes
+Review access to an unresolved record does not resolve the record and does not make it publishable.
 
-Current child lanes visible from this session:
+---
 
-| Lane | Purpose | Status | Notes |
-|---|---|---|---|
-| [`flora-steward/`](flora-steward/README.md) | Flora steward review access for sensitive Flora records, transforms, corrections, and rollback recommendations | CONFIRMED README exists | Review-only capability; not public release authority |
-| Additional access lanes | Other role or capability policies | NEEDS VERIFICATION | Inventory required before claiming presence |
+## 6. Capability model
 
-Potential future lanes should be added only when there is a clear role, capability, owner, policy runtime path, fixtures, and tests.
+Prefer capability-specific permissions over broad roles.
 
-## 8. Diagram
+Illustrative capabilities:
+
+```text
+review_flora_candidate
+inspect_restricted_occurrence
+review_geoprivacy_transform
+review_rights_question
+submit_correction_recommendation
+recommend_release_rollback
+administer_access_mapping
+```
+
+Avoid:
+
+```text
+flora_access
+reviewer_all
+admin_everything
+can_see_sensitive
+superuser
+```
+
+Each capability should bind:
+
+| Dimension | Examples |
+|---|---|
+| Operation | inspect, review, propose, annotate, export, administer |
+| Object | candidate, occurrence, claim, layer, transform, release artifact |
+| Scope | assigned object, project, geography, quantity, time window |
+| Purpose | sensitivity review, rights review, correction, incident response |
+| Audience/interface | public, steward, service; API, review console, worker |
+| Obligations | redact, generalize, no export, audit, second review |
+
+---
+
+## 7. Child access-lane contract
+
+Each child directory under `policy/access/` should document one coherent capability boundary.
+
+Required sections:
+
+1. purpose and non-goals;
+2. owners and reviewers;
+3. subject/capability identity;
+4. accepted operations and object scope;
+5. purpose, audience, interface, and time constraints;
+6. required evidence, rights, sensitivity, review, and release context;
+7. finite decision mapping;
+8. reason codes and obligations;
+9. audit and minimization rules;
+10. revocation and freshness;
+11. separation of duties and break-glass posture;
+12. fixtures, tests, rollback, and open verification items.
+
+### Current child lanes
+
+| Lane | Purpose | Status |
+|---|---|---|
+| [`flora-steward/`](flora-steward/README.md) | Bounded Flora steward review access | README exists; runtime enforcement remains unverified |
+
+Do not create a child lane merely because a role name exists. A lane needs a bounded capability, owner, governed caller, reason codes, obligations, fixtures, tests, audit expectations, and revocation behavior.
+
+---
+
+## 8. Policy input contract
+
+Access evaluation should receive an explicit `PolicyInputBundle` or compatible equivalent.
+
+Required semantic families:
+
+- immutable bundle identity;
+- authenticated subject reference and subject type;
+- requested operation/capability;
+- governed object reference and lifecycle/release state;
+- geography, quantity, project, assignment, and time scope;
+- purpose and ticket/review context;
+- audience and interface;
+- evidence/source refs where consequential;
+- rights and sensitivity state;
+- review and separation-of-duties context;
+- release, correction, and rollback refs where relevant;
+- policy bundle id/hash/version and evaluator version;
+- correlation id and safe audit target;
+- prior, superseded, stale, or revoked decisions.
+
+Rules:
+
+- no hidden fetches from UI state, prompts, operator memory, or generated prose;
+- no raw protected records when refs or generalized values suffice;
+- unresolved state is explicit;
+- input bundles are immutable after evaluation;
+- reevaluation creates a new bundle and decision.
+
+---
+
+## 9. Evaluation order
+
+```text
+1. Validate input and evaluator integrity
+2. Authenticate subject
+3. Resolve active capability
+4. Check expiry, revocation, and freshness
+5. Validate operation, object, scope, purpose, audience, and interface
+6. Evaluate evidence, rights, sensitivity, review, and release prerequisites
+7. Evaluate quantity, export, rate, and anti-enumeration constraints
+8. Produce finite outcome, reasons, and obligations
+9. Enforce obligations before object access
+10. Emit minimized audit event
+11. Reevaluate after material state change
+```
 
 ```mermaid
 flowchart TD
-    req["Access request"] --> subject{"Subject authenticated?"}
-    subject -->|no| deny["DENY"]
-    subject -->|yes| role{"Role or capability active?"}
-    role -->|no| deny2["DENY"]
-    role -->|yes| object{"Governed object reference?"}
-    object -->|no| abstain["ABSTAIN"]
-    object -->|yes| context{"Purpose and audit context?"}
-    context -->|no| abstain2["ABSTAIN"]
-    context -->|yes| policy{"Policy context resolved?"}
-    policy -->|no| abstain3["ABSTAIN"]
-    policy -->|yes| allow["ALLOW bounded capability"]
-
-    allow --> surface["Governed review/API surface"]
-    surface --> audit["Audit event / review record / receipt as applicable"]
-
-    classDef deny fill:#ffd7d7,stroke:#9b1d1d,color:#000;
-    classDef abstain fill:#fff4ce,stroke:#8a6d00,color:#000;
-    classDef allow fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20;
-    class deny,deny2 deny;
-    class abstain,abstain2,abstain3 abstain;
-    class allow allow;
+    A["PolicyInputBundle"] --> B{"Valid input/evaluator?"}
+    B -->|no| E["ERROR"]
+    B -->|yes| C{"Authenticated and capability active?"}
+    C -->|no| D["DENY"]
+    C -->|yes| F{"Operation, object, purpose, scope, interface present?"}
+    F -->|no| G["ABSTAIN"]
+    F -->|yes| H{"Policy prerequisites satisfied or explicit review exception?"}
+    H -->|blocked| D
+    H -->|missing support| G
+    H -->|yes| I["ANSWER + obligations"]
+    I --> J{"Obligations enforceable?"}
+    J -->|no| D
+    J -->|yes| K["Bounded capability proceeds"]
+    K --> L["Minimized audit event"]
 ```
 
-## 9. Decision outcomes
+---
 
-| Outcome | Meaning | Required behavior |
-|---|---|---|
-| `ALLOW` | A bounded capability may proceed | Scope and audit the action |
-| `DENY` | Access is blocked by policy | Do not reveal protected object details beyond safe denial message |
-| `ABSTAIN` | Policy cannot decide because support is missing | Block access and name the missing prerequisite where safe |
-| `ERROR` | Runtime, tool, schema, or policy evaluation failed | Block access and record failure |
+## 10. Decision contract
 
-> [!IMPORTANT]
-> `ALLOW` must be capability-specific. Avoid broad permission language such as “has access to Flora” or “admin can see everything.” State the action, object scope, time window, and audit obligation.
+The paired `PolicyDecision` schema uses:
 
-## 10. Role and capability rules
+```text
+outcome: ANSWER | ABSTAIN | DENY | ERROR
+policy_family: access
+```
 
-Access lanes should prefer capability-specific permissions over broad roles.
-
-| Rule | Reason |
+| Outcome | Meaning |
 |---|---|
-| Least privilege by default | Reduces unnecessary exposure |
-| Purpose-bound access | Keeps steward and reviewer actions auditable |
-| Time-bounded authorization where practical | Supports review windows and revocation |
-| Separation from release approval | Prevents access from becoming publication authority |
-| Sensitivity-aware display | Prevents role access from exposing unnecessary precision |
-| Audit before privilege expansion | Keeps exceptions reviewable |
-| No silent admin shortcut | Prevents emergency paths from becoming normal public paths |
+| `ANSWER` | The bounded operation may proceed only if obligations are enforced |
+| `ABSTAIN` | Required admissible support is missing, unresolved, stale, or ambiguous |
+| `DENY` | Access policy blocks the operation |
+| `ERROR` | Shape, identity, evaluator, policy, or process failure prevents a decision |
 
-## 11. Audit expectations
+A lower-level engine may use `ALLOW | RESTRICT | HOLD | DENY | ABSTAIN | ERROR`, but it requires an explicit tested mapping:
 
-Every consequential access decision should record:
+| Engine | Runtime decision |
+|---|---|
+| `ALLOW` | `ANSWER` |
+| `RESTRICT` | `ANSWER` with restrictive obligations |
+| `HOLD` | `ABSTAIN` |
+| `ABSTAIN` | `ABSTAIN` |
+| `DENY` | `DENY` |
+| `ERROR` | `ERROR` |
 
-- subject reference
-- role or capability evaluated
-- requested action
-- target object reference
-- decision outcome
-- reason code
-- policy bundle or version reference when available
-- sensitivity, rights, release, or review state considered when relevant
-- timestamp
-- request channel
-- review or ticket reference when available
+`ANSWER` is not release approval, evidence closure, sensitivity downgrade, rights clearance, or permission for another operation.
 
-> [!WARNING]
-> Audit logs must not become a side channel for sensitive coordinates, secrets, private identity details, or unreleased source records.
+---
 
-## 12. Inspection path
+## 11. Reason-code vocabulary
 
-Policy language, runtime, fixtures, and tests are `NEEDS VERIFICATION`. Use these local inspection commands before treating this lane as implemented.
+### Permit/restrict
+
+- `ACCESS_CAPABILITY_ACTIVE`
+- `ACCESS_PURPOSE_BOUND`
+- `ACCESS_OBJECT_SCOPE_MATCH`
+- `ACCESS_REVIEW_ASSIGNMENT_MATCH`
+- `ACCESS_REVIEW_UNRESOLVED_STATE_PERMITTED`
+- `ACCESS_GENERALIZED_VIEW_REQUIRED`
+- `ACCESS_EXPORT_PROHIBITED`
+- `ACCESS_SECOND_REVIEW_REQUIRED`
+
+### Deny
+
+- `ACCESS_UNAUTHENTICATED`
+- `ACCESS_CAPABILITY_MISSING`
+- `ACCESS_CAPABILITY_INACTIVE`
+- `ACCESS_AUTHORIZATION_EXPIRED`
+- `ACCESS_AUTHORIZATION_REVOKED`
+- `ACCESS_SCOPE_MISMATCH`
+- `ACCESS_INTERFACE_NOT_ALLOWED`
+- `ACCESS_PUBLIC_CLIENT_RESTRICTED`
+- `ACCESS_EXPORT_DENIED`
+- `ACCESS_BULK_EXTRACTION_DENIED`
+- `ACCESS_SENSITIVITY_POLICY_BLOCK`
+- `ACCESS_RIGHTS_POLICY_BLOCK`
+- `ACCESS_RELEASE_AUTHORITY_REQUIRED`
+- `ACCESS_OBLIGATION_UNENFORCEABLE`
+
+### Abstain
+
+- `ACCESS_OBJECT_REF_MISSING`
+- `ACCESS_OPERATION_MISSING`
+- `ACCESS_PURPOSE_MISSING`
+- `ACCESS_AUDIT_CONTEXT_MISSING`
+- `ACCESS_SCOPE_UNRESOLVED`
+- `ACCESS_EVIDENCE_STATE_UNRESOLVED`
+- `ACCESS_RIGHTS_STATE_UNRESOLVED`
+- `ACCESS_SENSITIVITY_STATE_UNRESOLVED`
+- `ACCESS_REVIEW_STATE_UNRESOLVED`
+- `ACCESS_RELEASE_STATE_UNRESOLVED`
+
+### Error
+
+- `ACCESS_INPUT_INVALID`
+- `ACCESS_IDENTITY_INTEGRITY_ERROR`
+- `ACCESS_POLICY_BUNDLE_MISSING`
+- `ACCESS_POLICY_BUNDLE_STALE`
+- `ACCESS_POLICY_EVALUATOR_ERROR`
+- `ACCESS_POLICY_TIMEOUT`
+- `ACCESS_AUDIT_SINK_ERROR`
+- `ACCESS_REVOCATION_CHECK_ERROR`
+
+Reason strings must not contain protected coordinates, secrets, private identity attributes, or unreleased records.
+
+---
+
+## 12. Obligation vocabulary
+
+| Obligation | Meaning |
+|---|---|
+| `audit_access_event` | Emit a minimized audit event |
+| `limit_to_assigned_objects` | Enforce object assignment/allowlist |
+| `limit_to_purpose` | Permit only the recorded purpose |
+| `limit_to_authorization_window` | Recheck expiry and revocation |
+| `reviewer_surface_only` | Do not expose through public clients |
+| `withhold_exact_location` | Do not return exact geometry |
+| `generalize_geometry` | Apply approved generalization |
+| `redact_sensitive_fields` | Remove protected attributes |
+| `prohibit_bulk_export` | Block bulk or repeated extraction |
+| `prohibit_download` | Block object/file download |
+| `apply_rate_limit` | Bound enumeration and frequency |
+| `attach_rights_notice` | Preserve rights/attribution |
+| `attach_evidence_refs` | Preserve evidence refs in review surfaces |
+| `require_second_reviewer` | Require independent review |
+| `require_release_gate` | Prevent access from becoming publication |
+| `require_correction_flow` | Route mutation through correction governance |
+| `require_fresh_decision` | Reevaluate instead of using stale cache |
+| `record_break_glass_review` | Trigger independent post-event review |
+
+Unknown mandatory obligations fail closed.
+
+---
+
+## 13. State, lifecycle, and public boundary
+
+Distinguish:
+
+- **missing** — required context was not supplied;
+- **unresolved** — an explicit unknown/disputed state exists;
+- **restricted** — policy blocks or limits the operation;
+- **stale** — prior decision is no longer current;
+- **revoked** — authorization was withdrawn;
+- **superseded** — a newer decision replaces an older one.
+
+```text
+RAW -> WORK / QUARANTINE -> PROCESSED -> CATALOG / TRIPLET -> PUBLISHED
+```
+
+Access policy may gate operations at any phase, but it does not move artifacts between phases. Normal public clients must not access RAW, WORK, QUARANTINE, or canonical/internal stores directly.
+
+---
+
+## 14. Audit and data minimization
+
+Minimum fields for consequential access:
+
+- event/correlation id;
+- subject reference and type;
+- capability;
+- safe object reference and type;
+- purpose, audience, and interface;
+- outcome, reasons, and obligations;
+- policy family and bundle version/hash;
+- evaluator version and evaluated time;
+- authorization expiry/freshness;
+- review/ticket/assignment reference;
+- prior/superseded decision reference when applicable.
+
+Do not log by default:
+
+- passwords, tokens, secrets, or signing keys;
+- exact protected coordinates;
+- full rare-species/culturally sensitive records;
+- unnecessary living-person attributes;
+- unredacted DNA/genomic data;
+- source credentials;
+- complete restricted exports;
+- generated prompts containing protected content.
+
+For high-risk restricted access, required audit-sink failure should return `ERROR` and block access.
+
+---
+
+## 15. Revocation, freshness, and caching
+
+Required posture:
+
+- honor revocation and expiry;
+- bind cached decisions to subject, operation, object scope, purpose, interface, policy version, authorization version, and material object state;
+- re-evaluate after role, assignment, policy, sensitivity, rights, evidence, review, release, correction, or break-glass changes;
+- avoid caching exact sensitive payloads in browsers or shared intermediaries;
+- preserve superseded decisions for audit.
+
+A role-only cache key is insufficient.
+
+---
+
+## 16. Separation of duties
+
+| Decision | Owner |
+|---|---|
+| Authenticate subject | Identity/authentication system |
+| Map role/capability | Access steward / identity governance |
+| Decide access | `policy/access/` evaluator |
+| Decide sensitivity | `policy/sensitivity/` and reviewer |
+| Decide rights | domain/rights policy and reviewer |
+| Resolve evidence | EvidenceBundle/evidence resolver |
+| Review domain object | Domain steward/reviewer |
+| Approve release | Release authority |
+| Correct/withdraw/rollback | Correction/release governance |
+| Audit exceptional access | Audit/security function |
+
+Access-policy maintenance authority must not become self-approved exceptional access. Policy-significant release duties should remain independently reviewable.
+
+---
+
+## 17. Threat and break-glass posture
+
+| Threat | Mitigation |
+|---|---|
+| Broad-role privilege creep | Capability-specific policy and inventory |
+| Stale authorization | Expiry, revocation, reevaluation |
+| Object enumeration | Rate limits, assignment scope, safe denials |
+| Bulk extraction | Separate export capability and quantity limits |
+| Log leakage | Minimized fields and stable reason codes |
+| Public UI invokes restricted capability | Audience/interface binding |
+| Decision reused for another operation | Operation-bound decision/cache key |
+| Access mistaken for release | `require_release_gate` and separate authority |
+| Prompt-generated role claim | Generated content is untrusted |
+| Join-induced sensitivity | Reevaluate after joins/precision changes |
+| Shared service identity | Distinct service principals and correlation ids |
+| Client-only enforcement | Server-side governed enforcement |
+
+Break-glass, if implemented, requires a separately named capability, strong authentication, short expiry, bounded scope, ticket/reason, enhanced audit, independent review, immediate revocation, and no automatic export, release, or sensitivity downgrade.
+
+---
+
+## 18. Validation and acceptance matrix
+
+| Case | Expected |
+|---|---|
+| Public capability on public-safe released object | `ANSWER` |
+| Unauthenticated subject | `DENY` |
+| Missing/inactive/revoked/expired capability | `DENY` |
+| Missing operation, object, purpose, or audit context | `ABSTAIN` |
+| Invalid input or stale/missing policy bundle | `ERROR` |
+| Authorized restricted review | `ANSWER` with reviewer-only/audit/no-export obligations |
+| Authorized review of unresolved sensitivity | `ANSWER`; unresolved state preserved; release blocked |
+| Public request for restricted object | `DENY` |
+| Caller cannot enforce obligation | `DENY` or `ERROR` |
+| Bulk extraction or inference attack | `DENY` or restricted response |
+| Decision reused for another operation | `DENY` |
+| Decision reused after material change | Reevaluate |
+| Public UI invokes steward capability | `DENY` |
+| Audit sink fails for high-risk access | `ERROR` |
+| Break-glass without activation | `DENY` |
+| Valid break-glass activation | `ANSWER` with short expiry/enhanced audit |
+| Evaluator timeout | `ERROR` |
+| AI-generated role claim | `DENY` or `ABSTAIN` |
+
+Fixtures must be synthetic or public-safe.
+
+---
+
+## 19. Repository inspection path
 
 ```bash
-# From the repository root, inspect access-policy lanes.
-find policy/access -maxdepth 4 -type f | sort
-
-# Inspect the wider policy root.
-find policy -maxdepth 4 -type f | sort
-
-# Inspect likely access-policy tests and fixtures.
-find tests fixtures -maxdepth 5 -type f 2>/dev/null | grep -E 'policy|access|auth|role|steward' | sort
+find policy/access -maxdepth 5 -type f | sort
+find contracts/policy schemas/contracts/v1/policy -maxdepth 5 -type f | sort
+find packages/policy-runtime -maxdepth 6 -type f | sort
+find apps/governed-api apps/review-console apps/explorer-web -maxdepth 6 -type f 2>/dev/null | sort
+find fixtures tests -maxdepth 7 -type f 2>/dev/null \
+  | grep -E 'policy|access|auth|role|capability|steward|revocation' \
+  | sort
 ```
 
-## 13. Validation expectations
+Evidence required before claiming enforcement:
 
-Useful validation for access policy should cover:
+- executable policy and bundle packaging;
+- accepted identity/capability mapping;
+- schema, validator, fixtures, and tests;
+- governed caller integration;
+- audit event and sink;
+- revocation propagation;
+- workflow/check evidence;
+- rollback procedure.
 
-- unauthenticated requests return `DENY`
-- missing role or capability returns `DENY`
-- missing object reference returns `ABSTAIN`
-- missing purpose or audit context returns `ABSTAIN`
-- unresolved sensitivity, rights, review, or release context returns `ABSTAIN` when relevant
-- `ALLOW` is scoped to one bounded capability
-- public clients cannot invoke steward-only lanes
-- denied and abstained decisions include safe reason codes
-- audit events are produced without leaking sensitive data
-- emergency or admin override, if ever introduced, is documented, constrained, audited, and not the normal path
+---
 
-## 14. Definition of done
+## 20. Implementation sequence
 
-- [ ] Owners are confirmed and `OWNER_TBD` is replaced.
-- [ ] Access-policy runtime language and bundle location are confirmed.
-- [ ] Identity provider and role/capability claim names are documented or linked.
-- [ ] Child access lanes are inventoried.
-- [ ] Decision outcomes are represented in policy fixtures.
-- [ ] Tests cover `ALLOW`, `DENY`, `ABSTAIN`, and `ERROR` paths.
-- [ ] Public clients cannot bypass governed APIs through access policy helpers.
-- [ ] Audit event shape is documented or linked.
-- [ ] Release approval remains separate from access decisions.
-- [ ] Rollback target is documented for policy changes.
+1. inventory child lanes and policy modules;
+2. confirm identity and capability vocabulary;
+3. strengthen `PolicyInputBundle` access fields;
+4. confirm `PolicyDecision` mapping for `policy_family=access`;
+5. register reason codes and obligations;
+6. implement synthetic fixtures and negative tests;
+7. wire the policy runtime through governed surfaces;
+8. implement minimized audit events;
+9. implement revocation and cache invalidation;
+10. add anti-enumeration and export controls;
+11. add break-glass only after normal access is proven;
+12. run rollback and negative-path drills;
+13. update docs from verified evidence.
 
-## 15. Open verification items
+---
 
-| Item | Why it matters |
+## 21. Definition of done
+
+- [ ] Owners and reviewers are confirmed.
+- [ ] Child lanes are inventoried.
+- [ ] Identity and capability claim names are documented.
+- [ ] Policy language and bundle packaging are confirmed.
+- [ ] `PolicyInputBundle` access fields are schema-enforced.
+- [ ] `PolicyDecision` uses `ANSWER | ABSTAIN | DENY | ERROR`.
+- [ ] Reason codes and obligations are registered and tested.
+- [ ] Missing, unresolved, restricted, stale, revoked, and superseded states are distinguished.
+- [ ] Revocation, expiry, and cache invalidation are tested.
+- [ ] Public clients cannot invoke restricted/steward/admin capabilities.
+- [ ] Audit minimization, bulk-extraction, and enumeration controls are tested.
+- [ ] Access does not bypass evidence, sensitivity, rights, review, release, correction, or rollback.
+- [ ] Break-glass, if present, is isolated, expiring, audited, and independently reviewed.
+- [ ] Fixtures are synthetic/public-safe.
+- [ ] CI evidence and rollback instructions exist.
+- [ ] README status reflects evidence, not aspiration.
+
+---
+
+## 22. Open verification register
+
+| Item | Status |
 |---|---|
-| Confirm access-policy runtime language | Prevents writing non-runnable policy modules |
-| Confirm policy bundle packaging | Required for runtime enforcement |
-| Confirm identity and role claim names | Prevents mismatched authorization logic |
-| Confirm child access lanes | Keeps this root README complete |
-| Confirm tests and fixtures | Required before promotion beyond draft |
-| Confirm audit event schema | Required for accountability and incident response |
-| Confirm review-console integration | Prevents steward/reviewer access from becoming a public path |
-| Confirm admin/emergency override posture | Ensures shortcuts are constrained, documented, and audited |
+| Access-policy executable language | NEEDS VERIFICATION |
+| Bundle packaging/versioning | NEEDS VERIFICATION |
+| Identity provider | UNKNOWN |
+| Subject/role/capability claims | NEEDS VERIFICATION |
+| Review-console implementation | NEEDS VERIFICATION |
+| Governed API enforcement coverage | NEEDS VERIFICATION |
+| Policy input schema maturity | NEEDS VERIFICATION |
+| Audit event contract and sink | NEEDS VERIFICATION |
+| Revocation propagation | NEEDS VERIFICATION |
+| Decision cache implementation | UNKNOWN |
+| Anti-enumeration and bulk export controls | NEEDS VERIFICATION |
+| Break-glass posture | UNKNOWN |
+| Complete child-lane inventory | NEEDS VERIFICATION |
+| Separation-of-duties enforcement | NEEDS VERIFICATION |
+| CI enforcement and rollback drill | NEEDS VERIFICATION |
 
-<details>
-<summary>Appendix A — illustrative access input shape</summary>
+---
 
-This example is illustrative. It is not a verified schema.
+## Appendix — illustrative decision
 
 ```json
 {
-  "subject": {
-    "id": "SUBJECT_ID_TBD",
-    "roles": ["ROLE_TBD"],
-    "active": true
-  },
-  "action": "ACTION_TBD",
-  "object": {
-    "id": "OBJECT_ID_TBD",
-    "type": "OBJECT_TYPE_TBD",
-    "state": "candidate"
-  },
-  "context": {
-    "purpose": "PURPOSE_TBD",
-    "ticket_ref": "TICKET_TBD",
-    "evidence_ref": "EVIDENCE_REF_TBD"
-  }
+  "decision_id": "poldec:20260714:access:review-example",
+  "outcome": "ANSWER",
+  "policy_family": "access",
+  "reasons": [
+    "ACCESS_CAPABILITY_ACTIVE",
+    "ACCESS_REVIEW_ASSIGNMENT_MATCH"
+  ],
+  "obligations": [
+    "reviewer_surface_only",
+    "prohibit_bulk_export",
+    "audit_access_event",
+    "require_release_gate"
+  ],
+  "evaluated_at": "2026-07-14T16:30:00Z"
 }
 ```
 
-</details>
+`ANSWER` permits only the evaluated access operation. It does not publish, clear rights, downgrade sensitivity, or resolve evidence.
 
-<details>
-<summary>Appendix B — no-loss preservation note</summary>
+---
 
-The target file was an empty placeholder. This README adds a bounded access-policy root contract without claiming runtime enforcement, tests, identity-provider mappings, production readiness, or complete child-lane inventory.
+## v0.1 → v0.2 preservation and correction
 
-It preserves KFM’s policy posture by separating access from publication, sensitivity decisions, rights clearance, schema authority, source truth, release authority, and lifecycle data.
+Preserved:
 
-</details>
+- singular `policy/` authority;
+- least privilege and fail-closed behavior;
+- access is not publication;
+- governed-interface requirement;
+- child-lane concept;
+- audit expectations;
+- no credentials/secrets;
+- constrained admin paths;
+- bounded implementation claims.
+
+Corrected and expanded:
+
+- replaced runtime-facing `ALLOW` with `ANSWER | ABSTAIN | DENY | ERROR`;
+- added explicit engine-to-contract mapping;
+- added capability, scope, purpose, audience, interface, reason, and obligation rules;
+- distinguished missing and unresolved states;
+- added revocation, caching, separation of duties, threat, bulk-export, and break-glass posture;
+- added deterministic acceptance criteria, implementation sequence, and verification register.
+
+Reverting the documentation commit restores v0.1. No executable policy, schema, fixture, test, runtime, workflow, data, receipt, proof, or release artifact is changed.
+
+---
 
 ## Status summary
 
-`policy/access/` should define the access-policy root for KFM role and capability decisions.
+`policy/access/` is the canonical access-control lane for bounded KFM capabilities.
 
-It should enable constrained, auditable, least-privilege access while preserving governed API boundaries, fail-closed behavior, sensitivity controls, rights posture, evidence requirements, review state, release separation, correction lineage, and rollback visibility.
+Every consequential access decision should bind:
+
+```text
+subject + operation + object + scope + purpose + audience/interface
++ policy/evidence/rights/sensitivity/review/release context
++ finite outcome + reasons + enforceable obligations + audit
+```
+
+Access may enable governed review. It must never silently become truth, sensitivity, rights, evidence, or release authority.
 
 <p align="right"><a href="#top">Back to top</a></p>


### PR DESCRIPTION
## Summary

Updates `policy/access/README.md` from v0.1 to v0.2 as the governing root contract for bounded KFM access capabilities.

The revision preserves the existing least-privilege, fail-closed, governed-interface, and non-publication boundaries while adding:

- alignment with the repository `PolicyInputBundle` and `PolicyDecision` contracts;
- correction of runtime-facing `ALLOW` language to `ANSWER | ABSTAIN | DENY | ERROR` with `policy_family=access`;
- an explicit mapping from engine-native `ALLOW | RESTRICT | HOLD | DENY | ABSTAIN | ERROR` values;
- capability-specific authorization instead of broad role grants;
- child access-lane requirements;
- input, evaluation-order, reason-code, and obligation contracts;
- distinctions among missing, unresolved, restricted, stale, revoked, and superseded states;
- audit minimization, revocation, freshness, cache invalidation, separation of duties, anti-enumeration, bulk-export, and break-glass posture;
- a deterministic negative-path validation matrix, implementation sequence, definition of done, and verification register;
- a v0.1 → v0.2 preservation and rollback note.

## Scope

| Field | Value |
|---|---|
| Repository | `bartytime4life/Kansas-Frontier-Matrix` |
| Base | `main` at `03e92d65ad07188dea60cafb7a26ae3919268d41` |
| Branch | `agent/policy-access-readme-v2` |
| Target | `policy/access/README.md` |
| Change budget | One documentation file |
| Runtime/schema/policy/test changes | None |

## Evidence used

- current `policy/access/README.md`;
- `policy/README.md`;
- `policy/access/flora-steward/README.md` as the existing child lane;
- `contracts/policy/policy_input_bundle.md`;
- `contracts/policy/policy_decision.md` and paired schemas;
- `packages/policy-runtime/README.md`;
- `apps/governed-api/README.md`;
- `docs/doctrine/directory-rules.md` and KFM doctrine supplied in the project.

## Validation

- branch is exactly one commit ahead of `main` and zero behind;
- only `policy/access/README.md` changed;
- remote blob verified as `ca53007caa4ee15ac3ec0c1305169a42d188755e`;
- balanced code fences;
- no trailing whitespace;
- internal quick-jump anchors resolve;
- examples use synthetic identifiers and contain no credentials or sensitive records;
- implementation claims remain bounded as `PROPOSED`, `UNKNOWN`, or `NEEDS VERIFICATION`.

## Acceptance matrix

| Criterion | Result |
|---|---|
| Preserve v0.1 authority boundaries | PASS |
| Align finite outcomes with repository contract | PASS |
| Keep access distinct from sensitivity, rights, evidence, and release | PASS |
| Define child-lane minimum contract | PASS |
| Add revocation, audit, threat, and negative-path guidance | PASS |
| Restrict diff to requested README | PASS |
| Runtime enforcement validation | NOT APPLICABLE — documentation-only change |
| GitHub Actions result | PENDING |

## Rollback

Revert commit `29da2d479b83fe0eca698c924ec9d584dd0e4ec2` to restore v0.1. No executable policy, schema, fixture, test, runtime, workflow, data, receipt, proof, or release artifact is changed.