### PR TITLE
docs(connectors): refresh NOAA HMS smoke boundary

### DIFF
--- a/connectors/noaa-hms-smoke/README.md
+++ b/connectors/noaa-hms-smoke/README.md
@@ -1,307 +1,582 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://doc/connectors-noaa-hms-smoke-readme
-title: connectors/noaa-hms-smoke/ — NOAA HMS Smoke Connector Lane
+title: connectors/noaa-hms-smoke/ — NOAA HMS Fire and Smoke README-Only Connector Boundary
 type: readme
-version: v0.1
+version: v0.2
 status: draft
-owners: OWNER_TBD — Source steward · Connector steward · NOAA steward · Hazards steward · Atmosphere steward · Data steward · Docs steward
+owners: OWNER_TBD — Source steward · Connector steward · NOAA steward · Hazards steward · Atmosphere steward · Public-safety reviewer · Rights reviewer · Validation steward · Docs steward
 created: 2026-06-19
-updated: 2026-06-19
-policy_label: public; not-life-safety
+updated: 2026-07-14
+policy_label: public-doctrine; connector-boundary; noaa; hms; multi-component; analyst-augmented; placement-open; not-life-safety; no-publication
+truth_posture: CONFIRMED README-only sibling / PROPOSED placement / INACTIVE source authority / IMPLEMENTATION NEEDS VERIFICATION
+evidence_snapshot: main@a6f3defda415462f595f098ca7758aa14826bfa7
 related:
   - ../README.md
-  - ../../docs/doctrine/directory-rules.md
+  - ../noaa/README.md
+  - ../noaa/src/README.md
+  - ../noaa/tests/README.md
+  - ../hms_smoke/README.md
+  - ../../docs/sources/catalog/noaa/README.md
   - ../../docs/sources/catalog/noaa/hms-fire-smoke.md
-  - ../../docs/sources/catalog/noaa/hrrr-smoke.md
-  - ../../docs/sources/catalog/noaa/goes-abi-aod.md
-  - ../../docs/sources/catalog/noaa/viirs-hotspot.md
-  - ../../docs/domains/hazards/README.md
-  - ../../docs/domains/atmosphere/README.md
+  - ../../docs/architecture/smoke-atmosphere-hazards.md
   - ../../docs/architecture/hazards-trust-membrane.md
-  - ../../data/registry/sources/
-  - ../../data/raw/
-  - ../../data/quarantine/
-  - ../../data/receipts/
-  - ../../data/proofs/
-  - ../../policy/rights/
-  - ../../policy/sensitivity/
-  - ../../release/
-tags: [kfm, connectors, noaa, hms, smoke, fire, hazards, atmosphere, satellite, analyst-augmented, source-admission, raw, quarantine, governance]
+  - ../../docs/doctrine/directory-rules.md
+  - ../../docs/architecture/directory-rules.md
+  - ../../control_plane/source_authority_register.yaml
+  - ../../pipeline_specs/hazards/noaa_hms_smoke.yaml
+  - ../../tools/ingest/firms_hms_watch/README.md
+  - ../../data/raw/atmosphere/observed/hms/README.md
+  - ../../contracts/domains/atmosphere/SmokeContext.md
+tags: [kfm, connectors, noaa, hms, smoke, fire, hazards, atmosphere, analyst-augmented, multi-component, source-admission, raw, quarantine, governance]
 notes:
-  - "Connector lane for NOAA HMS smoke and fire source intake/admission helpers."
-  - "Placement is draft / open: Directory Rules §7.3 lists noaa/ as canonical but does not settle this noaa-hms-smoke sibling versus a nested connectors/noaa/ lane."
-  - "Source-product doctrine belongs under docs/sources/catalog/noaa/hms-fire-smoke.md and source descriptors, not here."
-  - "Connector output may enter raw or quarantine admission lanes only."
-  - "HMS smoke polygons are qualitative analyst plume boundaries, not surface PM2.5, exposure, or alert authority."
-  - "Fire points, smoke polygons, smoke density classes, issue time, source files, and analyst-augmented provenance must be preserved separately."
+  - "This file documents a proposed connector boundary; it does not prove executable NOAA HMS connector code."
+  - "The repository also contains the canonical NOAA family lane and a documentation-only underscore compatibility lane; this README does not settle final HMS placement."
+  - "HMS fire detections and smoke polygons are distinct components and must not be collapsed into one source role or truth claim."
+  - "Smoke polygons and density categories are qualitative analyst-augmented context, not surface PM2.5, AQI, exposure, or health guidance."
+  - "Fire detections are satellite-signal evidence with analyst augmentation, not ground-confirmed fire status."
+  - "Connector output is limited to RAW or QUARANTINE handoff and is never KFM alert or publication authority."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-# NOAA HMS Smoke Connector
+# NOAA HMS Fire and Smoke README-Only Connector Boundary
 
-> Source-specific intake and admission lane for NOAA Hazard Mapping System fire and smoke source material, especially smoke polygons and related fire-detection context used by KFM Hazards and Atmosphere lanes.
+> Boundary for proposed NOAA Hazard Mapping System (HMS) fire-and-smoke source admission at `connectors/noaa-hms-smoke/`. Repository evidence at the pinned snapshot proves this README, not a runnable product connector. Final placement among the NOAA family lane, this hyphenated sibling, and the underscore compatibility lane remains unresolved.
 
 <p>
   <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
-  <img alt="Owner: OWNER_TBD" src="https://img.shields.io/badge/owner-OWNER__TBD-lightgrey">
-  <img alt="Connector scope" src="https://img.shields.io/badge/scope-source__admission-blue">
-  <img alt="Placement: needs ADR" src="https://img.shields.io/badge/placement-NEEDS__ADR-orange">
-  <img alt="Life safety: not alert authority" src="https://img.shields.io/badge/life__safety-NOT__ALERT__AUTHORITY-red">
-  <img alt="Smoke density: qualitative" src="https://img.shields.io/badge/smoke__density-qualitative-orange">
-  <img alt="Lifecycle: raw or quarantine only" src="https://img.shields.io/badge/lifecycle-raw%20%7C%20quarantine%20only-orange">
+  <img alt="Implementation: not proven" src="https://img.shields.io/badge/implementation-not__proven-lightgrey">
+  <img alt="Placement: open" src="https://img.shields.io/badge/placement-open-orange">
+  <img alt="Product: multi-component" src="https://img.shields.io/badge/product-multi__component-purple">
+  <img alt="Life safety: never alert authority" src="https://img.shields.io/badge/life__safety-never__alert__authority-red">
+  <img alt="Lifecycle: RAW or QUARANTINE only" src="https://img.shields.io/badge/lifecycle-RAW%20%7C%20QUARANTINE%20only-orange">
 </p>
 
