### PR TITLE
docs(runtime): ground Flora compatibility boundary

### DIFF
--- a/runtime/flora/README.md
+++ b/runtime/flora/README.md
@@ -1,237 +1,795 @@
-# `runtime/flora/` — Flora Runtime Review Lane
-
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://doc/runtime-flora-readme
-title: runtime/flora/ — Flora Runtime Review Lane
-version: v1
-status: draft
-policy_label: public
-owners:
-  - <runtime-steward>
-  - <flora-domain-steward>
-  - <policy-steward>
-  - <evidence-steward>
-  - <docs-steward>
-updated: 2026-07-03
-tags: [kfm, runtime, flora, domain-runtime, governed-ai, receipts, validation, geoprivacy]
+title: runtime/flora/ — Flora Runtime Compatibility and Governed Handoff Index
+type: readme; directory-readme; compatibility-index; domain-runtime-placement-drift; governed-flora-runtime-boundary
+version: v1.1
+status: draft; repository-grounded; compatibility-index; path-canonicality-conflicted; README-only; domain-runtime-lane-unratified; implementation-unconfirmed; sensitivity-critical; ci-unproved; non-authoritative
+owners: OWNER_TBD — Runtime steward · Flora domain steward · Governed-AI steward · Governed-API steward · Evidence steward · Policy steward · Sensitivity steward · Geoprivacy steward · Receipt steward · Validation steward · Release steward · Migration steward · Docs steward
+created: NEEDS VERIFICATION — blank file was replaced by v1 on 2026-07-03
+updated: 2026-07-15
+supersedes: v1 Flora runtime review lane guide
+policy_label: "public-doctrine; runtime; flora; compatibility-index; placement-drift; readme-only; evidence-subordinate; policy-subordinate; sensitivity-deny-default; exact-location-protected; cite-or-abstain; finite-outcomes; no-direct-public-runtime; no-lifecycle-authority; no-release-authority; no-parallel-domain-runtime; migration-required; rollback-aware"
+current_path: runtime/flora/README.md
+truth_posture: >
+  CONFIRMED target v1 README, latest runtime root v0.3, Directory Rules v1.4 canonical runtime root and six named functional sublanes,
+  omission of runtime/flora from the canonical runtime tree and latest runtime-root index, Flora canonical-path register and domain-placement pattern,
+  Flora domain README, Flora helper-package and geoprivacy-helper boundaries, draft Flora policy and sensitivity scaffolds,
+  draft/PROPOSED public-occurrence semantic contract, Flora AI-receipt lane documentation, Flora test-root documentation,
+  TODO-only domain-flora workflow, and bounded absence of selected runtime/flora implementation files /
+  PROPOSED compatibility-index posture, functional-lane routing, governed Flora runtime context profile, finite outcome mapping,
+  sensitive-context minimization, receipt linkage, validation expectations, migration, correction, and rollback /
+  CONFLICTED repository-present runtime/flora path versus Directory Rules and runtime-root functional-lane topology;
+  prior v1 language permitting Flora adapter, mock, envelope, receipt-route, and service-config notes here versus their canonical functional homes;
+  HELD_FOR_REVIEW vocabulary versus schema-paired runtime envelopes limited to ANSWER, ABSTAIN, DENY, and ERROR /
+  UNKNOWN accepted owners, permanent path disposition, active Flora runtime consumers, approved runtime request profile,
+  executable adapters, policy enforcement, EvidenceRef resolution, citation validation, receipt persistence, deployment, and operational health /
+  NEEDS VERIFICATION drift-register entry, migration decision, inbound links, functional-lane profile design, sensitive-context tests,
+  dedicated runtime integration tests, substantive CI, correction propagation, and rollback automation
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  repository_id: "1059091169"
+  visibility: public
+  base_ref: main
+  base_commit: 6c71c48e88b34d76d00b43ab39d0a3a1b99328c7
+  prior_blob: 42f413073e877af22a1bd713b0e9b98aaa220019
+  runtime_root_blob: 894d15bb2e2d0185f433e35c690e0a6b42327fb9
+  directory_rules_blob: 2affb080e6f0043867c64c7f06c1ca52030fbd55
+  flora_canonical_paths_blob: 367d40d9781387019443fbd5ca98070be543f31c
+  flora_domain_readme_blob: 43a47d828c4926e539790a055a5e1034c6ce62bc
+  flora_package_readme_blob: b8db06bad49b996101e0020672d36e99423a10b8
+  flora_geoprivacy_package_blob: 8e8981f700c007e7420012acb8243a5e65ce0c6f
+  flora_policy_readme_blob: b040bff13e654cff9d2f7336d6d6783c8467eaa9
+  flora_sensitivity_policy_blob: 4c65abec24135f7e4467fd108e163cdce594d5f9
+  flora_public_occurrence_contract_blob: 4daeb572122177cec9157973e01d85020ba21d95
+  flora_ai_receipts_readme_blob: 668a62c47e09c1d44e73ba4b1d324664ff117b35
+  flora_tests_readme_blob: 40411105df823911edbc662d2619389d64edb217
+  domain_flora_workflow_blob: c7737001b3de3f0a1150ea467ef656a52c26b0fd
+  bounded_path_checks:
+    - runtime/flora/README.md is the only runtime/flora result returned by the bounded repository search
+    - runtime/flora/__init__.py was not found
+    - runtime/flora/adapter.py was not found
+    - runtime/flora/handoff.py was not found
+    - runtime/flora is not listed among Directory Rules' six canonical runtime sublanes
+    - runtime/flora is not indexed by the latest runtime root README
+    - Flora canonical-path and domain-root documentation do not assign domain authority to runtime/flora
+    - policy/domains/flora/README.md is a greenfield scaffold
+    - policy/sensitivity/flora/README.md is a proposed scaffold
+    - data/receipts/ai/flora/README.md documents a receipt lane but does not prove emitted receipts or runtime integration
+    - tests/domains/flora/README.md is documentation-first and says executable coverage and CI enforcement remain unknown
+    - .github/workflows/domain-flora.yml runs TODO echo commands only
+related:
+  - ../README.md
+  - ../local/README.md
+  - ../model_adapters/README.md
+  - ../mock/README.md
+  - ../ollama/README.md
+  - ../envelopes/README.md
+  - ../service_configs/README.md
+  - ../../apps/governed-api/README.md
+  - ../../packages/domains/flora/README.md
+  - ../../packages/domains/flora/geoprivacy/README.md
+  - ../../docs/domains/flora/README.md
+  - ../../docs/domains/flora/CANONICAL_PATHS.md
+  - ../../contracts/domains/flora/occurrence_public.md
+  - ../../contracts/domains/flora/occurrence_restricted.md
+  - ../../contracts/domains/flora/rare_plant_record.md
+  - ../../contracts/domains/flora/redaction_receipt.md
+  - ../../contracts/runtime/decision_envelope.md
+  - ../../contracts/runtime/runtime_response_envelope.md
+  - ../../contracts/runtime/ai_receipt.md
+  - ../../policy/domains/flora/README.md
+  - ../../policy/sensitivity/flora/README.md
+  - ../../data/receipts/ai/flora/README.md
+  - ../../tests/domains/flora/README.md
+  - ../../.github/workflows/domain-flora.yml
+  - ../../docs/doctrine/directory-rules.md
+tags: [kfm, runtime, flora, compatibility, placement-drift, governed-ai, rare-plants, geoprivacy, sensitivity, evidence, finite-outcomes, receipts, no-public-runtime, migration, rollback]
+notes:
+  - "This revision changes only runtime/flora/README.md."
+  - "The path remains visible for compatibility and migration; it is not promoted to a canonical domain-runtime implementation lane."
+  - "New Flora runtime implementation belongs in functional runtime lanes, shared Flora code belongs in packages/domains/flora, and domain authority remains in Flora responsibility roots."
+  - "This README creates no adapter, service, model, policy, schema, receipt, test, workflow, deployment, release, or public route."
 [/KFM_META_BLOCK_V2] -->
 
