### PR TITLE
docs(validators): ground catalog record boundary

### DIFF
--- a/data/receipts/generated/genrec-tools-validators-catalog-readme-e5e81223.json
+++ b/data/receipts/generated/genrec-tools-validators-catalog-readme-e5e81223.json
@@ -1,0 +1,200 @@
+{
+  "receipt_id": "genrec-tools-validators-catalog-readme-e5e81223",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    "tools/validators/catalog/README.md"
+  ],
+  "artifact_hashes": {
+    "tools/validators/catalog/README.md": "sha256:e5e81223f5f20bb44ac636911fb27d4945d92a0edfdac5ab2eb5c3a9129381e6"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "GPT-5.6 Thinking",
+    "version": "2026-07-16-session"
+  },
+  "prompt_or_contract": "sha256:b061d3d8b153af8083cd1f62f447b389c396b5a882e590328ede7c3e3ff25e85",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "Python validation"
+    ]
+  },
+  "inputs": {
+    "attached_docs": [
+      "KFM GitHub Repository Documentation Implementation Agent — Full Operating Prompt v3.1",
+      "Directory Rules.pdf",
+      "Kansas Frontier Matrix — AI Build Operating Contract.md"
+    ],
+    "evidence_refs": [
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/05e403a1d607c8e69f028baf92010f4b2501203a",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/tools/validators/catalog/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/tools/validators/catalog_closure/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/tools/validators/validate_catalog_matrix.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/tools/validators/_common/run_all.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/data/catalog/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/data/catalog/stac/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/data/catalog/dcat/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/data/catalog/prov/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/catalog/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/pipelines/catalog/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/packages/catalog/src/catalog/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/contracts/data/catalog_matrix.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/schemas/contracts/v1/data/catalog_matrix.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/contracts/data/validation_report.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/policy/data/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/docs/adr/ADR-0022-catalog-matrix--stac-+-dcat-+-prov-must-agree.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/docs/sources/catalog/GLOSSARY.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/.github/workflows/validator-suite.yml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/docs/doctrine/directory-rules.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/schemas/contracts/v1/receipts/generated_receipt.schema.json",
+      "project://KFM Documentation Implementation Agent v3.1"
+    ]
+  },
+  "truth_labels": {
+    "tools/validators/catalog/README.md": "PROPOSED"
+  },
+  "validation_gates": [
+    {
+      "gate": "repository-preflight",
+      "outcome": "PASS",
+      "reason": "Repository identity, current main, target blob, direct-lane inventory, adjacent catalog and closure lanes, lifecycle catalog roots, package/pipeline scaffolds, contracts/schemas, policy, shared validator runtime, workflow, Directory Rules, and receipt schema were inspected."
+    },
+    {
+      "gate": "base-and-target-concurrency",
+      "outcome": "PASS",
+      "reason": "Branch was created from main commit 05e403a1d607c8e69f028baf92010f4b2501203a; target blob e4736954d8cecdc55b3ce48b52523f0c9ba61343 was rechecked before mutation."
+    },
+    {
+      "gate": "directory-rules-placement",
+      "outcome": "PASS",
+      "reason": "The README remains under tools/validators; catalog data, compatibility redirects, contracts, schemas, policy, registry, evidence, receipts, release, published artifacts, packages, pipelines, tests, and public serving remain in their owning roots."
+    },
+    {
+      "gate": "direct-lane-inventory",
+      "outcome": "PASS",
+      "reason": "Bounded search surfaced only README.md under tools/validators/catalog and no validate_catalog_candidate executable, CATALOG_VALIDATION producer, or dedicated catalog-validator test implementation."
+    },
+    {
+      "gate": "runtime-maturity",
+      "outcome": "PASS",
+      "reason": "The top-level CatalogMatrix validator was verified as a NotImplementedError placeholder; the shared aggregate was verified to run five validators and exclude placeholder stubs."
+    },
+    {
+      "gate": "catalog-topology-and-anti-duplication",
+      "outcome": "PASS",
+      "reason": "The update separates individual catalog-record validation from catalog closure, catalog construction, lifecycle storage, source-profile documentation, and release authority."
+    },
+    {
+      "gate": "catalog-matrix-conflict",
+      "outcome": "PASS",
+      "reason": "ADR-0011 versus ADR-0022 placement/authority conflict and validator-path mismatch remain explicit and unresolved rather than being silently normalized."
+    },
+    {
+      "gate": "contract-schema-policy-maturity",
+      "outcome": "PASS",
+      "reason": "CatalogMatrix and ValidationReport schemas are accurately classified as permissive placeholders; data-policy runtime enforcement remains unverified."
+    },
+    {
+      "gate": "markdown-structure",
+      "outcome": "PASS",
+      "reason": "One H1, balanced fenced blocks, explicit anchors, tables, finite outcomes, verification register, evidence ledger, migration, correction, and rollback sections were checked."
+    },
+    {
+      "gate": "internal-link-resolution",
+      "outcome": "PASS",
+      "reason": "All 51 internal fragment links resolved in local validation."
+    },
+    {
+      "gate": "secret-pattern-review",
+      "outcome": "PASS",
+      "reason": "No common private-key, GitHub token, AWS credential, or OpenAI key pattern was found."
+    },
+    {
+      "gate": "sensitive-content-review",
+      "outcome": "PASS",
+      "reason": "No source secrets, private endpoints, signed URLs, sensitive coordinates, restricted catalog payloads, unpublished metadata values, credentials, or policy-hidden thresholds were included."
+    },
+    {
+      "gate": "artifact-integrity",
+      "outcome": "PASS",
+      "reason": "README SHA-256 is e5e81223f5f20bb44ac636911fb27d4945d92a0edfdac5ab2eb5c3a9129381e6."
+    },
+    {
+      "gate": "executable-tests",
+      "outcome": "SKIPPED",
+      "reason": "No executable validator, schema, policy, fixture, test, workflow, package, pipeline, runtime, catalog record, or release implementation changed."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "target-readme",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/tools/validators/catalog/README.md"
+    },
+    {
+      "id": "catalog-closure",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/tools/validators/catalog_closure/README.md"
+    },
+    {
+      "id": "catalog-matrix-stub",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/tools/validators/validate_catalog_matrix.py"
+    },
+    {
+      "id": "catalog-lifecycle",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/data/catalog/README.md"
+    },
+    {
+      "id": "catalog-package",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/packages/catalog/src/catalog/README.md"
+    },
+    {
+      "id": "catalog-matrix-contract-schema",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/contracts/data/catalog_matrix.md"
+    },
+    {
+      "id": "adr-0011",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md"
+    },
+    {
+      "id": "adr-0022",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/docs/adr/ADR-0022-catalog-matrix--stac-+-dcat-+-prov-must-agree.md"
+    },
+    {
+      "id": "validator-suite",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/.github/workflows/validator-suite.yml"
+    },
+    {
+      "id": "directory-rules",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/05e403a1d607c8e69f028baf92010f4b2501203a/docs/doctrine/directory-rules.md"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-16T23:25:00Z",
+  "emitter": "openai:gpt-5.6-thinking",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "Documentation-only update. No catalog validator executable, catalog record, package/pipeline implementation, schema, contract, policy decision, source admission, EvidenceBundle, receipt instance, lifecycle transition, release record, hosted catalog, search index, API route, or public artifact was created or modified. Human review remains pending."
+}

--- a/tools/validators/catalog/README.md
+++ b/tools/validators/catalog/README.md
@@ -1,255 +1,374 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://doc/tools-validators-catalog-readme
-title: tools/validators/catalog README
-type: README
-version: v0.1
-status: draft
-owner: TODO-tooling-qa-owner-plus-catalog-steward-plus-evidence-steward-plus-release-steward-plus-policy-steward
+title: tools/validators/catalog/ — Catalog Record Validator Boundary
+type: readme; validator-lane; catalog-record-validation; stac; dcat; prov; non-authoritative
+version: v0.2
+status: draft; repository-grounded; README-only; catalog-matrix-stub-confirmed; shared-runtime-confirmed; aggregate-registration-absent; catalog-closure-sibling-confirmed; data-catalog-canonical; root-catalog-compatibility-only; placeholder-schemas; catalog-matrix-placement-conflicted; dedicated-tests-unestablished; dedicated-ci-unestablished; release-gated; fail-closed
+owners: OWNER_TBD — Catalog · STAC · DCAT · PROV/PAV · Validator · Schema · Contract · Source · Evidence · Rights/Sensitivity · Policy · Release · Security · CI · Docs stewards
 created: 2026-07-07
-updated: 2026-07-07
-policy_label: repository-facing; catalog-validator-lane; discovery-not-truth; release-gated
+updated: 2026-07-16
+supersedes: v0.1
+policy_label: repository-facing; catalog; discovery; interchange; evidence-aware; rights-aware; sensitivity-aware; release-gated; fail-closed; discovery-not-truth
 owning_root: tools/
-responsibility: proposed catalog validator lane for STAC, DCAT, PROV, domain catalog, catalog index, release-reference, evidence-reference, source-descriptor, policy-posture, correction, and lifecycle-boundary checks
-truth_posture: cite-or-abstain; implementation claims require current repo evidence
+current_path: tools/validators/catalog/README.md
+responsibility: Validate individual catalog discovery/interchange records and bounded indexes; delegate cross-record closure, evidence, policy, release, storage, construction, and public serving to their owning lanes.
+truth_posture: >
+  CONFIRMED target v0.1 and prior blob; direct lane README-only in bounded search; catalog_closure sibling documented;
+  top-level validate_catalog_matrix.py raises NotImplementedError; shared five-entry aggregate excludes placeholder validators;
+  data/catalog is canonical CATALOG-stage home with RELEASED ONLY exposure; root catalog is compatibility-only; STAC, DCAT,
+  PROV and domain catalog sublanes exist; catalog package and pipeline are scaffolds/documentation-led; CatalogMatrix and
+  ValidationReport schemas are permissive placeholders / PROPOSED packet, report, reason codes, fixtures, CI and rollback /
+  CONFLICTED ADR-0011 versus ADR-0022 CatalogMatrix placement and validator/schema paths / NEEDS VERIFICATION owners,
+  profiles, namespace, canonical matrix path, policies, tests, CI and public-route enforcement / UNKNOWN runtime consumers,
+  emitted reports, hosting/search behavior, metrics, deployment and pass results
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  base_commit: "05e403a1d607c8e69f028baf92010f4b2501203a"
+  prior_blob: e4736954d8cecdc55b3ce48b52523f0c9ba61343
+  data_catalog_blob: 9cf67c4ce5308b9088466b023a244107e3863a48
+  catalog_closure_blob: fef3e0df1d566d2839b6c3da17d75723f16628fc
+  catalog_matrix_contract_blob: c67923beb505aa39e7c0c768c16e75a00826ff31
+  catalog_matrix_schema_blob: 75a927376066226d8a0f89a630d7bb3693143c41
+  catalog_matrix_stub_blob: 91ecf78675cf19672a0e94a3899df3074c36ddc4
+  catalog_package_blob: 14d0462d9dfa0d594df33e9a8da6cc7bc1f8ebf0
+  catalog_pipeline_blob: 6404f3228f307faa7e1e5347a185011e8589f840
+  adr_0011_blob: 158ad6d31946d7d32537d5278ec6d2828ec880b3
+  adr_0022_blob: b09c1d7aaa39f3030afdcec419c58236fd324f17
+  run_all_blob: 3375cce172631dc3675cf2e46bb7788d273ff425
+  validator_suite_blob: 7651f0571ba8f879819b197155d160c08f9fe7ac
 related:
   - ../README.md
   - ../_common/README.md
+  - ../catalog_closure/README.md
+  - ../validate_catalog_matrix.py
   - ../../../data/catalog/README.md
-  - ../../../docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md
+  - ../../../data/catalog/stac/README.md
+  - ../../../data/catalog/dcat/README.md
+  - ../../../data/catalog/prov/README.md
+  - ../../../data/catalog/domain/README.md
+  - ../../../catalog/README.md
+  - ../../../pipelines/catalog/README.md
+  - ../../../packages/catalog/src/catalog/README.md
   - ../../../contracts/data/catalog_matrix.md
   - ../../../contracts/data/validation_report.md
-  - ../../../data/catalog/
-  - ../../../data/triplets/
-  - ../../../data/proofs/
-  - ../../../data/receipts/
-  - ../../../data/registry/
-  - ../../../data/published/
-  - ../../../release/
-  - ../../../schemas/
-  - ../../../policy/
-  - ../../../tests/
+  - ../../../schemas/contracts/v1/data/catalog_matrix.schema.json
+  - ../../../policy/data/README.md
+  - ../../../docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md
+  - ../../../docs/adr/ADR-0022-catalog-matrix--stac-+-dcat-+-prov-must-agree.md
+  - ../../../docs/doctrine/directory-rules.md
+  - ../../../.github/workflows/validator-suite.yml
+tags: [kfm, tools, validators, catalog, stac, dcat, prov, evidence, lifecycle, rights, sensitivity, release, rollback]
 notes:
-  - "This README documents a proposed catalog validator lane. It does not confirm executable files."
-  - "Catalog records are discovery and interchange carriers. They are not receipts, proof records, release decisions, or publication by themselves."
-  - "Validators enforce declared catalog contracts, schemas, policy, release links, and evidence references. They do not create catalog authority, approve release, or publish public outputs."
+  - Documentation-only update paired with a generated provenance receipt.
+  - No executable, catalog record, schema, policy, test, workflow, pipeline, package code, lifecycle object, release record or public artifact changes.
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-# tools/validators/catalog
+# Catalog Record Validator Boundary
 
-![status](https://img.shields.io/badge/status-draft-orange)
-![root](https://img.shields.io/badge/root-tools%2F-blue)
-![scope](https://img.shields.io/badge/scope-catalog--validators-informational)
-![boundary](https://img.shields.io/badge/boundary-discovery--not--truth-blueviolet)
-![truth](https://img.shields.io/badge/truth-cite--or--abstain-success)
+`tools/validators/catalog/`
 
-> **One-line purpose.** `tools/validators/catalog/` is the proposed validator lane for catalog records and catalog indexes: STAC, DCAT, PROV, domain catalog entries, release references, source-descriptor links, evidence/proof links, policy posture, correction lineage, and lifecycle-boundary checks.
+> Validate individual catalog discovery/interchange records without turning catalog metadata into truth, proof, policy, release approval or publication.
+
+<p>
+  <img alt="Status draft" src="https://img.shields.io/badge/status-draft-yellow">
+  <img alt="README only" src="https://img.shields.io/badge/implementation-README__only-orange">
+  <img alt="Discovery not truth" src="https://img.shields.io/badge/catalog-discovery__not__truth-blueviolet">
+  <img alt="Release gated" src="https://img.shields.io/badge/exposure-release__gated-critical">
+  <img alt="Fail closed" src="https://img.shields.io/badge/posture-fail__closed-red">
+</p>
+
+> [!IMPORTANT]
+> No working executable was established in this directory. The observed top-level CatalogMatrix validator is a `NotImplementedError` stub excluded from the shared five-entry aggregate.
+
+**Quick links:** [Purpose](#purpose) · [Status and evidence](#status) · [Directory Rules and authority](#placement) · [Validator topology](#topology) · [Record families](#families) · [Validation packet](#packet) · [Identity, digest, namespace and time](#identity) · [STAC rules](#stac) · [DCAT rules](#dcat) · [PROV/PAV rules](#prov) · [Domain catalog and index rules](#domain-index) · [Reference and family separation](#references) · [Lifecycle and public boundary](#lifecycle) · [Rights, sensitivity and metadata exposure](#sensitivity) · [CatalogMatrix conflict register](#matrix-conflict) · [Validation report contract](#report) · [Outcomes and reason codes](#outcomes) · [Security and resource posture](#security) · [Tests and fixtures](#tests) · [CI admission](#ci) · [Implementation sequence](#sequence) · [Definition of done](#done) · [Migration and deprecation](#migration) · [Correction, supersession and rollback](#rollback) · [Open verification register](#open) · [Evidence ledger](#ledger) · [Changelog](#changelog)
 
 ---
+<a id="purpose"></a>
 
 ## Purpose
 
-`tools/validators/catalog/` exists to hold catalog-specific validator entrypoints and helpers under the durable `tools/validators/` surface.
-
-The durable KFM question for this lane is:
-
-> Does a catalog candidate describe governed data accurately without becoming source truth, proof support, release approval, or publication?
-
-The answer should be a deterministic validation result. It should not create source truth, EvidenceBundles, receipts, release decisions, public artifacts, or catalog records by itself.
+Validate one catalog record or bounded index against an explicit profile and governed references. The lane does not build records, close a release, create evidence, decide policy, publish, host, search, or serve public clients.
 
 [Back to top](#top)
 
 ---
+<a id="status"></a>
 
-## Status
+## Status and evidence
 
-| Surface | Status | Notes |
+**Snapshot:** `main@05e403a1d607c8e69f028baf92010f4b2501203a` · **prior blob:** `e4736954d8cecdc55b3ce48b52523f0c9ba61343`.
+
+| Surface | Status |
+|---|---|
+| Direct lane | README-only in bounded search |
+| `validate_catalog_matrix.py` | Confirmed `NotImplementedError` stub |
+| Shared aggregate | Five non-placeholder validators; catalog absent |
+| CatalogMatrix/ValidationReport schemas | Confirmed permissive placeholders |
+| Dedicated catalog tests/CI | Not established |
+| Runtime consumers and pass results | UNKNOWN |
+
+A future pass proves only configured checks for the identified record/profile/input digest.
+
+[Back to top](#top)
+
+---
+<a id="placement"></a>
+
+## Directory Rules and authority
+
+`tools/validators/catalog/` owns record-local checks. `catalog_closure/` owns cross-record readiness; `pipelines/catalog/` builds; `packages/catalog/` provides reusable helpers; `data/catalog/` stores CATALOG-stage records; `release/` decides publication; governed APIs serve released outputs. Root `catalog/` remains a compatibility fence.
+
+[Back to top](#top)
+
+---
+<a id="topology"></a>
+
+## Validator topology
+
+Route STAC/DCAT/PROV/domain-record shape here; route STAC↔DCAT↔PROV agreement and CatalogMatrix completeness to `catalog_closure/`; route source, evidence, rights, sensitivity, lifecycle and release checks to their owning validators. Do not create a second closure engine or validator-local policy/profile authority.
+
+[Back to top](#top)
+
+---
+<a id="families"></a>
+
+## Record families
+
+Supported families require an explicit profile: STAC Catalog/Collection/Item/Asset/Link; DCAT Catalog/Dataset/Distribution/DataService; PROV Entity/Activity/Agent plus PAV fields; domain catalog entries; bounded indexes; quality summaries; CatalogMatrix references. Unknown families return `ABSTAIN` or `UNSUPPORTED_PROFILE`.
+
+[Back to top](#top)
+
+---
+<a id="packet"></a>
+
+## Validation packet
+
+Use immutable inputs:
+```yaml
+packet_version: kfm.catalog.validation-packet.v1
+operation: validate_catalog_record
+candidate: {record_ref: ..., record_family: ..., profile_ref: ..., candidate_digest: ...}
+context: {lifecycle_state: CATALOG, source_descriptor_refs: [], evidence_refs: [], policy_decision_refs: [], release_ref: null}
+limits: {network: deny, max_bytes: configured, max_reference_depth: configured}
+```
+Missing required context produces a finding, never an inferred default.
+
+[Back to top](#top)
+
+---
+<a id="identity"></a>
+
+## Identity, digest, namespace and time
+
+Check canonical record/artifact identity, profile digest, asset/distribution/entity checksums, accepted KFM namespace, URI normalization, and distinct observation/source/valid/retrieval/catalog/release/correction times. Stale or superseded records cannot appear current.
+
+[Back to top](#top)
+
+---
+<a id="stac"></a>
+
+## STAC rules
+
+Bind the accepted STAC version/profile; check object type, links, collection relation, geometry/bbox/time, assets, media type, roles, checksums, extension declarations and governed references. STAC validity does not prove asset existence, truth, permission or release.
+
+[Back to top](#top)
+
+---
+<a id="dcat"></a>
+
+## DCAT rules
+
+Bind the accepted DCAT profile; check class, identifier, publisher, themes, coverage, distributions/services, URLs, formats, checksums, rights, provenance and release references. Metadata URLs do not guarantee availability or public access.
+
+[Back to top](#top)
+
+---
+<a id="prov"></a>
+
+## PROV/PAV rules
+
+Check Entity/Activity/Agent identities, generation/usage/derivation/association, times, plans and PAV versioning. Keep semantic provenance separate from receipts, EvidenceBundles and supply-chain attestations.
+
+[Back to top](#top)
+
+---
+<a id="domain-index"></a>
+
+## Domain catalog and index rules
+
+Require owning domain/object family, stable artifact version, source/evidence/policy/release references, spatial/temporal scope, rights/sensitivity, lifecycle and correction state. Index membership is not completeness, truth or release.
+
+[Back to top](#top)
+
+---
+<a id="references"></a>
+
+## Reference and family separation
+
+Resolve syntax, target family, existence, digest and authority separately. Enforce `receipt ≠ proof ≠ catalog ≠ publication`; reject a receipt as proof, CatalogMatrix as ReleaseManifest, ValidationReport as PolicyDecision, compatibility README as data, or UI/generated text as evidence.
+
+[Back to top](#top)
+
+---
+<a id="lifecycle"></a>
+
+## Lifecycle and public boundary
+
+Preserve `RAW -> WORK / QUARANTINE -> PROCESSED -> CATALOG / TRIPLET -> PUBLISHED`. Public-bound records cannot expose internal stages; `data/catalog/` placement alone is not release; withdrawn/superseded/rolled-back entries cannot remain active; public clients use governed interfaces.
+
+[Back to top](#top)
+
+---
+<a id="sensitivity"></a>
+
+## Rights, sensitivity and metadata exposure
+
+Fail closed on rights gaps or metadata that can reveal rare species/plants, archaeology/cultural places, living-person/DNA/land/private-well data, critical infrastructure, restricted endpoints, precise geometry, sensitive cadence or reconstructable link graphs. Most-restrictive policy propagates.
+
+[Back to top](#top)
+
+---
+<a id="matrix-conflict"></a>
+
+## CatalogMatrix conflict register
+
+| Evidence | Posture |
+|---|---|
+| `contracts/data/catalog_matrix.md` | Draft semantic contract |
+| `schemas/contracts/v1/data/catalog_matrix.schema.json` | Placeholder, only `id` required |
+| Schema-declared validator | `tools/validators/data/validate_catalog_matrix.py` |
+| Observed validator | top-level stub raising `NotImplementedError` |
+| ADR-0011 | Proposed proof-side placement |
+| ADR-0022 | Proposed catalog/release matrix and different homes |
+| `catalog_closure/` | Documented closure lane |
+
+This README chooses no canonical matrix path and creates no duplicate implementation.
+
+[Back to top](#top)
+
+---
+<a id="report"></a>
+
+## Validation report contract
+
+A future report should identify target/profile/validator/input digests, finite outcome, safe findings, dependency results, policy implications and lifecycle effect:
+```yaml
+overall_outcome: PASS | WARN | FAIL | ABSTAIN | ERROR | REVIEW_REQUIRED
+findings: [{code: CAT_<FAMILY>_<REASON>, severity: blocking, safe_message: ...}]
+```
+Reports are not receipts, proof closure, policy decisions or release approval.
+
+[Back to top](#top)
+
+---
+<a id="outcomes"></a>
+
+## Outcomes and reason codes
+
+Top outcomes are `PASS`, `WARN`, `FAIL`, `ABSTAIN`, `ERROR`, `REVIEW_REQUIRED`. Proposed stable families: `CAT_PROFILE_*`, `CAT_SHAPE_*`, `CAT_IDENTITY_*`, `CAT_DIGEST_*`, `CAT_TIME_*`, `CAT_LINK_*`, `CAT_SOURCE_*`, `CAT_EVIDENCE_*`, `CAT_RIGHTS_*`, `CAT_SENSITIVITY_*`, `CAT_LIFECYCLE_*`, `CAT_RELEASE_*`, `CAT_CORRECTION_*`, `CAT_PUBLIC_*`, `CAT_RESOURCE_*`, `CAT_INTERNAL_*`.
+
+[Back to top](#top)
+
+---
+<a id="security"></a>
+
+## Security and resource posture
+
+Default no-network; local profiles only; bounded bytes/nesting/reference depth/diagnostics; safe URI schemes; no remote schema fetch, redirects, shell/template/query injection, credential discovery or secret-bearing diagnostics; deterministic ordering; fail closed on parser/resolver/resource errors.
+
+[Back to top](#top)
+
+---
+<a id="tests"></a>
+
+## Tests and fixtures
+
+No dedicated executable suite surfaced. Future synthetic fixtures must cover valid record families, unknown profile, malformed shape, identity/digest/time mismatch, missing dependencies, unreleased public exposure, sensitive metadata leakage, stale state, family collapse, hostile URIs, oversized/deep inputs, network denial and deterministic reruns.
+
+[Back to top](#top)
+
+---
+<a id="ci"></a>
+
+## CI admission
+
+Current `validator-suite` runs `make schemas`; the shared aggregate excludes placeholders and does not establish catalog coverage. A future job must require nonempty positive/negative fixtures, record/closure separation, reason-code uniqueness, no-network/resource canaries, safe diagnostics, retained machine reports and approved release significance.
+
+[Back to top](#top)
+
+---
+<a id="sequence"></a>
+
+## Implementation sequence
+
+1. Decide registry/path/CatalogMatrix authority. 2. Accept profiles and strengthen schemas. 3. Implement pure record-local validator. 4. Add public-safe fixtures/tests. 5. Bind policy/release/correction adapters. 6. Register CI/consumers. Keep each step reversible and independently reviewed.
+
+[Back to top](#top)
+
+---
+<a id="done"></a>
+
+## Definition of done
+
+Owners, one executable/registry id, accepted STAC/DCAT/PROV/domain profiles, namespace/identity/digest/time rules, meaningful schemas, source/evidence/rights/sensitivity/lifecycle/release adapters, nonempty fixtures, deterministic no-network tests, stable reports/codes, CI, governed RELEASED ONLY serving and tested correction/rollback are required.
+
+[Back to top](#top)
+
+---
+<a id="migration"></a>
+
+## Migration and deprecation
+
+Track root `catalog/` versus `data/catalog/`, proof-side versus catalog-side CatalogMatrix proposals, `schemas/.../data` versus proposed `.../catalog`, top-level stub versus schema-declared validator path, record versus closure lanes and namespace drift. Migration needs an accepted target, inventory, one active implementation, compatibility plan, deprecation and rollback.
+
+[Back to top](#top)
+
+---
+<a id="rollback"></a>
+
+## Correction, supersession and rollback
+
+On source/rights/sensitivity/evidence/digest/profile/release changes: issue governed correction/withdrawal; mark records stale/superseded/withdrawn; invalidate indexes/closure; rebuild or withdraw released records; update governed caches; preserve lineage and rollback target. Documentation rollback reverts this README and receipt.
+
+[Back to top](#top)
+
+---
+<a id="open"></a>
+
+## Open verification register
+
+1. Owners/CODEOWNERS. 2. Executable and registry id. 3. STAC profile/namespace. 4. DCAT profile/serialization. 5. PROV/PAV profile. 6. Domain/index contracts. 7. ADR-0011/0022 resolution. 8. CatalogMatrix homes. 9. ValidationReport schema/destination. 10. Record/closure dependency. 11. Source/evidence adapters. 12. Rights/sensitivity policy. 13. Lifecycle/release fields. 14. Identity/digest/time rules. 15. URI/media/link registries. 16. Local profile registry. 17. Network/resource budgets. 18. Diagnostic redaction. 19. Fixtures/tests. 20. Package/pipeline behavior. 21. CatalogBuildReceipt. 22. CI/required check. 23. Public consumers. 24. Compatibility producer exclusion. 25. Correction/cache invalidation. 26. Sensitive-domain review. 27. Stub disposition. 28. Duplicate authority detection. 29. Separation of duties. 30. Metrics/pass results/deployment.
+
+---
+<a id="ledger"></a>
+
+## Evidence ledger
+
+| Evidence | Status | Supports |
 |---|---|---|
-| `tools/validators/catalog/README.md` | **CONFIRMED** | This README replaces the previous empty file. |
-| Catalog validator executables | **PROPOSED / NEEDS VERIFICATION** | No script name is claimed here. |
-| `data/catalog/` boundary | **CONFIRMED in repo evidence / draft** | Catalog records are discovery/provenance projections, not truth, proof, receipts, or release authority. |
-| Artifact-family separation | **CONFIRMED in repo evidence / proposed ADR** | ADR-0011 separates receipts, proofs, catalog, and manifests/publication. |
-| Catalog schemas and fixtures | **NEEDS VERIFICATION** | STAC, DCAT, PROV, and domain catalog schema paths must be checked before implementation claims. |
-| Release/public exposure wiring | **PROPOSED / NEEDS VERIFICATION** | This README does not prove release gates, public API behavior, or CI wiring. |
+| target `e4736954d8cecdc55b3ce48b52523f0c9ba61343` | CONFIRMED | prior v0.1 |
+| `data/catalog/` and STAC/DCAT/PROV READMEs | CONFIRMED draft | canonical lifecycle/carrier boundaries |
+| root `catalog/` | CONFIRMED compatibility | drift fence |
+| `catalog_closure/` | CONFIRMED README-only | record versus closure split |
+| CatalogMatrix/ValidationReport contracts and schemas | CONFIRMED draft/placeholders | intended meaning and maturity gap |
+| top-level CatalogMatrix stub | CONFIRMED | placeholder, not enforcement |
+| package/pipeline READMEs | CONFIRMED scaffold/docs | implementation boundary |
+| ADR-0011/ADR-0022 | CONFIRMED documents; PROPOSED decisions | unresolved placement/closure conflict |
+| `policy/data/` | CONFIRMED draft | fail-closed intent |
+| `run_all.py` and validator-suite | CONFIRMED executable/workflow | five-entry aggregate, no catalog |
+| Directory Rules | CONFIRMED doctrine | responsibility-root placement |
 
-[Back to top](#top)
-
----
-
-## Authority boundary
-
-| Responsibility | Home |
-|---|---|
-| Catalog validator entrypoints | `tools/validators/catalog/` |
-| Shared validator plumbing | `tools/validators/_common/` |
-| Catalog records and indexes | `data/catalog/` |
-| Graph/triplet projection | `data/triplets/` |
-| EvidenceBundle and proof support | `data/proofs/` |
-| Receipts and run memory | `data/receipts/` |
-| Source descriptors | `data/registry/` or accepted source registry roots |
-| Release decisions, release manifests, rollback, corrections | `release/` |
-| Published public-safe artifacts | `data/published/` |
-| Catalog contracts and schemas | `contracts/`, `schemas/` |
-| Policy rules | `policy/` |
-| Tests and fixtures | `tests/` and accepted fixture conventions |
-
-Safe interpretation:
-
-- **CONFIRMED:** this README exists.
-- **PROPOSED:** catalog validator code may live here when it validates declared catalog contracts, schemas, policy, release references, and evidence pointers.
-- **NEEDS VERIFICATION:** exact executable names, schema homes, fixture paths, STAC/DCAT/PROV conventions, source registry shape, and CI wiring.
-- **DENY:** using this folder as catalog storage, source registry, proof storage, receipt storage, release record storage, published artifact storage, contract home, schema home, policy home, or public runtime surface.
-
-[Back to top](#top)
+This supports documentation only, not production validation or release adoption.
 
 ---
+<a id="changelog"></a>
 
-## What belongs here
+## Changelog
 
-Good fits for `tools/validators/catalog/` include checks that:
+**v0.2 — 2026-07-16:** repository-grounded status; record/closure split; CatalogMatrix stub and path conflicts; canonical/compatibility catalog roots; record-family, identity, lifecycle, rights/sensitivity, packet/report, reason-code, security, fixture, CI, implementation, migration and rollback guidance. No executable or trust-bearing behavior changed.
 
-- validate STAC catalog records against accepted KFM catalog requirements;
-- validate DCAT catalog records against accepted KFM catalog requirements;
-- validate PROV catalog records against accepted KFM catalog requirements;
-- validate domain catalog entries and indexes;
-- require source descriptor references where catalog records describe source-derived data;
-- require EvidenceRef, EvidenceBundle, ProofPack, CatalogMatrix, or validation-report references where material;
-- require release-state references before public exposure;
-- check sensitivity, rights, source-role, and policy posture fields;
-- check correction, supersession, withdrawal, and rollback references;
-- ensure catalog records do not substitute for proof, release, or publication authority.
-
-[Back to top](#top)
+**v0.1 — 2026-07-07:** initial proposed lane.
 
 ---
-
-## What does not belong here
-
-| Do not put in `tools/validators/catalog/` | Correct home |
-|---|---|
-| Catalog records and indexes | `data/catalog/` |
-| Graph/triplet records | `data/triplets/` |
-| EvidenceBundles, ProofPacks, CatalogMatrix instances | `data/proofs/` |
-| Receipts | `data/receipts/` |
-| Source descriptors | `data/registry/` |
-| Release manifests or release decisions | `release/` |
-| Public materialized artifacts | `data/published/` |
-| Contracts | `contracts/` |
-| Schemas | `schemas/` |
-| Policy rules | `policy/` |
-| Tests and fixtures | `tests/` and fixture conventions |
-| Catalog builder pipelines | `pipelines/` or accepted implementation root |
-
-[Back to top](#top)
-
----
-
-## Catalog validation posture
-
-Catalog validators should preserve the family split:
-
-```text
-receipt != proof != catalog != publication
-```
-
-They should fail closed, abstain, or route to review when a catalog candidate:
-
-- lacks required source descriptor references;
-- lacks evidence/proof support for claims that need it;
-- lacks release-state references for public exposure;
-- treats a catalog record as proof or publication approval;
-- omits sensitivity, rights, source-role, or policy posture where material;
-- points at RAW, WORK, QUARANTINE, or unresolved candidate data from a public-facing catalog;
-- lacks correction, supersession, withdrawal, or rollback references where required.
-
-The validator lane must preserve the KFM lifecycle invariant:
-
-```text
-RAW -> WORK / QUARANTINE -> PROCESSED -> CATALOG / TRIPLET -> PUBLISHED
-```
-
-[Back to top](#top)
-
----
-
-## Standard outcomes
-
-| Outcome | Meaning |
-|---|---|
-| `CATALOG_VALIDATION_PASS` | Configured catalog checks passed. |
-| `CATALOG_VALIDATION_FAIL` | Configured catalog checks failed. |
-| `CATALOG_SCHEMA_MISSING` | Required catalog schema could not be resolved. |
-| `SOURCE_DESCRIPTOR_MISSING` | Required source descriptor reference is absent. |
-| `EVIDENCE_REF_MISSING` | Required EvidenceRef or EvidenceBundle pointer is absent. |
-| `PROOF_REFERENCE_MISSING` | Required proof support pointer is absent. |
-| `RELEASE_REFERENCE_MISSING` | Required release-state pointer is absent. |
-| `POLICY_POSTURE_MISSING` | Required policy/sensitivity/rights/source-role posture is absent. |
-| `FAMILY_COLLAPSE` | Candidate treats catalog as receipt, proof, release, or publication. |
-| `PUBLIC_BOUNDARY_VIOLATION` | Candidate is not safe for public/governed catalog exposure as shaped. |
-| `LIFECYCLE_VIOLATION` | Candidate appears to skip required lifecycle states. |
-| `ABSTAIN` | Validator cannot decide safely with available context. |
-| `ERROR` | Validator could not safely complete. |
-
-[Back to top](#top)
-
----
-
-## Validation
-
-Suggested future test surface:
-
-```text
-tests/validators/catalog/
-├── README.md
-├── test_catalog_validators.py
-└── fixtures/
-    ├── valid_stac_record/
-    ├── valid_dcat_record/
-    ├── valid_prov_record/
-    ├── missing_source_descriptor/
-    ├── missing_evidence_ref/
-    ├── missing_release_ref/
-    ├── family_collapse_catalog_as_proof/
-    └── public_catalog_to_unreleased_candidate_denied/
-```
-
-Suggested future command pattern:
-
-```bash
-pytest -q tests/validators/catalog
-```
-
-```bash
-python tools/validators/catalog/validate_catalog_candidate.py --fixtures --dry-run
-```
-
-> [!NOTE]
-> This is a proposed interface, not proof that `validate_catalog_candidate.py` or the test path exists.
-
-[Back to top](#top)
-
----
-
-## Review checklist
-
-- [ ] Validator reads declared catalog contracts and schemas rather than defining shape locally.
-- [ ] Validator reads declared policy posture rather than defining policy locally.
-- [ ] Catalog records are kept separate from receipts, proofs, release records, and published artifacts.
-- [ ] SourceDescriptor, EvidenceBundle, proof, validation report, policy, and release references are checked where required.
-- [ ] Public-bound catalog entries do not point at RAW, WORK, QUARANTINE, or unresolved candidates.
-- [ ] Correction, supersession, withdrawal, and rollback references are checked where required.
-- [ ] Tests use public-safe or synthetic fixtures.
-- [ ] Executable claims are backed by current repo evidence.
-
-[Back to top](#top)
-
----
-
-## Last reviewed
-
-| Field | Value |
-|---|---|
-| Last reviewed | 2026-07-07 |
-| Review state | Draft README replacement for empty file. |
-| Next smallest safe change | Verify catalog schemas, STAC/DCAT/PROV conventions, fixtures, source descriptor references, validator entrypoints, and CI wiring before promoting this lane beyond draft. |


### PR DESCRIPTION
## Goal

Update `tools/validators/catalog/README.md` from a broad proposal into a repository-grounded catalog record validator and discovery/interchange boundary.

The revision keeps individual STAC, DCAT, PROV/PAV, domain-catalog, and index validation in this lane; keeps cross-record release/readiness closure in `tools/validators/catalog_closure/`; preserves `data/catalog/` as the canonical CATALOG-stage home; preserves root `catalog/` as compatibility-only; and keeps source, evidence, rights, sensitivity, policy, release, correction, rollback, construction, hosting, search, and public serving in their owning roots.

Task contract: `kfm-doc-tools-validators-catalog-readme-20260716` · evidence snapshot `main@05e403a1d607c8e69f028baf92010f4b2501203a` · prior target blob `e4736954d8cecdc55b3ce48b52523f0c9ba61343` · two-file change budget.

## Status labels

- `CONFIRMED` — target README; canonical `data/catalog/`; STAC/DCAT/PROV sublanes; root catalog compatibility fence; catalog-closure sibling; CatalogMatrix and ValidationReport contracts/schemas; top-level CatalogMatrix stub; catalog package/pipeline scaffolds; data policy; shared validator aggregate/workflow; Directory Rules; and receipt schema were inspected.
- `PROPOSED` — immutable validation packet, structured report profile, `CAT_` reason codes, no-network fixtures, dedicated CI admission, migration/deprecation, correction cascade, and rollback.
- `CONFLICTED` — ADR-0011 proof-side CatalogMatrix versus ADR-0022 release/catalog matrix; `schemas/contracts/v1/data/` versus proposed catalog schema homes; schema-declared `tools/validators/data/validate_catalog_matrix.py` versus observed top-level stub; canonical `data/catalog/` versus compatibility `catalog/`.
- `NEEDS VERIFICATION` — owners, CODEOWNERS, accepted STAC/DCAT/PROV profiles and namespace, canonical CatalogMatrix homes, policies, fixtures/tests, report destination, CI significance, public-route enforcement, correction cascade, and release adoption.
- `UNKNOWN` — runtime consumers, emitted reports, hosting/search behavior, metrics, deployment, current pass results, and branch-protection significance.

## Directory Rules basis

- The target remains under `tools/validators/`, the validator/checker implementation root.
- Catalog records remain under `data/catalog/`; compatibility redirects remain under root `catalog/`.
- Cross-record closure remains under `catalog_closure/`; catalog construction remains in pipelines/packages.
- Meaning, shape, decisions, source registry, evidence/proofs, receipts, lifecycle records, release records, published artifacts, tests, and public serving remain in their owning roots.
- No new authority root, lifecycle phase, public catalog endpoint, search index, release gate, or parallel CatalogMatrix authority is created.

## Changed files

- `tools/validators/catalog/README.md`
- `data/receipts/generated/genrec-tools-validators-catalog-readme-e5e81223.json`

## What changed

- Reclassifies the lane as repository-grounded and README-only with executable enforcement unestablished.
- Records that no direct catalog executable or dedicated test implementation surfaced.
- Records the top-level `validate_catalog_matrix.py` as a `NotImplementedError` stub excluded from the shared five-entry aggregate.
- Separates record-local validation from catalog closure, construction, lifecycle storage, source-profile documentation, release, and public serving.
- Adds bounded rules for STAC, DCAT, PROV/PAV, domain catalog entries, and indexes.
- Adds identity, digest, namespace, time, reference-family, lifecycle, rights, sensitivity, metadata-leakage, correction, supersession, withdrawal, rollback, and public-boundary rules.
- Preserves the ADR-0011/ADR-0022 and validator/schema-path conflicts instead of choosing an unverified canonical path.
- Adds a proposed immutable packet, report contract, finite outcomes and `CAT_` reason-code families, security/resource posture, fixture strategy, CI contract, implementation sequence, definition of done, migration guidance, verification register, evidence ledger, and changelog.
- Adds a generated provenance receipt with human review `pending`.

## What did not change

No validator executable, catalog record, schema, semantic contract, policy rule, fixture, test, workflow, pipeline, package code, lifecycle object, SourceDescriptor, EvidenceBundle, receipt instance other than generated provenance, release record, hosted catalog, search index, API route, or public artifact changed.

## Validation

Performed:

- repository/base/target and bounded implementation preflight
- inspection of catalog/closure/lifecycle/compatibility/package/pipeline/contract/schema/policy/runtime/workflow boundaries
- one H1 and balanced fenced blocks
- all 51 internal fragment links resolved
- no trailing whitespace or tabs; final newline present
- common credential-pattern review
- sensitive-content review: no private endpoints, signed URLs, secrets, sensitive coordinates, restricted payloads, unpublished metadata values, or hidden policy thresholds
- README SHA-256 `e5e81223f5f20bb44ac636911fb27d4945d92a0edfdac5ab2eb5c3a9129381e6`
- remote README blob `2b05c5e0054862d2990e59adfead83f14f409d5f`
- generated receipt blob `f08118d73916e5114ee2962f1fa779c6bd0047c1`
- branch contains exactly the README and receipt as task changes

Not performed:

- executable catalog tests: no executable implementation changed
- schema/policy/runtime/public-catalog execution: no implementation changed
- release dry run: this PR has no publication authority
- branch-protection/ruleset verification: not exposed by the inspected connector surface

`main` advanced through unrelated documentation/receipt commits after the task branch was written. The comparison showed no overlap with the target files; the draft branch may therefore be behind current `main` while remaining scoped to the two intended files.

## Rollback

Before merge, close this draft PR and abandon the branch. After merge, revert the two commits or restore prior README blob `e4736954d8cecdc55b3ce48b52523f0c9ba61343` through a reviewed branch and revert/supersede the generated receipt. No runtime, catalog, schema, policy, lifecycle, hosting, deployment, or release rollback is required.

## Sensitive / public boundary

The README contains no catalog payload, source secret, private endpoint, signed URL, sensitive coordinate, restricted metadata value, or hidden policy parameter. It explicitly treats catalog metadata as a potential leakage carrier and requires fail-closed rights, sensitivity, lifecycle, and release posture.

## GENERATED_RECEIPT

`data/receipts/generated/genrec-tools-validators-catalog-readme-e5e81223.json`

Human review remains `pending`; the receipt is provenance evidence, not approval, policy permission, merge authorization, catalog closure, or release authority.

## ADR triggers

No structural decision is exercised. A future CatalogMatrix canonical-home decision, validator/registry selection, profile/namespace adoption, compatibility-root retirement, policy adapter, runtime/public integration, or release-gate adoption may require an accepted ADR or reviewed migration note.

## CONTRACT_VERSION followed

`3.0.0`
