### PR TITLE
ci(codeql): enable governed static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,15 +1,93 @@
-# KFM CI workflow stub: codeql
-# Status: PROPOSED greenfield scaffold.
+# KFM CI workflow: CodeQL static analysis
+# Status: implementation-bearing security analysis; non-authoritative for release.
+#
+# Responsibility:
+# - Run GitHub CodeQL analysis for repository-owned Python and
+#   JavaScript/TypeScript source on pull requests, main pushes, a weekly schedule,
+#   and explicit maintainer dispatch.
+# Authority:
+# - A successful run means the configured CodeQL queries completed for the
+#   checked revision. It is not proof that the repository is vulnerability-free,
+#   release approval, publication authority, or a substitute for threat modeling,
+#   dependency scanning, secret scanning, runtime controls, or human review.
+# Pull-request posture:
+# - Uses pull_request, never pull_request_target. Untrusted code is analyzed with
+#   the minimum token permissions required to upload code-scanning results.
+# Network:
+# - GitHub-hosted actions and CodeQL bundles may use GitHub-managed network
+#   access. This workflow does not call KFM source systems or public APIs.
+# Outputs:
+# - Code-scanning SARIF/results managed by GitHub. No KFM proof, receipt, release,
+#   lifecycle, catalog, triplet, or published artifact is created by this workflow.
+# Compatibility:
+# - Workflow name `codeql` and job id `codeql-scan` are retained because
+#   branch-protection dependencies have not been verified.
 name: codeql
 
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
+  schedule:
+    - cron: "23 9 * * 3"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  pull-requests: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   codeql-scan:
+    name: codeql-scan (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - javascript-typescript
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO codeql-scan'
+      - name: Check out analyzed revision
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Analyze source
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+
+      - name: Record analysis boundary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## CodeQL — ${LANGUAGE}"
+            echo
+            echo "CodeQL was configured for the security-extended query suite."
+            echo
+            echo "A successful job means analysis completed for this language and revision."
+            echo "It does not prove vulnerability absence or authorize release or publication."
+          } >> "${GITHUB_STEP_SUMMARY}"
+        env:
+          LANGUAGE: ${{ matrix.language }}

