### PR TITLE
docs(hashing): ground source envelope boundary

### DIFF
--- a/packages/hashing/src/README.md
+++ b/packages/hashing/src/README.md
@@ -1,327 +1,946 @@
 <!-- [KFM_META_BLOCK_V2]
-doc_id: kfm://doc/NEEDS-VERIFICATION/packages-hashing-src-readme
-title: Hashing Package Source README
+doc_id: kfm://doc/packages-hashing-src-readme
+title: packages/hashing/src/ — Hashing Source Envelope and Implementation Placement Boundary
 type: readme
-version: v1
+version: v1.1
 status: draft
-owners: OWNER_TBD
-created: NEEDS VERIFICATION — target file existed before this repair but contained only placeholder text
-updated: 2026-06-14
-policy_label: public
-related: [packages/hashing/README.md, packages/README.md, docs/doctrine/directory-rules.md, docs/architecture/identity-and-spec-hash.md, docs/architecture/evidence-identity.md, docs/architecture/contract-schema-policy-split.md, contracts/, schemas/contracts/v1/, policy/, data/receipts/, data/proofs/, release/]
-tags: [kfm, packages, hashing, src, deterministic-identity, spec-hash, content-hash, run-id, sha256, jcs, receipts, replay]
-notes: ["README-like source-directory guide for deterministic hash and identity helper code.", "This directory may contain source code for canonicalization, digest, spec_hash, content_hash, geometry_hash, artifact_hash, merkle_root, run_id, and comparison helpers only; it must not own schemas, contracts, policy, lifecycle data, receipts, proofs, release decisions, API routes, UI surfaces, signing authority, or AI truth claims.", "Import layout, package metadata, tests, CI workflows, and runtime bindings remain NEEDS VERIFICATION until the live repo is recursively inspected."]
+owners: OWNER_TBD — Package steward · Integrity/canonicalization steward · Contract steward · Schema steward · Security steward · Validation steward · Migration steward · CI steward · Docs steward
+created: NEEDS VERIFICATION — target existed before the current evidence-grounded revision
+updated: 2026-07-15
+policy_label: "public-doctrine; package-source-boundary; hashing; implementation-empty; api-unratified; canonicalization-conflicted; spec-hash-shape-conflicted; tools-package-ownership-conflicted; no-network; pure-functions; fail-closed; no-authority; no-secrets; migration-required; rollback-aware"
+current_path: packages/hashing/src/README.md
+truth_posture: CONFIRMED target README, merged child namespace README v1.1, empty hashing package initializer, kfm-hashing 0.0.0 placeholder metadata, package/root READMEs, Directory Rules package placement, draft identity and canonicalization doctrine, draft common spec_hash contract and schema, schema fixtures and generic schema test harness, placeholder dedicated validator, README-only tools/spec_hash lane, generated-receipt digest vocabulary, and bounded absence of proposed implementation modules and package-specific test/workflow paths / PROPOSED source-envelope rules, import direction, pure-library placement, dependency controls, package-tool-validator delegation, typed result families, resource limits, staged implementation, tests, correction, migration, deprecation, and rollback / CONFLICTED jcs:sha256 string doctrine versus object-wrapped sha256 schema and contract, packages/hashing versus tools/spec_hash implementation ownership, canonicalization-profile representation, SHA-256 authority baseline versus BLAKE3-permitted provenance/content fields, and documentation richness versus empty implementation / UNKNOWN accepted Python runtime, build backend, dependency set, pinned JCS implementation, export surface, consumer inventory, installability, runtime behavior, cross-language parity, package-specific tests, CI enforcement, release use, and operational health / NEEDS VERIFICATION owners, ADR or migration decision, canonical hash vocabulary, schema/contract reconciliation, package ownership, dependencies, source layout, API shape, resource limits, test vectors, consumer migration, CI gates, correction path, compatibility period, deprecation, and rollback automation
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  repository_id: "1059091169"
+  visibility: public
+  base_ref: main
+  base_commit: 2ad80d6362541db0d1933fe729e9a552f7aa19a9
+  prior_blob: 309afb28791d0f1136358b79f690ee99786a7ae8
+  package_readme_blob: c9440697c02f71a8c83f0293d72364bb89930c01
+  namespace_readme_blob: 05a1320e395ad3b1e64ff72f16c844a5e43c3441
+  package_metadata_blob: 94a3799821298b4e99ea7bc638d8ab3c4bd7eea2
+  namespace_initializer_blob: e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  packages_root_blob: fc18fb3334fefe992a551fe12aa98c812232cd17
+  directory_rules_blob: 2affb080e6f0043867c64c7f06c1ca52030fbd55
+  identity_architecture_blob: d8b3836bae160ac0f2027407989d383fa016a49b
+  canonicalization_standard_blob: 393a4450f64993c26b20d727656a1e6b6494db4e
+  spec_hash_contract_blob: 0c2c1161ddb565d4f9f17ef81080b27b8d951937
+  spec_hash_schema_blob: 80b496b01b8de8c0e8ba67bf020977e6b1f3c652
+  spec_hash_fixture_readme_blob: bc787595d5869c7bd212b0c7909c3eb0b980daf9
+  common_contract_test_blob: b04342cc034d7f1cc554e155fdd02d6e972976e6
+  spec_hash_validator_blob: de69c6c7001082af29827a4b287a80b7c6a05af3
+  tools_spec_hash_readme_blob: 69beb3e00d0c9c59e42348a918da0d11faa82850
+  generated_receipt_schema_blob: fba21ed27ebccf1362fe397fe0c3ebd85e072685
+  evidence_bundle_schema_blob: cf5256831b63dca46a5f68b168441adcf68b8751
+  bounded_path_checks:
+    - packages/hashing/src/README.md existed at version v1 before this revision
+    - packages/hashing/src/hashing/README.md exists at version v1.1
+    - packages/hashing/src/hashing/__init__.py exists and is empty
+    - packages/hashing/pyproject.toml contains only project name kfm-hashing and version 0.0.0
+    - packages/hashing/package.json was not found
+    - packages/hashing/src/hashing.py was not found
+    - canonical_json.py, digests.py, spec_hash.py, content_hash.py, geometry_hash.py, merkle.py, run_id.py, compare.py, and fixtures.py were not found under packages/hashing/src/hashing/
+    - packages/hashing/tests/README.md and tests/packages/hashing/README.md were not found
+    - .github/workflows/hashing.yml, package-hashing.yml, and spec-hash.yml were not found
+    - tools/spec_hash/jcs_hash.py and tools/spec_hash/spec_hash.py were not found
+    - tools/validators/validate_spec_hash.py raises NotImplementedError
+related:
+  - ../README.md
+  - hashing/README.md
+  - hashing/__init__.py
+  - ../pyproject.toml
+  - ../../README.md
+  - ../../../docs/doctrine/directory-rules.md
+  - ../../../docs/architecture/identity-and-spec-hash.md
+  - ../../../docs/standards/CANONICALIZATION.md
+  - ../../../contracts/common/spec_hash.md
+  - ../../../schemas/contracts/v1/common/spec_hash.schema.json
+  - ../../../schemas/contracts/v1/evidence/evidence_bundle.schema.json
+  - ../../../schemas/contracts/v1/receipts/generated_receipt.schema.json
+  - ../../../fixtures/contracts/v1/common/spec_hash/README.md
+  - ../../../tests/schemas/test_common_contracts.py
+  - ../../../tools/validators/validate_spec_hash.py
+  - ../../../tools/spec_hash/README.md
+  - ../../../contracts/
+  - ../../../schemas/
+  - ../../../policy/
+  - ../../../data/receipts/
+  - ../../../data/proofs/
+  - ../../../release/
+tags: [kfm, packages, hashing, src, deterministic-identity, canonicalization, jcs, urdna2015, sha256, blake3, spec-hash, content-hash, geometry-hash, artifact-hash, merkle-root, run-id, replay, compatibility, migration, fail-closed]
+notes:
+  - "This revision changes only packages/hashing/src/README.md."
+  - "The source envelope currently contains this README and the hashing/ child namespace; that namespace contains its README and an empty __init__.py."
+  - "This README does not activate an API, select a canonical spec_hash representation, ratify a package/tool implementation owner, or claim installability."
+  - "The current docs and machine contracts disagree about spec_hash representation; source code must not silently translate between them."
+  - "Hash equality is integrity evidence about declared bytes/profile only. It is not truth, evidence closure, policy approval, release approval, or public safety."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-# Hashing Package Source
+# Hashing Source Envelope and Implementation Placement Boundary
 
