### PR TITLE
docs: add missing folder README contracts

### DIFF
--- a/contracts/domains/habitat/land_cover/README.md
+++ b/contracts/domains/habitat/land_cover/README.md
@@ -1,0 +1,172 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/contracts-domains-habitat-land-cover-readme
+title: Habitat Land Cover Contracts README
+type: readme
+version: v0.1
+status: draft; PROPOSED; NEEDS VERIFICATION before promotion
+owners:
+  - OWNER_TBD — Habitat domain steward
+  - OWNER_TBD — Land-cover steward
+  - OWNER_TBD — Contract steward
+  - OWNER_TBD — Schema and validation steward
+  - OWNER_TBD — Policy and release steward
+  - OWNER_TBD — Docs steward
+created: 2026-07-16
+updated: 2026-07-16
+policy_label: public-with-gates; readme; semantic-contracts; habitat; land-cover; source-role-aware; evidence-bound; release-gated
+tags: [kfm, contracts, habitat, land_cover, README, LandCoverObservation, ClassSchemeProfile, CoverClassCrosswalk, LandCoverChangeSummary, ModelRunReceipt, UncertaintySurface, correction, rollback]
+related:
+  - ../README.md
+  - ../ecoregions/README.md
+  - ../../../../docs/domains/habitat/sublanes/land_cover.md
+  - ../../../../docs/doctrine/directory-rules.md
+  - ../../../../schemas/contracts/v1/domains/habitat/land_cover/README.md
+  - ../../../../fixtures/domains/habitat/land_cover/
+  - ../../../../tests/domains/habitat/land_cover/README.md
+  - ../../../../tools/validators/domains/habitat/README.md
+  - ../../../../policy/domains/habitat/land_cover/
+  - ../../../../pipelines/domains/habitat/land_cover/README.md
+  - ../../../../pipeline_specs/habitat/land_cover/README.md
+notes:
+  - "Directory README required by docs/doctrine/directory-rules.md section 15."
+  - "This directory is authoritative for Habitat land-cover semantic-contract meaning only; it does not own machine shape, executable validation, policy, data, or release authority."
+  - "All six direct contract documents are draft and PROPOSED. Five paired schemas exist as permissive scaffolds; the ModelRunReceipt schema was not found. Field-level enforcement remains NEEDS VERIFICATION."
+[/KFM_META_BLOCK_V2] -->
+
+# Habitat Land Cover Contracts
+
+`contracts/domains/habitat/land_cover/`
+
+## Purpose
+
+This folder owns the semantic meaning, invariants, and anti-collapse boundaries for Habitat land-cover contract objects. It keeps observations, classification schemes, crosswalks, change summaries, model-run receipts, and uncertainty distinct before schemas, validators, pipelines, policy, release, API, map, or AI surfaces use them.
+
+## Authority level
+
+**Canonical responsibility lane for Habitat land-cover semantic-contract Markdown.** Files here define object meaning and field intent under the `contracts/` root; they do not provide machine-checkable shape or executable enforcement.
+
+Authority is deliberately split:
+
+| Concern | Authority |
+|---|---|
+| Land-cover object meaning and invariants | This directory |
+| Machine-checkable field shape | `schemas/contracts/v1/domains/habitat/land_cover/` |
+| Admissibility and sensitivity decisions | `policy/domains/habitat/land_cover/` and `policy/sensitivity/habitat/` |
+| Executable validation and behavioral proof | `tools/validators/`, `fixtures/`, and `tests/` |
+| Source identity, role, rights, and cadence | `data/registry/sources/habitat/` |
+| Processing and configuration | `pipelines/domains/habitat/land_cover/` and `pipeline_specs/habitat/land_cover/` |
+| Publication, correction, and rollback decisions | `release/` |
+
+## Status
+
+**PROPOSED / NEEDS VERIFICATION before promotion.** The directory and six semantic-contract documents are confirmed present. Their prose is draft contract guidance, not proof that consumers or enforcement exist.
+
+Current enforcement posture:
+
+- `observation`, `class_scheme`, `crosswalk`, `change_summary`, and `uncertainty` have paired JSON Schema files, but each schema has empty `properties`, no required fields, and `additionalProperties: true`.
+- `model_run_receipt.md` has no paired schema at `schemas/contracts/v1/domains/habitat/land_cover/model_run_receipt.schema.json` in the inspected tree.
+- `tools/validators/domains/habitat/validate_schema.py` raises `NotImplementedError` and `validate_model_run_receipt.py` is a `PROPOSED` placeholder.
+- No executable test modules were found below `tests/domains/habitat/land_cover/`; the current child lanes are README-level plans.
+- The object-family names, field constraints, fixture corpus, validator behavior, policy rules, CI wiring, and release integration therefore remain **NEEDS VERIFICATION**.
+
+## What belongs here
+
+- Directory orientation for the Habitat land-cover semantic-contract lane.
+- Markdown contracts defining one Habitat land-cover object family or support object.
+- Object identity, field intent, invariants, source-role boundaries, temporal and spatial scope, evidence expectations, and model-versus-observation rules.
+- Semantic requirements for correction, supersession, and rollback references.
+- Compatibility notes for an accepted contract rename or version change, when governed by the required ADR and migration work.
+
+New files belong here only when their primary responsibility is **semantic meaning** and the object cannot be represented by an existing Habitat or shared contract.
+
+## What does NOT belong here
+
+- JSON Schema, JSON-LD contexts, or other machine-shape artifacts.
+- Validator code, test modules, fixtures, golden outputs, or CI configuration.
+- Policy rules, sensitivity decisions, review records, or release approvals.
+- Source descriptors, source exports, RAW/WORK/QUARANTINE/PROCESSED data, catalogs, triplets, proofs, emitted receipts, tiles, or public artifacts.
+- Pipeline code, pipeline specifications, renderer logic, API payloads, UI components, Focus Mode content, or generated AI claims.
+- Species or plant occurrence truth, critical-habitat designation truth, crop truth, hydrology truth, soil truth, hazard truth, land/title truth, or publication authority.
+- Silent class recodes, modeled-as-observed claims, or the treatment of a receipt, schema pass, map layer, or generated summary as evidence by itself.
+
+## Inputs
+
+Contract authors use:
+
+- Habitat doctrine and the land-cover sublane charter under `docs/domains/habitat/`;
+- admitted source-family and SourceDescriptor evidence from `data/registry/sources/habitat/`;
+- reviewed object-family decisions, schema-home rules, and relevant ADRs;
+- paired schema, fixture, test, validator, policy, and release evidence from their owning roots; and
+- steward-reviewed correction or supersession decisions.
+
+Source rasters, lifecycle records, model outputs, and generated summaries are not authored into this folder.
+
+## Outputs
+
+This folder supplies semantic definitions and review vocabulary to schema authors, validator and fixture authors, pipeline implementers, policy reviewers, release stewards, and governed downstream interfaces.
+
+It emits no source data, processed data, proof, policy decision, release manifest, public layer, API response, or AI answer. A contract file does not promote an object or authorize publication.
+
+## Validation
+
+Review each change against the following checks:
+
+1. Confirm the file describes semantic meaning rather than machine shape, policy, execution, data, or release state.
+2. Preserve distinct identities for `LandCoverObservation`, `ClassSchemeProfile`, `CoverClassCrosswalk`, `LandCoverChangeSummary`, `ModelRunReceipt`, and `UncertaintySurface`.
+3. Confirm every claimed schema, fixture, validator, test, policy, source, and release path exists; label absent or incomplete enforcement `PROPOSED` or `NEEDS VERIFICATION`.
+4. Check paired schemas under `schemas/contracts/v1/domains/habitat/land_cover/` for non-empty constraints before claiming field-level enforcement.
+5. Require explicit source role, source vintage, class-scheme/crosswalk posture, spatial and temporal scope, evidence, uncertainty, policy, review, correction, and rollback semantics where material.
+6. Reject silent recoding, modeled-as-observed output, occurrence/regulatory truth collapse, and any contract-to-publication shortcut.
+7. Run repository Markdown/link checks and `git diff --check` available to the change; do not describe the placeholder Habitat validators as passing enforcement.
+
+Active land-cover-specific validator and CI coverage is **not confirmed**. Promotion requires implemented validators, valid and invalid fixtures, executable tests, and verified CI wiring rather than README claims alone.
+
+## Review burden
+
+Changes require review by the Habitat domain steward, land-cover steward, and contract steward. Add schema/validation review when fields or pairing expectations change; source/evidence review for provenance semantics; and policy, sensitivity, release, and correction review when public or sensitive behavior could change.
+
+**CODEOWNERS posture:** CONFIRMED. [`.github/CODEOWNERS`](../../../../.github/CODEOWNERS) assigns the repository wildcard to `@kfm/maintainers` and specifically routes `/contracts/` changes to `@kfm/contract-stewards`. The `OWNER_TBD` domain-role entries above remain assignment gaps; they do not replace that automated contract-steward route.
+
+## Related folders
+
+| Folder | Relationship |
+|---|---|
+| [`../`](../README.md) | Parent Habitat semantic-contract lane. |
+| [`../ecoregions/`](../ecoregions/README.md) | Adjacent Habitat regionalization-context contracts; not land-cover identity. |
+| [`../../../../docs/domains/habitat/`](../../../../docs/domains/habitat/README.md) | Human-facing Habitat doctrine and source-family guidance. |
+| [`../../../../schemas/contracts/v1/domains/habitat/land_cover/`](../../../../schemas/contracts/v1/domains/habitat/land_cover/README.md) | Paired machine-shape lane. |
+| `../../../../fixtures/domains/habitat/land_cover/` | Synthetic child fixture families; no parent `README.md` was confirmed. |
+| [`../../../../tests/domains/habitat/land_cover/`](../../../../tests/domains/habitat/land_cover/README.md) | Planned behavioral proof lanes. |
+| [`../../../../tools/validators/domains/habitat/`](../../../../tools/validators/domains/habitat/README.md) | Habitat validator lane; current scripts are placeholders. |
+| `../../../../policy/domains/habitat/land_cover/` | Policy-family placeholders; no active rule files were confirmed. |
+| [`../../../../pipelines/domains/habitat/land_cover/`](../../../../pipelines/domains/habitat/land_cover/README.md) | Executable processing responsibility. |
+| [`../../../../pipeline_specs/habitat/land_cover/`](../../../../pipeline_specs/habitat/land_cover/README.md) | Declarative processing responsibility. |
+| [`../../../../data/registry/sources/habitat/`](../../../../data/registry/sources/habitat/README.md) | Habitat source descriptors, including NLCD, NWI, and GAP/LANDFIRE profiles. |
+| `../../../../release/` | Publication, correction, and rollback authority; no `release/manifests/habitat/` path was confirmed. |
+
+## ADRs
+
+- [`ADR-0001 — Schema Home`](../../../../docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md) is `proposed` but reflects the Directory Rules boundary: `contracts/` owns meaning and `schemas/contracts/v1/` owns machine shape.
+- [`ADR-0011 — Receipts vs Proofs vs Manifests vs Catalog Separation`](../../../../docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md) is `proposed` and applies to `ModelRunReceipt` separation: a receipt is not proof, catalog truth, or publication.
+- No accepted land-cover-specific ADR was confirmed during this review. A rename that changes object meaning, a new canonical root, or a schema-home change requires ADR-backed migration rather than a README-only decision.
+
+## Current contract inventory
+
+| Contract | Semantic responsibility | Enforcement posture |
+|---|---|---|
+| [`observation.md`](observation.md) | `LandCoverObservation`: governed categorical or continuous classification over declared space and time. | Paired schema is a permissive `PROPOSED` scaffold. |
+| [`class_scheme.md`](class_scheme.md) | `ClassSchemeProfile`: versioned classification vocabulary and class identity. | Paired schema is a permissive `PROPOSED` scaffold. |
+| [`crosswalk.md`](crosswalk.md) | `CoverClassCrosswalk`: explicit, reviewed mapping between schemes; no silent recode. | Paired schema is a permissive `PROPOSED` scaffold. |
+| [`change_summary.md`](change_summary.md) | `LandCoverChangeSummary`: derived comparison between governed observations. | Paired schema is a permissive `PROPOSED` scaffold; threshold enforcement is unverified. |
+| [`model_run_receipt.md`](model_run_receipt.md) | `ModelRunReceipt`: process memory for modeled or transformed output, not proof or release. | Paired schema absent; validator file is a placeholder. |
+| [`uncertainty.md`](uncertainty.md) | `UncertaintySurface`: accuracy, footprint, source-vintage, crosswalk, model, and display caveats. | Paired schema is a permissive `PROPOSED` scaffold. |
+
+## Correction and rollback
+
+Correct or roll back a contract change when it creates parallel authority, overstates enforcement, collapses object families or source roles, permits silent recoding, relabels modeled output as observed, or implies that semantic prose authorizes publication.
+
+A correction must identify affected contract paths and update paired schema links, fixture/test plans, validator references, policy references, downstream consumers, and correction/supersession notes where they exist. If a released artifact depended on the changed meaning, the release steward must handle its correction notice, rollback target, replacement reference, and public-cache invalidation under `release/`; deleting or rewriting contract history is not a substitute.
+
+## Last reviewed
+
+2026-07-16 — draft directory contract; owner assignment, fielded schemas, land-cover validators, executable tests, policy enforcement, CI coverage, and release integration remain **NEEDS VERIFICATION**.

