### PR TITLE
ci(deny): enforce governed boundary checks

### DIFF
--- a/.github/workflows/deny-test.yml
+++ b/.github/workflows/deny-test.yml
@@ -1,25 +1,131 @@
-# KFM CI workflow stub: deny-test
-# Status: PROPOSED greenfield scaffold.
+# KFM governed deny-path verification.
+#
+# This workflow executes narrow repository-owned denial and boundary tests.
+# A green run proves only that the named checks passed for the checked revision.
+# It does not prove complete policy coverage, authorize publication, or replace
+# runtime authorization, evidence, sensitivity, rights, and human review gates.
 name: deny-test
 
 on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deny-test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONHASHSEED: "0"
+  PYTHONDONTWRITEBYTECODE: "1"
+  PYTHONUNBUFFERED: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_NO_INPUT: "1"
+  TZ: UTC
+  PYTHONPATH: apps/governed-api/src
 
 jobs:
   public-boundary-deny:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO public-boundary-deny'
+      - name: Check out tested revision
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install test dependencies
+        run: python -m pip install -e ".[test]"
+
+      - name: Verify public route rejection behavior
+        run: >-
+          python -m pytest -q --strict-config --strict-markers
+          apps/governed-api/tests/test_boundary_guards.py::test_unknown_route_returns_404
+          apps/governed-api/tests/test_boundary_guards.py::test_non_get_methods_rejected_for_scaffolded_routes
+          apps/governed-api/tests/test_boundary_guards.py::test_api_surface_manifest
+
+      - name: Record public-boundary scope
+        if: always()
+        run: |
+          {
+            echo "## public-boundary-deny"
+            echo
+            echo "Checks unknown-route rejection, method rejection, and the current API surface manifest."
+            echo "It does not prove authentication, authorization, policy, sensitivity, or publication safety for every route."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   raw-leak-deny:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO raw-leak-deny'
+      - name: Check out tested revision
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install test dependencies
+        run: python -m pip install -e ".[test]"
+
+      - name: Verify governed API avoids internal-store literals
+        run: >-
+          python -m pytest -q --strict-config --strict-markers
+          apps/governed-api/tests/test_boundary_guards.py::test_no_internal_data_store_path_literals_in_api_code
+
+      - name: Record raw-leak scope
+        if: always()
+        run: |
+          {
+            echo "## raw-leak-deny"
+            echo
+            echo "Checks the governed API source for the repository's forbidden internal-store path literals."
+            echo "It does not inspect runtime payloads, generated artifacts, logs, caches, databases, or external services."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   model-runtime-deny:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO model-runtime-deny'
+      - name: Check out tested revision
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install test dependencies
+        run: python -m pip install -e ".[test]"
+
+      - name: Verify forbidden runtime imports remain absent
+        run: >-
+          python -m pytest -q --strict-config --strict-markers
+          apps/governed-api/tests/test_boundary_guards.py::test_forbidden_runtime_imports_absent
+
+      - name: Record model-runtime scope
+        if: always()
+        run: |
+          {
+            echo "## model-runtime-deny"
+            echo
+            echo "Checks governed API Python source for direct MapLibre, Cesium, and Ollama import prefixes."
+            echo "It does not prove complete dependency isolation, subprocess isolation, network denial, or model policy enforcement."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/data/receipts/generated/genrec-deny-test-workflow-c1a40f45.json
+++ b/data/receipts/generated/genrec-deny-test-workflow-c1a40f45.json
@@ -1,0 +1,48 @@
+{
+  "receipt_id": "genrec-deny-test-workflow-c1a40f45",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "0bce5c7662a0ed37a6b3cc71133329fcdf44c17a",
+  "branch": "agent/deny-test-workflow-20260718",
+  "target_path": ".github/workflows/deny-test.yml",
+  "previous_blob": "d2dd40c274d55a33488b7f601ee33440911431b9",
+  "new_blob": "9042554d4d9f74bebf3bb580b1be34fbb1455959",
+  "sha256": "c1a40f4519128abfc346d7cd0d4f8c8a23dc470a00add1e6df85d9aae4c6224c",
+  "truth_labels": {
+    "confirmed": [
+      "The prior workflow only executed TODO echo steps.",
+      "The governed API boundary test file contains route rejection, internal-store literal, and forbidden runtime import checks.",
+      "Workflow name deny-test and all three job ids are preserved."
+    ],
+    "proposed": [
+      "The selected node-level tests are the current executable deny-path checks for these three lanes."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Branch-protection dependencies.",
+      "Independent policy and security review.",
+      "Whether action references should be pinned to immutable SHAs.",
+      "Broader runtime payload, authentication, authorization, network, and model-policy denial coverage."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch.",
+    "Added contents: read permission.",
+    "Added concurrency cancellation and timeouts.",
+    "Added deterministic Python and pip environment settings.",
+    "Disabled persisted checkout credentials.",
+    "Replaced three TODO echoes with narrow repository-owned pytest node selections.",
+    "Added bounded always-run job summaries."
+  ],
+  "authority_boundary": "A green run is evidence only for the selected repository-owned denial checks. It is not complete policy proof, release approval, lifecycle promotion, source admission, or publication authority.",
+  "rollback": {
+    "strategy": "Revert the receipt commit and workflow commit in reverse order or close the pull request without merge.",
+    "restores_blob": "d2dd40c274d55a33488b7f601ee33440911431b9"
+  },
+  "human_review": {
+    "state": "pending"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/deny-test.yml` scaffold with narrow repository-owned denial checks while preserving compatibility-sensitive workflow and job identities.

## Evidence status

- **CONFIRMED:** the prior workflow only checked out the repository and echoed TODO messages for all three jobs.
- **CONFIRMED:** baseline run `29636387211` completed successfully without executing denial tests.
- **CONFIRMED:** `apps/governed-api/tests/test_boundary_guards.py` contains executable route-rejection, internal-store-literal, and forbidden-runtime-import checks.
- **PROPOSED:** the selected node-level tests are the current executable deny-path lanes.
- **NEEDS VERIFICATION:** final-head CI, branch-protection dependencies, independent policy/security review, and broader authentication, authorization, payload, network, and model-policy denial coverage.

## What changed

- Preserved workflow name `deny-test`.
- Preserved job ids `public-boundary-deny`, `raw-leak-deny`, and `model-runtime-deny`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch`.
- Added explicit `contents: read`, concurrency cancellation, deterministic Python settings, and ten-minute timeouts.
- Disabled persisted checkout credentials.
- Added Python 3.11 setup with pip caching and repository test dependency installation.
- Wired `public-boundary-deny` to unknown-route, disallowed-method, and API-surface-manifest tests.
- Wired `raw-leak-deny` to the governed API internal-store-path-literal test.
- Wired `model-runtime-deny` to the forbidden MapLibre/Cesium/Ollama import-prefix test.
- Added bounded always-run summaries for every lane.
- Added generated receipt `data/receipts/generated/genrec-deny-test-workflow-c1a40f45.json`.

## Authority boundary

A successful run means only that the selected repository-owned denial checks passed for the checked revision. It does not prove complete authentication, authorization, policy, sensitivity, rights, payload, network, model-runtime, or publication safety and does not authorize release, deployment, source admission, lifecycle promotion, or publication.

## Validation

| Check | Outcome |
|---|---|
| Base/target preflight | PASS |
| Workflow and three job identities preserved | PASS |
| Existing repository tests wired by node id | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Exact changed paths | workflow + generated receipt only |
| Workflow SHA-256 | `c1a40f4519128abfc346d7cd0d4f8c8a23dc470a00add1e6df85d9aae4c6224c` |
| Remote Git blob | `9042554d4d9f74bebf3bb580b1be34fbb1455959` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `cc20a515ff820b68f9e460476069783a87e40abf` and `cb3fd20f1c4a75b14415f47fa14981e4b24d6d0a` in reverse order. This restores prior workflow blob `d2dd40c274d55a33488b7f601ee33440911431b9` and removes the generated receipt.

## CONTRACT_VERSION

`3.0.0`