### PR TITLE
chore(github): govern Dependabot updates for the monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,147 @@
+# Kansas Frontier Matrix Dependabot configuration
+# Version: v1.0
+# Updated: 2026-07-17
+#
+# Authority boundary:
+# - Dependabot proposes dependency changes through pull requests.
+# - It does not approve, merge, release, publish, change policy, or establish
+#   that an update is compatible, secure, rights-cleared, or production-ready.
+# - Security updates stay on the default branch because no target-branch is set.
+# - Group rules below apply only to version updates; security updates remain
+#   isolated for focused review.
+# - Labels are intentionally omitted until the repository label inventory is
+#   verified. CODEOWNERS remains the review-routing surface.
+# - Docker base-image monitoring is not enabled here because the current files
+#   use custom Dockerfile.* placeholder names; supported discovery and intended
+#   activation remain NEEDS VERIFICATION.
+
 version: 2
+
 updates:
-  - package-ecosystem: pip
+  # Python monorepo: root app, application, package, domain-package, pipeline,
+  # and connector manifests. Globs are intentionally bounded to known
+  # responsibility roots rather than scanning every repository directory.
+  - package-ecosystem: "pip"
+    directories:
+      - "/"
+      - "/apps/*"
+      - "/packages/*"
+      - "/packages/domains/*"
+      - "/pipelines/*"
+      - "/connectors/*"
+      - "/connectors/*/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 6
+    assignees:
+      - "bartytime4life"
+    commit-message:
+      prefix: "deps(python)"
+      prefix-development: "deps(python-dev)"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "-"
+    groups:
+      python-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        group-by: "dependency-name"
+      python-major:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+        group-by: "dependency-name"
+
+  # The root package.json declares the apps/* and packages/* workspaces.
+  - package-ecosystem: "npm"
     directory: "/"
-    schedule: { interval: weekly }
-  - package-ecosystem: npm
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 4
+    assignees:
+      - "bartytime4life"
+    commit-message:
+      prefix: "deps(node)"
+      prefix-development: "deps(node-dev)"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "-"
+    groups:
+      node-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      node-major:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  # GitHub Actions references in .github/workflows and repository-local actions.
+  - package-ecosystem: "github-actions"
     directory: "/"
-    schedule: { interval: weekly }
-  - package-ecosystem: github-actions
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 3
+    assignees:
+      - "bartytime4life"
+    commit-message:
+      prefix: "ci(actions)"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "-"
+    groups:
+      actions-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  # Root .pre-commit-config.yaml hook revisions.
+  - package-ecosystem: "pre-commit"
     directory: "/"
-    schedule: { interval: weekly }
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 2
+    assignees:
+      - "bartytime4life"
+    commit-message:
+      prefix: "chore(pre-commit)"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "-"
+    groups:
+      pre-commit-hooks:
+        applies-to: "version-updates"
+        patterns:
+          - "*"