-`connectors/noaa-hms-smoke/`
-
-## Quick jumps
-
-[Scope](#scope) · [Repo fit](#repo-fit) · [Lifecycle sketch](#lifecycle-sketch) · [Authority boundary](#authority-boundary) · [Inputs](#inputs) · [Exclusions](#exclusions) · [Source interface notes](#source-interface-notes) · [Admission posture](#admission-posture) · [Anti-collapse posture](#anti-collapse-posture) · [Placement status](#placement-status) · [Validation](#validation) · [Definition of done](#definition-of-done)
-
----
-
-## Scope
-
-`connectors/noaa-hms-smoke/` is the connector lane for NOAA HMS smoke and related fire source intake/admission helpers.
-
-This folder may contain connector-local documentation, source-admission helpers, download or service manifest builders, KML/shapefile/WFS metadata helpers, no-network fixture pointers, and raw/quarantine output adapters for HMS source products.
-
-It must not become NOAA source-family truth, HMS product doctrine, smoke truth, surface air-quality truth, fire-ground-truth authority, alert authority, policy authority, schema authority, catalog/triplet authority, proof authority, release authority, pipeline authority, or publication authority.
-
 > [!IMPORTANT]
-> **Status:** draft / `NEEDS VERIFICATION`  
-> **Owner:** `OWNER_TBD`  
-> **Path:** `connectors/noaa-hms-smoke/`  
-> **Truth posture:** the path exists in the repository as this README; source activation, endpoint behavior, file formats, tests, fixtures, CI wiring, rights status, parser behavior, analyst-pass provenance, and placement ratification remain `NEEDS VERIFICATION`.
+> **Truth posture:** `CONFIRMED` README-only sibling · `PROPOSED` placement · source authority `INACTIVE / NOT ESTABLISHED` · product-specific runtime `NEEDS VERIFICATION`.
 
----
-
-## Repo fit
-
-```text
-connectors/
-└── noaa-hms-smoke/
-    └── README.md
-```
-
-Related responsibility roots:
-
-```text
-connectors/                                      # source-specific fetch and admission code
-docs/sources/catalog/noaa/hms-fire-smoke.md     # HMS source-product doctrine and product boundary
-docs/sources/catalog/noaa/                      # NOAA source-family catalog
-docs/domains/hazards/                           # hazards domain context and non-alert posture
-docs/domains/atmosphere/                        # atmosphere/air context and smoke interpretation boundaries
-data/registry/sources/                          # source descriptors and activation state
-data/raw/hazards/                               # possible raw hazard-context source outputs
-data/raw/atmosphere/                            # possible raw atmosphere/smoke-context source outputs
-data/quarantine/                                # held material requiring source/rights/role/freshness review
-data/receipts/                                  # ingest, checksum, analyst-pass, transform, and aggregation receipts
-data/proofs/                                    # EvidenceBundles and proof packs
-policy/rights/                                  # terms, attribution, and source-use review
-policy/sensitivity/                             # public-safety, infrastructure, and exact-location release rules
-release/                                        # release decisions, manifests, rollback, correction state
-apps/governed-api/                              # downstream public trust membrane, not connector-owned
-apps/explorer-web/                              # downstream map UI, never direct RAW/QUARANTINE access
-```
-
----
-
-## Lifecycle sketch
-
-```mermaid
-flowchart LR
-  SRC[NOAA HMS source surface] --> CONN[connectors/noaa-hms-smoke]
-  CONN --> RAWH[data/raw/hazards]
-  CONN --> RAWA[data/raw/atmosphere]
-  CONN --> QUAR[data/quarantine/<domain>]
-
-  RAWH --> NEXT[downstream governed stages]
-  RAWA --> NEXT
-  QUAR --> REVIEW[source / role / freshness / safety review]
-
-  NEXT -. outside this connector .-> WORK[data/work]
-  NEXT -. outside this connector .-> PROC[data/processed]
-  NEXT -. outside this connector .-> CAT[data/catalog + data/triplets]
-  NEXT -. outside this connector .-> PUB[data/published]
-
-  PUB -. served only through .-> API[apps/governed-api]
-  API -. public rendering .-> UI[apps/explorer-web]
-```
+> [!WARNING]
+> **KFM is not an alert, emergency-response, air-quality, or life-safety authority.** This connector must never issue warnings, recommend evacuation or sheltering, determine exposure, declare an area safe, or replace official NOAA, NWS, AirNow, public-health, fire, or emergency-management channels.
 
 > [!CAUTION]
-> Connector code admits source material. It does not issue alerts, provide emergency guidance, derive PM2.5, confirm ground fire status, publish layers, answer public claims, or decide release state. Promotion remains a governed state transition, not a file move.
+> HMS smoke polygons are analyst-augmented qualitative plume context, not surface PM2.5, AQI, exposure, or health guidance. HMS fire detections are satellite-signal evidence with analyst augmentation, not ground-confirmed fire status.
+
+**Quick jumps:** [Purpose](#1-purpose) · [Status](#3-status) · [Validation](#8-validation) · [Topology](#connector-topology-and-placement) · [Component boundary](#component-and-source-role-boundary) · [Runtime contract](#proposed-runtime-contract) · [Evidence](#evidence-ledger) · [Backlog](#verification-backlog)
 
 ---
 
-## Authority boundary
+## 1. Purpose
+
+`connectors/noaa-hms-smoke/` defines a conservative source-admission boundary for NOAA HMS fire-detection and smoke-polygon source material and its source metadata.
+
+If executable code is later approved here, it may discover or retrieve an explicitly configured source object, preserve its native bytes and component identity, validate only admission preconditions, and hand the result to a domain-owned `RAW` or `QUARANTINE` lane. This README does not activate a source, select a live endpoint, establish a current format or cadence, or prove that product-specific code exists.
+
+The boundary is narrow:
 
 ```text
-OUTPUT LIMIT:
-  data/raw/<domain>/<source_id>/<run_id>/
-  data/quarantine/<domain>/<source_id>/<run_id>/
-
-NOT HERE:
-  source-family truth
-  HMS product doctrine
-  smoke concentration truth
-  exposure or health guidance
-  emergency alert authority
-  ground-fire confirmation
-  source descriptor authority
-  rights or sensitivity policy
-  processed smoke/fire derivatives
-  catalog records
-  triplet records
-  public tiles or map artifacts
-  receipts/proofs as authority
-  release decisions
-  published artifacts
-  public API behavior
-  public UI behavior
+configured HMS source object
+           |
+           v
+bounded retrieval and integrity checks
+           |
+           v
+component-preserving admission
+       fire detection != smoke polygon
+           |
+           +----> RAW         only when admission preconditions pass
+           |
+           `----> QUARANTINE  when identity, component, role, time,
+                              integrity, rights, safety, or routing is unresolved
 ```
 
+[Back to top ↑](#top)
+
 ---
 
-## Inputs
+## 2. Authority level
 
-| Accepted item | Required posture |
+**Authority: IMPLEMENT boundary documentation; no source, alert, or publication authority.**
+
+This README may describe what a future connector at this path is allowed to do. It may not:
+
+- ratify this sibling as the canonical HMS implementation home;
+- override `connectors/noaa/` as the declared NOAA family lane;
+- turn `connectors/hms_smoke/` into a runtime path;
+- activate HMS in the source-authority register;
+- promote the NOAA family scaffold into a working HMS connector by declaration;
+- select among duplicate SmokeContext contract or schema paths;
+- assign authoritative source roles without accepted descriptors and contracts;
+- define NOAA/HMS product truth, rights, sensitivity, or freshness policy;
+- confirm fire on the ground, quantify smoke, or provide health or emergency guidance;
+- promote data beyond source admission;
+- create release authority or public behavior.
+
+The two Directory Rules copies agree on the connector lifecycle limit but differ in version and status. This README relies only on their shared rule: connectors fetch and parse source material and may write to `RAW` or `QUARANTINE`, not later lifecycle stages. It does not decide which Directory Rules file is authoritative.
+
+---
+
+## 3. Status
+
+| Question | Evidence-backed status |
 |---|---|
-| Source adapter | Preserve source identity, product family, request/download URL, retrieval time, response status, and review posture. |
-| Smoke polygon parser | Preserve geometry, start/end time, density class, satellite/source fields, file identity, and source issue context. |
-| Fire point parser | Preserve longitude, latitude, satellite, method, ecosystem, fire radiative power when present, and acquisition time. |
-| KML/shapefile/WFS helper | Preserve original format, component files, projection, field names, digest, and source URL. |
-| Analyst-pass helper | Preserve issued time, product pass or source delivery identity where available, and analyst-augmented provenance without inventing internal analyst details. |
-| Freshness helper | Preserve observation time, issue/update time, retrieval time, and expiry/review notes. |
-| Cross-product hint helper | Emit candidate joins to FIRMS, HRRR-smoke, GOES AOD, AirNow, CAP, or NWS products only as downstream review candidates. |
-| Rights/citation helper | Preserve source terms, citation, attribution posture, and review status. |
-| Test references | Point to owning fixture/test roots; fixtures do not become source authority. |
+| Does `connectors/noaa-hms-smoke/README.md` exist? | **CONFIRMED.** |
+| Is executable code proven in this exact lane? | **No.** Bounded probes found no package file, source root, client, parser, initializer, or test README. |
+| Is there another HMS connector path? | **Yes.** `connectors/hms_smoke/README.md` is a documentation-only compatibility/reconciliation lane that forbids implementation there. |
+| Is there a canonical NOAA family lane? | **Yes, as repository doctrine.** `connectors/noaa/README.md` calls `connectors/noaa/` the canonical family lane while preserving this sibling as placement-pending. |
+| Is a nested HMS product lane present under `connectors/noaa/`? | **No file was found at the bounded `hms-smoke/` or `hms_smoke/` README probes.** |
+| Does the NOAA package prove HMS runtime support? | **No.** It is version `0.0.0`; the initializer is empty, fetch/admit files are placeholder comments, the local descriptor has `TBD` role and rights, and the proposed `products/hms_smoke.py` file was not found. |
+| Is an HMS pipeline implemented by the named pipeline spec? | **No.** `pipeline_specs/hazards/noaa_hms_smoke.yaml` is a four-line `PROPOSED` placeholder. |
+| Is the FIRMS/HMS watcher executable? | **Not proven.** Its README explicitly defines a proposed tooling boundary. |
+| Is an active HMS SourceDescriptor present? | **Not proven.** Named NOAA/HMS registry probes returned no files, and the source-authority register is `PROPOSED` with `entries: []`. |
+| Are SmokeContext contracts and schemas enforceable? | **Not proven.** Duplicate contract/schema names exist; inspected schemas are permissive `PROPOSED` scaffolds with empty properties. |
+| Are HMS RAW payloads, receipts, tests, CI, and release wiring proven? | **No.** The RAW lane and test surfaces are documentation; operational evidence remains unverified. |
+
+Absence statements above are limited to named repository paths inspected at `main@a6f3defda415462f595f098ca7758aa14826bfa7`; they are not claims of an exhaustive recursive inventory.
 
 ---
 
-## Exclusions
+## 4. What belongs
 
-| Do not store here | Correct home |
+If this path is ratified, it may contain product-specific connector artifacts such as:
+
+- request or object-discovery adapters that take an approved SourceDescriptor reference;
+- bounded retrieval helpers with explicit timeouts, retries, redirect policy, and maximum size;
+- checksum, content-length, component-package, and source-fingerprint verification;
+- lossless capture of source files, component files, sidecars, and exposed metadata;
+- fire-detection parsing that preserves signal identity and uncertainty;
+- smoke-polygon parsing that preserves qualitative categories and analyst-augmentation context;
+- component splitting without semantic rewriting;
+- deterministic RAW or QUARANTINE handoff envelopes;
+- sanitized process receipts that reference, rather than redefine, governing records;
+- no-network fixtures representing approved structural cases;
+- unit and contract tests for source admission and anti-collapse behavior.
+
+Every artifact must preserve source identity, component identity, time roles, and uncertainty, and must fail closed when required evidence is missing or contradictory.
+
+---
+
+## 5. What does NOT belong
+
+| Excluded responsibility | Governing surface or next decision |
 |---|---|
-| HMS source-product doctrine | `docs/sources/catalog/noaa/hms-fire-smoke.md` |
-| NOAA source-family documentation | `docs/sources/catalog/noaa/` |
-| Authoritative `SourceDescriptor` records | `data/registry/sources/` |
-| Hazards or Atmosphere doctrine | `docs/domains/hazards/`, `docs/domains/atmosphere/` |
-| Alerting, public-safety, sensitivity, or release policy | `policy/`, `policy/sensitivity/`, `release/` |
-| Processed smoke or fire derivatives | `data/processed/` |
-| Catalog or triplet records | `data/catalog/`, `data/triplets/` |
-| Tile packages or public map artifacts | `data/published/` after governed release |
-| Receipts and proof packs as authority | `data/receipts/`, `data/proofs/` |
-| Schemas or semantic contracts | `schemas/`, `contracts/` |
-| Generated reports | `artifacts/` |
-| Public UI or API behavior | `apps/governed-api/`, `apps/explorer-web/` |
+| Canonical connector placement | Directory decision or accepted ADR with migration and rollback; do not infer it from directory presence. |
+| NOAA family or HMS product doctrine | `docs/sources/catalog/noaa/` and the HMS product page. |
+| Source activation | `control_plane/source_authority_register.yaml` plus approved descriptors and review. |
+| SourceDescriptor schema authority | Resolve the documented source-schema conflict outside this README. |
+| SmokeContext contract/schema authority | Resolve duplicate naming and schema-home drift outside this connector. |
+| Source-role vocabulary or final component roles | Accepted SourceDescriptors, contracts, and source-role governance. |
+| Fire-event or active-wildfire truth | Hazards-domain evidence and official operational authorities. |
+| Surface PM2.5, AQI, exposure, or health guidance | Ground-monitor and air-quality authorities with governed downstream derivation. |
+| Warning, watch, advisory, evacuation, or route-safety behavior | Official authorities; never this connector or KFM. |
+| FIRMS/HMS/CAP/NWS/AirNow joins | Downstream pipelines with explicit temporal/spatial rules and receipts. |
+| Watcher material-change decisions | Approved tooling and review workflow; watcher signals are not event truth. |
+| Normalized or processed products | Downstream domain pipelines after admission. |
+| Catalog, triplet, tile, or published artifacts | Governed lifecycle and release surfaces. |
+| Rights, sensitivity, or public-safety decisions | `policy/` and release review. |
+| EvidenceBundle closure | Downstream proof processes; connector receipts are process evidence only. |
+| Public API, UI, map, notification, or generated-answer behavior | Governed application surfaces after release. |
 
 ---
 
-## Source interface notes
+## 6. Inputs
 
-These notes describe external source surfaces this connector may support. They are not implementation proof.
+A future connector invocation should accept only explicit, governed inputs. At minimum:
 
-NOAA OSPO’s Hazard Mapping System page identifies HMS as a fire and smoke product and exposes current analysis, Fire KML, Smoke KML, Smoke Text Product, Smoke Text Archive, and WFS data links for HMS Fire Detection and HMS Smoke Detection. NOAA’s page also documents 2022 data/file convention changes, including `hms_fireYYYYMMDD` for fire products and `hms_smokeYYYYMMDD` for smoke products, and smoke density values as `light`, `medium`, and `heavy`.
+| Input | Required treatment |
+|---|---|
+| SourceDescriptor reference and revision | Required before retrieval; must resolve to an approved source identity, component scope, and activation posture. |
+| Product and component identity | Preserve source family, HMS product, fire/smoke component, product or issue identity, and any exposed version. |
+| Approved source locator | Treat as configuration, not a hard-coded claim in this README. Redact credentials and sensitive query material. |
+| Expected object identity | Preserve filename or object key, expected component files, size when known, checksum algorithm/digest when known, and source metadata. |
+| Retrieval policy | Bound schemes, hosts, redirects, timeouts, retries, maximum object size, pagination, and resume behavior. |
+| Time interpretation | Preserve observation/acquisition window, smoke start/end, issue/update, retrieval, expiry/review, and correction/supersession time as distinct roles where exposed. |
+| Routing context | Name the owning domain and proposed RAW/QUARANTINE destination without granting downstream promotion. |
+| Rights and attribution reference | Carry governing record identifiers and unresolved review state; do not decide rights locally. |
+| Public-safety posture | Carry a permanent not-life-safety marker and official-source redirection policy. |
 
-| Source surface | KFM use | Connector posture |
+Live endpoints, file/service formats, filename conventions, field names, cadence, coverage, access requirements, rights, and analyst-pass metadata are version-sensitive external facts. They must be verified in product-specific evidence before implementation or activation; this README intentionally does not pin them.
+
+---
+
+## 7. Outputs
+
+The connector may emit only an atomic source-admission handoff to one of:
+
+```text
+data/raw/<owning-domain>/<source-id>/<run-id>/
+data/quarantine/<owning-domain>/<source-id>/<run-id>/
+```
+
+The exact layout remains subject to governing repository contracts. Conceptually, a handoff should include:
+
+- byte-preserving source payload or an immutable reference permitted by policy;
+- source sidecars and original component files;
+- a sanitized request/retrieval manifest;
+- source, product, component, issue/pass, and object identity;
+- distinct fire-detection and smoke-polygon records or references;
+- native field names, qualitative categories, geometry, projection/CRS, and source uncertainty;
+- exposed analyst-augmentation identifiers or times without invented internal details;
+- observed/acquisition, start/end, issue/update, retrieval, expiry/review, and correction time roles;
+- source and content fingerprints;
+- observed size and checksum results;
+- rights, attribution, sensitivity, and public-safety references or unresolved flags;
+- validation results and deterministic quarantine reasons;
+- owning-domain routing and run identity.
+
+The connector must not emit directly to `WORK`, `PROCESSED`, `CATALOG`, `TRIPLETS`, `PUBLISHED`, release, API, UI, notification, or generated-answer surfaces.
+
+---
+
+## 8. Validation
+
+Validation is source admission validation, not scientific confirmation, operational warning validation, or publication approval.
+
+### Required checks
+
+- source identity and SourceDescriptor revision resolve and are approved for use;
+- product, component, object/package, issue/pass, and source-file identity are present where applicable;
+- fire detections and smoke polygons cannot enter as one undifferentiated role;
+- retrieval follows configured scheme, host, redirect, timeout, retry, pagination, and size constraints;
+- payload and all required component files are complete and content digests are recorded;
+- archives and multi-file packages are bounded and safe to materialize;
+- native geometry, projection/CRS, fields, qualitative categories, and uncertainty can be read without semantic mutation;
+- observation/acquisition, start/end, issue/update, retrieval, expiry/review, and correction times remain distinct where applicable;
+- analyst-augmentation context preserves only what the source exposes;
+- smoke categories remain qualitative and cannot produce numeric PM2.5, AQI, exposure, or health claims;
+- fire detections remain evidence of satellite signals and cannot become ground-confirmed fire state;
+- rights, attribution, sensitivity, public-safety, and routing references are present or the object is quarantined;
+- output destination is limited to RAW or QUARANTINE;
+- logs and receipts contain no credentials, signed URLs, unsafe payload excerpts, or sensitive operational detail.
+
+### Quarantine conditions
+
+Quarantine on missing, ambiguous, or conflicting evidence, including:
+
+- unresolved source, product, component, issue/pass, or object identity;
+- mixed fire/smoke payload with no deterministic component split;
+- checksum, size, member-list, or component-package mismatch;
+- unreadable, truncated, structurally unsafe, or partially retrieved content;
+- unexpected fields, geometry, projection, qualitative category, or source-schema drift;
+- stale, future-dated, timezone-ambiguous, conflicting, or unsupported time roles;
+- missing analyst-augmentation context that governing descriptors require;
+- attempt to translate qualitative smoke category into concentration or exposure;
+- attempt to treat a fire detection as confirmed ground state;
+- unresolved rights, attribution, sensitivity, public-safety, or domain routing;
+- duplicate identity with different bytes;
+- any attempt to treat the connector as alert, promotion, or publication authority.
+
+An empty, missing, or partially available source object is not proof of no fire, no smoke, or safe conditions.
+
+### No-network test posture
+
+Tests should be deterministic and no-network by default. Fixtures should cover, at minimum:
+
+- valid fire-detection and smoke-polygon components kept separate;
+- a mixed package that splits deterministically and one that must quarantine;
+- checksum, size, component-list, and archive-safety failures;
+- missing or conflicting source/component/issue/pass identity;
+- stale, future-dated, timezone-ambiguous, and corrected/reissued products;
+- unknown or changed fields, categories, geometry, or projection;
+- smoke category to PM2.5/AQI/exposure conversion attempts;
+- fire detection to ground-confirmed wildfire conversion attempts;
+- empty or partial source objects that must not become an all-clear;
+- duplicate source identity with identical bytes and with conflicting bytes;
+- rights, sensitivity, or routing state that forces quarantine;
+- credential and signed-URL redaction;
+- rejection of every output destination beyond RAW or QUARANTINE;
+- rejection of warning, notification, evacuation, sheltering, or health-guidance output.
+
+---
+
+## 9. Review burden
+
+Changes here require review proportional to their effect:
+
+| Change | Minimum review burden |
+|---|---|
+| README clarification with no authority change | Connector steward, NOAA source steward, and docs review. |
+| Placement, rename, merge, redirect, or removal of an HMS lane | Architecture/governance review and accepted migration decision. |
+| New endpoint, access method, credential flow, or retrieval behavior | Source steward, security review, rights review, and no-network tests. |
+| New format, component, field, category, cadence, or time behavior | Source, Hazards, Atmosphere, spatial, and validation review with versioned fixtures. |
+| Source-role or component mapping | Source-role governance and domain contract review; never connector-only approval. |
+| Hash, deduplication, replay, correction, or quarantine change | Data/validation review with deterministic regression tests. |
+| FIRMS, CAP, NWS, AirNow, monitor, or model join | Downstream pipeline, evidence, policy, and domain review. |
+| Activation, promotion, public display, or operational use | Source authority, rights, safety, proof, and release review outside this lane. |
+
+`OWNER_TBD` must be replaced before operational activation. The global CODEOWNERS file does not establish a NOAA HMS-specific owner at the pinned snapshot.
+
+---
+
+## 10. Related folders
+
+| Path | Relationship |
+|---|---|
+| [`../README.md`](../README.md) | Root connector boundary and RAW/QUARANTINE limit. |
+| [`../noaa/README.md`](../noaa/README.md) | Declared canonical NOAA connector-family boundary. |
+| [`../noaa/src/README.md`](../noaa/src/README.md) | Proposed NOAA source-root contract; not product implementation proof. |
+| [`../noaa/tests/README.md`](../noaa/tests/README.md) | Proposed no-network family test contract; not passing-test proof. |
+| [`../hms_smoke/README.md`](../hms_smoke/README.md) | Documentation-only underscore compatibility/reconciliation lane. |
+| [`../hazards/README.md`](../hazards/README.md) | Hazard connector compatibility index and source-family-first posture. |
+| [`../../docs/sources/catalog/noaa/README.md`](../../docs/sources/catalog/noaa/README.md) | NOAA source-family catalog context. |
+| [`../../docs/sources/catalog/noaa/hms-fire-smoke.md`](../../docs/sources/catalog/noaa/hms-fire-smoke.md) | Draft multi-component HMS product doctrine and open questions. |
+| [`../../docs/architecture/smoke-atmosphere-hazards.md`](../../docs/architecture/smoke-atmosphere-hazards.md) | Draft cross-domain smoke seam architecture. |
+| [`../../docs/architecture/hazards-trust-membrane.md`](../../docs/architecture/hazards-trust-membrane.md) | Hazards public-safety and trust boundary. |
+| [`../../pipeline_specs/hazards/noaa_hms_smoke.yaml`](../../pipeline_specs/hazards/noaa_hms_smoke.yaml) | `PROPOSED` pipeline placeholder, not executable wiring. |
+| [`../../tools/ingest/firms_hms_watch/README.md`](../../tools/ingest/firms_hms_watch/README.md) | Proposed review-signal watcher boundary, not confirmed executable. |
+| [`../../data/raw/atmosphere/observed/hms/README.md`](../../data/raw/atmosphere/observed/hms/README.md) | Draft RAW lane boundary; payloads and activation remain unproven. |
+| [`../../contracts/domains/atmosphere/SmokeContext.md`](../../contracts/domains/atmosphere/SmokeContext.md) | Draft semantic contract for smoke context. |
+| [`../../contracts/domains/atmosphere/smoke-context.md`](../../contracts/domains/atmosphere/smoke-context.md) | Parallel contract name; canonical naming is not selected here. |
+| [`../../schemas/contracts/v1/domains/atmosphere/SmokeContext.schema.json`](../../schemas/contracts/v1/domains/atmosphere/SmokeContext.schema.json) | Permissive `PROPOSED` scaffold. |
+| [`../../schemas/contracts/v1/domains/atmosphere/smoke-context.schema.json`](../../schemas/contracts/v1/domains/atmosphere/smoke-context.schema.json) | Parallel permissive scaffold; not selected here. |
+| [`../../schemas/contracts/v1/domains/atmosphere/smoke_context.schema.json`](../../schemas/contracts/v1/domains/atmosphere/smoke_context.schema.json) | Third permissive scaffold; not selected here. |
+
+---
+
+## 11. ADRs
+
+- [`../../docs/adr/README.md`](../../docs/adr/README.md) is the ADR index and process surface.
+- [`../../docs/adr/ADR-0012-connector-outputs-to-data-raw-or-data-quarantine-only.md`](../../docs/adr/ADR-0012-connector-outputs-to-data-raw-or-data-quarantine-only.md) records the connector-output proposal; its draft/proposed state does not independently create authority.
+- No accepted HMS connector-placement ADR was identified in the bounded evidence review.
+- [`../../docs/registers/DRIFT_REGISTER.md`](../../docs/registers/DRIFT_REGISTER.md) had no `noaa-hms-smoke`, `hms_smoke`, `NOAA HMS`, or `HMS Smoke` text match in a bounded scan. That does not mean the path drift is resolved or exhaustively audited.
+
+Required decisions before product-specific implementation or activation:
+
+1. Choose the canonical HMS connector topology and define redirects or deprecation for non-canonical paths.
+2. Choose stable product/component source IDs, aliases, package/import names, and domain routing.
+3. Resolve SourceDescriptor schema authority and active component descriptors.
+4. Resolve SmokeContext contract/schema naming and domain ownership.
+5. Define current source access, component split, time, correction, rights, sensitivity, and not-life-safety rules.
+6. Define owner, fixture, validator, pipeline, watcher, correction, and rollback responsibilities.
+
+This README does not pre-decide any of those outcomes.
+
+---
+
+## 12. Last reviewed
+
+**2026-07-14**, against repository snapshot `main@a6f3defda415462f595f098ca7758aa14826bfa7`.
+
+Review scope was bounded to the named connector, NOAA family scaffold, underscore compatibility lane, source catalog, rules, source authority, named registry paths, source-schema contract, pipeline placeholder, watcher README, RAW lane, smoke contracts/schemas, domain architecture, drift, ownership, and workflow surfaces cited here. Re-review after any topology decision, source activation, descriptor/schema migration, source-interface change, component/category change, rights change, or executable implementation.
+
+---
+
+## Connector topology and placement
+
+Repository evidence exposes several different homes or proposals:
+
+| Path | Observed state | Safe interpretation |
 |---|---|---|
-| HMS Smoke KML | Candidate smoke polygon source material. | Preserve density, start/end time, geometry, file identity, and retrieval metadata. |
-| HMS Smoke shapefile or WFS | Candidate smoke polygon source material. | Preserve component files, fields, projection, geometry, and digest. |
-| HMS Smoke Text Product / Archive | Candidate text summary and source-side context. | Preserve text source identity and review status; do not convert to alert authority. |
-| HMS Fire KML / shapefile / WFS | Candidate fire detection context. | Preserve fire point fields and source-role distinction from smoke polygons. |
-| Current Analysis page | Discovery/current-product context. | Discovery surface only; not a release decision. |
-| Historical fire/smoke data | Backfill or time-series source material. | Preserve product date, issue/update time, and format/version details. |
+| `connectors/noaa/` | Declared canonical NOAA family lane; package is a `0.0.0` greenfield scaffold. | Family coordination and future implementation root, not current HMS runtime proof. |
+| `connectors/noaa-hms-smoke/` | This README exists; named implementation probes found no code or tests. | Proposed hyphenated product sibling. |
+| `connectors/hms_smoke/` | v0.2 README exists and explicitly forbids implementation there. | Documentation-only compatibility/reconciliation lane. |
+| `connectors/noaa/hms-smoke/` | Bounded README probe returned no file. | Possible nested home, not repository-present at the inspected path. |
+| `connectors/noaa/hms_smoke/` | Bounded README probe returned no file. | Possible nested home, not repository-present at the inspected path. |
+| `connectors/noaa/src/noaa/products/hms_smoke.py` | Bounded probe returned no file. | Proposed module named by source-root docs, not implemented evidence. |
+
+Directory Rules §7.3 lists the `noaa/` family. The NOAA family README calls its family lane canonical while treating this sibling as draft and migration-pending. Do not copy code across lanes, split component responsibility by path, create import aliases, delete compatibility documentation, or move descriptors until an accepted decision covers lineage, redirects, deprecation, tests, activation, correction, and rollback.
 
 ---
 
-## Admission posture
+## Component and source-role boundary
 
-HMS intake should preserve:
+### Multi-component product
 
-- source identity and source surface;
-- source descriptor reference and source activation state;
-- product component: `fire_point`, `smoke_polygon`, `smoke_text`, or source-provided equivalent;
-- source URL, download URL, service URL, or catalog item identifier;
-- product date, observation time, start/end time, issue/update time, retrieval time, and timezone convention;
-- response status, file identity, component files, projection, geometry profile, and content digest;
-- smoke density class as a qualitative source category;
-- fire detection fields as satellite-pixel signal fields;
-- analyst-augmented and quality-control limitation notes where available;
-- rights/citation/attribution posture;
-- domain-lane routing hint such as hazards or atmosphere;
-- public-safety limitation notes;
-- quarantine reason when review is required.
+HMS fire detections and smoke polygons travel in related source products but represent different kinds of evidence. They must retain distinct component identifiers, source-role decisions, time semantics, uncertainty, validation, and downstream routing.
 
----
+The draft HMS product page proposes:
 
-## Anti-collapse posture
-
-HMS has several high-risk interpretation boundaries. Keep them visible at connector admission time.
-
-| Rule | Connector implication |
-|---|---|
-| Smoke polygon is not surface concentration. | Do not emit PM2.5, exposure, or concentration claims from density classes. |
-| Smoke density is qualitative. | Preserve `light`, `medium`, `heavy` as source categories, not numeric concentration bins. |
-| Fire point is not ground-fire authority. | Preserve fire detections as satellite-pixel signals with known uncertainty. |
-| HMS is not a KFM alert. | Do not package connector output as emergency, public-safety, or evacuation guidance. |
-| Analyst pass is provenance. | Preserve source issue/update and analyst-augmented context where available; do not invent internal analyst details. |
-| Joins are downstream. | FIRMS, HRRR, AOD, CAP, NWS, AirNow, and monitor joins require downstream receipts and review. |
-| Public display is downstream. | The connector must not build public tiles, UI layers, or alert payloads. |
-
----
-
-## Placement status
-
-`connectors/noaa-hms-smoke/README.md` is intentionally conservative because connector placement is not yet fully ratified.
-
-| Claim | Status | Notes |
+| Component | Draft repository posture | Connector limitation |
 |---|---|---|
-| `connectors/noaa-hms-smoke/README.md` contains this connector README | `CONFIRMED` after this update | The file itself now carries the connector-lane boundary. |
-| `connectors/noaa-hms-smoke/` is a source-admission lane only | `PROPOSED / draft` | Consistent with `connectors/` responsibility, but Directory Rules §7.3 lists `noaa/` rather than this sibling lane. |
-| HMS source-product docs exist under `docs/sources/catalog/noaa/hms-fire-smoke.md` | `CONFIRMED` in repo evidence | Product/source doctrine belongs there, not here. |
-| A live NOAA HMS `SourceDescriptor` exists and is active | `NEEDS VERIFICATION` | Must be checked under `data/registry/sources/`. |
-| Endpoint behavior, tests, fixtures, and CI are implemented | `UNKNOWN` | Not proven by this README. |
-| HMS outputs are validated, cataloged, tiled, and published | `UNKNOWN` | Connector README does not prove downstream promotion. |
+| Fire detection | Observation of an analyst-confirmed satellite signal. | Not ground-confirmed fire, ignition cause, containment status, evacuation trigger, or all-clear. |
+| Smoke polygon | Modeled/interpretive analyst-drawn visible-plume boundary. | Not surface concentration, PM2.5, AQI, exposure, health guidance, or advisory. |
+| Reprojected/aggregated derivative | Aggregate with transform/aggregation lineage. | Not connector output and not per-place truth. |
+| Unresolved or mixed admission | Candidate/quarantine. | Not publishable and not safe to summarize as current conditions. |
+
+Those role labels remain draft product doctrine until accepted descriptors and source-role contracts settle the authoritative enum and mapping. The connector’s non-negotiable duty is to prevent component collapse and preserve the evidence needed for the governing layer to decide.
+
+### Analyst augmentation
+
+Analyst review changes provenance burden, not epistemic category into ground truth. Preserve only source-exposed issue/pass identifiers, review state, source inputs, or timestamps. Do not invent analyst identity, internal procedures, thresholds, confidence, or review parameters.
+
+### Time and freshness
+
+Do not collapse:
+
+```text
+satellite acquisition or observation window
+!= smoke start/end or product-valid window
+!= source issue/update time
+!= KFM retrieval time
+!= expiry/review time
+!= correction or supersession time
+```
+
+A successful retrieval does not prove that conditions are current. A historical, stale, corrected, partial, or empty product must remain visibly qualified.
+
+### Anti-collapse rules
+
+- smoke polygon does not prove smoke at breathing height at every enclosed location;
+- qualitative smoke category does not map directly to numeric concentration or exposure;
+- fire detection does not prove a currently burning ground event;
+- analyst augmentation does not create independent field observation;
+- watcher material-change signal does not confirm an event or authorize publication;
+- cross-product proximity does not create causal or identity truth;
+- RAW presence does not imply validation, release, or public eligibility;
+- HMS source material never becomes a KFM warning or all-clear.
 
 ---
 
-## Validation
+## Proposed runtime contract
 
-Before relying on this connector, verify:
+No product-specific runtime is proven at this path. If implementation is approved, it should follow these fail-closed phases:
 
-- placement is intentional and documented by ADR, migration note, or updated Directory Rules;
-- source descriptors exist and are active for HMS source surfaces;
-- NOAA rights, citation, attribution, endpoint, and distribution posture are captured in source descriptors;
-- current product files, WFS services, text-product endpoints, cadence, filename conventions, field names, and formats are re-verified;
-- parsers preserve fire-point and smoke-polygon source roles separately;
-- smoke density classes remain qualitative and are not converted to PM2.5 or exposure claims;
-- time handling preserves observation/start/end/issue/update/retrieval time;
-- tests use no-network fixtures where practical;
-- output paths are limited to raw/quarantine admission lanes;
-- downstream receipts, proofs, catalog/triplet records, tile artifacts, and release records are produced only outside this connector;
-- public products are released only through governed publication controls and never as KFM alerts.
+1. **Resolve** approved SourceDescriptor revisions, product/component scope, and source locator.
+2. **Plan** a bounded request without exposing credentials, signed material, or unsafe parameters.
+3. **Retrieve** into temporary storage with size, timeout, redirect, pagination, and retry limits.
+4. **Verify** response identity, package members, byte length, digest, sidecars, and source metadata.
+5. **Split** fire and smoke components without losing native fields, uncertainty, or package lineage.
+6. **Inspect** geometry, projection, categories, and time roles without deriving concentration or ground state.
+7. **Decide** RAW versus QUARANTINE using deterministic admission rules.
+8. **Commit** the handoff atomically so partial objects never appear complete.
+9. **Record** sanitized process evidence and source/content fingerprints.
+
+Retry only transient, bounded failures. Do not retry authentication failure, forbidden access, component or role contradiction, unsafe archive structure, deterministic checksum mismatch, unsupported schema/category change, or unresolved policy state as though those were network transients.
+
+### Idempotency, deduplication, correction, and replay
+
+- source identity is not only a URL or calendar date;
+- a locator with changed bytes must create a new reviewable identity or correction lineage;
+- identical verified bytes may be deduplicated only through a governed immutable-reference mechanism;
+- duplicate source identity with conflicting bytes must quarantine;
+- corrected or reissued source material must not overwrite prior captures;
+- replay must pin descriptor revisions, retrieval policy, component mapping, validation version, and output target;
+- replay must preserve prior outcomes and quarantine reasons;
+- caches may accelerate retrieval but never substitute for integrity, freshness, or provenance checks.
+
+---
+
+## Evidence ledger
+
+| Evidence surface | Observed state | What it supports | What it does not support |
+|---|---|---|---|
+| This README | Prior v0.1 draft exists. | A documented hyphenated product boundary. | Code, activation, source access, or canonical placement. |
+| NOAA family README | Calls `connectors/noaa/` canonical and this lane draft/migration-pending. | Source-family-first placement posture. | A final HMS subpath or working implementation. |
+| NOAA package files | `0.0.0` placeholder; empty initializer; placeholder fetch/admit; descriptor role/rights `TBD`. | Greenfield family scaffolding exists. | HMS parser, package readiness, active descriptor, or endpoint behavior. |
+| Underscore compatibility README | Documentation-only; implementation forbidden there. | A reconciliation path and explicit drift warning. | A third runtime authority. |
+| Draft HMS product page | Multi-component, analyst-augmented, anti-collapse doctrine and open questions. | Required semantic caution and proposed component roles. | Current endpoints, cadence, rights, formats, or accepted implementation. |
+| Source-authority register | `PROPOSED`; `entries: []`. | No repository-level HMS activation at snapshot. | Future activation status. |
+| Named registry probes | No NOAA/HMS descriptor file found at inspected paths. | No descriptor is proven by those paths. | Exhaustive registry absence. |
+| HMS pipeline YAML | Four-line `PROPOSED` placeholder. | A named future spec location. | Pipeline implementation, schedule, validation, or release wiring. |
+| FIRMS/HMS watcher README | Proposed review-signal-only boundary. | Watcher safeguards are documented. | Executable watcher, cadence, thresholds, or run evidence. |
+| HMS RAW lane README | Draft source-capture boundary. | A no-public-path RAW posture. | Payloads, descriptor, receipts, role split, or release evidence. |
+| SmokeContext contracts/schemas | Duplicate naming; inspected schemas allow arbitrary properties. | Semantic work has candidate homes. | Enforceable canonical schema. |
+| Connector/source-descriptor workflows | Inspected workflows are TODO echo-only stubs. | No meaningful automated connector/descriptor gate is proven. | Runtime or activation readiness. |
+| CODEOWNERS | Global placeholder; no NOAA HMS-specific rule identified. | Owner remains unresolved. | Operational accountability. |
+
+---
+
+## Rights, sensitivity, and public safety
+
+Repository documentation is not a substitute for current source terms. Before activation, governing records must verify licensing or terms, attribution, redistribution, caching, service constraints, access method, intended use, and product-specific restrictions.
+
+The connector must:
+
+- carry rights, attribution, sensitivity, and review record identifiers;
+- quarantine when terms, component use, retention, or attribution are unresolved;
+- keep credentials, tokens, cookies, signed URLs, and sensitive query strings out of commits, manifests, logs, receipts, and exceptions;
+- preserve source uncertainty and not-life-safety limitations with every handoff;
+- avoid presenting cultural/prescribed burns, industrial signals, false positives, or other ambiguous detections as confirmed wildfire events;
+- avoid joins or location detail that could create sensitive infrastructure, community, cultural, tribal, health, or response claims;
+- defer aggregation, generalization, suppression, notification, and public-safe rendering to governed downstream policy and release controls.
+
+Public availability or operational source status does not mean connector output is automatically approved for KFM publication or life-safety use.
+
+---
+
+## Activation, promotion, and rollback
+
+### Activation prerequisites
+
+Do not activate this connector until all of the following are true:
+
+- topology, package/import identity, ownership, and compatibility plan are ratified;
+- authoritative SourceDescriptor and source-schema paths are resolved for each admitted component;
+- the source-authority register records approved HMS component entries;
+- SmokeContext contract/schema naming and domain ownership are resolved where required;
+- current endpoint/access, format/package, fields/categories, cadence, coverage, time, correction, and analyst-augmentation evidence is verified;
+- rights, attribution, sensitivity, and permanent not-life-safety reviews are complete;
+- component split, integrity, geometry, time, redaction, quarantine, replay, correction, and no-network tests pass;
+- RAW/QUARANTINE paths and downstream domain ownership are approved;
+- watcher and pipeline boundaries cannot promote, alert, or publish;
+- correction, deactivation, and rollback procedures have named owners.
+
+### Promotion boundary
+
+Successful admission means only that source material entered RAW with required evidence. It does not mean a fire is confirmed, smoke is at the surface, air is unsafe or safe, an advisory exists, a join is valid, a product is scientifically validated, or anything is public. Every later transition belongs to downstream governed stages.
+
+### Correction and deactivation
+
+If source identity, component mapping, bytes, time, geometry, categories, rights, or validation are later found wrong:
+
+1. stop new admissions for the affected configuration;
+2. preserve prior immutable bytes, manifests, and receipts;
+3. mark affected runs, joins, and downstream dependencies for review;
+4. quarantine new or replayed material until the contradiction is resolved;
+5. issue correction, notification, and release actions only through their governing surfaces;
+6. reactivate only with a new reviewed configuration or SourceDescriptor revision.
+
+Do not rewrite history, silently replace source objects, delete evidence, or publish an all-clear to simulate rollback.
+
+---
+
+## Verification backlog
+
+- [ ] Ratify one canonical HMS connector home and document migration, redirect, and deprecation for other paths.
+- [ ] Record the NOAA/HMS path drift or accepted decision in the appropriate governance surface.
+- [ ] Replace `OWNER_TBD` with accountable reviewers and NOAA HMS CODEOWNERS coverage.
+- [ ] Replace NOAA family greenfield placeholders with reviewed package/runtime decisions or keep them explicitly inactive.
+- [ ] Resolve SourceDescriptor schema authority and create approved component-specific descriptors.
+- [ ] Add approved HMS entries to the source-authority register before activation.
+- [ ] Resolve SmokeContext contract/schema naming and domain ownership.
+- [ ] Verify current source endpoints, access, formats/packages, fields/categories, cadence, coverage, time semantics, corrections, terms, attribution, and analyst-augmentation metadata.
+- [ ] Implement bounded retrieval, component separation, credential redaction, integrity checks, atomic handoff, and deterministic quarantine.
+- [ ] Add no-network fixtures and executable tests for component, role, time, geometry, category, safety, replay, and failure cases.
+- [ ] Replace placeholder pipeline/watcher behavior and TODO connector/descriptor gates with meaningful validation before treating them as readiness evidence.
+- [ ] Verify RAW captures, downstream pipelines, joins, receipts, proofs, release, correction, API/UI, and official-source redirection independently.
 
 ---
 
 ## Definition of done
 
-- [ ] Owners are confirmed and `OWNER_TBD` is replaced.
-- [ ] Directory placement is ratified or the conflict is recorded in the drift/open-question register.
-- [ ] Actual connector contents are inventoried.
-- [ ] NOAA HMS `SourceDescriptor` IDs and source-family activation are verified.
-- [ ] NOAA rights, citation, attribution, source terms, endpoint, and current product-suite posture are documented.
-- [ ] Request/download builders preserve source URL, component type, product date, issue/update time, file identity, and digest.
-- [ ] Fire-point and smoke-polygon parsing preserves distinct source roles and fields.
-- [ ] Smoke density tests prevent silent conversion to PM2.5, exposure, or alert claims.
-- [ ] Outputs are verified to enter only raw or quarantine admission lanes.
-- [ ] No source-family, domain, processed, catalog, triplet, published, release, schema, policy, proof, receipt, registry, fixture, report, API, UI, tile, alert, or concentration authority lives here.
-- [ ] Tests, fixtures, and CI behavior are verified or marked `NEEDS VERIFICATION`.
+This README update is complete when it accurately preserves the current boundary without claiming implementation. The connector itself is not done until every activation prerequisite and verification item above is resolved through its governing surface.
+
+In all states:
+
+- fire detections and smoke polygons remain distinct components;
+- analyst augmentation is preserved as provenance without invented internal details;
+- smoke categories remain qualitative and never become PM2.5, AQI, exposure, or health advice;
+- fire detections never become ground-confirmed event truth;
+- time roles, freshness, corrections, native geometry, uncertainty, and source identity remain intact;
+- empty or missing source output never becomes an all-clear;
+- connector output stops at RAW or QUARANTINE;
+- placement, schema, registry, policy, pipeline, watcher, proof, release, alert, API, and UI authority remain outside this folder.
 
 ---
 
-## Status summary
+## Changelog
 
-`connectors/noaa-hms-smoke/` is for NOAA HMS source-admission code only. It is not source-family truth, smoke concentration truth, air-quality truth, ground-fire authority, life-safety alert authority, policy authority, schema authority, catalog/triplet authority, proof closure, release authority, tile publication authority, public API behavior, public UI behavior, or pipeline authority.
+### v0.2 — 2026-07-14
+
+- Reframed the path as a README-only proposed product connector boundary.
+- Surfaced the canonical NOAA family lane, underscore compatibility lane, absent nested lane, and greenfield NOAA package state.
+- Added evidence-pinned status for descriptors, source activation, pipeline, watcher, RAW lane, contracts, schemas, tests, workflows, and ownership.
+- Tightened the fire/smoke component split, analyst-augmentation, qualitative-density, ground-fire, time/freshness, empty-product, and not-life-safety rules.
+- Removed version-sensitive live-source claims from the connector contract and moved them into the verification backlog.
+- Added fail-closed retrieval, quarantine, no-network testing, replay, correction, activation, deactivation, and rollback requirements.
+- Preserved the RAW/QUARANTINE-only lifecycle limit and prohibited alert/publication authority.
+
+### v0.1 — 2026-06-19
+
+- Established the initial NOAA HMS smoke connector-lane documentation.
 
 <p align="right"><a href="#top">Back to top</a></p>


### PR DESCRIPTION
## Summary

Refresh `connectors/noaa-hms-smoke/README.md` as an evidence-pinned, README-only NOAA HMS connector boundary.

- surfaces the unresolved NOAA family, hyphenated sibling, underscore compatibility, and absent nested-lane topology without choosing a migration;
- records the actual NOAA `0.0.0` scaffold and absence of a product-specific HMS module in bounded probes;
- keeps fire detections and smoke polygons as separate components with separate role decisions and time/provenance burdens;
- preserves smoke categories as qualitative context and fire detections as satellite-signal evidence;
- strengthens not-life-safety, no-all-clear, freshness, analyst-augmentation, quarantine, replay, correction, and rollback safeguards;
- records the inactive source-authority register, absent named HMS descriptors, proposed pipeline placeholder, proposed watcher boundary, and permissive duplicate SmokeContext schemas;
- makes no code, schema, registry, policy, workflow, activation, pipeline, watcher, release, alert, or publication change.

## Evidence snapshot

- Base: `main@a6f3defda415462f595f098ca7758aa14826bfa7`
- Prior target blob: `14e535edf2275fde7cda241ea1b3fea2fc7a06e9`
- Task: `kfm-connectors-noaa-hms-smoke-readme-v2-20260714`
- Operation journal: `oj-kfm-noaa-hms-smoke-20260714-01`

The base moved during drafting only through `connectors/newspapers/src/README.md`; comparison showed no NOAA HMS or governing-evidence change.

## Validation

- [x] Target metadata and prior blob re-read from the pinned base.
- [x] Required Directory Rules README sections appear in the prescribed order.
- [x] Every relative repository link in the revised README resolves in the inspected checkout.
- [x] One-commit comparison against the pinned base shows exactly one modified file.
- [x] No product-specific runtime, active descriptor, current endpoint, alert, or publication claim was inferred.
- [ ] GitHub Actions complete.

## Risk and rollback

Documentation-only, low runtime risk. The main risk is overstating immature runtime or life-safety authority; the README explicitly labels placement, package scaffolding, descriptors, contracts, schemas, pipelines, watcher behavior, activation, and downstream wiring.

Rollback by reverting commit `82eb3fac81d0692a1e374dec7ade70dd689af8fd` or restoring prior blob `14e535edf2275fde7cda241ea1b3fea2fc7a06e9`.