--- a/data/receipts/generated/genrec-missing-readme-contracts-68d7c6e6.json
+++ b/data/receipts/generated/genrec-missing-readme-contracts-68d7c6e6.json
@@ -1,0 +1,136 @@
+{
+  "receipt_id": "genrec-missing-readme-contracts-68d7c6e6",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    "contracts/domains/habitat/land_cover/README.md",
+    "docs/atlases/README.md",
+    "docs/sources/catalog/_template/README.md",
+    "packages/domains/soil/src/soil/README.md"
+  ],
+  "artifact_hashes": {
+    "contracts/domains/habitat/land_cover/README.md": "sha256:fea50218a24b5338242cd4477f229a3d373035f2472a7ebd394b875c19c06929",
+    "docs/atlases/README.md": "sha256:516c290b02b9264f6b09fa5680d067b461b43d186dfdb122df769961ad90ab44",
+    "docs/sources/catalog/_template/README.md": "sha256:65c7558de7415818438efc51ff5b75f1adf9dd5eedd69d3ea741099384a95b70",
+    "packages/domains/soil/src/soil/README.md": "sha256:1486a6bad1a024cecf82cc177385c954f2ec70196b06ef3dc88d0ed5e931ac26"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "GPT-5 Codex",
+    "version": "2026-07-16-work-mode"
+  },
+  "prompt_or_contract": "sha256:fb88e0eff14139c9ea2be49debfec4c401ed57392e01e826575a2e7debef8cc7",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "local git",
+      "repository validation"
+    ]
+  },
+  "inputs": {
+    "attached_docs": [
+      "docs/doctrine/directory-rules.md",
+      "docs/doctrine/ai-build-operating-contract.md"
+    ],
+    "evidence_refs": [
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/9741610a833bc7112a1d42a766fae592baf8f1af",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/docs/doctrine/directory-rules.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/docs/atlas/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/contracts/domains/habitat/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/contracts/domains/habitat/ecoregions/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/docs/sources/catalog/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/docs/sources/catalog/_examples/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/packages/domains/soil/src/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/.github/CODEOWNERS",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/schemas/contracts/v1/receipts/generated_receipt.schema.json"
+    ]
+  },
+  "truth_labels": {
+    "contracts/domains/habitat/land_cover/README.md": "PROPOSED",
+    "docs/atlases/README.md": "PROPOSED",
+    "docs/sources/catalog/_template/README.md": "PROPOSED",
+    "packages/domains/soil/src/soil/README.md": "PROPOSED"
+  },
+  "validation_gates": [
+    {
+      "gate": "repository-and-target-preflight",
+      "outcome": "PASS",
+      "reason": "The repository, authoritative Directory Rules, populated target directories, parent and sibling READMEs, direct file inventories, CODEOWNERS, and current enforcement surfaces were inspected at the pinned audit snapshot."
+    },
+    {
+      "gate": "missing-path-classification",
+      "outcome": "PASS",
+      "reason": "Only four unambiguous folder-contract gaps were selected; proposed runbooks, deprecated aliases, typo paths, compatibility layouts, empty leaves, and unresolved authority homes were excluded."
+    },
+    {
+      "gate": "directory-rules-placement",
+      "outcome": "PASS",
+      "reason": "Each README documents an existing populated directory inside its current responsibility root and creates no new canonical root, parallel authority home, lifecycle phase, implementation, or public path."
+    },
+    {
+      "gate": "markdown-structure-and-links",
+      "outcome": "PASS",
+      "reason": "All four artifacts have one H1, one KFM metadata block, the required section order, balanced fences, final newlines, and resolving relative Markdown links."
+    },
+    {
+      "gate": "whitespace-and-sensitive-content-review",
+      "outcome": "PASS",
+      "reason": "New-file whitespace checks and common private-key, GitHub token, AWS key, and OpenAI token pattern scans passed."
+    },
+    {
+      "gate": "repository-native-validation",
+      "outcome": "PASS",
+      "reason": "PYTHONPATH=/tmp/kfm-validation-deps make validate completed successfully: valid schema fixtures passed, invalid fixtures were rejected as expected, and 16 schema/contract tests passed."
+    },
+    {
+      "gate": "runtime-and-executable-behavior",
+      "outcome": "SKIPPED",
+      "reason": "Documentation-only change; no package behavior, validator, schema, policy, fixture payload, pipeline, workflow, release object, runtime, or public artifact changed."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "directory-readme-contract",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/docs/doctrine/directory-rules.md"
+    },
+    {
+      "id": "atlas-canonical-lane",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/docs/atlas/README.md"
+    },
+    {
+      "id": "habitat-land-cover-contract-inventory",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/contracts/domains/habitat/README.md"
+    },
+    {
+      "id": "source-catalog-template-lane",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/docs/sources/catalog/README.md"
+    },
+    {
+      "id": "soil-source-namespace",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/9741610a833bc7112a1d42a766fae592baf8f1af/packages/domains/soil/src/README.md"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-17T03:55:10Z",
+  "emitter": "openai-codex/gpt-5",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "AI-authored documentation-hygiene change on a scoped review branch. The four README files document existing repository state and responsibility boundaries without filling speculative paths or claiming unimplemented enforcement. Human review remains pending; this receipt is provenance evidence, not merge authorization, source admission, policy permission, evidence closure, release approval, or publication authority."
+}

--- a/docs/atlases/README.md
+++ b/docs/atlases/README.md
@@ -1,0 +1,152 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/docs-atlases-readme
+title: docs/atlases/ — Atlas Documentation Lane
+type: README; directory-readme; documentation-index
+version: v0.1
+status: draft; repository-grounded; canonical-lane; naming-conflicted
+owners: @kfm/maintainers; docs-steward-NEEDS-VERIFICATION; atlas-editor-NEEDS-VERIFICATION
+created: 2026-07-16
+updated: 2026-07-16
+policy_label: public
+current_path: docs/atlases/README.md
+truth_posture: >
+  CONFIRMED current directory inventory, Directory Rules v1.4 placement rule and
+  anti-pattern resolution, wildcard CODEOWNERS coverage, and documentation QA
+  scaffolds / PROPOSED atlas-carrier and chapter-extract authority choices,
+  filename reconciliation, PDF placement, and dedicated docs validation / NEEDS
+  VERIFICATION ADR acceptance, named docs steward and atlas editor, rendered
+  publication path, and external-link state
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  base_ref: main
+  base_commit: 9741610a833bc7112a1d42a766fae592baf8f1af
+  reviewed_at: 2026-07-16
+related:
+  - ../doctrine/directory-rules.md
+  - ../atlas/README.md
+  - master-atlas-v1.1/README.md
+  - KFM_Domains_Culmination_Atlas_v1_1.pdf/README.md
+  - ../../.github/CODEOWNERS
+  - ../../tools/docs/README.md
+  - ../../tools/validators/docs/README.md
+tags: [kfm, docs, atlases, directory-readme, navigation, drift-control]
+notes:
+  - "This README documents the observed lane; it does not select a canonical atlas-carrier filename or accept an ADR."
+  - "At the evidence snapshot, twelve pre-existing direct Markdown files and two direct child directories were present; no direct PDF file was present."
+  - "The PDF-suffixed child is a directory and its own README records the unresolved collision with the proposed PDF file path."
+[/KFM_META_BLOCK_V2] -->
+
+# `docs/atlases/`
+
+## Purpose
+
+`docs/atlases/` is the canonical documentation lane for versioned KFM atlases, atlas navigation carriers, and reviewable atlas-derived reference material. It explains and indexes atlas content; it does not replace contracts, schemas, policy, evidence, or release decisions.
+
+## Authority level
+
+**Canonical documentation lane; human-facing and non-machine-authoritative.** Directory Rules v1.4 §6.1 places versioned atlases and dossiers here, and §13.5 selects this plural lane over the duplicate `docs/atlas/` path.
+
+The lane choice does not make every file inside it canonical. Several current carriers and the `master-atlas-v1.1/` chapter layout explicitly identify themselves as `PROPOSED`, `CONFLICTED`, pointer-only, or working extracts. When a document conflicts with an accepted contract, schema, policy decision, evidence object, or release record, the owning authority root wins.
+
+## Status
+
+**CONFIRMED lane; mixed-content maturity; naming reconciliation open.**
+
+- **CONFIRMED:** `docs/atlases/` exists and is the Directory Rules choice over `docs/atlas/`.
+- **CONFIRMED:** the reviewed snapshot contained twelve pre-existing direct Markdown files and two direct child directories; no direct PDF file was present.
+- **CONFLICTED:** multiple Markdown carriers cover overlapping atlas scope under different filename conventions.
+- **PROPOSED:** the chapter-extract layout under `master-atlas-v1.1/` and the final PDF placement described by current documents.
+- **NEEDS VERIFICATION:** acceptance of ADR-S-02, a canonical atlas-carrier filename, named stewards, and a publication/rendering pipeline.
+
+This README records the current inventory without resolving those open decisions.
+
+## What belongs here
+
+Accepted content is limited to:
+
+- versioned atlas carriers and explicit pointer/navigation files;
+- atlas-derived, human-readable registers and crosswalks whose upstream authority and truth posture are stated;
+- per-edition child folders when their layout status and relationship to the source atlas are explicit;
+- companion documentation for an atlas artifact, provided its path cannot collide with the artifact itself;
+- this directory contract and navigation index.
+
+### Current inventory
+
+| Group | Observed entries | Current boundary |
+|---|---|---|
+| Atlas carriers and pointers | `KFM_Domains_Culmination_Atlas_v1_1.md`, `KFM_Domains_v1_1_plus_Pass23_Pass32_Consolidated_Atlas.md`, `domains-atlas-v1.1.md`, `domains-v1.1-ch14.md`, `domains-v1.1.md`, `kfm-domains-v1.1-pass23-32-consolidated-atlas.md` | Overlapping names and roles are explicitly conflicted; this README does not select among them. |
+| Atlas-derived references | `maplibre-master.md`, `pipeline-gate-reference.md`, `receipt-catalog.md`, `sensitivity-tier-reference.md`, `source-role-anti-collapse.md`, `stale-state-reference.md` | Human-facing references only; they do not become machine authority by living here. |
+| Child lanes | `master-atlas-v1.1/`, `KFM_Domains_Culmination_Atlas_v1_1.pdf/` | The first documents a proposed chapter-extract layout. The second is a directory whose own README records a collision with the proposed PDF file path. |
+
+Before adding another carrier, confirm that it does not duplicate an existing scope or filename role. Current files repeatedly identify an atlas-Markdown naming ADR as blocking further carrier proliferation.
+
+## What does NOT belong here
+
+- Machine schemas, semantic contracts, or policy code; use `schemas/`, `contracts/`, and `policy/`.
+- Evidence bundles, proofs, receipts, promotion decisions, release manifests, or correction records; use their governed data and release roots.
+- Source datasets, generated tiles, application code, runtime configuration, or build output.
+- Per-domain operational documentation that belongs in `docs/domains/` or `docs/runbooks/`.
+- New atlas content under `docs/atlas/`; that singular lane is a compatibility/deprecation surface.
+- Another spelling, case, or punctuation variant of an existing carrier without an accepted naming decision and migration plan.
+- A directory named like a final artifact when that directory blocks the artifact's file path. The existing `.pdf/` collision is recorded here as unresolved, not endorsed as a pattern.
+
+## Inputs
+
+Inputs may include manually reviewed atlas editions, bounded Markdown extracts, atlas-to-domain crosswalks, accepted corrections, and navigation metadata from the owning documentation lanes. Each file must identify its upstream source, edition, truth posture, and supersession relationship.
+
+No executable atlas generator or accepted PDF build pipeline was verified in the reviewed snapshot. Generated or converted content therefore needs explicit provenance and human review before it is treated as more than a draft.
+
+## Outputs
+
+This lane supports:
+
+- human-readable atlas navigation and edition discovery;
+- reviewable Markdown carriers and chapter extracts;
+- cross-links from domain, architecture, doctrine, and register documentation;
+- documented inputs to steward review, correction, supersession, and future ADR work.
+
+It emits no policy decision, evidence closure result, schema conformance result, promotion approval, or release state by itself.
+
+## Validation
+
+For changes in this lane:
+
+1. Run `git diff --check`.
+2. Confirm every added or changed relative link and referenced local path resolves in the current tree.
+3. Review the KFM meta block, truth labels, edition lineage, supersession wording, and authority boundary against the changed source material.
+4. Check that no new carrier duplicates an existing role and that no path reintroduces `docs/atlas/` as writable authority.
+5. If content is generated or converted, verify its declared source and review record separately from the Markdown diff.
+
+There is no verified executable atlas-specific validator. At the reviewed snapshot, `.github/workflows/docs-build.yml` and `.github/workflows/link-check.yml` are TODO-only workflow stubs, `tools/docs/` contains no executable helper, and the child lanes under `tools/validators/docs/` contain README scaffolds plus `.gitkeep` files rather than validator programs. Do not cite those surfaces as successful enforcement.
+
+## Review burden
+
+`.github/CODEOWNERS` has no `docs/atlases/`-specific rule, so changes currently fall through to the repository-wide `@kfm/maintainers` owner.
+
+Substantive atlas changes should also receive review from the affected domain or subsystem steward and a docs/atlas editor. The exact handles for those roles are **NEEDS VERIFICATION**. Changes that choose a canonical filename, alter authority, or migrate an artifact path must include the relevant ADR or migration record rather than resolving the choice in an ordinary content edit.
+
+## Related folders
+
+| Folder | Relationship |
+|---|---|
+| [`../atlas/`](../atlas/) | Deprecated compatibility/mirror lane; do not add new atlas content there. |
+| [`master-atlas-v1.1/`](master-atlas-v1.1/) | Proposed per-chapter Markdown extract layout for Atlas v1.1. |
+| [`KFM_Domains_Culmination_Atlas_v1_1.pdf/`](KFM_Domains_Culmination_Atlas_v1_1.pdf/) | Existing PDF-suffixed directory; its README documents the unresolved artifact-path collision. |
+| [`../domains/`](../domains/) | Per-domain documentation and dossier context. |
+| [`../doctrine/`](../doctrine/) | Placement, authority, lifecycle, and truth-posture doctrine. |
+| [`../adr/`](../adr/) | Accepted and proposed architecture decisions; no ADR-S-02 file was found in the reviewed snapshot. |
+| [`../registers/`](../registers/) | Drift, verification, and document-register surfaces. |
+| [`../../tools/docs/`](../../tools/docs/) | Documentation-tooling boundary; executable helpers were not present at review time. |
+| [`../../tools/validators/docs/`](../../tools/validators/docs/) | Proposed documentation-validator lanes; no executable child validator was present at review time. |
+
+## ADRs
+
+- **ADR-S-02 — doctrine artifact placement under `docs/` (`dossiers/` vs `atlases/`):** referenced by Directory Rules and multiple atlas documents, but no matching ADR file was found. Acceptance remains **NEEDS VERIFICATION**.
+- **Atlas-Markdown naming decision:** repeatedly proposed by current carrier files to reconcile overlapping filename conventions. No accepted ADR file was found; further carrier variants should wait for that decision.
+- **Directory Rules v1.4 §13.5, “Docs naming duplication”:** the current documented resolution is to use `docs/atlases/` and deprecate or mirror `docs/atlas/`. Directory Rules §18 records OPEN-DR-09-h as the associated drift item.
+
+This README implements the existing folder-README requirement; it does not accept, number, or supersede an ADR.
+
+## Last reviewed
+
+2026-07-16 — reviewed against the direct directory inventory, `docs/atlas/README.md`, Directory Rules v1.4 §§6.1, 13.5, and 15, `.github/CODEOWNERS`, documentation workflow stubs, and the currently present docs-tooling and docs-validator files at commit `9741610a833bc7112a1d42a766fae592baf8f1af`.

--- a/docs/sources/catalog/_template/README.md
+++ b/docs/sources/catalog/_template/README.md
@@ -1,0 +1,116 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/docs-sources-catalog-template-readme
+title: docs/sources/catalog/_template README
+type: readme
+version: v0.1
+status: draft
+owners: ["@kfm/maintainers"]
+created: 2026-07-16
+updated: 2026-07-16
+policy_label: public
+owning_root: docs/
+responsibility: documentation-only templates for human-authored source-catalog pages
+truth_posture: repository inventory confirmed; template content remains proposed until completed and reviewed
+related:
+  - docs/sources/catalog/README.md
+  - docs/sources/catalog/_examples/README.md
+  - docs/doctrine/directory-rules.md
+  - docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md
+  - docs/adr/ADR-0017-source-descriptor-admission-process.md
+notes:
+  - "The four template files listed here were present in the repository on 2026-07-16."
+  - "This folder is documentation-only and does not define machine contracts, schemas, policy, source admission, or release authority."
+[/KFM_META_BLOCK_V2] -->
+
+# `_template`
+
+## Purpose
+
+This folder owns reusable Markdown starting points for human-authored pages in `docs/sources/catalog/`. It helps authors keep source-family, source-product, crosswalk, and rights-note documentation consistent without creating a second source of machine authority.
+
+## Authority level
+
+`exploratory` — documentation-only, non-authoritative scaffolding. The templates may explain repository contracts, schemas, policy, and source records, but they cannot replace or amend them.
+
+## Status
+
+`CONFIRMED` as a repository folder containing the four templates inventoried below. Each template is marked `draft` or `PROPOSED`; a copied page remains draft until its placeholders, links, source facts, and review requirements are resolved.
+
+## What belongs here
+
+Only Markdown templates for source-catalog documentation and this routing README belong here.
+
+| Template | Intended destination | Current role |
+|---|---|---|
+| [`SOURCE_FAMILY_TEMPLATE.md`](./SOURCE_FAMILY_TEMPLATE.md) | `<family>/README.md` | Source-family orientation and routing. |
+| [`SOURCE_PRODUCT_TEMPLATE.md`](./SOURCE_PRODUCT_TEMPLATE.md) | `<family>/<product-name>.md` | Product-level catalog-profile, provenance, temporal, geometry, rights, and sensitivity notes. |
+| [`CROSSWALK_TEMPLATE.md`](./CROSSWALK_TEMPLATE.md) | An authored crosswalk page | Explanatory field mapping between two standards. |
+| [`RIGHTS_NOTE_TEMPLATE.md`](./RIGHTS_NOTE_TEMPLATE.md) | A rights note beside a family or product page | Per-source rights and sensitivity documentation that points to policy and source records. |
+
+Copying rules:
+
+1. Copy the closest matching template to its intended authored destination; do not use `_template/` as the home for a real source or product page.
+2. Give the destination one unique, destination-specific `KFM_META_BLOCK_V2`. Do not reuse the template asset's `doc_id`, and remove the literal `<KFM Meta Block v2 — ...>` instruction line.
+3. Replace every angle-bracket token and every `PLACEHOLDER`. Resolve each `NEEDS VERIFICATION`, `PROPOSED`, and `UNKNOWN` marker with repository or cited source evidence, or retain the marker when uncertainty is real.
+4. Rebase relative links for the destination directory. A link that works from `_template/` may not work from a family directory or product page.
+5. Do not invent identifiers, checksums, endpoint URLs, license terms, rights grants, sensitivity tiers, source roles, or catalog support. Link to the owning machine or policy artifact instead.
+6. Keep the original template unchanged unless the change is an intentional improvement for every future copy.
+
+## What does NOT belong here
+
+- Completed source-family, source-product, crosswalk, or rights-note pages.
+- `SourceDescriptor` records or source-admission decisions.
+- Contracts, JSON Schemas, policy rules, validator code, fixtures, catalog artifacts, receipts, proofs, or release manifests.
+- Source facts copied from a template without current verification.
+- Filled examples; illustrative payloads belong in [`_examples/`](../_examples/README.md).
+- Alternate template copies that drift from one of the four inventoried templates.
+
+## Inputs
+
+- Manual authoring based on the lane rules in [`docs/sources/catalog/README.md`](../README.md).
+- Placement and folder-README requirements from [`docs/doctrine/directory-rules.md`](../../../doctrine/directory-rules.md).
+- Object meaning from `contracts/`, machine shapes from `schemas/contracts/v1/`, decisions from `policy/`, and source records from `data/registry/sources/`.
+- Current repository evidence for links, validators, fixtures, and workflow status.
+
+## Outputs
+
+- Human-readable Markdown drafts placed under `docs/sources/catalog/`.
+- Cross-links from those drafts to their owning contracts, schemas, policy, source records, connectors, validators, and catalog lanes.
+- No machine-authoritative artifact and no publication or source-admission decision.
+
+## Validation
+
+For a template or copied page:
+
+- run `git diff --check` for whitespace and patch errors;
+- verify that every local link resolves from the authored destination;
+- search the authored file for unresolved angle-bracket tokens and `PLACEHOLDER` text;
+- when the page names a `SourceDescriptor`, validate the machine record with `python tools/validators/validate_source_descriptor.py --fixtures` or the fixture-backed aggregate runner `python tools/validators/_common/run_all.py`.
+
+The confirmed source-descriptor validator checks `schemas/contracts/v1/source/source_descriptor.schema.json` against `fixtures/contracts/v1/source/source_descriptor/`; it does **not** validate these Markdown templates. The current `docs-build`, `link-check`, and `source-descriptor-validate` GitHub workflows are present but execute `echo TODO ...`, so they are not evidence of an implemented template or documentation gate. No executable dedicated to validating this template folder is confirmed.
+
+## Review burden
+
+`.github/CODEOWNERS` has no narrower rule for `docs/sources/` or this folder, so the repository-wide fallback assigns changes to `@kfm/maintainers`. A copied page that changes source, rights, sensitivity, schema, or catalog claims also needs review from the relevant owner before its draft labels can be strengthened, even though that additional routing is not encoded in the current `CODEOWNERS` file.
+
+## Related folders
+
+- [`docs/sources/catalog/`](../README.md) — parent human-facing source-catalog lane.
+- [`docs/sources/catalog/_examples/`](../_examples/README.md) — illustrative payloads, explicitly non-authoritative.
+- [`docs/sources/`](../../README.md) — parent source-documentation lane.
+- [`schemas/contracts/v1/source/`](../../../../schemas/contracts/v1/source/) — current machine schema family referenced by the source-descriptor validator.
+- [`fixtures/contracts/v1/source/source_descriptor/`](../../../../fixtures/contracts/v1/source/source_descriptor/) — current source-descriptor fixtures.
+- [`tools/validators/validate_source_descriptor.py`](../../../../tools/validators/validate_source_descriptor.py) — confirmed fixture-backed SourceDescriptor validator entrypoint.
+- [`data/registry/sources/`](../../../../data/registry/sources/) — source-record lane; its contents, not these templates, carry repository source records.
+
+## ADRs
+
+No accepted ADR is confirmed as assigning authority to `_template/` itself. The following present ADR files are `proposed` and inform authored destinations without making these templates machine authority:
+
+- [`ADR-0001 — Schema Home`](../../../adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md) — proposed separation of semantic contracts from machine-checkable schemas.
+- [`ADR-0017 — Source Descriptor Admission Process`](../../../adr/ADR-0017-source-descriptor-admission-process.md) — proposed source-admission and descriptor discipline.
+- [`ADR-0022 — Catalog Matrix`](../../../adr/ADR-0022-catalog-matrix--stac-+-dcat-+-prov-must-agree.md) — proposed STAC, DCAT, and PROV catalog-closure agreement.
+
+## Last reviewed
+
+2026-07-16

--- a/packages/domains/soil/src/soil/README.md
+++ b/packages/domains/soil/src/soil/README.md
@@ -1,0 +1,142 @@
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/packages-domains-soil-src-soil-readme
+title: Soil Python Source Namespace
+type: readme
+version: v0.1
+status: draft; repository-grounded; greenfield-scaffold
+owners:
+  - OWNER_TBD — Soil package/domain steward
+  - OWNER_TBD — Validation reviewer
+created: 2026-07-16
+updated: 2026-07-16
+policy_label: public; packages; soil; implementation; non-authoritative
+path: packages/domains/soil/src/soil/README.md
+truth_posture: CONFIRMED package name and version, bounded file inventory, empty __init__.py, one-line placeholder modules, adjacent authority roots, and placeholder CODEOWNERS / UNKNOWN imports, public API, consumers, dependencies, build backend, test results, CI, runtime behavior, evidence closure, and release behavior / PROPOSED future helper behavior only
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  base_ref: main
+  base_commit: 9741610a833bc7112a1d42a766fae592baf8f1af
+related:
+  - ../README.md
+  - ../../README.md
+  - ../../pyproject.toml
+  - ../../../../../docs/domains/soil/README.md
+  - ../../../../../contracts/domains/soil/README.md
+  - ../../../../../schemas/contracts/v1/domains/soil/
+  - ../../../../../policy/domains/soil/
+  - ../../../../../tests/domains/soil/
+  - ../../../../../fixtures/domains/soil/
+  - ../../../../../docs/doctrine/directory-rules.md
+tags: [kfm, soil, python, package, source-namespace, greenfield]
+notes:
+  - "This README records the namespace as found; it does not claim that placeholder modules implement behavior."
+  - "Only importable Soil helper code belongs here; authority-bearing records remain in their governing roots."
+[/KFM_META_BLOCK_V2] -->
+
+# Soil Python Source Namespace
+
+`packages/domains/soil/src/soil/` is the importable-code boundary for the `kfm-domain-soil` package. The current package is a `0.0.0` greenfield scaffold, not an implemented library.
+
+## Purpose
+
+This folder owns future reusable Python helpers for the Soil domain. Helpers may transform or validate caller-supplied candidates, but they must not become an authority for soil truth, policy, evidence, lifecycle state, or release.
+
+## Authority level
+
+**Implementation-bearing boundary; currently a non-functional greenfield scaffold.**
+
+The namespace may implement accepted contracts and schemas. It does not define them, approve inputs, make policy decisions, close evidence, or authorize publication.
+
+## Status
+
+**CONFIRMED scaffold / UNKNOWN runtime behavior.** The bounded inventory at `main@9741610a833bc7112a1d42a766fae592baf8f1af` is:
+
+| File | Repository evidence | Implemented behavior |
+| --- | --- | --- |
+| `__init__.py` | Empty file | None; no exports or public API are declared. |
+| `identity.py` | One line: greenfield identity-normalization placeholder | None. |
+| `layers.py` | One line: greenfield layer-descriptor placeholder | None. |
+| `observations.py` | One line: greenfield observation-parsing placeholder | None. |
+
+`packages/domains/soil/pyproject.toml` declares package name `kfm-domain-soil` and version `0.0.0`; it does not declare dependencies or a build backend. Imports, packaging, consumers, test results, CI wiring, and production behavior remain **UNKNOWN**.
+
+## What belongs here
+
+- importable, deterministic Soil helper modules;
+- identity normalization that preserves source-native identifiers and ambiguity;
+- candidate observation parsing that preserves source, units, timestamps, depth, and quality context;
+- candidate layer-description helpers that preserve evidence and release references supplied by callers;
+- small internal value objects and explicit result types needed by those helpers;
+- package-local documentation describing implemented interfaces.
+
+Any future code must keep source values and governance references visible, avoid hidden I/O, and return explicit failures instead of inventing missing facts.
+
+## What does NOT belong here
+
+- semantic contracts or JSON Schemas;
+- executable policy or sensitivity rules;
+- source descriptors, credentials, fetchers, or admission decisions;
+- raw, work, quarantine, processed, catalog, triplet, or published data;
+- receipts, proofs, EvidenceBundles, release manifests, correction notices, or rollback records;
+- pipeline orchestration, public API routes, UI components, or map styles;
+- code that claims an observation is true, admissible, evidence-closed, reviewed, or released;
+- import-time network access, filesystem/database writes, secret loading, or publication side effects.
+
+Those concerns belong to their responsibility roots under `contracts/`, `schemas/`, `policy/`, `data/`, `pipelines/`, `release/`, and `apps/`.
+
+## Inputs
+
+Future functions may accept explicit, caller-supplied values from governed pipelines, validators, tests, and synthetic fixtures. Inputs should carry the source identity, support type, native identifiers, units, temporal context, quality flags, evidence references, policy context, and release references required by the accepted interface.
+
+This namespace must not silently fetch a missing value or infer authority from a filename, import path, or UI state.
+
+## Outputs
+
+Future modules may return normalized **candidates**, parsed values, candidate layer descriptors, or structured validation findings for downstream gates. An output from this namespace is not, by itself, a canonical soil object, policy decision, proof, receipt, lifecycle promotion, released artifact, or public claim.
+
+No output contract exists today because all three named modules are placeholders and `__init__.py` is empty.
+
+## Validation
+
+The following are review commands, not claims that this README or the current scaffold has passed them:
+
+```bash
+python -m compileall packages/domains/soil/src/soil
+python -m pytest tests/domains/soil -q
+python tools/validators/_common/run_all.py
+git diff --check
+```
+
+When behavior is implemented, reviewers should also require tests for malformed and ambiguous inputs, preservation of native identifiers and units, no-network operation, import-time side effects, and attempts to bypass contract, policy, evidence, or release authority.
+
+## Review burden
+
+Changes require the Soil package/domain steward and a reviewer for every authority surface the change consumes: contract/schema, policy/sensitivity, evidence, or release. `.github/CODEOWNERS` currently provides only the repository-wide `@kfm/maintainers` fallback for this path; a Soil-specific owner is not declared.
+
+Reviewers must verify that code remains inside the importable-helper boundary, that any public export is intentional, and that tests demonstrate behavior without promoting placeholder intent to fact.
+
+## Related folders
+
+- [`packages/domains/soil/`](../..): package overview and `pyproject.toml`.
+- [`packages/domains/soil/src/`](..): source-root boundary.
+- [`docs/domains/soil/`](../../../../../docs/domains/soil/): human-facing Soil domain documentation.
+- [`contracts/domains/soil/`](../../../../../contracts/domains/soil/): semantic contract authority.
+- [`schemas/contracts/v1/domains/soil/`](../../../../../schemas/contracts/v1/domains/soil/): machine-shape authority.
+- [`policy/domains/soil/`](../../../../../policy/domains/soil/): Soil policy authority.
+- [`tests/domains/soil/`](../../../../../tests/domains/soil/): current Soil-domain tests.
+- [`fixtures/domains/soil/`](../../../../../fixtures/domains/soil/): current Soil-domain fixtures.
+- [`docs/doctrine/directory-rules.md`](../../../../../docs/doctrine/directory-rules.md): placement and README contract.
+
+## ADRs
+
+- [`ADR-0001 — schema home`](../../../../../docs/adr/ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md) is **proposed** and identifies `schemas/contracts/v1/` as the candidate canonical schema home.
+
+No accepted ADR inspected for this change establishes a Soil-specific Python API or transfers contract, schema, policy, evidence, or release authority into this namespace.
+
+## Rollback
+
+This documentation-only addition is reversible by removing this README. If future code changes break callers, preserve evidence and release records, revert or supersede the code change through normal review, restore the last reviewed interface, and record any required correction in the governing release lane. Do not rewrite contracts, receipts, proofs, or published history to make an implementation rollback appear clean.
+
+## Last reviewed
+
+2026-07-16 — repository inventory and boundary reviewed; implementation and validation results remain unverified.


### PR DESCRIPTION
## Goal

Add the missing Directory Rules §15 folder contracts for four existing, populated repository directories, while preserving their current authority boundaries and implementation maturity.

## Status labels

- [x] `CONFIRMED` — target directories, direct inventories, parent/sibling contracts, CODEOWNERS, and available validation surfaces were inspected.
- [x] `PROPOSED` — all four new README artifacts remain draft pending human review.
- [x] `NEEDS VERIFICATION` — unresolved ownership, enforcement, and ADR-dependent details are called out in place.
- [x] `UNKNOWN` — unverified runtime, consumer, and publication behavior is not promoted to fact.

## Evidence inspected

- `docs/doctrine/directory-rules.md` §§6.1, 13.5, and 15
- `docs/doctrine/ai-build-operating-contract.md` Part IX
- `docs/atlas/README.md` and the direct `docs/atlases/` inventory
- `contracts/domains/habitat/README.md`, `ecoregions/README.md`, six land-cover contracts, paired schemas, validators, fixtures, and tests
- `docs/sources/catalog/README.md`, `_examples/README.md`, and all four catalog templates
- `packages/domains/soil/src/README.md`, `pyproject.toml`, namespace modules, sibling package READMEs, tests, and fixtures
- `.github/CODEOWNERS`
- `schemas/contracts/v1/receipts/generated_receipt.schema.json`

## Directory Rules basis

- §15 requires a folder README contract with purpose, authority, status, boundaries, inputs/outputs, validation, review, relationships, ADRs, and review date.
- §13.5 selects `docs/atlases/` as the canonical plural lane and treats `docs/atlas/` as deprecated/mirrored.
- Responsibility-root placement is unchanged: semantic meaning stays in `contracts/`, human documentation in `docs/`, reusable code boundaries in `packages/`, and generated provenance in `data/receipts/generated/`.
- No new root, parallel authority home, lifecycle phase, or public path is introduced.

## Affected roots

- [x] `docs/`
- [ ] `schemas/`
- [x] `contracts/`
- [ ] `policy/`
- [ ] `data/registry/`
- [ ] `tools/`
- [x] `packages/`
- [ ] `apps/`
- [ ] `pipelines/`
- [ ] `release/`
- [ ] `runtime/` / `infra/` / `configs/`
- [x] Other: `data/receipts/generated/`

Cross-cutting: repository-wide README-contract hygiene across existing responsibility roots; each artifact documents only its own current boundary.

## Affected object families

- [ ] `SourceDescriptor`
- [ ] `EvidenceRef` / `EvidenceBundle`
- [ ] `PolicyDecision`
- [ ] `ValidationReport`
- [ ] `RunReceipt`
- [ ] `AIReceipt`
- [x] `GENERATED_RECEIPT.json`
- [ ] `CitationValidationReport`
- [ ] `RuntimeResponseEnvelope`
- [ ] `PromotionDecision` / `ReleaseManifest`
- [ ] `CorrectionNotice` / `RollbackCard`
- [ ] `LayerManifest` / `MapReleaseManifest`
- [ ] `RedactionReceipt`
- [ ] None

## Affected lifecycle stages

- [ ] RAW
- [ ] WORK / QUARANTINE
- [ ] PROCESSED
- [ ] CATALOG / TRIPLET
- [ ] PUBLISHED
- [x] None — pure documentation/provenance change

## What changed

- Added `docs/atlases/README.md` for the confirmed canonical atlas lane and recorded internal carrier/path drift without resolving it.
- Added `contracts/domains/habitat/land_cover/README.md` for the six present semantic contracts and their currently incomplete enforcement posture.
- Added `docs/sources/catalog/_template/README.md` with the four-template inventory and safe copy/placeholder rules.
- Added `packages/domains/soil/src/soil/README.md` for the present `0.0.0` greenfield Python namespace.
- Added the required generated-work receipt with per-artifact SHA-256 closure.

## What did not change

- No source code, schemas, policies, fixtures, tests, validators, workflows, pipelines, releases, runtime behavior, or public artifacts changed.
- No proposed runbook, deprecated alias, typo path, empty leaf, or unresolved authority home was created.
- No implementation or enforcement claim was strengthened beyond inspected evidence.

## Validation

**Performed:**

- Required heading-order, one-H1, KFM metadata, fence-balance, final-newline, and relative-link checks passed for all four READMEs.
- New-file whitespace checks and `git diff --cached --check` passed.
- Common private-key and token pattern scan passed.
- Generated receipt validates against `generated_receipt.schema.json`; artifact path/hash/truth-label closure passed.
- `PYTHONPATH=/tmp/kfm-validation-deps make validate` passed: valid fixtures accepted, invalid fixtures rejected as expected, and 16 schema/contract tests passed.
- Remote readback matched all five local Git blob SHAs exactly.

**Not performed (and why):**

- Runtime, pipeline, release, atlas-render, package-build, and land-cover enforcement tests were not run because this diff is documentation-only and several named surfaces are confirmed placeholders.

## Rollback

Revert commit `4138798ff1a30f98abec8d9c8ffd3b348853b766` or remove the five newly added files. No data migration, schema migration, cache action, or release rollback is required.

## Open `UNKNOWN` / `NEEDS VERIFICATION`

- Atlas carrier naming, the PDF-suffixed directory collision, and ADR-S-02 acceptance.
- Habitat land-cover fielded schemas, model-run-receipt schema, executable validators/tests, and release integration.
- Soil package imports, build backend, consumers, API surface, and runtime behavior.
- Dedicated catalog-template/docs validation and named non-default stewards.

## Sensitive domains involved

- [x] None of the §23.1 categories apply; this change contains no sensitive payload, exact location, personal data, or access detail.
- [ ] One or more apply:

Required additional reviewer(s): `@kfm/contract-stewards` for the contract-root addition; relevant Habitat/Soil/docs stewards remain `OWNER_TBD`.

## Anti-prompt-injection check

- [x] No injection signals detected.
- [ ] Signal(s) detected and surfaced (not acted on):

## GENERATED_RECEIPT

- [ ] No AI-authored files in this diff.
- [x] AI-authored files present; `GENERATED_RECEIPT.json` attached or linked:

GENERATED_RECEIPT path or link: `data/receipts/generated/genrec-missing-readme-contracts-68d7c6e6.json`

## ADR triggers

- [ ] Adds/removes/renames a canonical root.
- [ ] Changes schema-home authority.
- [ ] Creates a parallel home (schemas/contracts/policy/registry/release).
- [ ] Changes lifecycle phase boundaries.
- [ ] Approves a direct public access path.
- [ ] Adopts a model runtime envelope.
- [ ] Changes promotion gates.
- [ ] Changes sensitive-location posture.
- [ ] Changes source-ledger authority.
- [ ] Changes release/proof/receipt separation.
- [ ] Introduces or retires a domain steward role.
- [ ] Changes `CONTRACT_VERSION` pinning.
- [x] None of the above.

ADR link: N/A

## CONTRACT_VERSION followed

`3.0.0`

## Remote CI status

- 37 of 38 GitHub Actions workflows passed.
- `promotion-gate / doctrine-artifact-prereq` failed on the repository's pre-existing required-doctrine-artifact blocker: `KFM_Pass_18_Idea_Index_Category_Atlas_and_Expansion_Dossier.pdf`, `Master_MapLibre_Components-Functions-Features.pdf`, and `Kansas_Frontier_Matrix_Definitive_Greenfield_Building_Plan_v1_1.pdf` are absent from both the PR base and head.
- `control_plane/doctrine_artifact_provenance_sources.yaml` marks all three sources `NEEDS_VERIFICATION`, and `docs/registers/DRIFT_REGISTER.md` already records the blocker. This PR does not fabricate placeholder doctrine artifacts.