--- a/data/receipts/generated/genrec-dependabot-config-bb88ad97.json
+++ b/data/receipts/generated/genrec-dependabot-config-bb88ad97.json
@@ -1,0 +1,135 @@
+{
+  "receipt_id": "genrec-dependabot-config-bb88ad97",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    ".github/dependabot.yml"
+  ],
+  "artifact_hashes": {
+    ".github/dependabot.yml": "sha256:bb88ad97cca9627407a36b922092e206ed30e1b91f7f5e4f0a95028664eeeda3"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "GPT-5.6 Thinking",
+    "version": "2026-07-17"
+  },
+  "prompt_or_contract": "sha256:b061d3d8b153af8083cd1f62f447b389c396b5a882e590328ede7c3e3ff25e85",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "repository evidence inspection",
+      "official GitHub Dependabot documentation",
+      "YAML and structural validation",
+      "remote repository verification"
+    ]
+  },
+  "inputs": {
+    "attached_docs": [
+      "Pasted text(40).txt — KFM GitHub Repository Documentation Implementation Agent v3.1"
+    ],
+    "evidence_refs": [
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/ff16fe04bacb732561dbd5f557250b949a14673f",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/.github/dependabot.yml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/.github/CODEOWNERS",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/pyproject.toml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/package.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/apps/explorer-web/package.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/.pre-commit-config.yaml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/infra/docker/Dockerfile.governed-api",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/infra/docker/Dockerfile.explorer-web",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/schemas/contracts/v1/receipts/generated_receipt.schema.json",
+      "https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference",
+      "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-version-updates"
+    ]
+  },
+  "truth_labels": {
+    ".github/dependabot.yml": "PROPOSED"
+  },
+  "validation_gates": [
+    {
+      "gate": "repository-and-base-preflight",
+      "outcome": "PASS",
+      "reason": "Verified repository identity, default branch, immutable base commit ff16fe04bacb732561dbd5f557250b949a14673f, target blob, and absence of overlapping open pull requests or similarly named branches."
+    },
+    {
+      "gate": "yaml-and-required-shape",
+      "outcome": "PASS",
+      "reason": "Parsed the final YAML and verified version 2, four unique update entries, exactly one of directory/directories per entry, weekly schedules with valid days/times/timezone, positive PR limits, and supported group fields."
+    },
+    {
+      "gate": "monorepo-manifest-coverage",
+      "outcome": "PASS",
+      "reason": "Confirmed the root Python project, distributed pyproject.toml manifests under apps/packages/connectors, the root npm workspace declaration, GitHub Actions workflows, and root pre-commit configuration; Python directory globs are bounded to known responsibility roots."
+    },
+    {
+      "gate": "security-update-isolation-and-default-branch",
+      "outcome": "PASS",
+      "reason": "No target-branch is configured, and every group explicitly applies only to version-updates, leaving security updates isolated and default-branch based."
+    },
+    {
+      "gate": "review-routing-and-metadata-restraint",
+      "outcome": "PASS",
+      "reason": "The only assignee is verified repository admin bartytime4life. Labels and unverified teams are omitted; CODEOWNERS remains the review-routing surface."
+    },
+    {
+      "gate": "unsupported-or-unverified-ecosystem-restraint",
+      "outcome": "PASS",
+      "reason": "Docker monitoring was not activated because the repository currently uses custom Dockerfile.* greenfield placeholders and intended Dependabot discovery behavior was not verified strongly enough."
+    },
+    {
+      "gate": "remote-readback-and-hash",
+      "outcome": "PASS",
+      "reason": "GitHub returned blob SHA f1bb101082f7b9910c3ceef4c9d9f64024ccf1dd, matching the computed Git blob SHA; SHA-256 recomputed as bb88ad97cca9627407a36b922092e206ed30e1b91f7f5e4f0a95028664eeeda3."
+    },
+    {
+      "gate": "dependabot-default-branch-runtime-validation",
+      "outcome": "SKIPPED",
+      "reason": "Dependabot parses and executes the configuration from the default branch after merge. Job logs, dependency graph status, generated PR behavior, and repository security settings remain NEEDS VERIFICATION."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "current-dependabot-config",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/.github/dependabot.yml"
+    },
+    {
+      "id": "python-monorepo-manifests",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/search/pyproject.toml@ff16fe04bacb732561dbd5f557250b949a14673f"
+    },
+    {
+      "id": "root-npm-workspace",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/ff16fe04bacb732561dbd5f557250b949a14673f/package.json"
+    },
+    {
+      "id": "dependabot-options-reference",
+      "validated": true,
+      "evidence_ref": "https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference"
+    },
+    {
+      "id": "dependabot-version-update-configuration",
+      "validated": true,
+      "evidence_ref": "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-version-updates"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-17T16:56:59Z",
+  "emitter": "openai/gpt-5.6-thinking",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "AI-authored Dependabot configuration update on a scoped review branch. The file proposes version-update scheduling and review metadata only. It does not prove that Dependabot version updates, security updates, dependency graph processing, grouped PR creation, branch protection, required reviews, labels, or runtime compatibility checks are active or successful. Human review remains pending."
+}


### PR DESCRIPTION
## Goal:

Replace the minimal root-only Dependabot configuration with a repository-grounded update policy for KFM's Python monorepo, root npm workspace, GitHub Actions, and pre-commit hooks while keeping security updates isolated and all dependency changes review-only.

## Task contract:

| Field | Value |
|---|---|
| `task_id` | `kfm-dependabot-config-20260717` |
| `goal` | Expand `.github/dependabot.yml` to cover confirmed dependency ecosystems and monorepo manifest locations without inventing labels, teams, registries, or automatic merge/release authority. |
| `repository` | `bartytime4life/Kansas-Frontier-Matrix` |
| `base_ref` | `main@ff16fe04bacb732561dbd5f557250b949a14673f` |
| `target_paths` | `.github/dependabot.yml`; generated receipt only |
| `operation` | `revise-existing-config` |
| `authority` | `IMPLEMENT` |
| `delivery_route` | review branch + draft PR |
| `execution_profile` | `API_ONLY_STRICT` through the authenticated GitHub connector |
| `source_inputs` | Current config, root and distributed Python manifests, root npm workspace, pre-commit config, workflows evidence, CODEOWNERS, generated-receipt schema, and current official GitHub Dependabot documentation |
| `in_scope` | Ecosystem coverage, manifest locations, schedules, grouping, PR limits, assignee, commit/branch naming, governance comments, validation, and provenance |
| `non_goals` | No auto-merge, labels, registries, secrets, target branches, dependency versions, lockfiles, workflows, branch protection, policy, runtime, release, or publication changes |
| `acceptance_criteria` | Valid version-2 YAML; cover confirmed ecosystems; use bounded Python directory globs; keep security updates ungrouped; use only verified assignee; omit unverified labels/teams; limit diff to config + receipt |
| `validation_required` | YAML parse, option structure, manifest evidence, security isolation, owner verification, remote hashes, receipt contract, base drift, and remote compare |
| `stop_conditions` | Base drift, overlapping work, target SHA mismatch, invalid option shape, unverified identity/label, security-update grouping, or unrelated changed path |
| `change_budget` | Two files across `.github/` and `data/receipts/generated/` |

## Status labels:

- [x] `CONFIRMED` — current config, root Python/npm manifests, distributed Python manifest pattern, npm workspace declaration, pre-commit config, GitHub Actions location, verified assignee, base, hashes, and remote diff were inspected.
- [x] `PROPOSED` — the updated configuration remains proposed until reviewed, merged to the default branch, and parsed by Dependabot.
- [x] `NEEDS VERIFICATION` — Dependabot default-branch parse result, job logs, dependency graph status, generated PR volume, group behavior, security-update settings, and branch-protection enforcement.
- [x] `UNKNOWN` — whether future manifests need additional directory patterns and whether custom `Dockerfile.*` placeholders should later be activated for Docker updates.

## Evidence inspected:

| Evidence location | Observation supported | Status |
|---|---|---|
| `.github/dependabot.yml@ff16fe04…` | Prior config monitored pip, npm, and GitHub Actions only at `/`, with minimal weekly schedules | `CONFIRMED` |
| `pyproject.toml@ff16fe04…` | Root Python project and dependencies | `CONFIRMED` |
| repository search for `pyproject.toml` | Python manifests exist under apps, packages, domain packages, and connectors | `CONFIRMED indexed inventory / complete tree NEEDS VERIFICATION` |
| `package.json@ff16fe04…` | Root npm project declares `apps/*` and `packages/*` workspaces | `CONFIRMED` |
| `apps/explorer-web/package.json@ff16fe04…` | Workspace package exists | `CONFIRMED` |
| `.pre-commit-config.yaml@ff16fe04…` | Standard root pre-commit hook manifest exists | `CONFIRMED` |
| `.github/CODEOWNERS@ff16fe04…` | `.github/` routes to verified repository admin `@bartytime4life` | `CONFIRMED` |
| `infra/docker/Dockerfile.governed-api` and `Dockerfile.explorer-web` | Custom-named greenfield Docker placeholders exist | `CONFIRMED files / Dependabot discovery NEEDS VERIFICATION` |
| official GitHub Dependabot options reference | Version 2 keys, multi-directory globs, groups, schedules, PR limits, assignees, commit messages, and branch separators | `CONFIRMED current primary documentation` |
| `schemas/contracts/v1/receipts/generated_receipt.schema.json@ff16fe04…` | Generated-receipt machine shape | `CONFIRMED` |

## Directory Rules basis:

| Path | Owning root | Basis | Status |
|---|---|---|---|
| `.github/dependabot.yml` | `.github/` | Existing GitHub-platform dependency-intake configuration; no move or new root | `CONFIRMED` |
| `data/receipts/generated/genrec-dependabot-config-bb88ad97.json` | `data/receipts/generated/` | Existing generated-work provenance lane | `CONFIRMED existing lane` |

- [x] No canonical root, lifecycle stage, schema home, policy home, registry home, proof home, receipt home, or release home is created or moved.
- [x] Dependabot is treated as a PR proposer, not policy, validation, approval, release, or publication authority.
- [x] No ADR or migration record is required for this bounded platform-configuration revision.

## Affected roots:

- [x] `.github/`
- [x] `data/receipts/generated/`
- [ ] Other canonical roots

**Cross-cutting explanation:** N/A — one platform configuration and its provenance record.

## Affected object families:

- [x] `GENERATED_RECEIPT`
- [ ] Trust-bearing domain, policy, evidence, promotion, release, correction, or rollback objects

## Affected lifecycle stages:

- [x] None — dependency PR orchestration and generated provenance only.

## Public surfaces and governed-interface impact:

- [x] No API, UI, map, AI, export, source, lifecycle-data, or published-artifact behavior changes.
- [x] No direct RAW, WORK, QUARANTINE, candidate, internal, or canonical-store access.

**Public-interface notes:** Future Dependabot PRs may propose dependency changes, but each remains a normal reviewable PR and receives no release or publication authority from this configuration.

## What changed:

- Expanded Python coverage from root-only to bounded globs for the root, apps, packages, domain packages, pipelines, top-level connectors, and two-level connector lanes.
- Preserved the root npm entry because the root `package.json` declares the workspace boundary.
- Retained GitHub Actions monitoring and added root pre-commit hook monitoring.
- Staggered weekly schedules across Monday, Tuesday, Wednesday, and Friday at `06:00 America/Chicago`.
- Added bounded open-PR limits per ecosystem.
- Assigned generated PRs only to verified repository admin `bartytime4life`.
- Added conventional commit prefixes and hyphenated Dependabot branch names.
- Grouped only version updates: Python updates are grouped by dependency across directories; Node and Actions routine/major updates are separated; pre-commit hooks are grouped.
- Left security updates ungrouped and omitted `target-branch`, preserving default-branch security-update behavior.
- Omitted unverified labels, teams, registries, secrets, and auto-merge behavior.
- Documented why Docker monitoring is not activated yet.
- Added the generated provenance receipt.

## What did not change:

- No dependency version, manifest, lockfile, source code, workflow, policy, schema, contract, fixture, test, runtime, infrastructure, release, correction, rollback, or published artifact.
- No Dependabot auto-merge or update command automation.
- No private registry, credential, secret, insecure external code execution, target branch, or release branch.
- No label or reviewer team whose existence was not verified.
- No grouping of security updates.
- No assertion that Dependabot or branch protection will accept or enforce the configuration before default-branch validation.

## Contract, schema, policy, test, and documentation impact:

| Surface | Changed? | Evidence or explanation |
|---|---:|---|
| Contracts / semantic meaning | No | Dependency object meaning unchanged. |
| Schemas / machine shape | No | Existing receipt schema consumed only. |
| Policy / admissibility | No | No Rego or policy change. |
| Fixtures / tests | No | Static configuration validation only. |
| GitHub automation | Yes | Dependabot version-update configuration changes after merge. |
| Manifests / dependency versions | No | Read-only evidence inputs. |
| Documentation | In-file governance comments only | No separate README changed. |
| Receipts | Yes, provenance only | One generated receipt added. |

## Workflow-trigger threat preflight:

- [x] This PR changes `.github/dependabot.yml` and a generated receipt; broad pull-request workflows may run.
- [x] No workflow YAML, trigger, runner, permission, secret, OIDC scope, environment, deployment, release, or publication step is changed.
- [x] Dependabot-generated PRs remain ordinary PRs and are not automatically merged by this configuration.
- [x] No private registries or secret references are introduced.
- [x] No `target-branch` is introduced; security updates remain associated with the default branch.
- [x] Version groups explicitly use `applies-to: version-updates`; security updates remain isolated.
- [x] Labels are omitted because label existence was not verified.
- [x] Future dependency PRs may trigger repository CI; their outcomes and compatibility remain separate validation obligations.

| Threat surface | Finding | Status / mitigation |
|---|---|---|
| Automated PR volume | Grouping and per-ecosystem limits reduce routine version-update volume | `PROPOSED; verify after scheduled runs` |
| Security update dilution | Security updates are not grouped by these rules | `PASS static configuration` |
| Credential exposure | No registries or secrets configured | `PASS` |
| Untrusted code execution | No Dependabot external-code-execution override configured | `PASS` |
| Automatic merge/release | Not configured | `PASS` |
| Future CI execution | Dependabot PRs can trigger normal PR checks | `NEEDS VERIFICATION per PR` |
| Branch protection / required review | Not changed | `NEEDS VERIFICATION` |

## Validation:

### Performed

| Check | Outcome | Evidence |
|---|---|---|
| Repository/ref/target preflight | PASS | `main@ff16fe04…`; target blob `89c236e0…` |
| Overlapping PR/branch search | PASS | No open matching PR or branch found |
| YAML parse | PASS | Parsed as mapping with `version: 2` and four updates |
| Required option structure | PASS | Each update has one directory form, weekly schedule, valid day/time/timezone, positive PR limit, and verified assignee |
| Ecosystem uniqueness | PASS | `pip`, `npm`, `github-actions`, `pre-commit` |
| Python multi-directory coverage | PASS | Seven bounded directory/glob entries |
| Security isolation | PASS | All groups apply only to version updates; no target branch |
| Unverified metadata exclusion | PASS | No labels, teams, registries, or secrets |
| Artifact SHA-256 | PASS | `bb88ad97cca9627407a36b922092e206ed30e1b91f7f5e4f0a95028664eeeda3` |
| Remote Git blob | PASS | `f1bb101082f7b9910c3ceef4c9d9f64024ccf1dd` |
| Receipt validation | PASS | Required fields, patterns, enums, citations, timestamps, and artifact hash checked |
| Receipt remote blob | PASS | `eef832ea7c95e070adedf090ed2f9bee093f981a` |
| Base-drift recheck | PASS | `main` remained `ff16fe04…` before PR creation |
| Remote compare | PASS | Two commits, two files, zero behind |

### Not performed

| Check | Reason | Consequence |
|---|---|---|
| Dependabot default-branch parse/job | Configuration is evaluated operationally after merge to the default branch | `NEEDS VERIFICATION` in dependency graph / Dependabot logs |
| Scheduled update run | Future time-based action | `NEEDS VERIFICATION` |
| Generated PR grouping/volume | Requires actual outdated dependencies and scheduled runs | `NEEDS VERIFICATION` |
| Security-update repository setting | Not changed and not exposed by this bounded mutation | `NEEDS VERIFICATION` |
| Docker manifest discovery | Custom placeholder filenames were intentionally not activated | `NEEDS VERIFICATION` |
| Branch protection / auto-merge settings | Out of scope | `NEEDS VERIFICATION` |

## Acceptance matrix:

| Criterion | Outcome | Evidence |
|---|---|---|
| Existing config revised in place | PASS | Same `.github/dependabot.yml` path |
| Required version-2 structure | PASS | Static YAML validation |
| Confirmed ecosystems covered | PASS | Four update entries |
| Python monorepo manifests covered by bounded globs | PASS | Final pip `directories` list |
| Root npm workspace preserved | PASS | Root npm directory entry |
| Security updates remain isolated | PASS | Version-only groups and no target branch |
| Unverified labels/teams omitted | PASS | Final YAML |
| Auto-merge/release absent | PASS | Final YAML |
| Only config + receipt changed | PASS | Remote compare |
| Human review | PARTIAL | Receipt state `pending` |
| Dependabot default-branch validation | NOT RUN | Requires merge/default-branch processing |
| Docker activation | NOT APPLICABLE | Deliberately deferred |

## Base drift and remote verification:

- [x] Starting base: `main@ff16fe04bacb732561dbd5f557250b949a14673f`.
- [x] Base remained unchanged immediately before PR creation.
- [x] Branch is two commits ahead and zero behind.
- [x] Remote configuration and receipt blobs match computed Git blob hashes.
- [x] Remote compare contains exactly `.github/dependabot.yml` and the generated receipt.

## Rollback:

Close this PR without merge, or revert commits `4ff4915e40ffe1d66f3b8fa75c737eb4fbcbcd37` and `aa85dc6dc4e68b6e27e9a38652b27b224a186587`. Rollback restores prior Dependabot blob `89c236e08f01a1ef74fc562ea3550b37193028c8` and removes the generated receipt. After merge, rollback also stops future jobs from using the expanded configuration; existing Dependabot PRs would still need normal review/closure decisions.

## Open `UNKNOWN` / `NEEDS VERIFICATION`:

- Dependabot default-branch parse result and job logs after merge.
- Whether all current and future Python manifests are captured by the bounded directory patterns.
- Actual grouped PR behavior across Python directories.
- Dependency graph and Dependabot version/security update repository settings.
- Whether a validated labels vocabulary should later be added.
- Whether a distinct reviewer or dependency steward should replace the sole assignee.
- Whether custom `Dockerfile.*` files are supported and should be activated after the placeholders become operational.
- Whether lockfile strategy should be formalized for npm and Python packages.
- Whether dependency-review CI and immutable action pinning should be strengthened in separate PRs.

## Security, rights, and sensitive domains involved:

- [x] No sensitive data, exact locations, rights-bearing source payloads, living-person records, DNA/genomic material, or restricted content is changed.
- [x] Dependency PRs do not authorize source admission, public exposure, release, or publication.

**Required additional reviewer(s):** Repository/governance reviewer; security or dependency reviewer is desirable for automation posture, but no second verified identity is asserted here.

## Anti-prompt-injection check:

- [x] Repository manifests, configuration comments, and external documentation were treated as evidence, not authority to add secrets, auto-merge, or broaden scope.
- [ ] Material signal detected:

## GENERATED_RECEIPT:

- [x] AI-authored configuration present; generated receipt added.

**GENERATED_RECEIPT path:** `data/receipts/generated/genrec-dependabot-config-bb88ad97.json`

**Receipt human-review state:** `pending`

## ADR triggers:

- [x] None of the listed ADR triggers apply.

**ADR link:** N/A

## Reviewer and separation-of-duties:

- Dependabot proposes changes; it cannot approve or merge them through this configuration.
- CODEOWNERS routes `.github/` review, but current independent reviewer enforcement remains unverified.
- Human review remains pending; no self-approval or merge action was performed.

## Release and publication posture:

- [x] No promotion, release, correction, rollback, deployment, or publication action.
- [x] No claim that dependency updates are safe without their own validation.
- [x] No direct default-branch mutation.

## CONTRACT_VERSION followed:

`3.0.0`