--- a/data/receipts/generated/genrec-codeql-workflow-51a2f5fb.json
+++ b/data/receipts/generated/genrec-codeql-workflow-51a2f5fb.json
@@ -1,0 +1,107 @@
+{
+  "receipt_id": "genrec-codeql-workflow-51a2f5fb",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    ".github/workflows/codeql.yml"
+  ],
+  "artifact_hashes": {
+    ".github/workflows/codeql.yml": "sha256:51a2f5fb4ec131f671a28343554054fbd5fa6f0cfe808850e04a23c8b08b6108"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "GPT-5.6 Thinking",
+    "version": "2026-07-17"
+  },
+  "prompt_or_contract": "sha256:5cf472a5795e5b7efdc21e38eced741aa0057173e1335bd11b85248a55f18ab6",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "official GitHub documentation search",
+      "workflow structure validation",
+      "remote repository verification"
+    ]
+  },
+  "inputs": {
+    "attached_docs": [
+      "KFM project doctrine and repository operating contract"
+    ],
+    "evidence_refs": [
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/a3241c8766b2b009489506a14973f8d2af2a2550",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/a3241c8766b2b009489506a14973f8d2af2a2550/.github/workflows/codeql.yml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/actions/runs/29605334923",
+      "github://github/codeql-action/releases/tag/v4.36.0",
+      "github://actions/checkout"
+    ]
+  },
+  "truth_labels": {
+    ".github/workflows/codeql.yml": "PROPOSED"
+  },
+  "validation_gates": [
+    {
+      "gate": "base-target-overlap-preflight",
+      "outcome": "PASS",
+      "reason": "Verified main base, prior workflow blob, latest stub run, repository Python and JavaScript/TypeScript evidence, and no overlapping branch or pull request."
+    },
+    {
+      "gate": "workflow-identity-and-trigger-compatibility",
+      "outcome": "PASS",
+      "reason": "Preserved workflow name codeql, job id codeql-scan, pull_request trigger, and push-to-main trigger; added weekly schedule and manual dispatch."
+    },
+    {
+      "gate": "real-codeql-wiring",
+      "outcome": "PASS",
+      "reason": "Configured CodeQL Action v4 init and analyze for Python and JavaScript/TypeScript using build-mode none and security-extended queries."
+    },
+    {
+      "gate": "least-privilege-and-threat-posture",
+      "outcome": "PASS",
+      "reason": "Uses pull_request rather than pull_request_target, disables persisted checkout credentials, and grants only read scopes plus security-events write needed for code-scanning results."
+    },
+    {
+      "gate": "artifact-hash-and-remote-readback",
+      "outcome": "PASS",
+      "reason": "Computed SHA-256 51a2f5fb4ec131f671a28343554054fbd5fa6f0cfe808850e04a23c8b08b6108 and Git blob f2e3412e9de21304fb690750d93780108e41bed4; GitHub returned the same blob."
+    },
+    {
+      "gate": "github-actions-final-head-run",
+      "outcome": "SKIPPED",
+      "reason": "The proposed-head workflow run had not yet been observed when this receipt was emitted."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "prior-codeql-workflow",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/a3241c8766b2b009489506a14973f8d2af2a2550/.github/workflows/codeql.yml"
+    },
+    {
+      "id": "prior-codeql-run",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/actions/runs/29605334923"
+    },
+    {
+      "id": "official-codeql-action-v4",
+      "validated": true,
+      "evidence_ref": "github://github/codeql-action/releases/tag/v4.36.0"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-18T00:00:00Z",
+  "emitter": "openai/gpt-5.6-thinking",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "AI-authored graduation of the CodeQL workflow from a TODO-only success stub to a real Python and JavaScript/TypeScript CodeQL v4 matrix. The workflow emits GitHub-managed code-scanning results but no KFM release, proof, receipt, lifecycle, catalog, triplet, or publication artifact. Human review and final-head Actions execution remain pending."
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/codeql.yml` scaffold with real GitHub CodeQL analysis while preserving compatibility-sensitive workflow and job identities.

## Evidence status

- **CONFIRMED:** the prior workflow only checked out the repository and echoed `TODO codeql-scan`.
- **CONFIRMED:** recent run `29605334923` succeeded without performing static analysis.
- **CONFIRMED:** the repository contains Python and JavaScript/TypeScript implementation surfaces.
- **PROPOSED:** this CodeQL v4 workflow remains subject to human review and final-head execution.
- **NEEDS VERIFICATION:** branch-protection dependencies, code-scanning upload behavior on this PR, specialist security review, and whether the selected query suite should be narrowed or expanded.

## What changed

- Preserved workflow name `codeql` and job id `codeql-scan`.
- Preserved pull-request and push-to-`main` triggers.
- Added weekly scheduled analysis and `workflow_dispatch`.
- Added a non-fail-fast matrix for `python` and `javascript-typescript`.
- Added `github/codeql-action/init@v4` and `analyze@v4` with `build-mode: none` and `security-extended` queries.
- Added explicit least-privilege permissions needed for code-scanning results.
- Disabled persisted checkout credentials.
- Added concurrency cancellation and a 30-minute timeout.
- Added an always-run summary that bounds what a green result proves.
- Added generated receipt `data/receipts/generated/genrec-codeql-workflow-51a2f5fb.json`.

## Authority boundary

A successful CodeQL run means the configured queries completed for the checked revision. It does not prove that the repository is vulnerability-free and does not authorize release, deployment, publication, source admission, policy approval, or bypass of runtime and human security controls.

## Threat and permission posture

- Uses `pull_request`, not `pull_request_target`.
- Grants read-only repository/action/package/PR scopes plus `security-events: write` for code-scanning result upload.
- Uses no repository secrets, OIDC, deployment credentials, KFM source-system endpoints, or lifecycle writes.
- Produces GitHub-managed code-scanning results, not KFM proofs, receipts, release objects, or publication artifacts.

## Validation

| Check | Outcome |
|---|---|
| Base/target/overlap preflight | PASS |
| Workflow and job identities preserved | PASS |
| Python + JavaScript/TypeScript matrix | PASS |
| CodeQL v4 init/analyze wiring | PASS |
| Least-privilege permissions | PASS |
| Persisted checkout credentials disabled | PASS |
| Workflow SHA-256 | `51a2f5fb4ec131f671a28343554054fbd5fa6f0cfe808850e04a23c8b08b6108` |
| Remote Git blob | `f2e3412e9de21304fb690750d93780108e41bed4` |
| Exact changed paths | workflow + generated receipt only |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `f46c30d0ce7f8c5206044ac8ced24a998ee31752` and `9226f147e26faa526caf11ae63690b463ef9ffce` in reverse order. This restores prior workflow blob `f17f0b03ac40a07dba40666301acf20fb73303f5` and removes the generated receipt.

## Open verification

- Final CodeQL matrix results and SARIF upload.
- Branch-protection references to `codeql` / `codeql-scan`.
- Whether actions should later be pinned to immutable commit SHAs.
- Whether `security-extended` is the accepted repository query suite.
- Whether generated/vendor/test paths require a future CodeQL configuration file.
- Security review and alert triage ownership.

## CONTRACT_VERSION

`3.0.0`