### PR TITLE
docs(ci): ground workflow README in repository evidence

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,65 +2,133 @@
 doc_id: kfm://doc/github-workflows-readme
 title: .github/workflows README
 type: README
-version: v0.1
-status: draft
+version: v0.2
+status: draft; repository-grounded workflow inventory
 owners: <repo stewards · governance reviewers · CI maintainers — placeholder, confirm via .github/CODEOWNERS>
 created: 2026-07-08
-updated: 2026-07-08
+updated: 2026-07-17
 policy_label: public; github-actions; workflow-governance; ci; fail-closed; non-publisher; release-gated; non-authoritative
 owning_root: .github/
-responsibility: workflow-subtree README for GitHub Actions orchestration; documents workflow placement, check-name discipline, CI/runtime policy-parity expectations, no-network/default-fail-closed posture, watcher-as-non-publisher constraints, generated-report boundaries, branch-protection coupling, CODEOWNERS review posture, and finite gate outcomes while deferring validator logic, watcher logic, policy, schemas, contracts, tests, fixtures, evidence/proofs/receipts, release decisions, lifecycle data, and public runtime behavior to their owning roots
-truth_posture: cite-or-abstain; implementation claims require current repo evidence
+responsibility: workflow-subtree README for GitHub Actions orchestration; records the repository-grounded workflow inventory, trigger and permission posture, local-parity commands, stub-vs-command-bearing maturity, check-name discipline, non-publisher constraints, generated-output boundaries, and open verification work while deferring validator logic, policy, schemas, contracts, tests, fixtures, evidence, proofs, receipts, release decisions, lifecycle data, and public runtime behavior to their owning roots
+truth_posture: cite-or-abstain; implementation claims are bounded to the evidence snapshot below
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  base_ref: main
+  base_commit: 66610a2ee8bdc15713d1e5a5b0350081a1d7771c
+  inventory_method: GitHub connector file reads plus code-index queries for workflow jobs and explicit greenfield-stub markers
 related:
   - ../README.md
   - ../CODEOWNERS
+  - ../PULL_REQUEST_TEMPLATE.md
   - ../../README.md
   - ../../SECURITY.md
   - ../../Makefile
-  - ../../tools/README.md
+  - ../../docs/doctrine/directory-rules.md
+  - ../../docs/doctrine/ai-build-operating-contract.md
+  - ../../docs/registers/DRIFT_REGISTER.md
   - ../../tools/ci/README.md
   - ../../tools/validators/README.md
-  - ../../tools/watchers/README.md
   - ../../policy/
   - ../../schemas/
   - ../../contracts/
   - ../../tests/
   - ../../fixtures/
   - ../../release/
-  - ../../data/receipts/
+  - ../../data/receipts/generated/README.md
   - ../../data/proofs/
   - ../../infra/
 notes:
-  - "This README replaces an empty placeholder at .github/workflows/README.md."
-  - "The parent `.github/README.md` is confirmed and marks workflow inventory, branch-protection coupling, action pinning, policy-parity wiring, generated receipts, release dry-runs, and CI/runtime enforcement as NEEDS VERIFICATION. This README preserves that boundary."
-  - "Workflow YAML files may orchestrate tools, validators, tests, policy checks, release dry-runs, and summaries. They must not contain canonical validator logic, policy authority, schema authority, contract meaning, release authority, source registry authority, lifecycle data authority, or public-runtime truth."
-  - "A workflow run is a platform signal, not sovereign evidence. Durable trust artifacts belong in data/receipts, data/proofs, release, accepted report roots, or other governed homes created by the tools the workflow invokes."
+  - "The indexed runnable-job inventory at the pinned base contains 41 workflow files with `runs-on`; 34 explicitly identify themselves as PROPOSED greenfield scaffolds and seven contain command-bearing CI wiring."
+  - "The inventory is repository-grounded but bounded: branch-protection settings, effective default token permissions, workflow run history, any workflow without an indexed `runs-on` match, and any `.yaml` file remain NEEDS VERIFICATION."
+  - "Workflow YAML orchestrates authority owned elsewhere. A check run, log, uploaded artifact, or passing workflow is not by itself EvidenceBundle closure, proof, release approval, or publication authority."
+  - "No workflow YAML, branch protection, repository setting, policy, schema, contract, test, runtime, release, or lifecycle artifact is changed by this documentation-only revision."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
 # `.github/workflows/`
 
