### PR TITLE
docs(artifacts): ground document lint report boundary

### DIFF
--- a/artifacts/qa/reports/doc-lint/README.md
+++ b/artifacts/qa/reports/doc-lint/README.md
@@ -1,1 +1,600 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/artifacts-qa-reports-doc-lint-readme
+title: artifacts/qa/reports/doc-lint/ — Documentation QA Report, Inspection, and Non-Authority Boundary
+type: readme; directory-readme; qa-report-output; documentation-lint-report; compatibility-boundary; inspection-contract
+version: v0.1
+status: draft; repository-grounded; compatibility-root; transitional; readme-empty-before-revision; gitkeep-tracked; report-payload-not-present; docs-validator-parent-readme-only; child-validator-readmes-only; citation-validator-readme-only; docs-workflows-todo-only; dedicated-tests-not-established; report-schema-not-established; retention-not-established; release-binding-unestablished; non-authoritative
+owners: OWNER_TBD — Docs steward · QA/report steward · Documentation-validator steward · Link/anchor steward · Metadata steward · Terminology steward · Evidence/truth-posture steward · Citation steward · Security/privacy steward · Rights/sensitivity reviewer · CI/artifact-retention steward · Receipt/proof steward · Release/publication steward
+created: 2026-07-16
+updated: 2026-07-16
+policy_label: public-doc; artifacts; qa; docs; lint; metadata; links; citations; terminology; truth-posture; generated-output; inspection-only; no-secrets; no-doctrine-authority; no-evidence-authority; no-policy-authority; no-release-authority; correction-aware; rollback-aware
+current_path: artifacts/qa/reports/doc-lint/README.md
+truth_posture: CONFIRMED target README existed as an empty tracked file; sibling .gitkeep retains a proposed document-lint report directory; parent artifacts/qa/reports and artifacts/qa boundaries; Directory Rules classification of artifacts as a transitional compatibility root; tools/docs as the general documentation-tooling lane; tools/validators/docs as a README-only proposed parent; link-check, meta-block, stale-scan, terminology-parity, and truth-label-lint child lanes as README-only; tools/validators/citation as a separately routed README-only citation-readiness lane; link-check, citation-validation, docs-control-plane, and docs-build workflows as TODO-only echo scaffolds; artifacts/docs as a generated-documentation preview boundary with no operational producer; root .gitignore covering direct artifacts/qa/*.xml only and not this nested report lane; bounded search surfacing no doc-lint producer or report payload; and checked absence of doc-lint-report.json, doc-lint-run.json, doc-lint-summary.md, .github/workflows/doc-lint.yml, and schemas/artifacts/doc-lint-report.schema.json / PROPOSED immutable report identity; explicit document class, scope, profile, and input digest; normalized findings; deterministic link, metadata, freshness, terminology, truth-label, citation, authority, and implementation-overclaim checks; safe diagnostics; finite outcomes; no-network defaults; CI artifact upload; access and expiry controls; canonical ValidationReport or validation receipt linkage; correction, invalidation, supersession, withdrawal, rollback, and retirement / CONFLICTED doc-lint naming versus no executable named doc-lint; style lint versus semantic docs validation; child validator responsibilities versus parent orchestration; citation validation inside and outside tools/validators/docs; generated report versus canonical validation memory; tracked compatibility output versus no ignore or retention rule; workflow names versus TODO-only behavior; and QA convenience versus doctrine, truth, evidence sufficiency, policy permission, release approval, or publication / UNKNOWN uncommitted local reports, CI-only artifacts, external documentation services, historical runs, dynamically loaded validators, package-local implementations, current finding counts, active consumers, branch-protection significance, report freshness, retention, hosting, deployment, and production use / NEEDS VERIFICATION accepted owners, CODEOWNERS, complete recursive inventory, generated-output commit policy, canonical report and receipt homes, accepted document profiles, canonical validator entry and registry id, child runner ownership, citation integration, severity mapping, suppression and baseline policy, sensitive-content redaction, workflow ownership, artifact retention, release significance, correction consumers, and rollback execution
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  repository_id: "1059091169"
+  visibility: public
+  base_ref: main
+  base_commit: ebdf9332c096facff23ff4379b576b6ae01c72b4
+  target_prior_blob: 8b137891791fe96927ad78e64b0aad7bded08bdc
+  confirmed_lane_files:
+    - artifacts/qa/reports/doc-lint/README.md
+    - artifacts/qa/reports/doc-lint/.gitkeep
+  confirmed_lane_blobs:
+    README.md: 8b137891791fe96927ad78e64b0aad7bded08bdc
+    .gitkeep: be0c1dfcf616d938fde3480b46688f3a6e7be710
+  checked_absent_paths:
+    - artifacts/qa/reports/doc-lint/doc-lint-report.json
+    - artifacts/qa/reports/doc-lint/doc-lint-run.json
+    - artifacts/qa/reports/doc-lint/doc-lint-summary.md
+    - .github/workflows/doc-lint.yml
+    - schemas/artifacts/doc-lint-report.schema.json
+  bounded_inventory_note: tracked repository evidence cannot establish uncommitted local reports, CI workspaces, external documentation services, historical artifacts, dynamically loaded implementations, branch-local outputs, object stores, hosting systems, branch-protection settings, or uninspected subprojects
+related:
+  - ../README.md
+  - ../../README.md
+  - ../../../README.md
+  - ../../../../artifacts/docs/README.md
+  - ../../../../docs/README.md
+  - ../../../../docs/doctrine/directory-rules.md
+  - ../../../../tools/docs/README.md
+  - ../../../../tools/validators/docs/README.md
+  - ../../../../tools/validators/docs/link-check/README.md
+  - ../../../../tools/validators/docs/meta-block/README.md
+  - ../../../../tools/validators/docs/stale-scan/README.md
+  - ../../../../tools/validators/docs/terminology-parity/README.md
+  - ../../../../tools/validators/docs/truth-label-lint/README.md
+  - ../../../../tools/validators/citation/README.md
+  - ../../../../.github/workflows/link-check.yml
+  - ../../../../.github/workflows/citation-validation.yml
+  - ../../../../.github/workflows/docs-control-plane.yml
+  - ../../../../.github/workflows/docs-build.yml
+  - ../../../../data/receipts/README.md
+  - ../../../../data/proofs/README.md
+  - ../../../../release/README.md
+  - ../../../../.gitignore
+tags: [kfm, artifacts, qa, reports, doc-lint, documentation-validation, markdown, links, anchors, metadata, freshness, terminology, truth-labels, citations, authority, overclaim, retention, correction, rollback]
+notes:
+  - "This is the first substantive contract for an otherwise empty README."
+  - "The direct lane contains only README.md and .gitkeep in bounded tracked evidence."
+  - "No doc-lint report, producer, schema, dedicated test suite, workflow, retained run manifest, consumer, or release binding was established."
+  - "The docs-validator parent and five child lanes are README-only; citation validation is separately documented and also README-only."
+  - "Named documentation workflows are real YAML files whose current bodies only echo TODO messages."
+  - "A report in this lane is an inspection copy, not doctrine, a canonical ValidationReport, receipt, proof, PolicyDecision, ReleaseManifest, publication approval, or public artifact."
+  - "This revision changes documentation only."
+[/KFM_META_BLOCK_V2] -->
 
+<a id="top"></a>
+
+# `artifacts/qa/reports/doc-lint/` — Documentation QA Report, Inspection, and Non-Authority Boundary
+
+> **Purpose.** Define the staging boundary for generated documentation-QA reports without allowing a clean finding list, green check, valid metadata block, resolved link, current date, approved vocabulary, citation presence, rendered preview, or workflow artifact to become doctrine, truth, evidence sufficiency, policy permission, release approval, publication, or production truth.
+
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
+  <img alt="Root: artifacts compatibility" src="https://img.shields.io/badge/root-artifacts__compatibility-orange">
+  <img alt="Direct inventory: README and gitkeep" src="https://img.shields.io/badge/direct__inventory-README%20%2B%20gitkeep-informational">
+  <img alt="Report payload: absent" src="https://img.shields.io/badge/report__payload-NOT__ESTABLISHED-critical">
+  <img alt="Docs validators: README only" src="https://img.shields.io/badge/docs__validators-README__only-red">
+  <img alt="Authority: none" src="https://img.shields.io/badge/trust__authority-none-purple">
+</p>
+
+**Quick navigation:** [Status](#status-and-evidence-boundary) · [Authority](#authority-and-directory-rules-basis) · [Inventory](#confirmed-current-inventory) · [Topology](#validator-and-report-topology) · [Check families](#documentation-check-family-matrix) · [Report](#proposed-report-contract) · [Security](#security-privacy-rights-and-sensitive-content) · [CI](#producer-ci-artifact-and-retention-contract) · [Outcomes](#validation-non-vacuity-and-finite-outcomes) · [Correction](#correction-invalidation-and-rollback) · [Done](#definition-of-done) · [Plan](#smallest-sound-implementation-sequence) · [Open](#open-verification-register) · [Evidence](#evidence-ledger) · [Rollback](#documentation-correction-and-rollback)
+
+---
+
+<a id="status-and-evidence-boundary"></a>
+
+## Status and evidence boundary
+
+> [!IMPORTANT]
+> **Snapshot:** `main@ebdf9332c096facff23ff4379b576b6ae01c72b4`<br>
+> **Prior README blob:** `8b137891791fe96927ad78e64b0aad7bded08bdc` — empty file<br>
+> **Confirmed direct files:** `README.md`, `.gitkeep`<br>
+> **Document-lint report payload:** not established<br>
+> **Docs-validator parent and child executables:** not established<br>
+> **Link, citation, control-plane, and docs-build workflows:** TODO-only<br>
+> **Dedicated report schema, tests, retention, and consumer:** not established
+
+`artifacts/qa/reports/doc-lint/` is a repository-confirmed compatibility placeholder. It is **not an operational documentation-validation reporting system**.
+
+### Safe conclusion
+
+| Capability | Status | Evidence-bounded conclusion |
+|---|---:|---|
+| Boundary README | `CONFIRMED` | The path existed, but the README was empty before this revision. |
+| Directory retention marker | `CONFIRMED` | `.gitkeep` identifies a proposed document-lint report directory. |
+| Report payload or run manifest | `NOT ESTABLISHED` | No checked JSON or Markdown report exists. |
+| General docs-tooling lane | `README ONLY` | `tools/docs/` documents intended helper responsibilities. |
+| Docs-validator parent | `README ONLY` | Parent intent exists; no parent runner is established. |
+| Link-check child | `README ONLY` | Link and anchor semantics are documented, not enforced. |
+| Meta-block child | `README ONLY` | Metadata semantics are documented, not enforced. |
+| Stale-scan child | `README ONLY` | Freshness semantics are documented, not enforced. |
+| Terminology-parity child | `README ONLY` | Vocabulary semantics are documented, not enforced. |
+| Truth-label-lint child | `README ONLY` | Truth-label hygiene semantics are documented, not enforced. |
+| Citation validator | `README ONLY` | Citation-readiness intent exists in a separate lane. |
+| Named docs workflows | `TODO ONLY` | Current jobs only echo TODO messages. |
+| Generated-docs producer | `NOT ESTABLISHED` | `artifacts/docs/` has no operational producer or manifest. |
+| Dedicated doc-lint tests/workflow | `NOT ESTABLISHED` | No dedicated suite or workflow surfaced. |
+| Generated-output ignore protection | `NOT ESTABLISHED` | Root ignore rules do not cover this nested report lane. |
+| Receipt/proof/release binding | `NOT ESTABLISHED` | No canonical record is linked to this lane. |
+| Production or public use | `UNKNOWN` | A path or workflow name cannot prove adoption. |
+| Doctrine, truth, or release proof | `DENY` | A document-lint report cannot establish those authorities. |
+
+### Truth labels
+
+| Label | Meaning in this README |
+|---|---|
+| `CONFIRMED` | Verified from current repository files, exact paths, workflow bodies, or bounded search. |
+| `PROPOSED` | A recommended object, command, profile, path, or gate not established as current implementation. |
+| `CONFLICTED` | Current files, paths, vocabularies, or responsibilities create incompatible expectations. |
+| `UNKNOWN` | Not observable or not established from inspected evidence. |
+| `NEEDS VERIFICATION` | Checkable, but not sufficiently proven for operational reliance or release significance. |
+| `DENY` | A prohibited authority, security, lifecycle, evidence, policy, release, or publication interpretation. |
+
+[Back to top](#top)
+
+---
+
+<a id="authority-and-directory-rules-basis"></a>
+
+## Authority and Directory Rules basis
+
+Directory Rules place this lane under `artifacts/` because it holds derived, regenerable, non-authoritative output. Topic does not transfer authority into the report.
+
+```text
+authored documentation and doctrine        docs/ and owning responsibility roots
+documentation tooling and validators       tools/docs/ and tools/validators/docs/
+citation-readiness validation              tools/validators/citation/
+generated documentation previews           artifacts/docs/
+documentation QA inspection reports        artifacts/qa/reports/doc-lint/
+canonical validation process memory        data/receipts/ and accepted validation-report homes
+proof and EvidenceBundle support            data/proofs/
+release and publication decisions          release/
+```
+
+This lane may hold generated inspection copies. It must not become a documentation-content root, doctrine or ADR authority, term-definition authority, source-admissibility authority, evidence-sufficiency authority, policy-decision root, canonical receipt/proof store, release authority, generated documentation site, public host, or second validator implementation root.
+
+### Core separation
+
+```text
+document syntax ≠ document meaning
+document meaning ≠ factual truth
+citation presence ≠ evidence resolution
+evidence resolution ≠ policy permission
+policy permission ≠ release approval
+release approval ≠ publication verification
+report presence ≠ canonical process memory
+```
+
+[Back to top](#top)
+
+---
+
+<a id="confirmed-current-inventory"></a>
+
+## Confirmed current inventory
+
+```text
+artifacts/qa/reports/doc-lint/
+├── README.md                         # empty before this revision
+└── .gitkeep                          # retains proposed report directory
+```
+
+| Path | Blob at snapshot | Status |
+|---|---|---:|
+| `README.md` | `8b137891791fe96927ad78e64b0aad7bded08bdc` | `EMPTY BEFORE REVISION` |
+| `.gitkeep` | `be0c1dfcf616d938fde3480b46688f3a6e7be710` | `CONFIRMED` |
+
+Checked representative report, run-manifest, summary, dedicated workflow, and report-schema paths were absent. Absence is commit-scoped and path-scoped; it does not prove that historical, ignored, branch-local, generated, CI-only, external, or uninspected outputs never existed.
+
+[Back to top](#top)
+
+---
+
+<a id="validator-and-report-topology"></a>
+
+## Validator and report topology
+
+| Responsibility | Owning lane | Current posture |
+|---|---|---:|
+| General documentation tooling | `tools/docs/` | README boundary |
+| Docs-validator parent/index | `tools/validators/docs/` | README-only |
+| Link and anchor checks | `tools/validators/docs/link-check/` | README-only |
+| Metadata-block checks | `tools/validators/docs/meta-block/` | README-only |
+| Freshness and stale-claim checks | `tools/validators/docs/stale-scan/` | README-only |
+| Terminology parity | `tools/validators/docs/terminology-parity/` | README-only |
+| Truth-label hygiene | `tools/validators/docs/truth-label-lint/` | README-only |
+| Citation readiness | `tools/validators/citation/` | Separate README-only lane |
+| Generated docs preview | `artifacts/docs/` | Boundary only; no producer |
+| QA report staging | `artifacts/qa/reports/doc-lint/` | This lane |
+| Canonical validation memory | accepted ValidationReport/receipt homes | Separate |
+| Proof and EvidenceBundle support | `data/proofs/` | Separate |
+| Release/publication decision | `release/` | Separate |
+
+A future parent runner may aggregate child results only if it preserves child identity, native reason codes, skipped/error outcomes, profile digests, input digests, deterministic ordering, and separate canonical trust records.
+
+[Back to top](#top)
+
+---
+
+<a id="documentation-check-family-matrix"></a>
+
+## Documentation check family matrix
+
+| Family | Intended question | Required boundary |
+|---|---|---|
+| Link/path/anchor | Do configured local references and fragments resolve? | Resolution does not prove target authority. |
+| Metadata/meta block | Does configured metadata parse and agree internally? | Valid metadata does not prove truth. |
+| Freshness/staleness | Does the document need time-aware steward review? | Staleness is a QA signal, not a truth verdict. |
+| Terminology parity | Does usage match accepted vocabulary and authority pointers? | Linter cannot define disputed terms. |
+| Truth-label hygiene | Does wording communicate evidence posture without overclaiming? | Linter cannot decide underlying truth. |
+| Citation readiness | Are citations present, scoped, and safely handed to evidence resolution? | Citation presence is not EvidenceBundle closure. |
+| Markdown structure | Are headings, fences, tables, anchors, and formatting parseable? | Render success is not semantic correctness. |
+| Generated-doc provenance | Does a generated document point to source/build identity? | Preview is not authored authority. |
+| Directory placement | Does the path conflict with known responsibility rules? | Linter cannot grant Directory Rules exceptions. |
+| Register parity | Do document registry pointers and metadata agree? | Control-plane workflow is currently TODO-only. |
+| Implementation overclaim | Does prose claim behavior without current evidence labels? | Finding routes to review; it is not auto-truth. |
+| Sensitive-content leak | Could diagnostics disclose secrets, private paths, or protected details? | Fail safe and redact. |
+
+### Scope contract
+
+Every future run must identify repository/ref, document selector, document count, document classes, profiles and digests, exclusions and reasons, network posture, reference time, dirty-tree state, locale/timezone, and resource limits. Empty collection, missing profile, missing child validator, parser failure, or wildcard suppression cannot yield a normal pass.
+
+[Back to top](#top)
+
+---
+
+<a id="proposed-report-contract"></a>
+
+## Proposed report contract
+
+The following shapes are **PROPOSED**, not current repository fact.
+
+### Minimum finding fields
+
+| Field | Requirement |
+|---|---|
+| `finding_id` | Stable within the report. |
+| `family` | Link, metadata, freshness, terminology, truth-label, citation, structure, authority, security, etc. |
+| `code` | Stable machine reason code. |
+| `severity` | Accepted normalized severity. |
+| `outcome_effect` | Blocking, warning, review-required, informational, or none. |
+| `document_ref` | Path plus input digest or immutable ref. |
+| `location` | Safe line, section, or anchor where permitted. |
+| `profile_ref` | Rule/profile identity and digest. |
+| `safe_message` | No secrets or sensitive excerpts. |
+| `suggested_action` | Fix, review, verify, suppress, correct, or abstain. |
+| `suppression_ref` | Optional governed exception reference. |
+
+### Candidate reason-code families
+
+`DOC_SCOPE_*`, `DOC_PROFILE_*`, `DOC_LINK_*`, `DOC_ANCHOR_*`, `DOC_META_*`, `DOC_FRESHNESS_*`, `DOC_TERM_*`, `DOC_TRUTH_*`, `DOC_CITATION_*`, `DOC_STRUCTURE_*`, `DOC_RENDER_*`, `DOC_AUTHORITY_*`, `DOC_SECURITY_*`, `DOC_SENSITIVITY_*`, `DOC_SUPPRESSION_*`, `DOC_RETENTION_*`, `DOC_INTERNAL_*`.
+
+### Proposed run manifest
+
+```yaml
+manifest_version: kfm.doc-lint-run.v1
+run_id: urn:kfm:doc-lint:<id>
+repository: {name: bartytime4life/Kansas-Frontier-Matrix, git_sha: <sha>, dirty: false}
+scope:
+  document_count: 0
+  document_classes: []
+  included_paths: []
+  excluded_paths: []
+profiles:
+  parent_profile_ref: <ref>
+  child_profiles: []
+execution:
+  network: denied
+  locale: C.UTF-8
+  timezone: UTC
+results:
+  overall_outcome: NOT_RUN
+  findings_count: 0
+  child_outcomes: []
+outputs:
+  report_ref: artifacts/qa/reports/doc-lint/doc-lint-report.json
+  report_digest: <sha256>
+  summary_ref: artifacts/qa/reports/doc-lint/doc-lint-summary.md
+governance:
+  validation_report_ref: null
+  receipt_ref: null
+  proof_refs: []
+  policy_decision_ref: null
+  release_ref: null
+  correction_refs: []
+retention:
+  class: ci-short
+  expires_at: <timestamp>
+```
+
+### Routing
+
+| Output | Correct posture |
+|---|---|
+| Machine report | Generated inspection copy in this lane |
+| Human summary | Reviewer aid; cannot strengthen machine result |
+| Native child output | Preserve or reference without silent remapping |
+| ValidationReport | Separate governed semantic object |
+| Validation receipt | Separate process-memory object |
+| EvidenceBundle/proof | Separate proof/evidence home |
+| PolicyDecision | Separate policy authority |
+| ReleaseManifest | Separate release authority |
+| Published documentation | Separate governed publication surface |
+
+[Back to top](#top)
+
+---
+
+<a id="security-privacy-rights-and-sensitive-content"></a>
+
+## Security, privacy, rights, and sensitive content
+
+Reports must not expose credentials, tokens, cookies, private keys, absolute local paths containing usernames, private repository or object-store URLs, internal endpoints, secret-bearing query strings, unpublished archaeological or cultural locations, rare-species coordinates, living-person/DNA/genealogy/land/private-well details, critical-infrastructure details, restricted excerpts, hidden sensitive comments, environment variables, or unnecessary CI workspace paths.
+
+Prefer safe diagnostics:
+
+```json
+{
+  "document_ref": "docs/example.md",
+  "location": {"line": 42},
+  "code": "DOC_LINK_TARGET_MISSING",
+  "safe_message": "Configured local target was not found.",
+  "redacted_value_digest": "sha256:..."
+}
+```
+
+A linter may detect missing rights or attribution fields. It cannot grant rights. Unknown rights or sensitivity should route to review, redaction, quarantine, staged access, or denial according to the owning policy.
+
+### Suppressions
+
+Suppressions require exact scope, owner, reason, authority/review reference, creation time, expiry/review time, affected profile/document digests, and correction path. Do not suppress parser failures, missing validators, empty scope, unsafe diagnostics, or contested doctrine by wildcard.
+
+[Back to top](#top)
+
+---
+
+<a id="producer-ci-artifact-and-retention-contract"></a>
+
+## Producer, CI artifact, and retention contract
+
+No operational producer is established today. A future producer must accept an immutable scope, resolve child profiles explicitly, fail or abstain when required children are unavailable, preserve native outcomes, emit safe normalized findings, separate deterministic and external checks, avoid editing source documents, avoid publishing, return stable exit codes, and write only to an accepted staging path.
+
+A substantive CI job should:
+
+1. check out the intended commit;
+2. install pinned tools;
+3. resolve profiles;
+4. prove nonempty collection;
+5. run deterministic local checks;
+6. run external checks separately;
+7. validate report shape and consistency;
+8. scan report output for secrets and sensitive values;
+9. upload with bounded retention;
+10. expose finite outcomes without hiding abstentions or errors.
+
+| Retention class | Use |
+|---|---|
+| `ephemeral` | local scratch |
+| `ci-short` | ordinary PR report |
+| `investigation` | active defect or correction |
+| `release-candidate` | release-significant review bound to canonical records |
+| `externally-published` | generally inappropriate here without separate approval |
+
+Retention duration, branch-protection significance, and release blocking are not established by this README.
+
+[Back to top](#top)
+
+---
+
+<a id="validation-non-vacuity-and-finite-outcomes"></a>
+
+## Validation, non-vacuity, and finite outcomes
+
+| Outcome | Meaning |
+|---|---|
+| `PASS` | Required checks passed for a nonempty, identified scope. |
+| `WARN` | Nonblocking findings exist. |
+| `FAIL` | Blocking findings exist. |
+| `ABSTAIN` | Required context is missing. |
+| `DENY` | Unsafe or prohibited condition blocks the requested use. |
+| `ERROR` | Tooling or parsing failed; validity cannot be inferred. |
+| `REVIEW_REQUIRED` | Human/steward judgment is required. |
+| `EMPTY_SCOPE` | No intended documents were collected. |
+| `PROFILE_NOT_ESTABLISHED` | Required profile could not be resolved. |
+| `CHILD_VALIDATOR_MISSING` | Required child validator was unavailable. |
+| `PLACEHOLDER_ONLY` | Inputs or outputs are placeholders, not run-bound evidence. |
+| `NOT_RUN` | No substantive run occurred. |
+
+Reject a run that validates only its own output, loads no rules, matches no files, suppresses every finding by wildcard, claims repository-wide success from a subset, treats a placeholder as a real report, treats workflow completion as validator completion, or treats report generation as document correctness.
+
+[Back to top](#top)
+
+---
+
+<a id="correction-invalidation-and-rollback"></a>
+
+## Correction, invalidation, and rollback
+
+Invalidate or supersede a report when document content/path, profile, validator, terminology, truth-label policy, citation/evidence reference, rights/sensitivity posture, release/publication state, external-link reference time, suppression, or report integrity changes.
+
+Correction flow:
+
+1. identify affected report and document refs;
+2. mark the prior report stale, invalid, superseded, or withdrawn;
+3. preserve prior digest and lineage;
+4. correct source documentation or validator/profile;
+5. rerun on immutable inputs;
+6. compare findings;
+7. update canonical ValidationReport or receipt linkage where material;
+8. invalidate previews, caches, dashboards, and release references;
+9. record rollback target.
+
+Do not silently overwrite a release-significant report.
+
+[Back to top](#top)
+
+---
+
+<a id="definition-of-done"></a>
+
+## Definition of done
+
+- [ ] Owners and CODEOWNERS are accepted.
+- [ ] Retain, migrate, or retire decision is documented.
+- [ ] Generated-output commit, access, and retention policy is accepted.
+- [ ] Parent runner and registry id are established.
+- [ ] Required child validators are executable.
+- [ ] Document classes and profiles are accepted and versioned.
+- [ ] Citation integration preserves EvidenceRef/EvidenceBundle boundaries.
+- [ ] Deterministic no-network mode exists.
+- [ ] External-link mode is separate and time-aware.
+- [ ] Stable findings, severities, and reason codes exist.
+- [ ] Report and run-manifest schemas are meaningful.
+- [ ] Safe diagnostics and redaction are tested.
+- [ ] Suppression and baseline governance is implemented.
+- [ ] Positive, negative, empty-scope, parser-error, missing-child, profile-conflict, placeholder, and sensitive fixtures exist.
+- [ ] Non-vacuity and deterministic rerun tests pass.
+- [ ] Workflow executes substantive commands and uploads bounded artifacts.
+- [ ] Canonical ValidationReport/receipt relation is accepted.
+- [ ] Correction, supersession, withdrawal, and rollback are tested.
+- [ ] Public publication remains separately governed.
+- [ ] Documentation reflects actual behavior.
+
+[Back to top](#top)
+
+---
+
+<a id="smallest-sound-implementation-sequence"></a>
+
+## Smallest sound implementation sequence
+
+1. **Authority and ownership:** accept owners, lane retention, report/receipt/ValidationReport split, and advisory versus blocking posture.
+2. **Profiles:** define document classes, parent/child profiles, required validators, vocabulary, and truth-label authority pointers.
+3. **Deterministic core:** add explicit target manifest, Markdown parser, path/anchor checks, metadata checks, profile loading, stable findings, and no-network defaults.
+4. **Fixtures and non-vacuity:** cover valid/invalid docs, empty scope, parser failure, missing child, profile conflict, expired suppression, sensitive diagnostics, and deterministic reruns.
+5. **Report and handoff:** add schemas, digests, identity, ValidationReport/receipt adapters, and correction lineage.
+6. **CI and external checks:** add substantive workflow, bounded retention, and separately governed external-link checks.
+7. **Release significance and retirement:** decide blocking posture, test rollback, and migrate or retire compatibility output when canonical routing stabilizes.
+
+Each phase should be independently reviewable and reversible.
+
+[Back to top](#top)
+
+---
+
+<a id="open-verification-register"></a>
+
+## Open verification register
+
+1. Accepted owners and CODEOWNERS.
+2. Retain, migrate, or retire decision.
+3. Complete direct/recursive inventory.
+4. Generated-output commit and ignore policy.
+5. Canonical parent runner and registry id.
+6. Report filename and schema home.
+7. Run-manifest filename and schema home.
+8. ValidationReport relationship.
+9. Validation receipt relationship.
+10. Human summary retention.
+11. Document-class registry.
+12. README profile.
+13. Doctrine profile.
+14. ADR profile.
+15. Runbook profile.
+16. Contract-companion profile.
+17. Source-profile requirements.
+18. Generated-document profile.
+19. Link/anchor algorithm.
+20. External-link network/retry policy.
+21. Meta-block grammar.
+22. Path/doc_id uniqueness.
+23. Freshness reference time and intervals.
+24. Implementation-overclaim policy.
+25. Terminology authority/version.
+26. Deprecated synonym policy.
+27. Truth-label vocabulary.
+28. Truth-label scope rules.
+29. Citation integration boundary.
+30. EvidenceRef/EvidenceBundle handoff.
+31. Rights/sensitivity checks.
+32. Diagnostic redaction.
+33. Private-path/endpoint scrubbing.
+34. Resource budgets.
+35. Symlink/generated-file policy.
+36. Severity normalization.
+37. Reason-code registry.
+38. Suppression ownership/expiry.
+39. Baseline migration.
+40. Deterministic serialization.
+41. Reproducibility comparison.
+42. Fixture inventory.
+43. Zero-collection/no-rule guards.
+44. Dedicated tests.
+45. CI workflow ownership.
+46. Artifact access/retention.
+47. Branch-protection significance.
+48. Correction consumers.
+49. Publication handoff.
+50. Rollback drill and lane retirement.
+
+[Back to top](#top)
+
+---
+
+<a id="evidence-ledger"></a>
+
+## Evidence ledger
+
+| Evidence | Blob/status | Supports |
+|---|---|---|
+| Target README | `8b137891791fe96927ad78e64b0aad7bded08bdc` | Empty prior target |
+| Target `.gitkeep` | `be0c1dfcf616d938fde3480b46688f3a6e7be710` | Proposed directory retention |
+| Structured reports parent | `0f07a8ea112f67f0b93eaa364cd23860789803ee` | Non-authoritative report boundary |
+| General docs tooling | `5150383183c27aaa7573649b0c55d92c6ef5a1d9` | Tooling/content authority split |
+| Docs validator parent | `c9ab91fca0c648a451615ca6ab050ebf5276da8a` | README-only topology |
+| Link child | `1c10fdcbf0ae3c995cb2fff5499f66006ea62bc9` | Link contract; no executable |
+| Meta child | `ebfb642074b187c365e7eabecb2f678fbe703b7c` | Metadata contract; no executable |
+| Stale child | `d72b0df3012336982952240f81ab6c4d43fb8046` | Freshness contract; no executable |
+| Terminology child | `2750ce27e77dd8eb6eb00968743b029f30691dc4` | Vocabulary contract; no executable |
+| Truth-label child | `479492c3673b86a951e3acaca044dfa197d5b8eb` | Posture contract; no executable |
+| Citation validator | `83643b6300da0e7b10079709f31876bdf851cc6b` | Separate README-only lane |
+| Link workflow | `9326c5dce2fd99c70293ac61886d289e2fc15a0c` | TODO-only |
+| Citation workflow | `644e60c968c8ad712ed5228d6bcaf1a4d1d9db38` | TODO-only |
+| Docs-control workflow | `e50351863cce87a00df03356832b8deada56b325` | TODO-only |
+| Docs-build workflow | `3841ed36c0af0a41621992aff1d932cfca9ac082` | TODO-only |
+| Generated docs boundary | `d445b4cbc3dff231129bf14dbf01a1d47ebec6d0` | No producer/manifest/deployment |
+| Root `.gitignore` | `50e0e0e2485e6dbd6b7e1c2767350b459335b22b` | Nested lane not protected |
+| Checked report/run/summary/workflow/schema paths | `404 at snapshot` | No representative operational report surface |
+
+This evidence supports documentation and maturity statements only. It does not establish exhaustive history, local tooling, CI workspace contents, external services, branch protection, deployment, production use, report freshness, pass/fail counts, or release significance.
+
+[Back to top](#top)
+
+---
+
+<a id="documentation-correction-and-rollback"></a>
+
+## Documentation correction and rollback
+
+This revision changes documentation only.
+
+Before merge, close the draft pull request or restore prior empty blob `8b137891791fe96927ad78e64b0aad7bded08bdc` in a transparent follow-up commit. After merge, revert the documentation commit or publish a corrective evidence-grounded revision.
+
+No operational rollback is required because this change does not modify validator code, report schemas, workflows, tests, fixtures, authored documentation outside this README, generated docs, receipts, proofs, policy, release records, public routes, deployment, or production state.
+
+The prior README was empty. This replacement adds the first substantive contract while preserving the `.gitkeep` boundary and avoiding claims that report generation or validator enforcement exists.
+
+### Changelog
+
+**v0.1 — 2026-07-16**
+
+- added commit-pinned inventory and evidence boundary;
+- separated documentation content, tooling, validators, QA reports, generated previews, receipts, proofs, policy, release, and publication;
+- documented README-only validator maturity and TODO-only workflow bodies;
+- added scope, check-family, report, security, non-vacuity, retention, correction, and rollback contracts;
+- added seven implementation phases and a 50-item verification register;
+- made no executable or trust-bearing changes.
+
+[Back to top](#top)


### PR DESCRIPTION
## Summary

Updates `artifacts/qa/reports/doc-lint/README.md` from an empty placeholder into a repository-grounded **documentation QA report, inspection, security, retention, and non-authority boundary**.

The direct lane contains only an empty-before-revision README and `.gitkeep`; no generated doc-lint report, producer, report schema, dedicated test suite, workflow, run manifest, retained artifact, consumer, or canonical receipt/proof/release binding was established. The documentation-validator parent and its link-check, meta-block, stale-scan, terminology-parity, and truth-label-lint children are README-only. Citation readiness is separately documented and also README-only. The link-check, citation-validation, docs-control-plane, and docs-build workflows currently only echo TODO messages.

The update preserves the responsibility split among authored documentation, documentation tooling, validator implementations, generated documentation previews, QA report staging, canonical validation memory, evidence/proofs, policy, release, and publication. It makes clear that a clean finding list, valid metadata block, resolved link, current date, consistent vocabulary, citation presence, or green workflow cannot establish doctrine, truth, evidence sufficiency, public safety, or release approval.

## Task contract

| Field | Value |
|---|---|
| Task ID | `kfm-artifacts-qa-reports-doc-lint-readme-v0-1-20260716` |
| Repository | `bartytime4life/Kansas-Frontier-Matrix` |
| Base | `main@ebdf9332c096facff23ff4379b576b6ae01c72b4` |
| Target | `artifacts/qa/reports/doc-lint/README.md` |
| Branch | `agent/artifacts-qa-reports-doc-lint-readme-v0-1-20260716` |
| Commit | `c243a6e8679fbae886d6a6b112a2b2a9cbc0eb80` |
| Prior blob | `8b137891791fe96927ad78e64b0aad7bded08bdc` — empty |
| New blob | `f32bde7ff4ea4f2a66d7f2a6a573bad82dcce618` |
| SHA-256 | `c8f4faf8379d1d60725c89d7853dafe5b55b02a4632d0e4fe73a5463fcbe85ee` |
| Change budget | one Markdown path only; no document content, validator, schema, contract, fixture, test, workflow, generated report, receipt, proof, policy, release, deployment, or public-surface changes |

## Evidence and placement determination

- Directory Rules classify `artifacts/` as a transitional compatibility root for derived, regenerable, non-authoritative material.
- The direct lane contains `README.md` and `.gitkeep` only in bounded tracked evidence.
- `tools/docs/` is the general documentation-tooling boundary.
- `tools/validators/docs/` is a README-only proposed parent.
- Link-check, meta-block, stale-scan, terminology-parity, and truth-label-lint are README-only child lanes.
- `tools/validators/citation/` is a separately routed README-only citation-readiness lane.
- Link-check, citation-validation, docs-control-plane, and docs-build workflows contain TODO-only echo steps.
- `artifacts/docs/` is a generated-documentation preview boundary with no operational producer, manifest, deployment, or generated payload established.
- Checked report, run-manifest, summary, workflow, and report-schema paths were absent.
- Root `.gitignore` does not protect this nested report lane from accidental generated-output commits.

## Main changes

- Adds a commit-pinned inventory and maturity matrix.
- Separates documentation syntax, meaning, truth, citations, EvidenceRef resolution, EvidenceBundle closure, policy permission, release approval, and publication verification.
- Defines the parent/child validator and report topology.
- Defines scope, profile, finding, severity, reason-code, run-manifest, and output-routing contracts.
- Defines link, metadata, freshness, terminology, truth-label, citation, structure, authority, implementation-overclaim, and sensitive-content check families.
- Adds empty-scope, missing-profile, missing-child, parser-error, placeholder, and wildcard-suppression non-vacuity safeguards.
- Adds no-network defaults, safe diagnostics, sensitive-content redaction, suppression governance, artifact retention classes, finite outcomes, correction, invalidation, supersession, withdrawal, and rollback procedures.
- Adds seven implementation phases and a 50-item verification register.

## Acceptance matrix

| Criterion | Result |
|---|---|
| Repository, current main, target, and prior blob resolved | PASS |
| Directory Rules and parent QA/report preflight | PASS |
| Documentation tooling/validator/preview boundaries inspected | PASS |
| Duplicate branch search | PASS — no matching branch before creation |
| Duplicate PR search | PASS — no matching PR before creation |
| Current target re-read before mutation | PASS |
| One-file change budget | PASS |
| Remote content readback | PASS |
| Prepared Git blob equals remote blob | PASS — `f32bde7ff4ea4f2a66d7f2a6a573bad82dcce618` |
| Base-to-head diff | PASS — one modified file, 599 additions, 0 deletions |
| Current-main drift after write | PASS — `main` remained at the branch base |
| Rendered H1 count | PASS — 1 |
| Heading hierarchy | PASS — 26 headings, no skips |
| Fenced code blocks | PASS — 10 markers, balanced |
| Internal navigation | PASS |
| Duplicate headings | PASS |
| Trailing whitespace and tabs | PASS |
| Common credential-pattern review | PASS |
| Executable doc-lint run/tests | NOT RUN — documentation-only change; no operational producer exists |
| GitHub Actions | PENDING |
| Human review | PENDING |

## Scope and non-goals

This PR does not:

- implement or register a documentation validator;
- create or modify documentation profiles, schemas, contracts, fixtures, tests, reason-code registries, or policy rules;
- add a doc-lint workflow or generated report payload;
- change authored documentation outside this README;
- change `.gitignore`, artifact retention, branch protection, release gates, public serving, or deployment;
- create receipts, proofs, PolicyDecisions, ReleaseManifests, corrections, or rollback records;
- claim that any repository documentation currently passes validation.

## Rollback

Before merge, close this draft PR or restore prior empty blob `8b137891791fe96927ad78e64b0aad7bded08bdc` in a transparent follow-up commit. After merge, revert this documentation PR or publish a corrective evidence-grounded revision. No document content, validator, test, release, deployment, or production rollback is required.