-![status](https://img.shields.io/badge/status-draft-yellow)
-![root](https://img.shields.io/badge/root-runtime%2F-blue)
-![domain](https://img.shields.io/badge/domain-flora-green)
-![posture](https://img.shields.io/badge/posture-domain--runtime--review-orange)
-![audit](https://img.shields.io/badge/audit-receipted-green)
+<a id="top"></a>
 
-## Purpose
+# `runtime/flora/` — Flora Runtime Compatibility and Governed Handoff Index
 
-`runtime/flora/` is a draft runtime review lane for Flora-specific runtime notes.
+> **One-line purpose.** Keep the repository-present `runtime/flora/` path inspectable while routing every Flora runtime concern to the functional runtime lane and every Flora authority object to its owning responsibility root, with fail-closed protection for exact rare, protected, culturally sensitive, or steward-controlled plant information.
 
-It may hold Flora runtime handoff notes, adapter notes, envelope notes, receipt-routing notes, mock-runtime notes, and validation notes that explain how Flora runtime behavior stays downstream of governed evidence, policy, sensitivity review, and release state.
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
+  <img alt="Lane: compatibility index" src="https://img.shields.io/badge/lane-compatibility__index-orange">
+  <img alt="Placement: conflicted" src="https://img.shields.io/badge/placement-CONFLICTED-critical">
+  <img alt="Maturity: README only" src="https://img.shields.io/badge/maturity-README__only-lightgrey">
+  <img alt="Sensitivity: deny by default" src="https://img.shields.io/badge/sensitivity-deny__by__default-red">
+  <img alt="Public runtime: denied" src="https://img.shields.io/badge/public__runtime-denied-critical">
+</p>
 
-This lane is not the Flora doctrine home, not the Flora package home, not a pipeline home, not a schema or contract home, not a policy home, and not a lifecycle data home.
+> [!IMPORTANT]
+> `runtime/flora/` is **not confirmed as a canonical runtime implementation lane**. Directory Rules and the current runtime root organize runtime work by function—local wiring, provider-neutral adapters, mocks, provider-specific runtimes, service configuration, and envelopes—not by domain. Until an accepted placement decision says otherwise, this path is a compatibility, discovery, and migration index only.
 
-## Status & authority
+> [!CAUTION]
+> A Flora runtime result cannot create botanical truth, establish taxonomic authority, reveal exact sensitive locations, satisfy an EvidenceBundle, decide policy, validate a release, promote lifecycle state, or publish a map/API/UI response.
 
-| Field | Value |
-|---|---|
-| Document type | Flora runtime README |
-| Owning root | `runtime/` |
-| Requested path | `runtime/flora/` |
-| Status | Draft |
-| Authority level | Runtime review guidance and index. Flora doctrine, contracts, schemas, policy, pipelines, packages, evidence records, validation receipts, release records, and steward decisions outrank this README. |
-| Path posture | Current-session evidence confirms this README existed as a blank file before this update. Directory Rules list functional runtime sublanes such as `local/`, `model_adapters/`, `ollama/`, `mock/`, `service_configs/`, and `envelopes/`; a domain-specific runtime lane needs maintainer confirmation. |
-| Default posture | Treat this lane as a draft domain-runtime pointer and review lane until maintainers confirm whether Flora runtime notes should live here or under functional runtime sublanes. |
-| Required reviewers | Runtime steward, Flora domain steward, policy steward when access or sensitivity posture is involved, evidence steward when evidence pointers are involved, and docs steward. |
+> [!WARNING]
+> Exact rare, protected, culturally sensitive, private-land-linked, source-restricted, or steward-controlled plant context must not enter prompts, logs, caches, diagnostics, receipts, examples, screenshots, or public envelopes unless a governed role, policy decision, minimization rule, and review path explicitly permit the bounded use.
 
-## Placement basis
+**Quick navigation:** [Status](#status-and-evidence-boundary) · [Purpose](#purpose-and-bounded-scope) · [Placement](#repository-fit-and-placement) · [Routing](#responsibility-routing) · [Authority](#authority-and-anti-collapse-rules) · [Allowed support](#allowed-runtime-support) · [Context](#governed-input-context) · [Sensitivity](#flora-sensitivity-and-geoprivacy-boundary) · [Evidence](#evidence-taxonomy-and-source-authority) · [Outcomes](#finite-runtime-outcomes-and-caller-states) · [Receipts](#receipts-observability-and-audit) · [Security](#security-privacy-and-data-minimization) · [Testing](#testing-validation-and-current-proof-boundary) · [Belongs](#what-may-remain-here) · [Does not](#what-must-not-land-here) · [Migration](#placement-migration-and-supersession) · [Done](#definition-of-done) · [Open](#open-verification-register) · [Maintenance](#maintenance-correction-and-rollback) · [Evidence basis](#evidence-basis)
 
-Current-session evidence confirms `runtime/README.md` describes `runtime/` as local runtime wiring, model adapters, and service harnesses subordinate to evidence, policy, and release.
+---
 
-Directory Rules describe `runtime/` as a runtime root with functional sublanes for local wiring, provider-neutral model adapters, local model runtime, mock adapters, service configuration, and finite-outcome envelope helpers.
+<a id="status-and-evidence-boundary"></a>
 
-Current-session evidence also confirms `packages/domains/flora/README.md` is the shared helper-code lane for Flora. That package README states that Flora helper code is not Flora doctrine, schema authority, contract authority, policy authority, lifecycle data, evidence closure, or release approval.
+## Status and evidence boundary
 
-## Repo fit
+| Surface | Status at the pinned snapshot | Safe conclusion |
+|---|---|---|
+| `runtime/flora/README.md` | **CONFIRMED** | The requested path and prior README exist. |
+| Other `runtime/flora/` files | **Not found in bounded checks** | No selected adapter, module, handoff implementation, profile, fixture, or test is established here. |
+| Directory Rules runtime tree | **CONFIRMED** | Names six functional runtime sublanes and does not list `flora/`. |
+| Latest `runtime/README.md` | **CONFIRMED v0.3** | Indexes canonical and compatibility runtime lanes but does not index `runtime/flora/`. |
+| Flora canonical-path register | **CONFIRMED draft standard** | Assigns Flora work across responsibility roots and does not establish `runtime/flora/` as a domain authority lane. |
+| Flora domain README | **CONFIRMED draft doctrine surface** | Defines fail-closed sensitivity, EvidenceBundle-first truth, and responsibility-root placement. |
+| `packages/domains/flora/` | **CONFIRMED helper-package documentation** | Reusable Flora helper code belongs there; it cannot decide policy, evidence, lifecycle, or release. |
+| Flora geoprivacy helper package | **CONFIRMED documentation surface** | May preserve access and governance refs; cannot approve disclosure or release. |
+| Flora policy lanes | **CONFIRMED scaffolds** | Policy path presence does not prove enforceable Flora or sensitivity policy. |
+| Flora public occurrence contract | **CONFIRMED draft/PROPOSED contract** | Public occurrence is a transformed derivative, not canonical exact truth; paired schema remains permissive. |
+| Flora AI receipt lane | **CONFIRMED documentation surface** | Records process memory only; emitted receipts and runtime integration are unproved. |
+| Flora test root | **CONFIRMED documentation-first** | Coverage map exists; executable coverage and CI enforcement remain unknown. |
+| `domain-flora` workflow | **CONFIRMED TODO-only** | Green workflow status cannot prove Flora validation, proof building, or release readiness. |
+| Active Flora runtime service, adapter, deployment, consumers, logs, receipts, or health | **UNKNOWN** | Documentation is not operational proof. |
+
+**Document authority:** compatibility, navigation, boundary, and migration guidance only. Directory Rules, accepted ADRs, Flora contracts and schemas, executable policy, EvidenceBundles, source descriptors, validators, tests, receipts, release records, correction records, and steward decisions outrank this README.
+
+[Back to top](#top)
+
+---
+
+<a id="purpose-and-bounded-scope"></a>
+
+## Purpose and bounded scope
+
+This README answers five questions:
+
+1. Why does `runtime/flora/` remain visible when runtime is organized by function rather than domain?
+2. Where should a Flora-scoped runtime concern actually be implemented?
+3. Which Flora context may a runtime consume without becoming Flora authority?
+4. Which finite result and receipt posture must be returned to a governed caller?
+5. How can this path be migrated, superseded, or retired without losing repository history?
+
+This lane may document:
+
+- compatibility pointers to functional runtime lanes;
+- migration inventories and deprecation notes;
+- bounded Flora runtime handoff requirements;
+- Flora-specific sensitivity, evidence, citation, correction, and release constraints that functional runtime profiles must preserve;
+- open implementation and verification gaps.
+
+This lane does **not** define:
+
+- a Flora runtime service or domain-specific model provider;
+- adapter, mock, envelope, or service-configuration implementation;
+- Flora contracts, schemas, policy, source authority, or sensitivity decisions;
+- lifecycle storage, receipt storage, proof closure, release state, API routes, UI components, or map layers;
+- a public or reviewer-facing shortcut around the governed API.
+
+[Back to top](#top)
+
+---
+
+<a id="repository-fit-and-placement"></a>
+
+## Repository fit and placement
+
+Directory Rules place runtime concerns under functional sublanes. Flora itself follows the domain-placement law inside the responsibility root that owns each artifact.
 
 ```text
 runtime/
 ├── README.md
-├── flora/                # you are here; draft domain-runtime review lane
-├── local/
-├── model_adapters/
-├── ollama/
-├── mock/
-├── service_configs/
-└── envelopes/
+├── flora/                    # this path; compatibility and migration index only
+├── local/                    # local wiring and service harnesses
+├── model_adapters/           # provider-neutral adapter boundary
+├── mock/                     # deterministic mock runtime
+├── ollama/                   # provider-specific local runtime
+├── service_configs/          # runtime service binding/config handoff
+└── envelopes/                # finite-outcome envelope coordination
 
-packages/
-└── domains/
-    └── flora/            # shared Flora helper-code lane, not runtime authority
+packages/domains/flora/       # reusable Flora helper code
+pipelines/domains/flora/      # executable Flora transformation logic
+pipeline_specs/flora/         # declarative Flora pipeline intent
+contracts/domains/flora/      # Flora object meaning
+schemas/contracts/v1/domains/flora/  # Flora machine shape
+policy/domains/flora/         # Flora policy
+policy/sensitivity/flora/     # Flora sensitivity/geoprivacy policy
+tests/domains/flora/          # Flora enforceability proof
+fixtures/domains/flora/       # synthetic/public-safe fixtures
+data/<phase>/flora/           # Flora lifecycle records
+data/receipts/ai/flora/       # Flora AI process memory
+release/                      # release, correction, withdrawal, rollback authority
+apps/governed-api/            # public/semi-public trust membrane
 ```
 
-## Flora runtime responsibilities
+### Placement determination
 
-| Responsibility | Expectation |
+| Question | Determination |
 |---|---|
-| Runtime scope | State whether the note concerns a Flora adapter, mock, envelope, receipt route, service configuration, or local runtime handoff. |
-| Canonical home | State whether the item belongs in `runtime/flora/`, a functional runtime sublane, `packages/domains/flora/`, or another governed root. |
-| Evidence posture | Link evidence pointers when Flora runtime behavior depends on evidence. |
-| Policy posture | Link policy decisions or policy notes when Flora access, sensitivity, or public posture affects runtime behavior. |
-| Geoprivacy posture | Link geoprivacy, generalization, or redaction support when sensitive Flora location posture affects runtime output. |
-| Receipt posture | Link AIReceipt, run receipt, validation receipt, or runtime envelope records when applicable. |
-| Release posture | Link release manifests, decisions, correction records, or notices when runtime behavior depends on release state. |
-| Validation posture | Link tests, fixtures, validators, or review receipts when behavior is claimed. |
-| Migration posture | Record whether the note should move to a functional runtime lane or remain here as a Flora runtime pointer. |
+| Is `runtime/` the correct responsibility root for runtime wiring? | **CONFIRMED.** |
+| Is `runtime/flora/` a named canonical runtime sublane? | **No evidence found; CONFLICTED with the functional runtime tree.** |
+| Is a permanent domain-runtime lane impossible? | **UNKNOWN.** It would require an explicit placement decision and root-index changes. |
+| May new implementation accumulate here while placement is unresolved? | **No by default.** Freeze implementation and route work by responsibility. |
+| Should reusable Flora code move here? | **No.** Use `packages/domains/flora/`. |
+| Should Flora policy, contracts, schemas, receipts, or data move here? | **No.** Link them; do not duplicate them. |
+| Does retaining this README create authority? | **No.** It preserves discoverability and migration history only. |
 
-## What belongs here
+[Back to top](#top)
 
-- Flora runtime README and index notes.
-- Flora runtime handoff notes.
-- Flora adapter or mock-runtime notes that are not canonical package code.
-- Flora runtime envelope and receipt-routing notes.
-- Runtime review notes that explain evidence, policy, sensitivity, geoprivacy, release, validation, or correction posture for Flora runtime behavior.
-- Pointers to `packages/domains/flora/`, `policy/domains/flora/`, `policy/sensitivity/flora/`, `contracts/domains/flora/`, `schemas/contracts/v1/domains/flora/`, `data/receipts/ai/flora/`, `runtime/envelopes/`, and functional runtime sublanes.
+---
 
-## What does not belong here
+<a id="responsibility-routing"></a>
 
-- Raw, work, quarantine, processed, catalog, triplet, or published data payloads.
-- Flora occurrence, specimen, plot, vegetation, taxon, or source records.
-- Exact sensitive Flora location payloads.
-- Canonical Flora doctrine, contracts, schemas, policy files, or package implementation code.
-- Executable pipeline logic.
-- Release manifests, release decisions, correction records, signatures, or notices.
-- Credentials, tokens, provider keys, or private configuration values.
-- Generated text treated as evidence, policy, review, or publication authority.
-- A parallel Flora runtime authority without a migration note or ADR.
+## Responsibility routing
 
-## Runtime outcomes
+| Flora runtime concern | Correct home | Role of this lane |
+|---|---|---|
+| Provider-neutral Flora-capable adapter | `runtime/model_adapters/` | Points to the adapter profile and records Flora obligations. |
+| Deterministic Flora mock behavior | `runtime/mock/` or accepted adapter-mock lane | Points to fixture and negative-path expectations. |
+| Local runtime/service harness | `runtime/local/` | Points to bounded local wiring. |
+| Provider-specific local runtime | `runtime/ollama/` or accepted provider lane | Points to provider-specific restrictions; no provider approval here. |
+| Runtime envelope profile | `runtime/envelopes/` plus contract/schema roots | Requires explicit profile; does not invent hybrid fields. |
+| Runtime service binding | `runtime/service_configs/` plus `configs/`/`infra/` | Points to reviewed binding and exposure posture. |
+| Reusable Flora parsing or geoprivacy helper | `packages/domains/flora/` | Points to helper API; does not host duplicate code. |
+| Executable Flora transformations | `pipelines/domains/flora/` | No execution authority here. |
+| Declarative Flora run intent | `pipeline_specs/flora/` | No spec authority here. |
+| Flora meaning and machine shape | `contracts/domains/flora/`, `schemas/contracts/v1/domains/flora/` | References exact contract/profile versions. |
+| Flora and sensitivity policy | `policy/domains/flora/`, `policy/sensitivity/flora/` | Requires resolvable policy decision; no hidden defaults. |
+| Evidence and source authority | source registry and proof roots | Requires governed refs; no direct internal-store access. |
+| AI process memory | `data/receipts/ai/flora/` or accepted receipt layout | Links receipt refs; does not persist receipt bytes here. |
+| Release/correction/rollback | `release/` | Runtime may surface state but cannot change it. |
+| Domain tests and fixtures | `tests/domains/flora/`, `fixtures/domains/flora/` | Requires proof before behavioral claims. |
+| Public API/UI/map behavior | governed application and released-artifact roots | No direct runtime or sensitive-data path. |
 
-Use finite runtime outcomes where possible:
+[Back to top](#top)
 
-| Outcome | Meaning |
-|---|---|
-| `ANSWER` | Runtime produced supported Flora response posture. |
-| `ABSTAIN` | Runtime did not answer because evidence, policy, sensitivity, citation, or release support was insufficient. |
-| `DENY` | Runtime denied the request because policy or governance state forbids response. |
-| `ERROR` | Runtime could not complete due to validation, adapter, configuration, or envelope failure. |
-| `HELD_FOR_REVIEW` | Runtime note requires steward review before use or migration. |
+---
 
-## Required Flora runtime fields
+<a id="authority-and-anti-collapse-rules"></a>
 
-Every Flora runtime note should capture:
+## Authority and anti-collapse rules
 
-- Runtime note ID
-- Runtime note status
-- Runtime scope
-- Flora domain scope
-- Canonical home
-- Runtime mode
-- Evidence posture
-- Policy posture
-- Geoprivacy posture, when applicable
-- Receipt pointer, when applicable
-- Runtime envelope pointer, when applicable
-- Release pointer, when applicable
-- Validation pointer, when applicable
-- Outcome posture
-- Reviewer
-- Review date
-- Open blockers
-- Follow-up items
-
-## Minimal Flora runtime note
-
-```markdown
-# <flora-runtime-note-id>
-
-## Status
-DRAFT / READY_FOR_REVIEW / ACTIVE / HELD_FOR_REVIEW / MIGRATE / SUPERSEDED / RETIRED
-
-## Runtime scope
-<adapter, mock runtime, local runtime, envelope helper, receipt route, service config, or N/A>
-
-## Flora domain scope
-<taxonomy, occurrence, specimen, vegetation, phenology, invasive plants, geoprivacy, sensitivity, public aggregate, or N/A>
-
-## Canonical home
-<runtime/flora/ / runtime/model_adapters/ / runtime/envelopes/ / runtime/mock/ / packages/domains/flora/ / other / N/A>
-
-## Governed support pointers
-- Evidence: <path or N/A>
-- Policy: <path or N/A>
-- Geoprivacy or sensitivity review: <path or N/A>
-- Receipt: <path or N/A>
-- Runtime envelope: <path or N/A>
-- Release: <path or N/A>
-- Validation: <path or N/A>
-
-## Outcome posture
-ANSWER / ABSTAIN / DENY / ERROR / HELD_FOR_REVIEW / N/A
-
-## Boundary notes
-<what this runtime note may support and what it must not become>
-
-## Reviewer
-<steward or maintainer>
-
-## Review date
-<YYYY-MM-DD>
-
-## Follow-up
-<open items or none>
-```
-
-## Review checklist
-
-- [ ] Runtime scope is clear.
-- [ ] Flora domain scope is clear.
-- [ ] Canonical home is explicit.
-- [ ] Evidence posture is linked or marked N/A.
-- [ ] Policy posture is linked or marked N/A.
-- [ ] Geoprivacy or sensitivity posture is linked or marked N/A.
-- [ ] Receipt and runtime-envelope pointers are linked when applicable.
-- [ ] Release-state pointer is linked when runtime behavior depends on release state.
-- [ ] Validation support is linked when behavior is claimed.
-- [ ] No data payloads, sensitive location payloads, credentials, package implementation code, schemas, contracts, or policy files are stored here.
-- [ ] The note does not claim implementation maturity without tests, fixtures, runtime evidence, or code references.
-
-## Naming guidance
-
-Recommended runtime-note pattern:
+Disallowed collapses:
 
 ```text
-<YYYY-MM-DD>_<flora-runtime-scope>_runtime-note.md
+runtime/flora README -> canonical runtime lane
+Flora prompt context -> Flora evidence
+model answer -> taxonomic authority
+model answer -> occurrence truth
+runtime success -> validation pass
+public occurrence derivative -> canonical exact occurrence
+redacted/generalized result -> permission to reveal upstream exact geometry
+AIReceipt -> EvidenceBundle or proof closure
+DecisionEnvelope -> PolicyDecision or ReleaseManifest
+ANSWER -> lifecycle promotion or public release
+HELD_FOR_REVIEW -> new runtime envelope outcome
+runtime note -> executable adapter or deployed service
 ```
 
-Examples:
+Required separations:
+
+- runtime provider mechanics remain functional and replaceable;
+- Flora evidence, source role, rights, sensitivity, and release posture remain external to model discretion;
+- public occurrence objects remain derivatives with explicit upstream and transform lineage;
+- exact restricted occurrence support remains access-controlled and never leaks through explanation text or diagnostics;
+- AI receipts record process memory, not botanical truth;
+- public clients consume governed released responses, not runtime internals or receipt files;
+- runtime output never writes or promotes lifecycle truth.
+
+[Back to top](#top)
+
+---
+
+<a id="allowed-runtime-support"></a>
+
+## Allowed runtime support
+
+A governed Flora runtime may support only bounded, reviewable tasks such as:
+
+- summarizing released or role-authorized Flora evidence with citations;
+- comparing source-supported taxonomic names while preserving disagreement and authority refs;
+- explaining public-safe uncertainty, source-role, temporal, sensitivity, geoprivacy, or release caveats;
+- drafting steward-review notes that remain non-authoritative until reviewed;
+- classifying a request into a proposed workflow or review queue without changing domain state;
+- producing deterministic mock outputs for no-network tests;
+- explaining why the governed caller must abstain, deny, hold, quarantine, or request review;
+- describing a released public derivative without inferring its hidden exact counterpart.
+
+Runtime support is inappropriate when it would:
+
+- identify or reconstruct an exact sensitive plant location;
+- infer restricted geometry from public aggregates, nearby features, narrative clues, timestamps, photographs, land records, or cross-domain joins;
+- settle taxonomy, conservation status, legal status, nativity, invasiveness, rarity, or occurrence truth without governed evidence;
+- fabricate source citations or EvidenceRefs;
+- create or edit Flora records, proofs, policies, release decisions, or public artifacts;
+- bypass required steward review or geoprivacy transformation.
+
+[Back to top](#top)
+
+---
+
+<a id="governed-input-context"></a>
+
+## Governed input context
+
+### Minimum caller posture
+
+A caller requesting Flora runtime support should provide or resolve:
+
+- traceable request and caller identity;
+- bounded Flora scope: taxon, occurrence class, specimen, vegetation, phenology, invasive record, public aggregate, or review question;
+- geographic and temporal scope at the minimum safe precision;
+- released or role-authorized EvidenceRefs and source-role context;
+- policy, rights, sensitivity, access, review, release, freshness, correction, and withdrawal state;
+- explicit adapter and envelope profile;
+- citation requirement and safe-output obligations;
+- receipt/run context and deterministic identity inputs;
+- timeout, resource, network, tool, and output limits.
+
+### Context minimization
+
+Prefer:
+
+- released public derivatives;
+- coarse geography and time buckets;
+- stable identifiers and safe summaries;
+- public-safe evidence excerpts or governed retrieval handles;
+- synthetic fixtures for tests.
+
+Do not provide by default:
+
+- RAW, WORK, QUARANTINE, or unrestricted canonical records;
+- exact rare/protected/culturally sensitive coordinates;
+- private-land or steward-only joins;
+- restricted herbarium/source payloads;
+- unpublished botanical-survey notes;
+- credentials, private endpoints, secret-bearing configuration, or hidden model instructions;
+- private chain-of-thought or unrestricted conversation history.
+
+Missing or ambiguous policy, sensitivity, rights, release, correction, or evidence support fails closed before provider execution.
+
+[Back to top](#top)
+
+---
+
+<a id="flora-sensitivity-and-geoprivacy-boundary"></a>
+
+## Flora sensitivity and geoprivacy boundary
+
+Flora runtime behavior must distinguish at least these classes:
+
+| Context class | Runtime posture |
+|---|---|
+| Public-safe common-species derivative | May support bounded answer when evidence, citation, release, freshness, and correction posture resolve. |
+| Generalized or binned sensitive derivative | May explain only the released representation and its caveats; must not infer the hidden exact record. |
+| Exact rare/protected occurrence | Deny public use; internal use requires explicit role, policy, purpose, minimization, and review. |
+| Culturally sensitive plant knowledge | Default deny or restricted review; community/sovereignty obligations outrank runtime capability. |
+| Steward-only or source-restricted record | Deny unless the caller and purpose are explicitly authorized. |
+| Private-land-linked occurrence | Minimize or deny; do not expose owner, access route, or inferred exact position. |
+| Public aggregate with re-identification risk | Abstain or deny when joins or narrative could reconstruct protected detail. |
+| Unknown sensitivity or rights state | Abstain/deny and route to review; never assume public-safe. |
+
+### Precision anti-inference rule
+
+The runtime must not increase spatial precision. It must not combine:
+
+- coarse occurrence geometry;
+- roads, trails, parcels, land ownership, imagery, collection date, collector narrative, photographs, habitat descriptions, or nearby landmarks;
+- other domain records;
+
+in a way that reconstructs or materially narrows a protected location.
+
+### Transform evidence
+
+When public Flora material depends on generalization, suppression, delay, binning, masking, or aggregation, the governed caller should resolve the relevant policy, review, transform/redaction receipt, release, correction, and rollback refs. Runtime prose cannot substitute for those artifacts.
+
+[Back to top](#top)
+
+---
+
+<a id="evidence-taxonomy-and-source-authority"></a>
+
+## Evidence, taxonomy, and source authority
+
+### Evidence hierarchy
 
 ```text
-2026-07-03_flora-mock-adapter_runtime-note.md
-2026-07-03_flora-geoprivacy-envelope_runtime-note.md
-2026-07-03_flora-ai-receipt-route_runtime-note.md
+SourceDescriptor and source snapshot
+  -> EvidenceRef resolves to admissible EvidenceBundle or proof support
+  -> policy / rights / sensitivity / review / release checks
+  -> bounded runtime interpretation
+  -> citation validation and finite envelope
+  -> AIReceipt or run pointer when applicable
 ```
 
-Use lowercase filenames and hyphenated scope names.
+Generated language never occupies an earlier position in this chain.
 
-## Open verification
+### Taxonomic posture
 
-- [ ] Confirm whether `runtime/flora/` remains a domain-runtime lane or should migrate to functional runtime sublanes.
-- [ ] Confirm CODEOWNERS for `runtime/flora/`.
-- [ ] Confirm relationship to `packages/domains/flora/`.
-- [ ] Confirm relationship to `data/receipts/ai/flora/`.
-- [ ] Confirm Flora runtime adapter paths.
-- [ ] Confirm Flora runtime envelope paths.
-- [ ] Confirm Flora geoprivacy and sensitivity review pointer formats.
-- [ ] Confirm evidence pointer format.
-- [ ] Confirm policy pointer format.
-- [ ] Confirm receipt and validation pointer formats.
-- [ ] Confirm whether Flora runtime notes require schema validation.
-- [ ] Confirm whether `runtime/README.md` should index `flora/` directly.
+Runtime may describe:
 
-## Last reviewed
+- source names and accepted/candidate crosswalk posture;
+- synonymy or disagreement recorded by governed sources;
+- limitations and unresolved identification;
+- public-safe label choices already approved by the caller's evidence and policy path.
 
-| Field | Value |
+Runtime must not:
+
+- silently choose a canonical taxon;
+- upgrade a candidate identification to accepted;
+- treat a source label as cross-source consensus;
+- infer legal, conservation, native, invasive, or rarity status from model knowledge;
+- erase source-specific classification or temporal versioning.
+
+### Source-role posture
+
+Observed, regulatory, modeled, aggregate, administrative, candidate, and synthetic roles remain distinct. Runtime summaries must preserve role and caveat; they cannot upgrade a source role or collapse multiple source roles into undifferentiated truth.
+
+[Back to top](#top)
+
+---
+
+<a id="finite-runtime-outcomes-and-caller-states"></a>
+
+## Finite runtime outcomes and caller states
+
+Schema-paired runtime envelope families currently use four finite outcomes:
+
+| Runtime outcome | Flora use |
 |---|---|
-| Last reviewed | 2026-07-03 |
-| Review status | Draft README replacing blank file |
-| Next review trigger | Domain-runtime placement decision, first Flora runtime note, Flora adapter update, Flora receipt update, Flora envelope update, policy update, sensitivity/geoprivacy update, validator update, or package/runtime integration review |
+| `ANSWER` | Bounded response supported by allowed evidence, policy, rights, sensitivity, citation, freshness, correction, and release posture. |
+| `ABSTAIN` | Support, citation, source authority, freshness, precision, taxonomy, rights, or confidence is insufficient. |
+| `DENY` | Access, sensitivity, exact-location, rights, consent/sovereignty, capability, render, or release posture forbids the response. |
+| `ERROR` | Runtime, adapter, configuration, validation, dependency, timeout, resource, or envelope failure prevents safe completion. |
+
+`HELD_FOR_REVIEW`, `HOLD`, `NEEDS_REVIEW`, `QUARANTINE`, `NO_OP`, and similar values may be **caller-owned workflow states**, but they are not additional runtime envelope outcomes unless an accepted contract/schema explicitly adds them.
+
+### Proposed caller mapping
+
+| Runtime outcome | Possible caller action |
+|---|---|
+| `ANSWER` | Continue as non-authoritative support; validate, review, and preserve receipts before downstream use. |
+| `ABSTAIN` | Request more evidence, narrow scope, or route to domain review. |
+| `DENY` | Stop delivery; preserve safe reason code and obligations without leaking protected facts. |
+| `ERROR` | Retry only if policy permits and idempotency/resource rules are satisfied; otherwise fail safely. |
+
+No outcome directly changes Flora lifecycle or release state.
+
+[Back to top](#top)
+
+---
+
+<a id="receipts-observability-and-audit"></a>
+
+## Receipts, observability, and audit
+
+A Flora runtime event that materially supports an answer, denial, abstention, review, export, or release-facing explanation should emit or join the accepted runtime/AI receipt family through the owning execution path.
+
+Receipt-ready facts may include:
+
+- request/run identity;
+- caller and adapter/profile identity;
+- model/provider reference when permitted;
+- canonicalized input/output digests;
+- evidence, source-role, policy, rights, sensitivity, review, release, correction, and citation-validation refs;
+- finite outcome and safe reason codes;
+- public-safe timing and resource measurements;
+- redaction/generalization refs when relevant;
+- supersession and incident refs.
+
+Receipts must not contain:
+
+- exact sensitive coordinates or reconstructive clues;
+- restricted source payloads or private botanical notes;
+- credentials, private endpoints, or secret values;
+- unrestricted prompts or context bodies when a digest/ref is sufficient;
+- private chain-of-thought;
+- generated language presented as proof.
+
+Observability should separate:
+
+- process health;
+- adapter/runtime health;
+- evidence-resolution health;
+- policy/sensitivity/citation blockers;
+- public-readiness state.
+
+A healthy process can still produce `ABSTAIN` or `DENY`. It is not evidence that the Flora answer is true or releasable.
+
+[Back to top](#top)
+
+---
+
+<a id="security-privacy-and-data-minimization"></a>
+
+## Security, privacy, and data minimization
+
+Default controls:
+
+- no direct public or browser-to-runtime path;
+- no direct runtime access to lifecycle or canonical stores;
+- no live network or tools unless an explicit capability policy allows them;
+- no wildcard/public model binding;
+- no hidden provider fallback;
+- least-privilege caller and service identity;
+- bounded context, output, concurrency, time, memory, and retries;
+- safe logging and diagnostics;
+- deterministic mock-first tests;
+- explicit kill switch and deactivation path.
+
+Flora-specific controls:
+
+- protected location detail is minimized before runtime invocation;
+- public derivatives cannot be reverse-resolved into exact occurrences;
+- cross-domain joins are policy-checked for induced sensitivity;
+- correction, withdrawal, and supersession state invalidate stale runtime support;
+- caches and indexes must not retain protected context beyond approved scope;
+- screenshots, examples, fixtures, and PR discussions use synthetic or public-safe material.
+
+[Back to top](#top)
+
+---
+
+<a id="testing-validation-and-current-proof-boundary"></a>
+
+## Testing, validation, and current proof boundary
+
+### Current proof
+
+The current repository evidence proves documentation surfaces, not a Flora runtime implementation. The Flora test root describes intended domain coverage, and the `domain-flora` workflow only echoes TODO commands.
+
+### Required future tests
+
+A mature Flora runtime integration should include:
+
+1. no-network deterministic mock tests;
+2. missing EvidenceBundle support produces `ABSTAIN`;
+3. exact sensitive location requests produce `DENY` without leaking confirmation;
+4. unknown rights or sensitivity state fails closed;
+5. public derivative explanations never reveal upstream exact detail;
+6. cross-domain join re-identification attempts are denied;
+7. taxonomic conflict remains unresolved rather than guessed;
+8. candidate source role is never upgraded;
+9. stale, corrected, withdrawn, or superseded support is not served as current;
+10. citation-validation failure prevents `ANSWER`;
+11. receipt output contains refs/digests but no protected context;
+12. malformed or unknown envelope/profile fields fail closed;
+13. adapter timeout, resource exhaustion, cancellation, and retry behavior is bounded;
+14. no direct lifecycle-store or model-endpoint public path exists;
+15. kill switch and rollback preserve the public contract.
+
+### Fixture posture
+
+Use synthetic, generalized, or public-safe fixtures. Never commit real precise rare-plant coordinates, restricted herbarium payloads, cultural knowledge, private-land details, credentials, or private steward material.
+
+### Substantive CI expectation
+
+```text
+inventory and placement checks
+  -> contract/schema validation
+  -> policy/sensitivity negative fixtures
+  -> domain and runtime boundary tests
+  -> no-network mock execution
+  -> receipt/redaction checks
+  -> correction and rollback drill
+```
+
+A green TODO/echo workflow is not enforcement.
+
+[Back to top](#top)
+
+---
+
+<a id="what-may-remain-here"></a>
+
+## What may remain here
+
+Until placement is resolved, accepted content is limited to:
+
+- this README;
+- a compatibility index of inbound references;
+- a migration plan or ADR pointer;
+- deprecation, supersession, and removal notes;
+- bounded handoff guidance that points to functional runtime and Flora responsibility roots;
+- an evidence-backed disposition register that does not become implementation, policy, schema, data, receipt, or release authority.
+
+New child files should not be added by default. A proposed exception must identify why no functional runtime lane or existing Flora responsibility root can own the artifact and must carry an accepted placement decision.
+
+[Back to top](#top)
+
+---
+
+<a id="what-must-not-land-here"></a>
+
+## What must not land here
+
+| Do not place in `runtime/flora/` | Correct home |
+|---|---|
+| Flora adapter implementation | `runtime/model_adapters/` or accepted adapter implementation lane |
+| Flora mock implementation | `runtime/mock/` or accepted adapter-mock lane |
+| Flora envelope implementation/profile authority | `runtime/envelopes/`, `packages/envelopes/`, contracts/schemas as applicable |
+| Flora service configuration or deployment | `runtime/service_configs/`, `configs/`, `infra/`, external deployment system |
+| Flora helper code or geoprivacy utilities | `packages/domains/flora/` |
+| Executable Flora pipelines | `pipelines/domains/flora/` |
+| Flora pipeline specs | `pipeline_specs/flora/` |
+| Flora contracts or schemas | `contracts/domains/flora/`, `schemas/contracts/v1/domains/flora/` |
+| Flora or sensitivity policy | `policy/domains/flora/`, `policy/sensitivity/flora/` |
+| Source descriptors, lifecycle records, exact occurrences, receipts, proofs, catalog, or published artifacts | owning `data/` lanes |
+| AI receipt instances | accepted `data/receipts/ai/flora/` layout |
+| Release manifests, decisions, corrections, withdrawals, rollback cards, signatures | `release/` |
+| Tests and fixtures | `tests/domains/flora/`, `fixtures/domains/flora/`, accepted runtime-test lanes |
+| Public API routes, UI components, maps, layers, exports | governed application and released-artifact roots |
+| Credentials, private config, model weights, protected context, private chain-of-thought | never in this tracked lane |
+
+[Back to top](#top)
+
+---
+
+<a id="placement-migration-and-supersession"></a>
+
+## Placement migration and supersession
+
+### Default migration posture
+
+1. Freeze new implementation under `runtime/flora/`.
+2. Inventory inbound links and any unverified child files.
+3. Classify each item by responsibility: adapter, mock, local wiring, provider runtime, envelope, service config, Flora helper, policy, data, receipt, test, release, or docs.
+4. Move or rewrite the item in the owning root through a small reviewable change.
+5. Preserve history, stable refs, evidence, review notes, and rollback target.
+6. Add compatibility pointers only when a real consumer requires them.
+7. Update `runtime/README.md`, Flora canonical-path docs, tests, workflows, and drift registers as appropriate.
+8. Mark this path `deprecated`, `superseded`, or `retired` only after inbound links and consumers are resolved.
+
+### Permanent-lane option
+
+If maintainers decide Flora needs a permanent domain-specific runtime lane, the decision should:
+
+- explain why functional runtime lanes are insufficient;
+- identify the owning root and authority boundary;
+- prevent duplicate adapter, envelope, config, policy, receipt, or test homes;
+- update Directory Rules or an accepted ADR as required;
+- update the runtime root index and CODEOWNERS;
+- define contracts, tests, CI, correction, migration, and rollback;
+- preserve the public trust membrane and sensitivity defaults.
+
+This README does not make that decision.
+
+[Back to top](#top)
+
+---
+
+<a id="definition-of-done"></a>
+
+## Definition of done
+
+This compatibility README is complete when it:
+
+- records the path-placement conflict without silently promoting the lane;
+- routes runtime concerns to functional runtime homes;
+- routes Flora authority objects to Flora responsibility roots;
+- preserves evidence-first and deny-by-default sensitive-location rules;
+- separates runtime outcomes from caller workflow states;
+- denies lifecycle, release, and public authority;
+- records current implementation and CI gaps;
+- provides a reversible migration and rollback path.
+
+A Flora runtime integration is implementation-backed only when:
+
+- an accepted request/context profile and explicit envelope profile exist;
+- the functional implementation path and consumer are verified;
+- evidence, policy, sensitivity, rights, citation, release, freshness, and correction gates are executable;
+- no-network mocks and negative tests pass;
+- receipts and safe diagnostics are emitted through accepted homes;
+- direct public/runtime and direct internal-store paths are denied;
+- exact-location and re-identification tests pass;
+- correction, deactivation, supersession, and rollback are demonstrated;
+- substantive CI executes the suite.
+
+[Back to top](#top)
+
+---
+
+<a id="open-verification-register"></a>
+
+## Open verification register
+
+| ID | Verification item | Status |
+|---|---|---|
+| `RFL-01` | Confirm owners and CODEOWNERS for the path and migration. | NEEDS VERIFICATION |
+| `RFL-02` | Open or confirm a drift-register entry for `runtime/flora/`. | NEEDS VERIFICATION |
+| `RFL-03` | Decide compatibility, deprecation, migration, or permanent-lane disposition. | NEEDS VERIFICATION |
+| `RFL-04` | Inventory all inbound links and any branch-only child files. | NEEDS VERIFICATION |
+| `RFL-05` | Confirm all Flora runtime consumers and call sites. | UNKNOWN |
+| `RFL-06` | Confirm accepted Flora runtime request/context profile. | NEEDS VERIFICATION |
+| `RFL-07` | Confirm functional adapter, mock, envelope, service-config, and provider profiles. | UNKNOWN |
+| `RFL-08` | Confirm executable Flora and sensitivity policy. | UNKNOWN |
+| `RFL-09` | Confirm EvidenceRef/EvidenceBundle and citation-validation integration. | UNKNOWN |
+| `RFL-10` | Confirm exact-location, join-sensitivity, and anti-reidentification enforcement. | UNKNOWN |
+| `RFL-11` | Confirm AIReceipt/runtime receipt layout and persistence. | NEEDS VERIFICATION |
+| `RFL-12` | Confirm correction, withdrawal, cache invalidation, and supersession propagation. | UNKNOWN |
+| `RFL-13` | Confirm dedicated runtime/domain integration tests and synthetic fixtures. | NEEDS VERIFICATION |
+| `RFL-14` | Replace TODO-only Flora CI with substantive checks. | NEEDS VERIFICATION |
+| `RFL-15` | Confirm deployment, public-path denial, logs, and operational health. | UNKNOWN |
+| `RFL-16` | Demonstrate kill switch, migration receipt, and rollback. | NEEDS VERIFICATION |
+
+[Back to top](#top)
+
+---
+
+<a id="maintenance-correction-and-rollback"></a>
+
+## Maintenance, correction, and rollback
+
+### README rollback
+
+This change is documentation-only. Before merge, close the review branch. After merge, transparently revert the commit or restore prior blob `42f413073e877af22a1bd713b0e9b98aaa220019`. No runtime, data, policy, receipt, release, or deployment rollback is required.
+
+### Correction
+
+If this README overstates evidence, placement, sensitivity, contracts, tests, or workflow behavior:
+
+1. narrow the claim immediately;
+2. identify the unsupported statement and affected downstream docs or PRs;
+3. correct links and truth labels;
+4. preserve the prior blob and correction history;
+5. add or update the verification backlog or drift entry.
+
+### Runtime incident posture
+
+If a future Flora runtime path exposes protected context, bypasses policy/evidence/release gates, serves stale or withdrawn support, or creates a direct public/runtime path:
+
+1. disable the binding or capability first;
+2. stop new calls and bound in-flight work;
+3. preserve safe audit/receipt references;
+4. assess affected responses, caches, indexes, logs, and public artifacts;
+5. issue correction/withdrawal and release actions through their owning roots;
+6. rotate or remove exposed access where applicable;
+7. restore only after negative tests, review, and rollback proof pass.
+
+[Back to top](#top)
+
+---
+
+<a id="evidence-basis"></a>
+
+## Evidence basis
+
+This revision is grounded in the pinned repository snapshot and the files named in the metadata block. Material conclusions are bounded as follows:
+
+- **CONFIRMED:** the target path, current runtime functional-lane doctrine, Flora responsibility-root pattern, Flora sensitivity doctrine, helper-package boundaries, public-occurrence derivative semantics, AI receipt documentation, test documentation, and TODO-only Flora workflow.
+- **PROPOSED:** compatibility disposition, governed Flora runtime handoff profile, caller mapping, tests, migration, and rollback procedures.
+- **CONFLICTED:** repository path presence versus canonical runtime topology; prior permission for domain-specific runtime artifacts here versus functional ownership; workflow-state vocabulary versus runtime envelope outcomes.
+- **UNKNOWN:** executable runtime behavior, consumers, enforcement, receipts, deployment, and operational health.
+- **NEEDS VERIFICATION:** owners, placement decision, migration, contracts/profiles, policy wiring, tests, CI, correction, and rollback automation.
+
+The bounded absence checks are not exhaustive proof that differently named files, other branches, ignored files, external deployments, or unindexed consumers do not exist.
+
+[Back to top](#top)
+
+---
+
+## Changelog
+
+### v1.1 — 2026-07-15
+
+- Reclassifies the path from a draft domain-runtime review lane to a compatibility and migration index.
+- Aligns placement with the latest runtime root and Directory Rules functional-lane topology.
+- Freezes new domain-specific runtime implementation here by default.
+- Routes adapters, mocks, envelopes, service configs, helpers, policy, receipts, tests, data, and release artifacts to their owning roots.
+- Strengthens exact-location, geoprivacy, cross-domain re-identification, evidence, taxonomy, receipt, security, correction, and rollback boundaries.
+- Separates four schema-paired runtime outcomes from caller-owned hold/review/quarantine states.
+- Records bounded implementation and CI gaps without presenting proposed behavior as repository fact.
+
+### v1 — 2026-07-03
+
+- Replaced a blank file with a draft Flora runtime review-lane guide.
+
+<p align="right"><a href="#top">Back to top</a></p>


### PR DESCRIPTION
Updates `runtime/flora/README.md` as a repository-grounded compatibility and migration index. The one-file revision clarifies ownership, current evidence limits, validation expectations, and reversible migration and rollback guidance.