-Source-code envelope for KFM deterministic identity primitives: canonicalization helpers, digest helpers, `spec_hash`, `content_hash`, `geometry_hash`, `artifact_hash`, `merkle_root`, `run_id`, replay comparison helpers, and receipt-ready hash metadata.
+`packages/hashing/src/`
 
-<p>
-  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
-  <img alt="Implementation: proposed" src="https://img.shields.io/badge/implementation-PROPOSED-orange">
-  <img alt="Owner: OWNER_TBD" src="https://img.shields.io/badge/owner-OWNER__TBD-lightgrey">
-  <img alt="Root: packages" src="https://img.shields.io/badge/root-packages-blue">
-  <img alt="Path: src" src="https://img.shields.io/badge/path-src-lightgrey">
-  <img alt="Hash: jcs sha256" src="https://img.shields.io/badge/hash-jcs%3Asha256-blueviolet">
-  <img alt="Network: no-network helpers" src="https://img.shields.io/badge/network-no--network__helpers-blueviolet">
-</p>
+> Repository-present source envelope for a future reusable deterministic hashing library. Current evidence establishes documentation and an empty import initializer—not a functioning canonicalizer, digest implementation, exported API, tested package, or CI-enforced integrity subsystem.
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![version](https://img.shields.io/badge/version-v1.1-informational)
+![maturity](https://img.shields.io/badge/maturity-source__scaffold-lightgrey)
+![canonicalization](https://img.shields.io/badge/canonicalization-CONFLICTED-orange)
+![ownership](https://img.shields.io/badge/ownership-CONFLICTED-orange)
+![network](https://img.shields.io/badge/network-none-critical)
+![authority](https://img.shields.io/badge/truth__authority-none-red)
+![behavior](https://img.shields.io/badge/behavior-fail__closed-blue)
+
+**Quick links:** [Purpose](#purpose) · [Evidence](#status-and-evidence) · [Placement](#directory-rules-and-authority) · [Responsibilities](#source-envelope-responsibilities) · [Conflicts](#compatibility-conflicts) · [Tree](#confirmed-and-proposed-source-tree) · [Invariants](#keystone-invariants) · [Imports](#import-and-dependency-direction) · [Canonicalization](#canonicalization-and-hash-boundary) · [Delegation](#package-tool-validator-and-caller-delegation) · [Outcomes](#expected-result-families) · [Security](#security-and-resource-bounds) · [Testing](#testing-fixtures-and-ci) · [Implementation](#smallest-sound-implementation-sequence) · [Done](#definition-of-done) · [Open](#verification-register) · [Rollback](#rollback-correction-deprecation-and-migration)
 
 > [!IMPORTANT]
-> **Status:** PROPOSED source-directory README  
-> **Path:** `packages/hashing/src/README.md`  
-> **Owning responsibility root:** `packages/`  
-> **Package lane:** `packages/hashing/`  
-> **Import/package layout:** NEEDS VERIFICATION  
-> **Repo implementation depth:** UNKNOWN for package metadata, import style, tests, CI workflows, API bindings, emitted receipts, proof packs, release manifests, branch protections, and runtime behavior.
+> **This README is not an implementation, API, dependency, or migration decision.** It does not establish exports, a pinned JCS library, supported canonicalization profiles, a canonical `spec_hash` shape, package ownership over `tools/spec_hash/`, CI enforcement, or operational consumers.
 
-## Quick links
-
-- [Scope](#scope)
-- [Repo fit](#repo-fit)
-- [Accepted inputs](#accepted-inputs)
-- [Exclusions](#exclusions)
-- [Expected source layout](#expected-source-layout)
-- [Hash helper outcomes](#hash-helper-outcomes)
-- [Trust-boundary flow](#trust-boundary-flow)
-- [Source anti-collapse rules](#source-anti-collapse-rules)
-- [Development rules](#development-rules)
-- [Validation checklist](#validation-checklist)
-- [Rollback](#rollback)
-- [Evidence boundary](#evidence-boundary)
+> [!CAUTION]
+> **A matching digest is not a truth decision.** It establishes only that declared inputs produce the same digest under the same declared algorithm and canonicalization profile. Schema validity, semantic correctness, provenance, evidence sufficiency, rights, sensitivity, policy, review, release, and public safety remain separate gates.
 
 ---
 
-## Scope
+<a id="purpose"></a>
 
-`packages/hashing/src/` is the proposed source-code root for the Hashing package.
+## Purpose
 
-This directory is for importable, deterministic helper code used by packages, validators, pipelines, replay tools, governed API assemblers, receipt builders, proof builders, release gates, and tests when they need stable identity and digest primitives.
+This README defines the allowed responsibility boundary for source code under `packages/hashing/src/`.
 
-This source tree may support helpers for:
+The source envelope may eventually contain one reusable, deterministic implementation used by governed callers for:
 
-- RFC 8785-style JSON canonicalization adapters when the project standard is pinned;
-- canonical byte production for supported trust-bearing record families;
-- SHA-256 digest helpers with explicit algorithm/profile prefixes;
-- `spec_hash` construction and comparison helpers;
-- `content_hash` construction for bytes and canonical JSON bodies;
-- `geometry_hash` helpers when supplied with normalized geometry, CRS, and precision rules;
-- `style_hash`, `artifact_hash`, and file-set `merkle_root` helpers from explicit inputs;
-- deterministic `run_id` helpers based on supplied run context;
-- replay comparison helpers that recompute and compare stored digests;
-- synthetic fixtures for valid, invalid, mismatch, unsupported-profile, and drift cases.
+- canonical byte production under accepted versioned profiles;
+- byte and canonical-content digest computation;
+- digest-reference parsing and formatting;
+- stored-versus-recomputed comparison;
+- deterministic file-set roots from explicit entries;
+- deterministic run identifiers from explicit run context;
+- replay and parity checks;
+- stable typed results and reason codes.
 
-This source tree must not define object meaning, define schema shape, decide policy, store receipts, store proofs, approve release, sign records, manage keys, expose API routes, render UI, call model providers, or generate truth claims.
+The source envelope must not become:
+
+- a second schema, contract, canonicalization-standard, or policy home;
+- a receipt, proof, EvidenceBundle, release, rollback, or lifecycle-data store;
+- a source connector or pipeline orchestrator;
+- a public API, UI, map, or AI answer surface;
+- signing, HMAC, encryption, password-hashing, key-management, or secret-storage authority;
+- a compatibility shortcut that silently converts conflicting hash representations;
+- an ambient filesystem scanner or network client.
+
+The child namespace README governs proposed import behavior. This parent README governs source placement, import direction, dependency boundaries, implementation delegation, and conditions for adding code.
+
+[Back to top](#top)
+
+---
+
+<a id="status-and-evidence"></a>
+
+## Status and evidence
+
+| Surface | Status | Safe conclusion |
+|---|---:|---|
+| This README | **CONFIRMED v1 before revision** | A source-envelope guide exists. |
+| Child `hashing/README.md` | **CONFIRMED v1.1** | The import namespace has an evidence-grounded compatibility boundary. |
+| `hashing/__init__.py` | **CONFIRMED empty** | No exports, import behavior, or side effects are established. |
+| `kfm-hashing` metadata | **CONFIRMED `0.0.0` placeholder** | Package name exists; build backend, dependencies, package discovery, and installability are not established. |
+| Proposed implementation modules | **NOT FOUND at bounded paths** | No canonicalizer, digest, comparison, Merkle, geometry, run-id, or fixture implementation is established. |
+| Package-specific tests | **NOT FOUND at checked README paths** | No dedicated hashing test boundary is established. |
+| Package-specific workflows | **NOT FOUND at checked paths** | No dedicated hashing CI behavior is established. |
+| Identity architecture | **CONFIRMED draft doctrine** | States JCS + SHA-256 and recompute-on-gate behavior. |
+| Canonicalization standard | **CONFIRMED draft standard** | JCS default; URDNA2015 reserved; pinned implementation remains unresolved. |
+| Common `spec_hash` contract/schema | **CONFIRMED draft/PROPOSED machine surface** | Requires an object with `value: sha256:<hex>`. |
+| `spec_hash` fixtures | **CONFIRMED minimal schema fixtures** | Test shape acceptance/rejection only. |
+| Generic contract test harness | **CONFIRMED executable test code** | Discovers and validates JSON Schema fixtures; it does not compute hashes. |
+| Dedicated `spec_hash` validator | **CONFIRMED placeholder** | Raises `NotImplementedError`. |
+| `tools/spec_hash/` | **CONFIRMED README-only lane at checked executable paths** | Tool-versus-package implementation ownership remains unresolved. |
+| Generated-receipt digest fields | **CONFIRMED schema vocabulary** | Permit `sha256:` or `blake3:` for specified provenance/content fields. |
+| EvidenceBundle checksums | **CONFIRMED schema vocabulary** | Use `sha256:` checksums and reference the common `spec_hash` object. |
+
+### Truth posture
+
+**CONFIRMED**
+
+- The source envelope has no verified hashing implementation.
+- The child import namespace is effectively empty.
+- Package metadata is a greenfield placeholder.
+- Repository doctrine and machine contracts disagree about `spec_hash` representation.
+- Existing fixtures prove only the current schema wrapper and pattern.
+- No checked executable implements RFC 8785 JCS in the package or tool lane.
+- The dedicated validator is not implemented.
+
+**PROPOSED**
+
+- The source-tree rules, dependency direction, package/tool delegation, result families, resource limits, implementation sequence, tests, migration, correction, deprecation, and rollback procedures below.
+
+**CONFLICTED**
+
+- `jcs:sha256:<hex>` strings in architecture/standards versus `{"value":"sha256:<hex>"}` in the common contract/schema.
+- Reusable implementation under `packages/hashing/` versus the proposed `tools/spec_hash/` helper home.
+- SHA-256 as the baseline for trust-bearing identity versus BLAKE3 being accepted for some content/provenance fields.
+- Canonicalization profile being semantically necessary while the current common schema does not carry one.
+- Rich package documentation versus no verified implementation.
+
+**UNKNOWN**
+
+- Supported Python version, build backend, dependency policy, pinned JCS implementation, exports, callers, performance, cross-language parity, release use, and operational health.
+
+**NEEDS VERIFICATION**
+
+- Owners, ADR or migration note, accepted hash-value model, profile vocabulary, source layout, package/tool ownership, dependency policy, API surface, fixtures, package tests, CI, consumer migration, compatibility period, correction, deprecation, and rollback automation.
+
+[Back to top](#top)
+
+---
+
+<a id="directory-rules-and-authority"></a>
+
+## Directory Rules and authority
+
+`packages/` is the responsibility root for shared reusable implementation libraries. The `src/` subdirectory is an implementation envelope within the existing `packages/hashing/` package.
+
+Directory Rules basis:
+
+| Responsibility | Owning home | This source envelope's posture |
+|---|---|---|
+| Reusable pure hashing implementation | `packages/hashing/src/` after governance accepts the implementation shape | May contain code; does not own meaning or policy. |
+| Import namespace | `packages/hashing/src/hashing/` | Child namespace boundary; currently empty. |
+| Human architecture and canonicalization rules | `docs/architecture/`, `docs/standards/`, accepted ADRs | Constrain code; source does not redefine them. |
+| Semantic meaning | `contracts/` | Contract authority remains outside source code. |
+| Machine shape | `schemas/contracts/v1/` | Schema authority remains outside source code. |
+| Valid/invalid schema examples | `fixtures/contracts/` | Fixtures are non-authoritative test inputs. |
+| Validators of record | `tools/validators/` or accepted validator root | May import the package; must not duplicate algorithms. |
+| Operator and CI wrapper | `tools/spec_hash/` after ownership resolution | Should be a thin adapter if retained. |
+| Policy decisions | `policy/` | Package returns facts/results, not policy outcomes. |
+| Receipts and proofs | `data/receipts/`, `data/proofs/` | Callers persist; source code does not store. |
+| Release, correction, rollback | `release/` and governed workflows | Source code supports verification only. |
+| Public behavior | Governed application/API boundaries | Package internals are not public authority. |
+
+This README introduces no new root and no parallel schema, contract, policy, receipt, proof, release, or public path.
+
+[Back to top](#top)
+
+---
+
+<a id="source-envelope-responsibilities"></a>
+
+## Source-envelope responsibilities
+
+This parent source README owns five documentation responsibilities:
+
+1. **Placement:** define what classes of implementation may live under `src/`.
+2. **Import direction:** prevent source code from importing authority and storage layers in ways that collapse boundaries.
+3. **Delegation:** keep reusable algorithms, CLI wrappers, validators, callers, and persistence separate.
+4. **Implementation gates:** state what must be verified before modules are added or exported.
+5. **Migration discipline:** require compatibility and rollback plans when representations, profiles, or ownership change.
+
+The child namespace README owns proposed import-level behavior, result structures, and API boundaries. It does not supersede contracts, schemas, standards, ADRs, or this source-envelope placement contract.
+
+### Source-envelope scope
+
+Allowed implementation classes, after verification:
+
+- canonicalization profile adapters;
+- raw-byte digest functions;
+- typed digest/profile value objects;
+- digest parsing and formatting;
+- deterministic comparison helpers;
+- deterministic Merkle construction from explicit ordered entries;
+- deterministic run-id construction from explicit fields;
+- geometry digest helpers that require already-normalized geometry and an explicit profile;
+- stable error/result types;
+- internal, non-authoritative compatibility adapters approved by migration documentation.
+
+Disallowed implementation classes:
+
+- source fetchers;
+- lifecycle readers/writers;
+- policy engines;
+- receipt/proof/release persistence;
+- schema or contract generators that become authority;
+- public endpoint handlers;
+- UI components;
+- AI/model calls;
+- secret handling;
+- signing and key management;
+- ambient directory discovery as an integrity input;
+- automatic representation conversion without an explicit migration profile.
+
+[Back to top](#top)
+
+---
+
+<a id="compatibility-conflicts"></a>
+
+## Compatibility conflicts
+
+### 1. `spec_hash` representation
+
+Current repository evidence exposes at least two incompatible surfaces:
 
 ```text
-RAW -> WORK / QUARANTINE -> PROCESSED -> CATALOG / TRIPLET -> PUBLISHED
+Doctrine / standards:
+  jcs:sha256:<64 lowercase hex>
+  urdna2015:sha256:<64 lowercase hex>   # reserved RDF-semantic case
+
+Common contract / schema:
+  {
+    "value": "sha256:<64 lowercase hex>"
+  }
 ```
 
-Hashing source code may support validation and promotion gates across that lifecycle. It does not own lifecycle state, proof state, receipt state, review state, release state, or public truth.
+The source tree must not silently:
 
-[⬆ Back to top](#top)
+- remove `jcs:` or `urdna2015:` profile prefixes;
+- add or remove the object wrapper;
+- infer canonicalization from `sha256:` alone;
+- treat a raw content checksum as `spec_hash`;
+- accept both forms as equivalent without a versioned adapter contract;
+- emit a third representation.
 
----
+Until contract, schema, standard, fixtures, validator, and consumers are reconciled, format conversion is **DENIED by default**.
 
-## Repo fit
+### 2. Package versus tool ownership
+
+Current documentation names both:
+
+- `packages/hashing/` for reusable hashing implementation;
+- `tools/spec_hash/` for spec-hash helpers and operator/CI use.
+
+A sound **PROPOSED** split is:
 
 ```text
-packages/hashing/src/
+packages/hashing/src/hashing/
+  one reusable pure implementation
+
+tools/spec_hash/
+  thin CLI/report adapter importing the package
+
+tools/validators/
+  validation orchestration importing the package or tool adapter
+
+callers/
+  own persistence, policy mapping, evidence, and release consequences
 ```
 
-`packages/` is the responsibility root for shared reusable code. `hashing/` is the package segment. `src/` is the source-code envelope.
+This split is not ratified by this README. An ADR or migration note must resolve ownership before implementation appears in both places.
 
-| Relationship | Expected home | Boundary rule |
-| --- | --- | --- |
-| Hashing source code | `packages/hashing/src/` | Deterministic canonicalization, digest, comparison, replay, and fixture helpers only. |
-| Importable module | `packages/hashing/src/hashing/` or repo-confirmed namespace | Package namespace, subject to repo package convention verification. |
-| Package entry README | `packages/hashing/README.md` | Explains the package as a whole. |
-| Identity architecture | `docs/architecture/identity-and-spec-hash.md` | Explains KFM identity and hash-family doctrine. |
-| Semantic contracts | `contracts/` | Defines meaning; source code references, not redefines. |
-| Machine schemas | `schemas/contracts/v1/` | Defines shape and field requirements. |
-| Policy rules | `policy/` | Owns allow/deny/restrict/hold/abstain decisions. |
-| Receipts and proofs | `data/receipts/`, `data/proofs/` | Stores hash-bearing trust artifacts and validation results. |
-| Release decisions | `release/` | Owns promotion, publication, correction, supersession, rollback, and merkle-root use. |
-| Tools and CLIs | `tools/` or repo-confirmed tool roots | May wrap this source tree; must not become authority by script placement. |
-| Public API and UI | `apps/`, `ui/`, `web/`, or repo-confirmed equivalents | May use validators that call hash helpers; package internals are not public authority. |
-| Tests and fixtures | `tests/packages/hashing/`, `fixtures/packages/hashing/`, or repo-confirmed equivalents | Proves deterministic behavior with stable fixtures. |
+### 3. Algorithm vocabulary
 
-> [!WARNING]
-> A source-code directory is not a trust-object home. Keep schemas, contracts, policy rules, lifecycle data, receipts, proofs, release decisions, signatures, transparency logs, and public API behavior in their owning roots.
+- SHA-256 is the documented baseline for trust-bearing identity.
+- Generated-receipt fields permit SHA-256 or BLAKE3 for specified content/provenance hashes.
+- BLAKE3 permission for those fields does not authorize BLAKE3 `spec_hash`.
+- Algorithms are never selected by performance preference alone.
+- Every digest must carry enough declared context for consumers to distinguish algorithm and canonicalization profile.
 
-[⬆ Back to top](#top)
+### 4. Profile representation
+
+Canonicalization profile is required for meaningful comparison, but the common `spec_hash` schema does not currently represent it. Code must not hide that gap in an internal default.
+
+[Back to top](#top)
 
 ---
 
-## Accepted inputs
+<a id="confirmed-and-proposed-source-tree"></a>
 
-Functions in this source tree should accept explicit values from governed callers. They should not fetch missing facts from raw stores, source systems, hidden globals, UI state, operator memory, or generated language.
+## Confirmed and proposed source tree
 
-| Input family | Accepted examples | Required handling |
-| --- | --- | --- |
-| Canonicalization context | canonicalization method, schema version, profile name, stable exclusion list | Require explicit method; do not infer a stronger identity profile. |
-| JSON-like record body | RunReceipt body, EvidenceBundle body, schema body, contract metadata, manifest body | Canonicalize according to pinned rules before hashing. |
-| Byte payload | file bytes, artifact bytes, report bytes, tile artifact bytes | Hash bytes exactly as supplied; preserve algorithm prefix. |
-| Geometry context | normalized geometry, CRS, precision rules, geometry profile id | Hash only after caller supplies normalization context. |
-| File-set context | ordered file entries, path refs, byte digests, manifest refs | Build merkle candidates deterministically; do not scan ambient folders. |
-| Run context | tool id, version, inputs, config, seed, timestamp policy, prior run refs | Produce run ids only from explicit fields; avoid ambient randomness unless recorded. |
-| Comparison context | stored digest, recomputed digest, algorithm, canonicalization profile | Return match, mismatch, invalid, or unsupported-profile state with reason. |
-| Fixture context | synthetic records, expected canonical bytes, expected digests | Keep fixtures deterministic and public-safe. |
-
-[⬆ Back to top](#top)
-
----
-
-## Exclusions
-
-| Do not put here | Correct home or owner | Reason |
-| --- | --- | --- |
-| JSON Schemas | `schemas/contracts/v1/` | Schemas own machine shape. |
-| Semantic contracts | `contracts/` | Contracts own meaning. |
-| Policy rules | `policy/` | Policy owns decisions and obligations. |
-| Receipts, proof packs, validation reports | `data/receipts/`, `data/proofs/` | Trust artifacts must remain separately auditable. |
-| Release manifests, rollback cards, correction notices | `release/` | Publication is a governed state transition. |
-| RAW, WORK, QUARANTINE, PROCESSED, CATALOG, TRIPLET, or PUBLISHED data | `data/<phase>/` | Lifecycle state must remain phase-visible. |
-| Source descriptors and source registries | `data/registry/` or repo-confirmed registry homes | Source authority, rights, and cadence are governance data. |
-| Artifact files, tiles, reports, exports, snapshots | Lifecycle/release artifact homes | Hash source may hash them; it must not store them. |
-| Signature keys, signing authority, transparency logs | security/key-management and release/proof homes | Hashing is not signing or attestation authority. |
-| API routes or public serializers | `apps/` or repo-confirmed API app | Public clients must use governed APIs. |
-| UI components or map rendering | `apps/`, `ui/`, `web/`, `packages/maplibre-runtime/`, or repo-confirmed UI roots | Rendering is downstream from governed hash-bearing objects. |
-| AI-generated truth or generated citations | governed AI runtime plus receipts and evidence validation | AI output is interpretive and evidence-subordinate. |
-| Secrets or private raw source content in fixtures | Nowhere in package fixtures | Fixtures must remain synthetic or public-safe. |
-
-[⬆ Back to top](#top)
-
----
-
-## Expected source layout
-
-> [!NOTE]
-> The tree below is PROPOSED. Confirm package metadata, language conventions, import namespace, test layout, and CI before committing code beyond README files.
+### Confirmed bounded inventory
 
 ```text
-packages/hashing/src/
-├── README.md                # This file: source-code boundary and trust rules
-└── hashing/
-    ├── README.md            # PROPOSED: importable namespace guide
-    ├── __init__.py          # PROPOSED: export boundary if Python convention is confirmed
-    ├── canonical_json.py    # PROPOSED: JCS/profile helpers
-    ├── digests.py           # PROPOSED: SHA-256 and algorithm-prefix helpers
-    ├── spec_hash.py         # PROPOSED: spec_hash helpers
-    ├── content_hash.py      # PROPOSED: content-hash helpers
-    ├── geometry_hash.py     # PROPOSED: geometry-hash helpers
-    ├── merkle.py            # PROPOSED: file-set root helpers
-    ├── run_id.py            # PROPOSED: deterministic run id helpers
-    ├── compare.py           # PROPOSED: recompute/compare helpers
-    ├── fixtures.py          # PROPOSED: synthetic fixtures
-    └── py.typed             # PROPOSED: include only if typed Python package convention is confirmed
+packages/hashing/
+├── README.md
+├── pyproject.toml              # name/version placeholder only
+└── src/
+    ├── README.md               # this file
+    └── hashing/
+        ├── README.md           # v1.1 namespace boundary
+        └── __init__.py         # empty
 ```
 
-Preferred import posture, subject to package verification:
+No additional implementation module is claimed.
 
-```python
-from hashing.spec_hash import compute_spec_hash
-from hashing.content_hash import compute_content_hash
-from hashing.compare import compare_digest_values
+### Proposed future decomposition
+
+The following is a design option, not a repository fact:
+
+```text
+packages/hashing/src/hashing/
+├── __init__.py                 # minimal explicit exports; no side effects
+├── canonicalization.py         # accepted profiles only
+├── digests.py                  # raw-byte algorithms and references
+├── values.py                   # typed profile/digest/result values
+├── compare.py                  # recompute/compare, no policy mapping
+├── merkle.py                   # explicit ordered entries only
+├── run_id.py                   # explicit context only
+├── geometry.py                 # normalized geometry + explicit profile only
+├── errors.py                   # stable internal exceptions/result reasons
+└── compatibility.py            # only during approved migrations
 ```
 
-[⬆ Back to top](#top)
+Before any path above is created:
+
+- verify Directory Rules and current package conventions;
+- resolve package/tool ownership;
+- resolve `spec_hash` shape/profile;
+- pin runtime and dependencies;
+- define tests and compatibility;
+- document rollback.
+
+Do not create separate `spec_hash.py`, `content_hash.py`, and tool implementations if that causes divergent canonicalization logic. Prefer one primitive implementation with explicit profiles and thin domain-specific adapters.
+
+[Back to top](#top)
 
 ---
 
-## Hash helper outcomes
+<a id="keystone-invariants"></a>
 
-Hashing source helpers should return explicit, inspectable outcomes that callers can map into validation reports, receipts, release gates, or runtime envelopes.
+## Keystone invariants
 
-| Helper outcome | Use when | Runtime posture |
-| --- | --- | --- |
-| `MATCH` | Stored digest and recomputed digest match under the same declared profile. | Candidate for downstream schema, policy, evidence, receipt, and release checks. |
-| `MISMATCH` | Stored digest and recomputed digest differ. | Fail closed; no promotion or trusted runtime use. |
-| `INVALID` | Digest syntax, algorithm prefix, input type, or canonicalization input is invalid. | `ERROR` or invalid validation report depending on caller. |
-| `UNSUPPORTED_PROFILE` | Canonicalization profile or algorithm is not accepted by the caller's contract. | `ABSTAIN` or `ERROR` with stable reason code. |
-| `DRIFT_DETECTED` | Recomputed identity differs from prior receipt, manifest, or replay expectation. | Block promotion and require review/correction path. |
+1. **Canonicalize first, hash second.**
+2. **Canonicalization profile is part of comparison context.**
+3. **Algorithm is explicit; no fallback.**
+4. **Raw-byte hash and canonical-record identity are different operations.**
+5. **A digest match is not truth, admissibility, evidence closure, or release.**
+6. **Stored hashes are recomputed at governance boundaries.**
+7. **Mismatch and drift fail closed.**
+8. **Profile or representation changes are migration-class changes.**
+9. **The package is pure and no-network by default.**
+10. **Imports have no filesystem, network, time, random, locale, or environment side effects.**
+11. **The source tree never writes authority records.**
+12. **Tools and validators delegate to one implementation rather than fork it.**
+13. **Fixtures are synthetic and non-authoritative.**
+14. **Secrets and sensitive payloads are not logged or embedded.**
+15. **Geometry hashing requires caller-supplied normalization context.**
+16. **Merkle roots use explicit ordered entries, not ambient directory scans.**
+17. **Run identity uses explicit fields, not an unrecorded current timestamp or randomness.**
+18. **Unsupported or ambiguous inputs return stable failure results.**
+19. **Compatibility adapters are temporary, versioned, tested, and removable.**
+20. **Rollback remains possible without rewriting historical receipts.**
 
-`MATCH` is not proof of truth, admissibility, release, or public safety. It only proves that the compared bytes and declared profile produce the expected digest.
-
-[⬆ Back to top](#top)
+[Back to top](#top)
 
 ---
 
-## Trust-boundary flow
+<a id="import-and-dependency-direction"></a>
 
-```mermaid
-flowchart LR
-    A[Governed caller] --> B[packages/hashing/src]
-    B --> C[Importable hashing helpers]
-    C --> D{Canonicalize / hash / compare}
-    D -->|MATCH| E[Valid identity candidate]
-    D -->|MISMATCH or DRIFT_DETECTED| F[Fail-closed reason]
-    D -->|INVALID| G[ERROR-ready reason]
-    D -->|UNSUPPORTED_PROFILE| H[ABSTAIN or ERROR-ready reason]
-    E --> I[Schema validation]
-    I --> J[Policy + evidence + release gates]
-    J --> K[Receipt / proof / release candidate]
-    K --> L[Governed API / audit / replay]
+## Import and dependency direction
 
-    C -. must not own .-> M[Schema authority]
-    C -. must not decide .-> N[Policy outcome]
-    C -. must not store .-> O[Receipts / proofs]
-    C -. must not approve .-> P[ReleaseManifest]
+### Allowed direction
+
+```text
+contracts / schemas / standards / ADRs
+                 |
+                 v
+packages/hashing pure implementation
+                 |
+        +--------+---------+
+        |                  |
+        v                  v
+tools/spec_hash      tools/validators
+        |                  |
+        +---------+--------+
+                  v
+ governed callers / gates
+                  |
+                  v
+ receipts / proofs / release records
 ```
 
-[⬆ Back to top](#top)
+The arrows show dependency or constraint direction, not authority transfer.
+
+### Import rules
+
+Source modules should:
+
+- import only standard-library and explicitly pinned approved dependencies;
+- expose pure functions and immutable/validated value objects where practical;
+- accept bytes, parsed values, explicit profiles, and explicit limits;
+- return values/results without writing files or records;
+- keep `__init__.py` minimal and side-effect free;
+- avoid optional dependency behavior that changes output silently;
+- avoid importing application, connector, pipeline, data-store, policy, release, or model-runtime modules.
+
+Source modules must not:
+
+- import from `data/`, `release/`, public app handlers, connectors, or pipeline orchestration;
+- resolve records by path or ID;
+- read environment secrets;
+- make network calls;
+- scan working directories;
+- use current time, locale, process ID, random state, or host information unless explicitly supplied and contractually part of the input;
+- return policy or publication decisions;
+- catch integrity errors and downgrade them to warnings.
+
+### Dependency policy
+
+A future canonicalization dependency must be:
+
+- version pinned;
+- license and supply-chain reviewed;
+- capable of the accepted standard, not an approximation;
+- tested against normative and project vectors;
+- deterministic across supported runtimes;
+- included in dependency scanning;
+- covered by an upgrade and rollback policy.
+
+A naive `json.dumps(sort_keys=True)` implementation must not be presented as RFC 8785-compliant for authority-bearing identity.
+
+[Back to top](#top)
 
 ---
 
-## Source anti-collapse rules
+<a id="canonicalization-and-hash-boundary"></a>
 
-| Boundary | Preserve as | Never collapse into |
-| --- | --- | --- |
-| Canonicalization profile | Explicit profile supplied by schema/contract/tooling | Silent inferred format |
-| `spec_hash` | Identity of canonical trust-bearing record body | Generic file checksum or display label |
-| `content_hash` | Digest of bytes or canonical content | Evidence admissibility or release approval |
-| `run_id` | Deterministic run identity from explicit fields | Ambient timestamp-only or random id without receipt support |
-| Hash comparison | Match/mismatch under declared algorithm/profile | Truth validation, policy decision, or release approval |
-| Merkle root | Deterministic file-set root from explicit entries | Publication approval or rollback record |
-| Fixture digest | Stable synthetic test expectation | Production receipt/proof object |
+## Canonicalization and hash boundary
 
-[⬆ Back to top](#top)
+### Distinct operation classes
 
----
+| Operation | Input | Required context | Output | Must not imply |
+|---|---|---|---|---|
+| Raw byte digest | Exact bytes | Algorithm | Digest reference | Canonical semantic identity |
+| JSON canonicalization | Parsed JSON value | Versioned profile and limits | Canonical UTF-8 bytes | Schema validity or authority |
+| RDF canonicalization | RDF dataset | Accepted RDF profile | Canonical dataset bytes | Default KFM identity |
+| `spec_hash` computation | Canonical trust-record body | Accepted representation/profile | Versioned identity value | Correctness or release |
+| Digest comparison | Expected and recomputed values | Same algorithm/profile/representation | Typed comparison result | Policy or evidence decision |
+| Merkle construction | Explicit ordered entry list | Leaf/node profile | Root digest | Release approval |
+| Geometry digest | Already-normalized geometry | CRS, precision, normalization profile | Geometry digest | Spatial correctness or public safety |
+| Run-id construction | Explicit run context | Versioned run-id profile | Deterministic identifier | Receipt existence or success |
 
-## Development rules
+### Parsing requirements
 
-1. Prefer pure functions with explicit input objects.
-2. Preserve algorithm prefix, canonicalization profile, schema version, and exclusion rules supplied by callers.
-3. Never infer missing schema, policy, evidence, release, or receipt authority from a hash match.
-4. Do not make network calls from `src/` helpers.
-5. Do not read directly from RAW, WORK, QUARANTINE, unpublished candidates, source systems, source credentials, canonical stores, or model runtimes.
-6. Do not write lifecycle data, receipts, proofs, release manifests, catalog records, API responses, signatures, or UI components.
-7. Do not sign records, manage keys, or claim attestation authority.
-8. Do not create schemas, contracts, policy rules, source registries, API routes, public answers, or release decisions from this source tree.
-9. Do not store chain-of-thought, raw provider payloads, secrets, private source records, or unrestricted sensitive context.
-10. Return typed invalid states instead of silent canonicalization changes, algorithm fallback, or mismatch warnings.
-11. Add deterministic tests for every behavior-changing helper and every negative path.
-12. Keep fixtures synthetic, sanitized, and stable.
-13. Preserve rollback and correction metadata supplied by callers when hash output can affect downstream publication candidates.
+Future parsers must reject or explicitly classify:
 
-[⬆ Back to top](#top)
+- malformed prefixes;
+- unknown algorithms;
+- unknown profiles;
+- uppercase or non-hex forms where the governing contract disallows them;
+- wrong digest lengths;
+- ambiguous wrappers;
+- duplicate JSON object keys;
+- invalid Unicode;
+- non-finite numbers;
+- numbers outside the supported canonicalization domain;
+- profile/representation mismatch;
+- conversion requests without an approved adapter.
 
----
+### Comparison rule
 
-## Validation checklist
+Two digest values are comparable only when:
 
-- [ ] Confirm `packages/hashing/src/` exists in the mounted repo with this README as its source-directory guide.
-- [ ] Confirm package manager and import convention (`pyproject.toml`, workspace config, or equivalent).
-- [ ] Confirm whether this source tree is Python-only, TypeScript-only, or mixed-language.
-- [ ] Confirm owners and CODEOWNERS path coverage.
-- [ ] Confirm canonicalization profile and whether RFC 8785 JCS is implemented directly or through a dependency.
-- [ ] Confirm schema homes for records that carry `spec_hash`, `content_hash`, `geometry_hash`, `artifact_hash`, `merkle_root`, and `run_id`.
-- [ ] Confirm validators and tests that exercise this namespace.
-- [ ] Confirm tests for canonical key ordering, whitespace removal, number handling, string escaping, digest prefix validation, mismatch failure, unsupported algorithms, and stable fixtures.
-- [ ] Confirm helpers do not access lifecycle stores or unpublished candidate stores.
-- [ ] Confirm helpers do not write receipts, proofs, release manifests, catalog records, API responses, signatures, or transparency logs.
-- [ ] Confirm promotion/replay validators recompute hashes rather than trusting stored values.
+- their intended operation class matches;
+- algorithm matches;
+- canonicalization profile matches when applicable;
+- representation version matches or an approved adapter is invoked;
+- the same inclusion/exclusion rules were used;
+- the compared body or bytes are defined by the same contract.
 
-Suggested inspection commands:
-
-```bash
-find packages/hashing/src -maxdepth 5 -type f | sort
-git grep -n "spec_hash\|content_hash\|geometry_hash\|artifact_hash\|merkle_root\|run_id\|jcs:sha256\|canonical" -- packages docs contracts schemas policy tests fixtures tools apps 2>/dev/null || true
-git grep -n "from hashing\|import hashing\|packages/hashing/src" -- . 2>/dev/null || true
-```
-
-[⬆ Back to top](#top)
+[Back to top](#top)
 
 ---
 
-## Rollback
+<a id="package-tool-validator-and-caller-delegation"></a>
 
-Rollback is required if this source tree:
+## Package, tool, validator, and caller delegation
 
-- creates a parallel authority home for schemas, contracts, policy, registries, lifecycle data, receipts, proofs, releases, API routes, UI surfaces, signing, key-management, model runtimes, or source data;
-- hashes non-canonical developer-formatted JSON as `spec_hash` authority;
-- silently changes canonicalization profiles, algorithm prefixes, exclusion rules, or mismatch handling;
-- treats hash match as proof of truth, admissibility, release, or public safety;
-- stores secrets, private source records, or unrestricted sensitive context in package fixtures;
-- permits promotion, replay, or runtime gates to trust stored digests without recomputation.
+| Surface | May do | Must not do |
+|---|---|---|
+| `packages/hashing/src/` | Implement reusable pure primitives. | Persist records, decide policy, or own CLI orchestration. |
+| `packages/hashing/src/hashing/` | Define accepted imports after ratification. | Hide compatibility conflicts or export unimplemented behavior. |
+| `tools/spec_hash/` | Parse CLI input, call package, produce review reports. | Fork canonicalization or become record authority. |
+| `tools/validators/` | Validate contract/schema alignment and map package results into validation reports. | Reimplement hashing or approve release. |
+| Receipt/proof builders | Call package and persist governed records. | Treat a digest as evidence closure. |
+| Promotion/release gates | Recompute, compare, and apply policy/review. | Trust stored digests without recomputation. |
+| Public apps/APIs | Consume governed released results. | Expose raw package internals as public truth. |
 
-Rollback target: revert the hashing-source PR, keep any generated audit notes as review evidence, and file the affected behavior in `docs/registers/DRIFT_REGISTER.md` or `docs/registers/VERIFICATION_BACKLOG.md` if the mounted repo uses those registers.
+### Thin-adapter requirement
 
-[⬆ Back to top](#top)
+A tool or validator adapter should contain only:
+
+- input decoding;
+- explicit profile selection from accepted configuration;
+- call into the package;
+- stable report formatting;
+- exit-code or validation-result mapping;
+- no duplicate canonicalization algorithm.
+
+Parity tests must prove that direct library use and tool/validator use produce identical bytes, digests, and reason codes for the same inputs.
+
+[Back to top](#top)
 
 ---
 
-## Evidence boundary
+<a id="expected-result-families"></a>
 
-| Source | Status | Supports | Limits |
-| --- | --- | --- | --- |
-| Current target file | CONFIRMED | `packages/hashing/src/README.md` existed and required replacement from placeholder content. | Did not prove source implementation maturity. |
-| Parent package README | CONFIRMED repo doc | `packages/hashing/` is a shared helper-code package for deterministic identity, hash-family, canonicalization, and replay-comparison helpers. | Does not prove source files, package metadata, tests, or CI. |
-| `packages/README.md` | CONFIRMED repo doc | `packages/` is for shared libraries used by apps, workers, pipelines, and tools. | Does not define this source namespace. |
-| `docs/architecture/identity-and-spec-hash.md` | CONFIRMED repo doc | KFM identity posture, JCS + SHA-256 `spec_hash`, hash-family names, recompute-and-compare gates, and implementation maturity limits. | Some paths and package/tool placements remain PROPOSED or NEEDS VERIFICATION in that doc. |
-| Current file-generation pass | CONFIRMED request | User-requested target path and README repair/replacement. | Does not inspect package metadata, tests, CI logs, dashboards, deployment posture, runtime behavior, or branch protection. |
+## Expected result families
 
-[⬆ Back to top](#top)
+Exact types and names remain **PROPOSED**. The source envelope should support finite, inspectable result classes such as:
+
+| Result | Meaning | Default posture |
+|---|---|---|
+| `DIGEST_COMPUTED` | Digest produced from explicit bytes/profile. | Return value; no authority created. |
+| `MATCH` | Stored and recomputed values match under identical context. | Continue to other gates. |
+| `MISMATCH` | Values differ. | Fail closed. |
+| `DRIFT_DETECTED` | Recomputed identity differs from a prior governed expectation. | Block and require review/correction. |
+| `INVALID_INPUT` | Input cannot be parsed or represented safely. | Fail closed. |
+| `INVALID_DIGEST` | Digest syntax or length is invalid. | Fail closed. |
+| `UNSUPPORTED_PROFILE` | Profile is not accepted. | Abstain/error; never infer. |
+| `UNSUPPORTED_ALGORITHM` | Algorithm is not accepted for the operation. | Abstain/error; never fallback. |
+| `FORMAT_CONFLICT` | Input representation is valid in one repo surface but conflicts with another. | Hold for migration decision. |
+| `PROFILE_MISMATCH` | Compared values use different profiles. | Not comparable. |
+| `DEPENDENCY_UNAVAILABLE` | Required canonicalization implementation is absent. | Fail closed. |
+| `RESOURCE_LIMIT` | Input exceeds configured bounds. | Fail closed without partial authority. |
+| `ERROR` | Unexpected safe failure. | No digest authority; sanitized diagnostics. |
+
+Reason codes should be stable, machine-readable, and separate from human explanations. Callers—not this package—map results into PolicyDecision, ValidationReport, PromotionDecision, or release outcomes.
+
+[Back to top](#top)
+
+---
+
+<a id="security-and-resource-bounds"></a>
+
+## Security and resource bounds
+
+Even a no-network library needs defensive limits.
+
+### Required controls
+
+- maximum byte-input size;
+- maximum JSON text size before parsing;
+- maximum nesting depth;
+- maximum object members and array items;
+- duplicate-key rejection or explicitly governed handling;
+- maximum string length;
+- strict UTF-8 behavior;
+- non-finite number rejection;
+- explicit numeric-domain support;
+- maximum Merkle entries;
+- maximum path/reference length for explicit entry metadata;
+- maximum geometry coordinate count when geometry helpers are enabled;
+- bounded diagnostic output;
+- no raw payload logging by default;
+- no secret, token, credential, or sensitive-record echo;
+- deterministic error ordering where multiple errors are returned.
+
+### Cryptographic scope exclusions
+
+This package is not automatically suitable for:
+
+- password storage;
+- HMAC or message authentication;
+- digital signatures;
+- encryption;
+- key derivation;
+- random-token generation;
+- certificate validation;
+- secure deletion;
+- transparency logging.
+
+Adding any of those is a separate security and architecture decision.
+
+### Denial-of-service posture
+
+Callers must be able to configure conservative limits. Exceeding a limit returns `RESOURCE_LIMIT`; it must not truncate input and compute a misleading digest.
+
+[Back to top](#top)
+
+---
+
+<a id="testing-fixtures-and-ci"></a>
+
+## Testing, fixtures, and CI
+
+### Current verified test posture
+
+- Common contract fixtures validate the object wrapper and `sha256:` pattern.
+- The generic schema harness checks valid and invalid JSON Schema fixtures.
+- The dedicated `spec_hash` validator raises `NotImplementedError`.
+- No package-specific hashing test README was found at checked paths.
+- No dedicated hashing workflow was found at checked paths.
+- No current test proves RFC 8785 canonicalization, URDNA2015 behavior, digest computation, package/tool parity, or import safety.
+
+### Required future test families
+
+| Test family | Minimum coverage |
+|---|---|
+| Import safety | No network, filesystem scan, environment read, logging, time/randomness, or lifecycle write during import. |
+| Raw bytes | Empty input, binary data, large input bounds, stable SHA-256 vectors. |
+| JCS | Normative vectors, key ordering, escapes, Unicode, integers, decimals, exponent forms, negative zero, duplicate keys, invalid numbers. |
+| RDF reserved profile | Only after profile acceptance; normative dataset vectors and explicit profile selection. |
+| Digest parsing | Valid prefixes, invalid prefixes, length, case, unknown algorithm/profile, wrapper conflicts. |
+| Comparison | Match, mismatch, profile mismatch, algorithm mismatch, format conflict, drift. |
+| Schema compatibility | Current object wrapper plus any approved migration representation. |
+| Tool parity | Library, CLI adapter, and validator produce identical results. |
+| Merkle | Ordering, duplicate paths/IDs, empty set policy, leaf/node separation, changed entry detection. |
+| Run ID | Explicit field inclusion, order independence where specified, no ambient state. |
+| Geometry | Requires normalized input and explicit CRS/precision profile; rejects missing context. |
+| Resource limits | Each configured limit fails closed without partial digest authority. |
+| Logging | Diagnostics are bounded and do not expose raw/sensitive input. |
+| Cross-runtime parity | Same canonical bytes and digest across every supported runtime/platform. |
+| Migration | Old/new representations remain distinguishable and adapters are one-way or explicitly reversible as designed. |
+
+### Fixture rules
+
+Package algorithm fixtures should be separate from contract-shape fixtures.
+
+They must:
+
+- be synthetic or normative public vectors;
+- include expected canonical bytes where licensing permits;
+- include expected digest and profile;
+- declare the implementation/version used to establish expectations;
+- remain stable;
+- avoid production secrets, source records, or sensitive geometry;
+- make intentional drift reviewable.
+
+### CI gates before operational use
+
+- package installs in a clean environment;
+- import safety passes;
+- algorithm/profile vectors pass;
+- package/tool/validator parity passes;
+- schema compatibility passes;
+- dependency and license scanning passes;
+- resource-bound tests pass;
+- negative paths pass;
+- no authority import cycles are introduced;
+- docs and type/API surfaces match implementation.
+
+A passing generic schema fixture test does not prove hashing implementation.
+
+[Back to top](#top)
+
+---
+
+<a id="smallest-sound-implementation-sequence"></a>
+
+## Smallest sound implementation sequence
+
+### Stage 0 — governance resolution
+
+Do not add hashing modules until:
+
+1. owners are assigned;
+2. accepted `spec_hash` representation is decided;
+3. canonicalization profiles and versioning are decided;
+4. package-versus-tool ownership is decided;
+5. supported runtime and dependency policy are pinned;
+6. migration and rollback are documented.
+
+**Stop condition:** unresolved representation or ownership conflict.
+
+### Stage 1 — raw-byte digest primitive
+
+Implement only:
+
+- explicit bytes input;
+- SHA-256;
+- typed digest value;
+- strict parsing/formatting for one accepted raw-content representation;
+- size limits;
+- deterministic vectors;
+- import safety.
+
+Do not call it `spec_hash` unless the profile and representation are accepted.
+
+### Stage 2 — accepted JSON canonicalization
+
+Add the pinned RFC 8785 implementation and normative vectors.
+
+Requirements:
+
+- explicit profile identifier;
+- strict input domain;
+- duplicate-key policy;
+- numeric edge-case tests;
+- no approximation;
+- no fallback.
+
+### Stage 3 — `spec_hash` adapter
+
+Only after contract/schema reconciliation:
+
+- define the canonical body and exclusions outside the package;
+- convert accepted canonical bytes to the accepted representation;
+- add compatibility fixtures;
+- update validators and consumers;
+- prohibit silent legacy conversion.
+
+### Stage 4 — tool and validator delegation
+
+Make `tools/spec_hash/` and `tools/validators/validate_spec_hash.py` import the package. Add parity tests and remove duplicate logic.
+
+### Stage 5 — optional families
+
+Add Merkle, run-id, geometry, RDF, or BLAKE3 support only when a real governed consumer, contract, and test surface exist.
+
+### Stage 6 — operational adoption
+
+Before promotion/release use:
+
+- inventory consumers;
+- run replay tests;
+- verify receipts and rollback targets;
+- stage migration;
+- monitor drift;
+- preserve old representation readers for the documented compatibility period.
+
+[Back to top](#top)
+
+---
+
+<a id="definition-of-done"></a>
+
+## Definition of done
+
+This source envelope is implementation-ready only when:
+
+- [ ] Owners and CODEOWNERS coverage are confirmed.
+- [ ] Directory Rules placement is rechecked.
+- [ ] Package/tool ownership is resolved by ADR or migration note.
+- [ ] `spec_hash` representation and profile are reconciled across standard, contract, schema, fixtures, validator, and consumers.
+- [ ] Supported runtime and build backend are pinned.
+- [ ] Package discovery and installability are proven.
+- [ ] Dependencies are pinned, reviewed, and scanned.
+- [ ] `hashing/__init__.py` exports are explicit, minimal, and side-effect free.
+- [ ] One implementation owns canonicalization and digest primitives.
+- [ ] Tools and validators delegate to it.
+- [ ] Raw-byte and canonical-record operations remain distinct.
+- [ ] Algorithms and profiles are explicit.
+- [ ] Unsupported or ambiguous inputs fail closed.
+- [ ] Resource bounds are implemented and tested.
+- [ ] Normative JCS vectors pass.
+- [ ] Cross-runtime parity passes for supported runtimes.
+- [ ] Package/tool/validator parity passes.
+- [ ] Schema-shape and algorithm fixtures remain separate.
+- [ ] No lifecycle, policy, receipt, proof, release, public app, or model authority is imported.
+- [ ] Consumers recompute rather than trust stored values.
+- [ ] Migration, correction, deprecation, and rollback paths are tested.
+- [ ] Documentation matches actual exports and behavior.
+- [ ] CI gates the relevant behavior.
+- [ ] A reviewer can reproduce canonical bytes and digest from declared inputs.
+
+[Back to top](#top)
+
+---
+
+<a id="verification-register"></a>
+
+## Verification register
+
+| ID | Verification item | Status |
+|---|---|---:|
+| HASH-SRC-001 | Assign package and canonicalization owners. | NEEDS VERIFICATION |
+| HASH-SRC-002 | Confirm CODEOWNERS coverage. | NEEDS VERIFICATION |
+| HASH-SRC-003 | Confirm current `main` source inventory recursively. | NEEDS VERIFICATION |
+| HASH-SRC-004 | Confirm supported Python version. | UNKNOWN |
+| HASH-SRC-005 | Confirm build backend and package discovery. | UNKNOWN |
+| HASH-SRC-006 | Confirm installability in a clean environment. | UNKNOWN |
+| HASH-SRC-007 | Resolve `packages/hashing/` versus `tools/spec_hash/` ownership. | CONFLICTED |
+| HASH-SRC-008 | Resolve `jcs:sha256:` versus object-wrapped `sha256:` representation. | CONFLICTED |
+| HASH-SRC-009 | Decide whether profile is embedded, adjacent, or versioned by type. | NEEDS VERIFICATION |
+| HASH-SRC-010 | Reconcile common contract and schema. | NEEDS VERIFICATION |
+| HASH-SRC-011 | Update valid and invalid fixtures after reconciliation. | NEEDS VERIFICATION |
+| HASH-SRC-012 | Implement the dedicated validator or revise its declared path. | NEEDS VERIFICATION |
+| HASH-SRC-013 | Pin an RFC 8785 implementation. | UNKNOWN |
+| HASH-SRC-014 | Review canonicalization dependency license and supply chain. | NEEDS VERIFICATION |
+| HASH-SRC-015 | Decide duplicate-key handling. | NEEDS VERIFICATION |
+| HASH-SRC-016 | Decide supported numeric domain. | NEEDS VERIFICATION |
+| HASH-SRC-017 | Define canonicalization profile versioning. | NEEDS VERIFICATION |
+| HASH-SRC-018 | Define raw-content digest representation. | NEEDS VERIFICATION |
+| HASH-SRC-019 | Confirm whether URDNA2015 belongs in this package. | UNKNOWN |
+| HASH-SRC-020 | Confirm BLAKE3 scope and prohibited uses. | CONFLICTED |
+| HASH-SRC-021 | Define result and reason-code types. | PROPOSED |
+| HASH-SRC-022 | Define size/depth/count limits. | PROPOSED |
+| HASH-SRC-023 | Confirm import-side-effect tests. | NOT FOUND |
+| HASH-SRC-024 | Confirm package-specific test root. | NOT FOUND |
+| HASH-SRC-025 | Add normative JCS vectors. | NEEDS VERIFICATION |
+| HASH-SRC-026 | Add digest parser negative tests. | NEEDS VERIFICATION |
+| HASH-SRC-027 | Add package/tool/validator parity tests. | NEEDS VERIFICATION |
+| HASH-SRC-028 | Add cross-runtime parity tests. | NEEDS VERIFICATION |
+| HASH-SRC-029 | Define Merkle leaf/node profile before implementation. | NEEDS VERIFICATION |
+| HASH-SRC-030 | Define run-id field inclusion before implementation. | NEEDS VERIFICATION |
+| HASH-SRC-031 | Define geometry normalization ownership before implementation. | NEEDS VERIFICATION |
+| HASH-SRC-032 | Inventory all current `spec_hash` consumers. | UNKNOWN |
+| HASH-SRC-033 | Inventory all current `sha256:` and `blake3:` producers. | UNKNOWN |
+| HASH-SRC-034 | Define compatibility adapter direction and lifetime. | NEEDS VERIFICATION |
+| HASH-SRC-035 | Define correction process for previously emitted conflicting digests. | NEEDS VERIFICATION |
+| HASH-SRC-036 | Define deprecation notices and consumer deadlines. | NEEDS VERIFICATION |
+| HASH-SRC-037 | Define rollback targets and replay checks. | NEEDS VERIFICATION |
+| HASH-SRC-038 | Add dedicated CI or prove equivalent repository-wide coverage. | NOT FOUND |
+| HASH-SRC-039 | Verify dependency and license scans include the package. | UNKNOWN |
+| HASH-SRC-040 | Verify docs reflect actual exports after implementation. | NEEDS VERIFICATION |
+
+[Back to top](#top)
+
+---
+
+<a id="rollback-correction-deprecation-and-migration"></a>
+
+## Rollback, correction, deprecation, and migration
+
+### Documentation rollback
+
+For this README-only change:
+
+- revert the commit that updates `packages/hashing/src/README.md`; or
+- restore prior blob `309afb28791d0f1136358b79f690ee99786a7ae8`.
+
+No implementation, contract, schema, fixture, validator, workflow, or runtime behavior is changed by this README.
+
+### Implementation rollback
+
+A future source implementation must be reversible by:
+
+- retaining the prior package version;
+- preserving test vectors and replay fixtures;
+- preserving old representation readers for the documented compatibility period;
+- preventing new writes in the deprecated representation after cutover;
+- restoring tool and validator adapters to the prior package version;
+- recomputing affected records before accepting rollback success.
+
+### Correction
+
+When an emitted digest is wrong because of implementation, profile, representation, or exclusion-rule error:
+
+1. do not overwrite historical receipts silently;
+2. identify affected producer version and consumers;
+3. preserve original digest and record;
+4. issue the appropriate correction/supersession artifact in its owning root;
+5. recompute using the accepted profile;
+6. link old and corrected records;
+7. verify replay and rollback;
+8. update tests to prevent recurrence.
+
+### Deprecation
+
+Deprecating a profile, algorithm, representation, function, or module requires:
+
+- replacement mapping;
+- consumer inventory;
+- compatibility period;
+- warnings with stable reason codes;
+- migration fixtures;
+- cutover criteria;
+- rollback target;
+- removal only after consumers and historical replay are addressed.
+
+### Migration principle
+
+Never change the meaning of an existing prefix or wrapper in place. Introduce a versioned representation or adapter, migrate explicitly, and preserve historical verifiability.
+
+[Back to top](#top)
+
+---
+
+## Status summary
+
+`packages/hashing/src/` is a source-code envelope, not a functioning integrity subsystem. Current evidence confirms documentation, placeholder package metadata, an empty child initializer, schema-shape fixtures, and conflicting hash representations. It does not confirm canonicalization code, digest exports, installability, package-specific tests, CI enforcement, operational consumers, or runtime health.
+
+The smallest safe next implementation step is governance reconciliation—not code: resolve representation, profile, ownership, runtime, dependency, tests, migration, and rollback before adding exports.
+
+<p align="right"><a href="#top">Back to top</a></p>


### PR DESCRIPTION
## Task contract

- **Goal:** Update `packages/hashing/src/README.md` into a repository-grounded source-envelope and implementation-placement boundary without inventing code, exports, dependencies, or canonical hash decisions.
- **Base:** `main@2ad80d6362541db0d1933fe729e9a552f7aa19a9`
- **Operation:** documentation-only revision
- **Delivery:** review branch + draft pull request
- **Change budget:** one file; no package code, metadata, dependencies, contracts, schemas, fixtures, validators, workflows, policy, receipts, proofs, release, runtime, or deployment changes

## Evidence basis

- `packages/hashing/src/` contains this README and the `hashing/` child namespace.
- The child namespace contains its v1.1 README and an empty `__init__.py`.
- `packages/hashing/pyproject.toml` is a `kfm-hashing` `0.0.0` placeholder with no verified build backend, dependencies, discovery, or entry points.
- Proposed implementation modules were not found at the checked paths.
- No package-specific hashing test README or dedicated hashing workflow was found at the checked paths.
- Architecture and canonicalization docs specify `jcs:sha256:<hex>` and reserved `urdna2015:sha256:<hex>` values.
- The common `spec_hash` contract/schema instead require `{"value":"sha256:<hex>"}` and do not represent canonicalization profile.
- Existing fixtures and the generic schema test harness prove the current schema shape only; they do not compute hashes or prove RFC 8785 behavior.
- `tools/validators/validate_spec_hash.py` raises `NotImplementedError`.
- `tools/spec_hash/` is README-only at the checked executable paths, leaving package-versus-tool implementation ownership unresolved.
- Directory Rules place reusable libraries under `packages/` and operator/validation behavior under `tools/` when appropriate.

## What changed

- Upgraded the source-envelope README from v1 to v1.1 with commit-pinned evidence, truth labels, and rollback references.
- Classified the source tree as an implementation scaffold with no verified hashing code, exports, tests, or CI enforcement.
- Marked the `jcs:sha256:` versus object-wrapped `sha256:` representation as **CONFLICTED**.
- Marked package-versus-tool implementation ownership as **CONFLICTED**.
- Separated parent source placement/dependency rules from child namespace API proposals.
- Added a confirmed bounded tree and a clearly labeled proposed future decomposition.
- Added import direction, dependency policy, pure/no-network rules, package/tool/validator delegation, result families, security/resource bounds, test/parity requirements, staged implementation gates, a 40-item verification register, correction, migration, deprecation, and rollback guidance.
- Kept hash equality non-authoritative and prohibited silent profile, prefix, wrapper, checksum, or algorithm conversion.

## Directory Rules basis

`packages/hashing/src/` is a sound source envelope for a reusable pure implementation because `packages/` owns shared libraries. Contracts, schemas, standards, policy, receipts, proofs, release records, and public interfaces remain in their owning roots. `tools/spec_hash/` may become a thin adapter only after an ADR or migration decision resolves ownership.

## Validation

| Criterion | Result |
|---|---|
| Only the requested file changed | PASS |
| Branch is one commit ahead of current base | PASS |
| Empty implementation state remains explicit | PASS |
| Representation and ownership conflicts surfaced | PASS |
| Parent/child README responsibilities separated | PASS |
| Hash match remains non-authoritative | PASS |
| 18 unique anchors present | PASS |
| All 34 internal Markdown links resolve | PASS |
| 10 fence markers / 5 fenced blocks are balanced | PASS |
| No duplicate anchors | PASS |
| No trailing whitespace | PASS |
| No common secret patterns detected | PASS |
| Local Git blob matches remote blob | PASS |
| Package implementation/tests/CI proved | NOT CLAIMED |

## Non-goals

- No canonical hash representation, profile, algorithm, dependency, or ownership decision
- No package/tool migration, rename, deletion, or deprecation
- No API, build, module, fixture, test, validator, or CI implementation
- No contract, schema, policy, receipt, proof, release, or consumer changes
- No merge

## Rollback

Revert commit `84e86994fe73497823953b40ede8c653641fbacd`, or restore prior blob `309afb28791d0f1136358b79f690ee99786a7ae8` for `packages/hashing/src/README.md`.