-![status](https://img.shields.io/badge/status-draft-orange)
+![status](https://img.shields.io/badge/status-repo--grounded%20draft-orange)
 ![root](https://img.shields.io/badge/root-.github%2F-blue)
 ![scope](https://img.shields.io/badge/scope-github--actions-informational)
 ![posture](https://img.shields.io/badge/posture-fail--closed-critical)
 ![publisher](https://img.shields.io/badge/publisher-no-red)
 ![truth](https://img.shields.io/badge/truth-cite--or--abstain-success)
+![inventory](https://img.shields.io/badge/indexed%20workflows-41-1f6feb)
 
-> **One-line purpose.** `.github/workflows/` is the GitHub Actions workflow lane for KFM: YAML orchestration that runs validators, tests, policy checks, release dry-runs, summaries, and guardrails without becoming validator authority, policy authority, evidence authority, release authority, lifecycle authority, or publisher.
+> **One-line purpose.** `.github/workflows/` is KFM's GitHub Actions orchestration lane: it runs repository-owned commands and exposes review signals without becoming policy authority, validator authority, evidence authority, release authority, lifecycle authority, or publisher.
+
+## Quick navigation
+
+- [Purpose](#purpose)
+- [Authority level](#authority-level)
+- [Status](#status)
+- [What belongs here](#what-belongs-here)
+- [What does NOT belong here](#what-does-not-belong-here)
+- [Inputs](#inputs)
+- [Outputs](#outputs)
+- [Validation](#validation)
+- [Review burden](#review-burden)
+- [Related folders](#related-folders)
+- [ADRs](#adrs)
+- [Last reviewed](#last-reviewed)
+- [Repository fit](#repository-fit)
+- [Indexed workflow inventory](#indexed-workflow-inventory)
+- [Trigger and permission preflight](#trigger-and-permission-preflight)
+- [Workflow authoring contract](#workflow-authoring-contract)
+- [Required negative checks](#required-negative-checks)
+- [Maintenance checklist](#maintenance-checklist)
+- [FAQ](#faq)
+- [Open verification items](#open-verification-items)
+- [Changelog](#changelog)
 
 ---
 
 ## Purpose
 
-`.github/workflows/` exists to hold GitHub Actions workflow definitions for the KFM repository.
+`.github/workflows/` holds GitHub Actions workflow definitions for the Kansas Frontier Matrix repository.
 
-The durable KFM question for this subtree is:
+This subtree answers one bounded operational question:
 
-> Which GitHub-hosted checks should run on pushes, pull requests, schedules, and manual dispatches to make KFM governance visible, repeatable, and fail-closed without allowing CI to invent rules, publish artifacts, or bypass the trust membrane?
+> Which GitHub-hosted checks should run for a change, and how should they report deterministic, reviewable outcomes without inventing authority or bypassing KFM's trust membrane?
 
-A workflow may call validators, tests, policy tooling, release dry-runs, QA helpers, and summary renderers. It must not become the place where rules, schemas, contracts, source descriptors, evidence records, receipts, release decisions, or public truth are authored.
+### Scope and audience
+
+This README is for maintainers, reviewers, CI/tooling stewards, domain-lane owners, policy reviewers, release stewards, and coding agents that create or revise workflow YAML.
+
+It documents:
+
+- the workflow subtree's authority boundary;
+- the indexed default-branch inventory at a pinned commit;
+- the difference between command-bearing workflows and explicit greenfield stubs;
+- trigger, token-permission, action-pinning, and fork-PR risks;
+- local-parity commands and current placeholder limits;
+- review, rollback, and documentation obligations.
+
+It does **not** certify that branch protection requires any named job, that a workflow has passed recently, that a report is release-grade proof, or that a stub implements its advertised check.
+
+[Back to top](#top)
+
+---
+
+## Authority level
+
+**Implementation-bearing platform orchestration.** Workflow YAML can execute commands and create GitHub check signals, but it does not define KFM truth or authorize publication.
+
+| Workflow concern | Authority owned by | Workflow role |
+|---|---|---|
+| Trigger selection, job graph, runner, GitHub token permissions | `.github/workflows/` | Own and document the GitHub Actions orchestration. |
+| Validator behavior | `tools/validators/` and tests | Invoke; do not reimplement inline. |
+| Policy decisions | `policy/` | Evaluate the pinned policy inputs; do not author policy in YAML. |
+| Object meaning and machine shape | `contracts/`, `schemas/` | Validate; do not redefine. |
+| Fixtures and expected behavior | `fixtures/`, `tests/` | Consume and execute. |
+| Receipts and proofs | `data/receipts/`, `data/proofs/` | Generate or verify through accepted tools; logs are not substitutes. |
+| Catalog and release closure | `data/catalog/`, `release/` | Dry-run or verify; do not approve or publish by workflow existence alone. |
+| Public API, map, UI, or AI behavior | governed app/runtime roots | Test the boundary; do not become the public path. |
+| Deployment and exposure posture | `infra/`, `runtime/`, `configs/` | Validate declared posture; do not hide deployment authority in CI. |
+
+> [!IMPORTANT]
+> A green check means the declared job completed successfully for its declared inputs. It does not automatically mean the underlying claim is true, the artifact is public-safe, or promotion is authorized.
 
 [Back to top](#top)
 
@@ -68,131 +136,340 @@ A workflow may call validators, tests, policy tooling, release dry-runs, QA help
 
 ## Status
 
-| Surface | Status | Notes |
+The table below is bounded to `main@66610a2ee8bdc15713d1e5a5b0350081a1d7771c` and the GitHub connector searches used for this revision.
+
+| Surface | Status | Evidence-bounded interpretation |
 |---|---|---|
-| `.github/workflows/README.md` | **CONFIRMED README** | This README replaces the previous empty placeholder. |
-| `.github/README.md` | **CONFIRMED parent README** | Parent platform-governance README marks workflow inventory and branch-protection coupling as **NEEDS VERIFICATION**. |
-| `.github/CODEOWNERS` | **CONFIRMED file** | Placeholder code-owner mappings exist under `.github/`; team validity and branch-protection enforcement remain **NEEDS VERIFICATION**. |
-| `.github/workflows/*.yml` inventory | **NEEDS VERIFICATION** | Search and spot checks did not establish a complete workflow inventory in this edit. |
-| Required checks / branch protection | **NEEDS VERIFICATION** | GitHub repository settings were not inspected. |
-| Workflow run logs, artifacts, receipts, reports, and pass/fail history | **NEEDS VERIFICATION** | No workflow run history or generated artifacts were inspected in this edit. |
+| This README | **CONFIRMED file / draft documentation** | Existing README fetched and revised in place. |
+| Indexed runnable-job inventory | **CONFIRMED: 41 files with `runs-on`** | Code-index search found 41 workflow files that define jobs. This does not prove there are no additional `.yaml`, reusable, disabled, or unindexed files. |
+| Explicit greenfield stubs | **CONFIRMED: 34 indexed files** | These files contain `Status: PROPOSED greenfield scaffold` and primarily execute `echo TODO ...`. |
+| Command-bearing workflows | **CONFIRMED: 7 indexed files** | These invoke Make targets, Python tests/validators, Node scripts, or artifact upload steps. Execution success remains **NEEDS VERIFICATION** without current runs. |
+| Required checks / branch protection | **UNKNOWN / NEEDS VERIFICATION** | Repository settings were not inspected. A workflow or job name must not be called required without settings evidence. |
+| Workflow run history, logs, artifacts, and recent pass rates | **NOT INSPECTED** | No current run proves these workflows pass at this snapshot. |
+| Effective default `GITHUB_TOKEN` permissions | **UNKNOWN** for workflows without an explicit `permissions:` block | Repository and organization defaults were not inspected. |
+| CODEOWNERS enforcement | **NEEDS VERIFICATION** | `.github/CODEOWNERS` exists, but it is a greenfield placeholder and branch-protection enforcement was not verified. |
+| Action pinning | **CONFIRMED major-tag usage in inspected files / hardening needed** | Inspected workflows use refs such as `actions/checkout@v7`, not immutable commit SHAs. |
 
 [Back to top](#top)
 
 ---
 
-## Workflow root rules
+## What belongs here
 
-| Rule | Required posture | Anti-pattern |
+- GitHub Actions workflow files: `*.yml` or `*.yaml`.
+- Trigger definitions for `pull_request`, `push`, `workflow_dispatch`, schedules, or approved reusable-workflow calls.
+- Stable workflow names, job ids, dependency graphs, concurrency controls, timeouts, matrices, and conditions.
+- Explicit least-privilege `permissions:` declarations.
+- Thin installation and command-invocation steps needed to run repository-owned validators, tests, policy checks, builds, and dry-runs.
+- Artifact uploads for reviewer aids, with bounded retention and clear non-authority labels.
+- Failure-only diagnostics that do not convert errors into success.
+- Comments documenting why a trigger, permission, network exception, or write is necessary.
+
+[Back to top](#top)
+
+---
+
+## What does NOT belong here
+
+- Canonical validator or business logic that belongs in `tools/`, `packages/`, or app code.
+- Rego policy, allowlists, sensitivity rules, rights rules, or release decisions that belong in `policy/`.
+- JSON Schema or semantic object definitions that belong in `schemas/` and `contracts/`.
+- Golden or invalid fixtures that belong in `fixtures/` or `tests/`.
+- Source descriptors, source registry records, or source admission decisions.
+- Canonical lifecycle data, EvidenceBundles, receipts, proofs, catalog records, release manifests, rollback cards, or correction notices.
+- Credentials, private endpoints, exact sensitive locations, restricted source payloads, or secrets echoed to logs.
+- Direct writes to `data/published/`, catalog/triplet authority, release authority, or public runtime truth by ordinary CI or watcher jobs.
+- A second copy of logic already reproducible through the Makefile, package scripts, or accepted tools.
+
+[Back to top](#top)
+
+---
+
+## Inputs
+
+Workflows may read:
+
+- the checked-out repository state for the triggering commit;
+- changed-path and event metadata supplied by GitHub;
+- `Makefile` targets and package-native scripts;
+- validators, QA helpers, and CI support code under `tools/`;
+- tests and deterministic fixtures;
+- schemas, contracts, policies, source descriptors, and control-plane registers from their canonical roots;
+- release candidates, receipts, proofs, and manifests when the job is explicitly a verifier or dry-run;
+- secrets or identity tokens only when a reviewed workflow has a documented, least-privilege requirement.
+
+Untrusted pull-request content remains data, not instructions. A workflow handling forks or external contributions must assume the submitted code and files are hostile until validated.
+
+[Back to top](#top)
+
+---
+
+## Outputs
+
+| Output | Accepted use | Boundary |
 |---|---|---|
-| Workflows orchestrate; they do not author authority. | YAML invokes tools, validators, policy checks, tests, and release dry-runs from owning roots. | Policy, schema, contract, validator, or release logic is embedded inline in workflow YAML. |
-| Fail closed. | Missing evidence, schema, policy, source descriptor, fixture, report, receipt, release reference, correction path, or rollback target blocks the relevant check. | Missing inputs produce success or best-effort public continuation. |
-| Local parity where possible. | Prefer commands that can be reproduced through `Makefile`, `scripts/dev/`, `tools/`, or package scripts. | CI-only logic cannot be rerun by maintainers. |
-| No-network by default. | First-pass PR checks should run offline unless a source-activated live tier is explicitly configured. | PR workflows fetch live sources or call external systems without source activation. |
-| Least privilege. | Workflow token permissions should be explicit and minimal. | Broad `contents: write`, secrets, or deployment permissions are granted to ordinary validation jobs. |
-| Pinned dependencies. | Actions and setup steps should use pinned refs/digests where practical. | Floating action tags silently change validation behavior. |
-| Watchers are non-publishers. | Workflow-triggered watchers emit candidates, reports, and receipts only. | A workflow or watcher writes directly to catalog, triplets, published, release, or public runtime truth. |
-| Public path stays governed. | CI validates public-surface denial of RAW/WORK/QUARANTINE/candidate/internal/model-output paths. | Workflow creates or blesses public artifacts without release and rollback support. |
-| Logs are not trust records. | Logs help debug; durable reports/receipts/proofs live in accepted homes. | A workflow log is the only proof of a gate. |
-| Branch-check names are governed. | Required-check names and job names are coordinated with branch protection. | Workflow/job rename silently breaks required checks. |
+| Check run / job conclusion | Branch-protection and review signal. | Not evidence or release authority by itself. |
+| Log and annotation | Debugging and reviewer context. | Must not disclose secrets or sensitive data. |
+| JUnit, coverage, lint, accessibility, or QA report | Review artifact. | Does not become canonical data or proof merely because it was uploaded. |
+| Deterministic PR summary | Human-readable obligations and failures. | Must be idempotent and avoid restricted details. |
+| Uploaded artifact | Temporary reviewer aid with retention policy. | Promotion into a governed receipt/proof/release home requires an accepted tool and state transition. |
+| Candidate receipt, proof, or release dry-run output | Input to review and later verification. | Candidate status must remain visible; workflow completion is not approval. |
+| Failure bundle | Diagnostic and rollback/correction aid. | `|| true` may preserve diagnostics but must not mask the governing job failure. |
 
 [Back to top](#top)
 
 ---
 
-## Authority boundary
+## Validation
 
-| Responsibility | Correct home | Workflow role |
-|---|---|---|
-| GitHub workflow YAML | `.github/workflows/` | This subtree. |
-| GitHub platform root, templates, CODEOWNERS | `.github/` | Parent platform-governance root. |
-| CI helper scripts and summary renderers | `tools/ci/` | Workflows may invoke helpers; helper logic lives outside YAML. |
-| Validators | `tools/validators/` | Workflows call validators; YAML does not define validator truth. |
-| Watchers | `tools/watchers/` | Workflows may schedule or smoke-check watchers; watchers remain non-publishers. |
-| Tests | `tests/` | Workflows run tests; tests prove behavior. |
-| Fixtures | `fixtures/` | Workflows consume fixtures; fixtures are not stored in workflow YAML. |
-| Policy | `policy/` | Workflows evaluate policy from the policy root; they do not inline policy. |
-| Schemas | `schemas/` | Workflows validate against schemas from the schema root. |
-| Contracts | `contracts/` | Workflows check contract/schema/test alignment. |
-| Evidence/proofs | `data/proofs/` | Tools produce or verify proof records. |
-| Receipts | `data/receipts/` | Tools produce or verify receipt records. |
-| Release decisions, manifests, rollback, corrections | `release/` | Workflows may dry-run release gates; they do not approve release. |
-| Deployment/exposure posture | `infra/` | Workflows validate infra assumptions; infra owns deployment. |
-| Public API/UI/map/AI runtime | governed app/runtime roots | Workflows test public boundaries; runtime owns public behavior. |
+### Repository-grounded local-parity surface
 
-[Back to top](#top)
-
----
-
-## Expected workflow families
-
-The names below are a target catalog until each file is individually verified.
-
-| Workflow family | Proposed filename | Purpose | Gate posture | Status |
-|---|---|---|---|---|
-| Integrity baseline | `integrity.yml` | Run local-parity baseline checks, schemas, policy, tests, receipts, and fixture closure. | A/B/C/F | **NEEDS VERIFICATION** |
-| Path and drift | `path-and-drift.yml` | Enforce Directory Rules, root discipline, MetaBlock presence, and placement drift checks. | A | **PROPOSED / NEEDS VERIFICATION** |
-| Contract/schema/UI/AI | `contracts-ui-ai.yml` | Validate contracts, schemas, fixtures, governed API/UI/AI envelopes. | B/C/G | **PROPOSED / NEEDS VERIFICATION** |
-| Governed UI | `ui-governed.yml` | Run UI build, component, a11y, map-shell, and trust-state checks without public-data shortcuts. | B/C/G | **PROPOSED / NEEDS VERIFICATION** |
-| Policy parity | `policy-parity.yml` | Check CI policy bundle digest and runtime/infra policy digest alignment. | C | **PROPOSED / NEEDS VERIFICATION** |
-| Promotion dry-run | `promotion-dry-run.yml` | Run promotion gates without side effects or public publication. | A-F | **PROPOSED / NEEDS VERIFICATION** |
-| Catalog closure | `catalog-closure.yml` | Verify catalog, citation, PROV/STAC/DCAT, EvidenceRef, and release-support closure. | F | **PROPOSED / NEEDS VERIFICATION** |
-| Signing / integrity | `signing-integrity.yml` | Verify RunReceipts, spec hashes, signatures, manifests, and artifact digests. | F | **PROPOSED / NEEDS VERIFICATION** |
-| Rollback drill | `rollback-drill.yml` | Replay rollback/correction support against dry-run releases. | F/G | **PROPOSED / NEEDS VERIFICATION** |
-| Boundary guards | `boundary-guards.yml` | Prove public clients cannot read RAW/WORK/QUARANTINE/candidate/internal/model-output paths. | C/D/G | **PROPOSED / NEEDS VERIFICATION** |
-| MapLibre governance | `maplibre-governance.yml` | Validate MapLibre/PMTiles/public-map performance, proof packs, and release gating. | B/C/F | **PROPOSED / NEEDS VERIFICATION** |
-
-[Back to top](#top)
-
----
-
-## Gate map
-
-| Gate | Intent | Workflow responsibility | Status |
+| Command or target | Current implementation at the evidence snapshot | Workflow users | Status |
 |---|---|---|---|
-| **A — Structure & Metadata** | MetaBlock, path role, root discipline, drift detection. | Run path/drift and metadata checks from tools/tests. | **PROPOSED / NEEDS VERIFICATION** |
-| **B — Schemas & Contracts** | Machine shape and semantic contract alignment. | Run schema/contract tests against canonical homes. | **PROPOSED / NEEDS VERIFICATION** |
-| **C — Policy Parity** | CI and runtime policy decisions use the same policy bundle/digest where shared. | Compare policy bundle refs and evaluate policy fixtures. | **PROPOSED / NEEDS VERIFICATION** |
-| **D — Security & Sensitivity** | Secret hygiene, rights, sensitivity, geoprivacy, public-safe defaults. | Run secret/sensitivity/rights/public-boundary checks. | **PROPOSED / NEEDS VERIFICATION** |
-| **E — Data Quality** | Profilers, assertions, quality thresholds, fixture quality. | Run no-network DQ checks or dry-run quality gates. | **PROPOSED / NEEDS VERIFICATION** |
-| **F — Provenance & Lineage** | Receipts, proofs, source refs, manifests, signatures, rollback support. | Verify generated trust artifacts and catalog/release closure. | **PROPOSED / NEEDS VERIFICATION** |
-| **G — Reviewability** | CODEOWNERS, review burden, release decision, rollback/correction trace. | Expose branch-protection-facing checks and review summaries. | **PROPOSED / NEEDS VERIFICATION** |
+| `make schemas` | Runs `python tools/validators/_common/run_all.py`. | `schema-validation.yml`, `validator-suite.yml` | **CONFIRMED command wiring / run result not inspected** |
+| `make test` | Runs `pytest tests/schemas tests/contracts -q`. | `contracts-validate.yml` | **CONFIRMED command wiring / run result not inspected** |
+| `make governed-api-smoke` | Runs the governed API test directory. | `api-test.yml` | **CONFIRMED command wiring / run result not inspected** |
+| `make boundary-guards-ci` | Runs four policy/API boundary test modules and emits JUnit. | `policy-boundary-guards.yml` | **CONFIRMED command wiring / run result not inspected** |
+| MapLibre perf scripts and validators | Builds smoke, render-diff, receipt, manifest, proof-pack, and failure artifacts. | `maplibre-perf-governance.yml` | **CONFIRMED command wiring / path drift and run result NEED VERIFICATION** |
+| PMTiles validators | Conditional header, Merkle-sidecar, and shape-only signature validation. | `pmtiles-attestation.yml` | **CONFIRMED command wiring / no-artifact paths currently skip successfully** |
+| `make policy`, `release-dry-run`, `publish-check`, `deny-test`, `ui-build` | Emit `TODO` messages in the current Makefile. | Advertised by several stubs | **PROPOSED placeholder; must not be treated as enforcement** |
 
-A gate that did not run should not be treated as a pass. Missing workflow evidence should route to **NEEDS VERIFICATION**, not to optimistic completion.
+### README validation for this subtree
 
-[Back to top](#top)
+A documentation-only change should at minimum verify:
 
----
-
-## Workflow permissions posture
-
-Use least privilege as the default.
-
-| Workflow class | Typical permissions | Notes |
-|---|---|---|
-| Lint/test/schema/contract checks | `contents: read` | Most PR checks should not need write permissions. |
-| PR summary comments | `pull-requests: write` or `issues: write` only when needed | Prefer deterministic comments; never include secrets or sensitive details. |
-| Artifact upload | `actions: read` plus upload-artifact action permissions as needed | Artifacts are reviewer aids unless promoted into governed receipt/proof/release homes by accepted tools. |
-| Release dry-run | read-only where possible | Dry-runs must not publish or mutate release authority. |
-| Release publication | requires separate governance | Do not treat a workflow dispatch alone as release approval. |
-| Fork PRs | minimal and secret-free | Avoid secret-bearing jobs or write permissions on untrusted code. |
+1. one H1 and a valid KFM Meta Block;
+2. all required Directory Rules README sections are present in order;
+3. repository-relative links resolve;
+4. named workflow files exist at the pinned snapshot;
+5. inventory totals match the evidence method;
+6. no credential or sensitive payload is introduced;
+7. no workflow or branch setting is changed unintentionally;
+8. a generated receipt is emitted when the change is AI-authored and the repository contract requires one.
 
 [Back to top](#top)
 
 ---
 
-## Outputs and artifact discipline
+## Review burden
 
-Workflow outputs should be easy to inspect and safe to discard unless promoted by governed tools.
+Changes under `.github/workflows/` are security- and governance-significant even when they appear small.
 
-| Output | Acceptable use | Boundary |
+- The current `.github/CODEOWNERS` is a **greenfield placeholder** with a global `@kfm/maintainers` entry; team validity and enforcement remain **NEEDS VERIFICATION**.
+- A workflow PR should receive CI/tooling review plus the owner of every authority root the job invokes materially.
+- Policy, release, sensitive-domain, identity-token, secret, deployment, artifact-signing, or write-permission changes require the corresponding steward review.
+- Renaming a workflow or job that may be a required check requires branch-protection coordination before merge.
+- Stub graduation is behavior change: reviewers must inspect the exact command, inputs, outputs, negative fixtures, permissions, network posture, and rollback/disable path.
+
+[Back to top](#top)
+
+---
+
+## Related folders
+
+| Path | Relationship |
+|---|---|
+| [`.github/`](../README.md) | Parent GitHub platform-governance root. |
+| [`.github/CODEOWNERS`](../CODEOWNERS) | Review-routing file; current entries are placeholders. |
+| [`.github/PULL_REQUEST_TEMPLATE.md`](../PULL_REQUEST_TEMPLATE.md) | PR evidence, validation, rollback, and generated-receipt contract. |
+| [`Makefile`](../../Makefile) | Local-parity command surface used by several workflows. |
+| [`tools/ci/`](../../tools/ci/README.md) | Long-lived CI summary/helper logic. |
+| [`tools/validators/`](../../tools/validators/README.md) | Validator implementation authority. |
+| [`policy/`](../../policy/) | Policy authority. |
+| [`schemas/`](../../schemas/) | Machine-shape authority. |
+| [`contracts/`](../../contracts/) | Semantic object meaning. |
+| [`tests/`](../../tests/) | Executable behavior evidence. |
+| [`fixtures/`](../../fixtures/) | Deterministic test inputs. |
+| [`data/receipts/generated/`](../../data/receipts/generated/README.md) | AI-authored artifact provenance records. |
+| [`data/proofs/`](../../data/proofs/) | Proof objects. |
+| [`release/`](../../release/) | Release decisions, manifests, corrections, and rollback. |
+| [`infra/`](../../infra/) | Deployment, identity, network, and exposure posture. |
+| [`DRIFT_REGISTER.md`](../../docs/registers/DRIFT_REGISTER.md) | Placement or behavior drift requiring explicit tracking. |
+
+[Back to top](#top)
+
+---
+
+## ADRs
+
+| ADR | Status at the evidence snapshot | Relevance |
 |---|---|---|
-| Check run | Branch-protection signal. | Not a proof object by itself. |
-| Log | Debugging and reviewer context. | Not durable evidence or release support. |
-| JUnit / coverage / QA report | Test/report artifact for review. | Must not become data authority. |
-| Deterministic PR comment | Human-readable obligations summary. | Must not disclose secrets, exact sensitive locations, or restricted source detail. |
-| Candidate receipt/proof path | Pointer to output generated by accepted tools. | Receipt/proof authority lives in `data/receipts/` or `data/proofs/`, not YAML. |
-| Release dry-run manifest | Candidate review artifact. | Actual release decision belongs in `release/` with review and rollback support. |
+| [`ADR-0018 — Promotion Gate Sequence`](../../docs/adr/ADR-0018-promotion-gate-sequence.md) | **PROPOSED, not accepted** | Defines a proposed canonical A–G outcome sequence. Do not claim current workflow enforcement from the ADR alone. |
+| [`ADR-0011 — Receipts vs Proofs vs Manifests vs Catalog Separation`](../../docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md) | **PROPOSED, not accepted** | Supports keeping CI artifacts distinct from receipts, proofs, catalog records, and publication. |
+
+A new ADR is required when workflow work changes a KFM invariant, creates a parallel authority home, changes lifecycle or release semantics, or establishes a new privileged publication path. Routine workflow corrections and command wiring usually require a reviewed PR, not an ADR.
+
+[Back to top](#top)
+
+---
+
+## Last reviewed
+
+| Field | Value |
+|---|---|
+| Date | **2026-07-17** |
+| Repository | `bartytime4life/Kansas-Frontier-Matrix` |
+| Base ref | `main` |
+| Pinned evidence commit | `66610a2ee8bdc15713d1e5a5b0350081a1d7771c` |
+| Review type | Repository-grounded documentation revision; workflow files and settings were not mutated. |
+| Next review trigger | Any workflow add/delete/rename, stub graduation, permission change, trigger change, required-check change, or six months after this date. |
+
+[Back to top](#top)
+
+---
+
+## Repository fit
+
+```text
+.github/
+├── README.md                       # parent platform-governance documentation
+├── CODEOWNERS                      # review routing; greenfield placeholder
+├── PULL_REQUEST_TEMPLATE.md        # PR evidence and receipt contract
+└── workflows/
+    ├── README.md                   # this inventory and operating boundary
+    ├── <command-bearing>.yml       # invokes repository-owned checks
+    └── <greenfield-stub>.yml       # named future responsibility; no enforcement claim
+```
+
+The workflow subtree is a GitHub-shaped implementation lane inside the canonical `.github/` responsibility root. It must remain thin: GitHub-specific orchestration here, reusable logic in its owning implementation or authority root.
+
+[Back to top](#top)
+
+---
+
+## Indexed workflow inventory
+
+### Inventory summary
+
+| Class | Count | Definition used in this revision |
+|---|---:|---|
+| Command-bearing | **7** | Indexed workflow with `runs-on` that invokes a repository test, validator, Make target, Node build/attestation chain, or artifact upload beyond an `echo TODO` scaffold. |
+| Explicit greenfield stub | **34** | Indexed workflow with `runs-on` and the exact marker `Status: PROPOSED greenfield scaffold`. |
+| Total indexed runnable-job files | **41** | Union of the two sets above. |
+
+> [!NOTE]
+> This is an **indexed runnable-job inventory**, not a byte-for-byte directory-tree proof. Any workflow without `runs-on`, any `.yaml` file, reusable workflow, disabled file, or search-index omission remains outside the confirmed count.
+
+### Command-bearing workflows
+
+| Workflow | Triggers observed | Command surface | Current limitations |
+|---|---|---|---|
+| [`api-test.yml`](api-test.yml) | Pull requests; pushes to `main` | `make governed-api-smoke`; targeted abstain-route pytest | File labels itself **PROPOSED trust-membrane CI wiring**; run results and branch requirement unknown. |
+| [`contracts-validate.yml`](contracts-validate.yml) | All pushes and pull requests | Installs `.[test]`; runs `make test` | Broad trigger; effective token permissions and recent pass state unknown. |
+| [`maplibre-perf-governance.yml`](maplibre-perf-governance.yml) | Path-scoped PR/push; manual dispatch | Node/Python setup, Playwright, perf/render/receipt/manifest/proof/failure chain, artifact uploads | Uses `id-token: write`; references `apps/web/**` and `schemas/maplibre/**`, which conflict with current Directory Rules guidance and require reconciliation. |
+| [`pmtiles-attestation.yml`](pmtiles-attestation.yml) | PMTiles/tool/policy path-scoped PR; manual dispatch | Header, Merkle-sidecar, and COSE shape validation | Missing artifacts exit successfully; signature verification is shape-only. This is not publication attestation closure. |
+| [`policy-boundary-guards.yml`](policy-boundary-guards.yml) | Path-scoped PR; manual dispatch | `make boundary-guards-ci`; JUnit upload | No explicit top-level `permissions:` block observed; effective permissions unknown. |
+| [`schema-validation.yml`](schema-validation.yml) | Pull requests; pushes to `main` | Installs package; runs `make schemas` | Overlaps `validator-suite.yml`; duplication rationale and required-check status unknown. |
+| [`validator-suite.yml`](validator-suite.yml) | Pull requests; pushes to `main` | `make schemas`; explicit invalid-EvidenceBundle fail-closed check | Covers only the declared invalid fixture in its negative job; broader gate coverage unknown. |
+
+### Explicit greenfield stubs
+
+These files are **CONFIRMED present as named scaffolds**. Their advertised function is **PROPOSED**, and an `echo TODO ...` job must not be represented as implemented validation.
+
+| Family | Stub workflows |
+|---|---|
+| Platform, docs, UI, and security | `accessibility.yml`, `codeql.yml`, `dependency-scan.yml`, `docs-build.yml`, `docs-control-plane.yml`, `e2e-smoke.yml`, `link-check.yml`, `ui-build.yml` |
+| Governance, trust, release, and source control | `citation-validation.yml`, `connector-gate.yml`, `contract-drift.yml`, `deny-test.yml`, `evidence-resolver.yml`, `focus-mock-test.yml`, `hydrology-proof-slice.yml`, `policy-test.yml`, `promotion-gate.yml`, `release-dry-run.yml`, `rollback-drill.yml`, `source-descriptor-validate.yml`, `telemetry-policy.yml` |
+| Domain lanes | `domain-agriculture.yml`, `domain-archaeology.yml`, `domain-atmosphere.yml`, `domain-fauna.yml`, `domain-flora.yml`, `domain-geology.yml`, `domain-habitat.yml`, `domain-hazards.yml`, `domain-hydrology.yml`, `domain-people-dna-land.yml`, `domain-roads-rail-trade.yml`, `domain-settlements-infrastructure.yml`, `domain-soil.yml` |
+
+### Stub graduation rule
+
+A stub is ready to become command-bearing only when the PR identifies:
+
+1. owner and reviewer burden;
+2. trigger and changed-path scope;
+3. explicit minimal permissions;
+4. exact repository-native command;
+5. deterministic valid and invalid fixtures;
+6. network and secret posture;
+7. outputs and retention;
+8. stable job/check name;
+9. failure and finite-outcome behavior;
+10. disable, rollback, and documentation path.
+
+[Back to top](#top)
+
+---
+
+## Trigger and permission preflight
+
+### README-only change impact
+
+At the pinned snapshot, a change to `.github/workflows/README.md` does **not** match the observed path filters in the MapLibre, PMTiles, or policy-boundary workflows. It does match broad `pull_request` workflows that do not narrow `paths`, including command-bearing validation workflows and several greenfield stubs.
+
+Expected broad-trigger candidates include:
+
+- `api-test.yml`;
+- `contracts-validate.yml`;
+- `schema-validation.yml`;
+- `validator-suite.yml`;
+- `codeql.yml` stub;
+- `docs-build.yml` stub;
+- `docs-control-plane.yml` stub;
+- `link-check.yml` stub.
+
+This means a documentation-only PR may launch jobs whose names imply more validation than they perform. Reviewers must inspect the job steps, not infer coverage from workflow names.
+
+### Threat-preflight findings
+
+| Check | Finding at the evidence snapshot | Posture |
+|---|---|---|
+| `pull_request_target` | No indexed match found. | **No privileged target-context trigger observed; inventory boundary applies.** |
+| `workflow_run` chaining | No indexed match found. | **No chained privileged handoff observed; inventory boundary applies.** |
+| Self-hosted runners | No indexed `self-hosted` match found. | **Hosted runners observed in inspected files.** |
+| Secret references | No indexed `secrets.` match found. | **No direct secret reference observed; repository/environment secret policy remains unknown.** |
+| Explicit write scopes | No indexed `contents: write`, `pull-requests: write`, `issues: write`, or `packages: write` match found. | **No ordinary write scope observed; effective defaults still need verification.** |
+| OIDC | `id-token: write` appears in `maplibre-perf-governance.yml`. | **Requires justification and periodic review; that workflow is not triggered by this README path.** |
+| Action refs | Inspected workflows use floating major tags (`@v6`, `@v7`). | **Supply-chain hardening needed; immutable SHA pinning is not confirmed.** |
+| Fork-PR secret/write posture | No dedicated fork guard was established in this review. | **NEEDS VERIFICATION before any secret-bearing or write-emitting PR job is introduced.** |
+
+[Back to top](#top)
+
+---
+
+## Workflow authoring contract
+
+Every new or materially changed workflow should document these fields in the YAML comments, this README, a runbook, or the PR body:
+
+| Field | Required answer |
+|---|---|
+| Responsibility | What single workflow family does this file own? |
+| Trigger | Why these events, branches, paths, and schedules? |
+| Untrusted-code posture | Can fork or external PR code execute, and in what token context? |
+| Permissions | What is the minimal explicit `permissions:` set? |
+| Runner | Why GitHub-hosted or self-hosted, and what is the trust boundary? |
+| Network | Is the job no-network, dependency-network only, or source-activated live? |
+| Command | Which repository-native command carries the logic? |
+| Inputs | Which schemas, policies, fixtures, manifests, or source descriptors are pinned? |
+| Outputs | What reports or artifacts are emitted, where, and for how long? |
+| Outcome | What constitutes pass, fail, deny, hold, abstain, restrict, explicit skip, or system error? |
+| Check name | Is the workflow/job name referenced by branch protection? |
+| Rollback / disable | How can the workflow be safely disabled or reverted without weakening hidden obligations? |
+
+### Naming and branch-protection discipline
+
+- Workflow filenames should be stable, kebab-case, and responsibility-specific.
+- Workflow `name`, job ids, and matrix-generated check names are compatibility surfaces once branch protection references them.
+- A rename requires branch-protection verification and a migration note; never assume GitHub updates required checks automatically.
+- A skipped gate is not a pass. Use explicit conditions and visible outcomes.
+- Avoid duplicate workflows that run the same command unless the distinct responsibility, trigger, and required-check purpose are documented.
+
+### Standard operational outcomes
+
+| Outcome | Meaning |
+|---|---|
+| `WORKFLOW_PASS` | All declared checks ran and passed for the declared scope. |
+| `WORKFLOW_FAIL` | Checks ran and found a defect. |
+| `WORKFLOW_DENY` | Policy or governance blocks the requested action or exposure. |
+| `WORKFLOW_HOLD` | Human, rights, sensitivity, release, correction, or rollback review is required. |
+| `WORKFLOW_ABSTAIN` | The workflow lacks enough supported input to evaluate the requested gate. |
+| `WORKFLOW_RESTRICT` | The action may proceed only under explicit constraints. |
+| `WORKFLOW_SKIPPED_EXPLICIT` | A documented condition skipped the job visibly. |
+| `WORKFLOW_KILL_SWITCH_ACTIVE` | An explicit kill switch prevented execution. |
+| `WORKFLOW_PUBLIC_SURFACE_DENIED` | Public exposure is blocked. |
+| `WORKFLOW_SYSTEM_ERROR` | Infrastructure, dependency, malformed configuration, or unexpected runtime failure prevented evaluation. |
+
+These names are documentation vocabulary unless a contract/schema makes them normative. Do not emit a new machine enum from README prose alone.
 
 [Back to top](#top)
 
@@ -200,96 +477,78 @@ Workflow outputs should be easy to inspect and safe to discard unless promoted b
 
 ## Required negative checks
 
-Workflow suites should eventually prove the system denies or holds unsafe states, including:
+Workflow suites should prove unsafe states fail closed, including:
 
-- public API/UI/map/AI reads from RAW, WORK, QUARANTINE, candidate, canonical/internal stores, or direct model runtimes;
-- policy bundle missing, stale, mismatched, or not equal between CI and runtime/infra;
-- schema or contract drift between `contracts/`, `schemas/`, fixtures, validators, and docs;
-- missing EvidenceRef/EvidenceBundle, citation validation, receipt, proof, release reference, rollback target, or correction path;
-- sensitive geometry, rare species, archaeology, cultural, infrastructure, living-person, DNA/genomic, private-land, or source-restricted material exposed to public surfaces;
-- watcher or pipeline code writing directly to catalog, published, release, or public runtime surfaces;
-- source-role collapse, AI-inferred authority, modeled-to-observed upgrade, or aggregate-to-place overclaim;
-- workflow job that succeeds after required input is missing;
-- action/tag drift, unpinned dependencies, or secret-bearing logs.
-
-[Back to top](#top)
-
----
-
-## Naming and branch-protection discipline
-
-Workflow `name`, job ids, and required-check names are part of the governance surface.
-
-| Item | Rule |
-|---|---|
-| Workflow file name | Stable, kebab-case, tied to one responsibility. |
-| Workflow `name` | Human-readable and stable after branch protection references it. |
-| Job id | Stable, lower-kebab or snake style; avoid accidental renames. |
-| Required check | Must match produced job/check name exactly. |
-| Rename | Requires coordinated branch-protection update and drift/ADR note when material. |
-| Deprecated workflow | Keep a migration note until branch protection and docs are updated. |
+- public API, UI, map, or AI access to RAW, WORK, QUARANTINE, candidate, internal/canonical, or direct-model stores;
+- missing, stale, or mismatched policy bundles;
+- contract/schema/fixture/validator/document drift;
+- missing EvidenceRef-to-EvidenceBundle resolution, citation validation, receipt, proof, release reference, rollback target, or correction path where required;
+- public exposure of rare-species, archaeology, cultural, critical-infrastructure, living-person, DNA/genomic, private-land, exact sensitive geometry, or source-restricted material;
+- connector, watcher, or pipeline code promoting or publishing directly;
+- source-role collapse, modeled-to-observed upgrade, AI-inferred authority, or aggregate-to-place overclaim;
+- a required input missing while the job still reports success;
+- diagnostic `|| true` masking the governing validation result;
+- floating action or dependency drift changing behavior without review;
+- secret, token, private endpoint, or restricted payload disclosure in logs or artifacts.
 
 [Back to top](#top)
 
 ---
 
-## Minimal future layout
+## Maintenance checklist
 
-```text
-.github/workflows/
-├── README.md                         # CONFIRMED README
-├── integrity.yml                     # NEEDS VERIFICATION
-├── path-and-drift.yml                # PROPOSED / NEEDS VERIFICATION
-├── contracts-ui-ai.yml               # PROPOSED / NEEDS VERIFICATION
-├── ui-governed.yml                   # PROPOSED / NEEDS VERIFICATION
-├── policy-parity.yml                 # PROPOSED / NEEDS VERIFICATION
-├── promotion-dry-run.yml             # PROPOSED / NEEDS VERIFICATION
-├── catalog-closure.yml               # PROPOSED / NEEDS VERIFICATION
-├── signing-integrity.yml             # PROPOSED / NEEDS VERIFICATION
-├── rollback-drill.yml                # PROPOSED / NEEDS VERIFICATION
-├── boundary-guards.yml               # PROPOSED / NEEDS VERIFICATION
-└── maplibre-governance.yml           # PROPOSED / NEEDS VERIFICATION
-```
+A workflow or workflow-documentation PR is ready for review when:
 
-Do not add workflow files until each one has an owning steward, trigger scope, permission posture, called command, no-network posture, artifact policy, branch-protection name, and rollback/disable path.
-
-[Back to top](#top)
-
----
-
-## Review checklist
-
-A workflow PR is ready for review when:
-
-- [ ] It names the owning workflow family and gate(s) it supports.
-- [ ] It invokes logic from `tools/`, `tests/`, `policy/`, `schemas/`, `contracts/`, `release/`, or package scripts instead of embedding canonical rules in YAML.
-- [ ] It uses explicit minimal permissions.
-- [ ] It is no-network by default or documents the source-activated exception.
-- [ ] It has deterministic failure outcomes and does not silently skip required gates.
-- [ ] It does not publish, promote, or mutate lifecycle/release/public surfaces without governed release machinery.
-- [ ] It avoids secret-bearing logs and sensitive-location output.
-- [ ] It documents any branch-protection-facing check names.
-- [ ] It has a kill-switch or disable path for long-running/write-emitting workflows.
-- [ ] It updates `.github/README.md`, this README, Makefile/scripts/runbooks, and verification backlog where behavior changes.
+- [ ] The exact base commit and target files were inspected.
+- [ ] Directory Rules placement and README requirements were checked.
+- [ ] Overlapping workflow branches and pull requests were checked.
+- [ ] Trigger expansion and privileged-event risk were reviewed.
+- [ ] Permissions are explicit and least-privilege, or the unresolved default is documented.
+- [ ] External actions are immutably pinned, or the pinning gap is recorded.
+- [ ] Repository-native local parity exists for the governing command.
+- [ ] Stub/TODO behavior is not described as implemented enforcement.
+- [ ] Valid and invalid fixtures exercise finite outcomes and fail-closed behavior.
+- [ ] Logs and artifacts are sensitivity-safe and retention-bounded.
+- [ ] Workflow/job/check names are coordinated with branch protection.
+- [ ] Release, publication, catalog, receipt, and proof boundaries remain separate.
+- [ ] Failure diagnostics do not suppress the governing failure.
+- [ ] A rollback/disable path is documented.
+- [ ] `.github/README.md`, this README, Makefile/runbooks, and verification backlog are updated when behavior—not merely prose—changes.
+- [ ] AI-authored changes include a schema-valid generated receipt and remain pending human review until approved.
 
 [Back to top](#top)
 
 ---
 
-## Standard workflow outcomes
+## FAQ
 
-| Outcome | Meaning |
-|---|---|
-| `WORKFLOW_PASS` | Declared checks ran and passed for the declared scope. |
-| `WORKFLOW_FAIL` | Declared checks ran and found a defect. |
-| `WORKFLOW_DENY` | Requested publication/exposure/action must not proceed. |
-| `WORKFLOW_HOLD` | Human, policy, rights, sensitivity, release, correction, or rollback review is required. |
-| `WORKFLOW_ABSTAIN` | Workflow lacks enough support to evaluate the requested claim or gate. |
-| `WORKFLOW_RESTRICT` | The action may proceed only under declared constraints. |
-| `WORKFLOW_SKIPPED_EXPLICIT` | A documented condition skipped the job visibly. |
-| `WORKFLOW_KILL_SWITCH_ACTIVE` | A kill switch stopped a workflow with an explicit outcome. |
-| `WORKFLOW_PUBLIC_SURFACE_DENIED` | Public-surface exposure is blocked. |
-| `WORKFLOW_SYSTEM_ERROR` | Infrastructure, dependency, malformed config, or unexpected runtime error prevented evaluation. |
+### Does a workflow file's presence prove the check is implemented?
+
+No. Thirty-four indexed workflow files explicitly call themselves greenfield scaffolds. Read the steps and invoked command before assigning implementation status.
+
+### Is a passing stub safe to require in branch protection?
+
+Not as substantive enforcement. An `echo TODO ...` job can pass while checking nothing. A required stub may create false assurance and should be graduated or clearly named as a placeholder before it carries governance weight.
+
+### Can a workflow publish to `data/published/` or create a release?
+
+Only through separately governed release machinery with explicit authority, policy, review, receipts/proofs, correction, and rollback. Ordinary CI and watchers are non-publishers.
+
+### Are uploaded GitHub Actions artifacts KFM proof objects?
+
+No. They are temporary platform artifacts unless an accepted, validated tool promotes their content into the correct governed home through an auditable state transition.
+
+### Why are actions such as `actions/checkout@v7` called a risk?
+
+A major tag is mutable. It is easier to maintain than a full SHA but does not provide immutable supply-chain pinning. KFM should record and deliberately resolve that tradeoff rather than calling it pinned.
+
+### Why does the MapLibre workflow need special attention?
+
+It is the only inspected workflow with `id-token: write`, it installs multiple network dependencies, and its path filters reference `apps/web/**` and `schemas/maplibre/**`, while current Directory Rules point to `apps/explorer-web/` and `schemas/contracts/v1/maplibre/`. That is a repository-grounded drift candidate, not a reason to rewrite it inside this README PR.
+
+### Should duplicate schema-validation workflows be deleted here?
+
+No. `schema-validation.yml` and `validator-suite.yml` both invoke `make schemas`, but deletion could break branch protection or reviewer expectations. First verify required checks, run history, intended ownership, and migration/rollback impact in a separate workflow PR.
 
 [Back to top](#top)
 
@@ -297,16 +556,19 @@ A workflow PR is ready for review when:
 
 ## Open verification items
 
-- **NEEDS VERIFICATION** — complete inventory of `.github/workflows/*.yml` and `.yaml` on the default branch.
-- **NEEDS VERIFICATION** — exact branch-protection required-check names.
-- **NEEDS VERIFICATION** — whether `integrity.yml` or equivalent exists and invokes the local verification script.
-- **NEEDS VERIFICATION** — whether `verify.sh`, Make targets, or package scripts reproduce CI locally.
-- **NEEDS VERIFICATION** — whether workflow actions are SHA-pinned.
-- **NEEDS VERIFICATION** — whether policy parity is checked against runtime/infra references.
-- **NEEDS VERIFICATION** — whether generated reports, receipts, proofs, release dry-runs, and artifacts write only to accepted homes.
-- **NEEDS VERIFICATION** — whether CODEOWNERS review is required by branch protection.
-- **NEEDS VERIFICATION** — whether AI-generated receipt gates are wired for AI-authored changes.
-- **NEEDS VERIFICATION** — whether public-boundary tests deny RAW/WORK/QUARANTINE/candidate/internal/model-output paths.
+- **NEEDS VERIFICATION** — byte-complete inventory of `.github/workflows/`, including `.yaml`, reusable workflows, disabled files, and files without `runs-on`.
+- **NEEDS VERIFICATION** — exact required-check names and branch-protection rules on `main`.
+- **NEEDS VERIFICATION** — effective default `GITHUB_TOKEN` permissions at repository and organization scope.
+- **NEEDS VERIFICATION** — current workflow run history, failure causes, duration, artifact contents, and pass rates.
+- **NEEDS VERIFICATION** — whether `.github/CODEOWNERS` teams exist and required-review enforcement is active.
+- **NEEDS VERIFICATION** — immutable SHA pinning plan for third-party actions and setup actions.
+- **NEEDS VERIFICATION** — dependency-network and source-network allowlists for jobs that install packages or fetch browser binaries.
+- **NEEDS VERIFICATION** — whether broad PR workflows should receive path filters to avoid unrelated doc-only execution.
+- **NEEDS VERIFICATION** — whether `schema-validation.yml` and `validator-suite.yml` are intentionally distinct required checks or accidental overlap.
+- **NEEDS VERIFICATION** — whether PMTiles no-artifact skips and shape-only signature checks meet their advertised assurance level.
+- **CONFLICTED / NEEDS VERIFICATION** — MapLibre workflow paths `apps/web/**` and `schemas/maplibre/**` versus current Directory Rules placement.
+- **NEEDS VERIFICATION** — parent `.github/README.md` still describes workflow inventory as unverified and should be synchronized in a separate bounded documentation change or the next behavior-changing workflow PR.
+- **UNKNOWN** — which of the 34 stubs should be graduated, retired, consolidated, or kept as explicit roadmap placeholders.
 
 [Back to top](#top)
 
@@ -314,6 +576,9 @@ A workflow PR is ready for review when:
 
 ## Changelog
 
-| Date | Change | Status |
-|---|---|---|
-| 2026-07-08 | Replaced empty placeholder with workflow-subtree README. | **CONFIRMED README / workflow behavior NEEDS VERIFICATION** |
+| Date | Version | Change | Status |
+|---|---|---|---|
+| 2026-07-08 | v0.1 | Replaced the empty placeholder with a workflow-subtree governance README. | **CONFIRMED README / workflow behavior largely NEEDS VERIFICATION** |
+| 2026-07-17 | v0.2 | Replaced the speculative future catalog with a pinned, repository-grounded 41-file indexed inventory; separated 34 explicit greenfield stubs from seven command-bearing workflows; added trigger/permission threat preflight, local-parity evidence, drift findings, stub-graduation rules, maintenance checks, and bounded open verification items. | **CONFIRMED documentation update / workflow execution and branch protection not changed** |
+
+[Back to top](#top)

--- a/data/receipts/generated/genrec-github-workflows-readme-cbd75db2.json
+++ b/data/receipts/generated/genrec-github-workflows-readme-cbd75db2.json
@@ -1,0 +1,134 @@
+{
+  "receipt_id": "genrec-github-workflows-readme-cbd75db2",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    ".github/workflows/README.md"
+  ],
+  "artifact_hashes": {
+    ".github/workflows/README.md": "sha256:cbd75db2f3903e0e625f47f01b45991e1fe429ca31c9476e6e821e9fde9d71ff"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "GPT-5.6 Thinking",
+    "version": "2026-07-17"
+  },
+  "prompt_or_contract": "sha256:b061d3d8b153af8083cd1f62f447b389c396b5a882e590328ede7c3e3ff25e85",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "repository code search",
+      "repository file reads",
+      "local deterministic content validation"
+    ]
+  },
+  "inputs": {
+    "attached_docs": [
+      "Pasted text(40).txt"
+    ],
+    "evidence_refs": [
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/66610a2ee8bdc15713d1e5a5b0350081a1d7771c",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/.github/workflows/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/.github/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/.github/CODEOWNERS",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/.github/PULL_REQUEST_TEMPLATE.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/docs/doctrine/directory-rules.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/docs/registers/DRIFT_REGISTER.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/docs/adr/ADR-0018-promotion-gate-sequence.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/Makefile",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/tools/ci/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/schemas/contracts/v1/receipts/generated_receipt.schema.json"
+    ]
+  },
+  "truth_labels": {
+    ".github/workflows/README.md": "CONFIRMED"
+  },
+  "validation_gates": [
+    {
+      "gate": "repository-and-authority-preflight",
+      "outcome": "PASS",
+      "reason": "Repository identity, default branch, immutable base commit, write permission, target blob SHA, Directory Rules, proposed workflow-related ADRs, drift register, CODEOWNERS, PR template, receipt schema, overlapping branches, and open pull requests were inspected before mutation."
+    },
+    {
+      "gate": "workflow-trigger-threat-preflight",
+      "outcome": "PASS",
+      "reason": "Indexed workflow searches found no pull_request_target, workflow_run, self-hosted, secrets., or ordinary write-scope matches. The only observed id-token: write permission is in the path-scoped MapLibre workflow, which is not triggered by this README path. Broad pull_request workflows and floating action major tags are documented as current risks."
+    },
+    {
+      "gate": "repository-grounded-inventory",
+      "outcome": "PASS",
+      "reason": "The README records a bounded indexed inventory of 41 runnable-job workflows: 34 files with the explicit PROPOSED greenfield scaffold marker and seven command-bearing workflows whose triggers and commands were inspected. The inventory explicitly does not claim byte-complete directory enumeration."
+    },
+    {
+      "gate": "directory-rules-and-readme-contract",
+      "outcome": "PASS",
+      "reason": "The file remains under the existing .github/workflows subtree, creates no authority root, preserves the existing doc_id and creation date, and contains the required README headings in Directory Rules order."
+    },
+    {
+      "gate": "markdown-structure-and-inventory-consistency",
+      "outcome": "PASS",
+      "reason": "The final document has one H1, balanced code fences, a final newline, all required headings in order, exactly 34 named stub workflows, exactly seven named command-bearing workflows, and a total inventory of 41."
+    },
+    {
+      "gate": "scope-and-sensitive-content",
+      "outcome": "PASS",
+      "reason": "The change is documentation plus provenance only. It adds no workflow YAML, secret, token, endpoint, sensitive location, source payload, policy decision, release object, deployment change, or publication path."
+    },
+    {
+      "gate": "workflow-execution-and-branch-protection",
+      "outcome": "SKIPPED",
+      "reason": "No workflow run history, branch-protection settings, or effective repository-level token defaults were modified or asserted as verified. These remain explicit open verification items."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "uploaded-authoring-operating-prompt-v3-1",
+      "validated": true,
+      "evidence_ref": "attachment://Pasted text(40).txt#sha256=b061d3d8b153af8083cd1f62f447b389c396b5a882e590328ede7c3e3ff25e85"
+    },
+    {
+      "id": "directory-rules-readme-contract-and-placement",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/docs/doctrine/directory-rules.md"
+    },
+    {
+      "id": "target-readme-baseline",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/.github/workflows/README.md"
+    },
+    {
+      "id": "workflow-command-and-trigger-inventory",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/tree/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/.github/workflows"
+    },
+    {
+      "id": "local-parity-make-targets",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/Makefile"
+    },
+    {
+      "id": "generated-receipt-machine-shape",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/66610a2ee8bdc15713d1e5a5b0350081a1d7771c/schemas/contracts/v1/receipts/generated_receipt.schema.json"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-17T15:56:22Z",
+  "emitter": "openai-chatgpt/gpt-5.6-thinking",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "AI-authored documentation revision on a scoped review branch. The update replaces speculative workflow planning with a pinned, evidence-bounded inventory and threat preflight. It does not change workflow behavior, branch protection, policy, schemas, contracts, tests, runtime, release, publication, or KFM evidence authority. Human review remains pending; this receipt is provenance evidence, not workflow success, proof closure, release approval, or publication authority."
+}


### PR DESCRIPTION
## Goal

Update `.github/workflows/README.md` from a mostly aspirational workflow catalog into a pinned, repository-grounded operating reference for the current GitHub Actions subtree.

## Status labels

- [x] `CONFIRMED` — target README, workflow files, Make targets, Directory Rules, PR template, receipt schema, CODEOWNERS placeholder, ADR status, branch, commit, and remote diff were inspected.
- [x] `PROPOSED` — workflow hardening recommendations, stub-graduation rules, and future verification work remain recommendations rather than implementation claims.
- [x] `NEEDS VERIFICATION` — branch protection, effective default token permissions, current run history, action SHA-pinning migration, complete non-indexed workflow inventory, and CODEOWNERS enforcement.
- [x] `UNKNOWN` — which greenfield stubs should be graduated, consolidated, retained, or retired.

## Task contract

| Field | Value |
|---|---|
| `task_id` | `kfm-github-workflows-readme-20260717` |
| Repository | `bartytime4life/Kansas-Frontier-Matrix` |
| Base | `main@66610a2ee8bdc15713d1e5a5b0350081a1d7771c` |
| Target | `.github/workflows/README.md` |
| Operation | `revise-existing-doc` |
| Authority | `IMPLEMENT` |
| Delivery | review branch + draft PR |
| Execution profile | `API_ONLY_STRICT` through the authenticated GitHub connector |
| Change budget | two files across `.github/` and `data/receipts/` |
| Non-goals | no workflow YAML, repository settings, branch protection, policy, schema, contract, test, runtime, release, deployment, or publication changes |

## Evidence inspected

- `.github/workflows/README.md`
- `.github/README.md`
- `.github/CODEOWNERS`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `docs/doctrine/directory-rules.md`
- `docs/registers/DRIFT_REGISTER.md`
- `docs/adr/ADR-0018-promotion-gate-sequence.md` — **proposed, not accepted**
- `docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md` — **proposed, not accepted**
- `Makefile`
- `tools/ci/README.md`
- `schemas/contracts/v1/receipts/generated_receipt.schema.json`
- indexed `.github/workflows/` searches and direct reads of command-bearing and broad-trigger workflows
- overlapping branches and open PRs for this target scope

## Directory Rules basis

- `.github/workflows/README.md` remains under the existing GitHub-platform orchestration root.
- `data/receipts/generated/genrec-github-workflows-readme-cbd75db2.json` records AI-authored artifact provenance in the existing generated-receipt lane.
- No root, lifecycle phase, schema home, policy home, registry home, release home, proof home, or publication path is created or changed.
- The README now includes the required folder-README headings in the Directory Rules order.

## Affected roots

- [ ] `docs/`
- [ ] `schemas/`
- [ ] `contracts/`
- [ ] `policy/`
- [ ] `data/registry/`
- [ ] `tools/`
- [ ] `packages/`
- [ ] `apps/`
- [ ] `pipelines/`
- [ ] `release/`
- [ ] `runtime/` / `infra/` / `configs/`
- [x] Other: `.github/`, `data/receipts/generated/`

Cross-cutting: N/A — two responsibility roots, both limited to documentation/provenance.

## Affected object families

- [ ] `SourceDescriptor`
- [ ] `EvidenceRef` / `EvidenceBundle`
- [ ] `PolicyDecision`
- [ ] `ValidationReport`
- [ ] `RunReceipt`
- [ ] `AIReceipt`
- [x] `GENERATED_RECEIPT.json`
- [ ] `CitationValidationReport`
- [ ] `RuntimeResponseEnvelope`
- [ ] `PromotionDecision` / `ReleaseManifest`
- [ ] `CorrectionNotice` / `RollbackCard`
- [ ] `LayerManifest` / `MapReleaseManifest`
- [ ] `RedactionReceipt`
- [ ] None

## Affected lifecycle stages

- [ ] RAW
- [ ] WORK / QUARANTINE
- [ ] PROCESSED
- [ ] CATALOG / TRIPLET
- [ ] PUBLISHED
- [x] None — documentation and generated provenance only

## What changed

- Updated the README metadata to v0.2 with a pinned repository evidence snapshot.
- Replaced the speculative future workflow catalog with a bounded indexed inventory of **41 runnable-job workflow files**.
- Separated **34 explicit `PROPOSED greenfield scaffold` workflows** from **seven command-bearing workflows**.
- Documented the inspected triggers, commands, artifact behavior, local-parity Make targets, current TODO targets, and workflow maturity limits.
- Added a workflow-trigger threat preflight covering privileged event types, self-hosted runners, secrets, write permissions, OIDC, action pinning, fork posture, and README-only trigger impact.
- Surfaced repository-grounded drift instead of silently fixing it, including MapLibre path filters that reference `apps/web/**` and `schemas/maplibre/**`.
- Added stub-graduation criteria, authoring contract, maintenance checklist, FAQ, and explicit open verification items.
- Added the required generated receipt for the AI-authored README.

## What did not change

- No `.yml` or `.yaml` workflow file.
- No trigger, job, permission, runner, action version, secret, environment, repository setting, or branch-protection rule.
- No policy, schema, contract, validator, fixture, test, app, runtime, release, catalog, proof, or publication behavior.
- No acceptance or authority upgrade for the proposed ADRs.
- No attempt to delete overlapping workflows or repair MapLibre path drift in a documentation PR.

## Workflow-trigger threat preflight

- No indexed `pull_request_target`, `workflow_run`, `self-hosted`, `secrets.`, or ordinary write-scope match was found.
- The only observed `id-token: write` is in `maplibre-perf-governance.yml`, whose path filters do not match this README.
- Broad `pull_request` workflows may still run on this docs-only PR, including command-bearing validation workflows and greenfield stubs.
- Inspected actions use floating major tags such as `@v6` and `@v7`; the README records this as a supply-chain hardening gap rather than calling them immutable pins.
- Effective repository/organization token defaults remain unverified.

## Validation

**Performed:**

- Repository identity, visibility, permissions, default branch, pinned base, and target blob SHA verified.
- Base rechecked immediately before mutation; no base drift detected.
- Target branch created from the immutable base SHA.
- README structural checks: one H1, valid Meta Block boundaries, balanced fences, final newline.
- Directory Rules README headings verified present and ordered.
- Inventory consistency verified: exactly 34 named stubs + seven named command-bearing workflows = 41.
- Uploaded prompt SHA-256 verified: `b061d3b8…25e85`.
- Final README SHA-256 verified: `cbd75db2…d71ff`.
- Remote README Git blob SHA matched the locally validated bytes: `c3dfbe1168d405e7244c6a7dacf0e0616faf120e`.
- Remote receipt Git blob SHA matched the locally validated bytes: `0e7bf2d7d5ca5c668ebac64d1d555a1b121cb3d1`.
- Generated receipt parsed as JSON and passed the repository schema contract's required-field, enum, pattern, hash, citation, and review-state checks.
- Remote compare confirms exactly two changed paths, two commits, no base divergence.

**Not performed (and why):**

- Workflow execution: this PR changes no workflow behavior; GitHub will report any broad-trigger runs separately.
- Branch-protection/settings inspection: not exposed by the selected safe mutation flow and not required to revise documentation; left explicit as `NEEDS VERIFICATION`.
- Live source or deployment checks: out of scope and unnecessary for documentation/provenance.

## Acceptance matrix

| Criterion | Outcome |
|---|---|
| Existing README revised in place; `doc_id` and creation date preserved | PASS |
| Repository-grounded inventory replaces speculative file claims | PASS |
| Stub and command-bearing maturity are separated truthfully | PASS |
| Trigger/permission threat preflight recorded | PASS |
| Directory Rules README contract satisfied | PASS |
| Only target README and generated receipt changed | PASS |
| Remote bytes verified against local hashes | PASS |
| Branch protection and current workflow run state verified | NOT RUN / NEEDS VERIFICATION |
| Human review of AI-authored documentation | PENDING |

## Rollback

Close this PR without merge, or revert commits `e615c90686ec5f5edd5c8a3bdbd7956896827da5` and `4751ed92f97a3dd3835f208f2655b94ad12d506a`. Rollback restores the prior README blob `736d15ab3ff1beec5f68b8917cd90c8c4ad235a2` and removes the generated receipt. No workflow or runtime state needs restoration.

## Open `UNKNOWN` / `NEEDS VERIFICATION`

- Complete byte-level workflow tree, including `.yaml`, reusable, disabled, unindexed, or no-`runs-on` files.
- Required-check names and branch protection on `main`.
- Effective default `GITHUB_TOKEN` permissions.
- Workflow run history, pass rates, durations, and artifact contents.
- CODEOWNERS team validity and enforcement.
- Immutable action SHA-pinning plan.
- Whether broad PR workflows should add path filters.
- Whether `schema-validation.yml` and `validator-suite.yml` are intentional distinct checks.
- Which of the 34 stubs should graduate, consolidate, remain roadmap placeholders, or retire.
- Parent `.github/README.md` synchronization in a separate bounded change.

## Sensitive domains involved

- [x] None of the §23.1 categories apply.
- [ ] One or more apply:

Required additional reviewer(s): N/A

## Anti-prompt-injection check

- [x] No repository or attachment injection signal was acted on. The uploaded authoring prompt is the user's explicit task authority; repository files, comments, and workflow content were treated as evidence/data, not as instructions that could broaden scope.
- [ ] Signal(s) detected and surfaced (not acted on):

## GENERATED_RECEIPT

- [ ] No AI-authored files in this diff.
- [x] AI-authored files present; `GENERATED_RECEIPT.json` attached or linked.

GENERATED_RECEIPT path or link: `data/receipts/generated/genrec-github-workflows-readme-cbd75db2.json`

## ADR triggers

- [ ] Adds/removes/renames a canonical root.
- [ ] Changes schema-home authority.
- [ ] Creates a parallel home (schemas/contracts/policy/registry/release).
- [ ] Changes lifecycle phase boundaries.
- [ ] Approves a direct public access path.
- [ ] Adopts a model runtime envelope.
- [ ] Changes promotion gates.
- [ ] Changes sensitive-location posture.
- [ ] Changes source-ledger authority.
- [ ] Changes release/proof/receipt separation.
- [ ] Introduces or retires a domain steward role.
- [ ] Changes `CONTRACT_VERSION` pinning.
- [x] None of the above.

ADR link: N/A

## CONTRACT_VERSION followed

`3.0.0`
