### PR TITLE
ci(dependencies): enforce Python audit and hold Node lane

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,20 +1,141 @@
-# KFM CI workflow stub: dependency-scan
-# Status: PROPOSED greenfield scaffold.
+# KFM dependency vulnerability scanning workflow.
+# Status: PROPOSED executable Python audit plus explicit Node lockfile hold.
+#
+# Authority boundary:
+# - This workflow queries public vulnerability advisory services and reports
+#   point-in-time dependency findings for the checked revision.
+# - It does not prove that dependencies are vulnerability-free, compatible,
+#   provenance-complete, rights-cleared, or approved for release/publication.
+# - It never modifies dependency manifests, lockfiles, source data, lifecycle
+#   artifacts, releases, deployments, or publication state.
 name: dependency-scan
 
 on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    # Advisory databases change independently of repository commits.
+    - cron: "17 11 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: UTC
+  PYTHONUNBUFFERED: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_NO_INPUT: "1"
 
 jobs:
   pip-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO pip-audit'
+      - name: Check out scanned revision
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install pinned audit tool
+        run: python -m pip install "pip-audit==2.10.1"
+
+      - name: Audit root Python project dependencies
+        run: >-
+          python -m pip_audit .
+          --progress-spinner off
+          --desc off
+          --format columns
+
+      - name: Record Python audit boundary
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Python dependency audit boundary
+
+          This lane audits dependencies resolved from the root `pyproject.toml`
+          with pinned scanner version `pip-audit==2.10.1`.
+
+          A green result means no known vulnerability was reported for the
+          dependency resolution produced during this run. The repository does
+          not currently provide a committed Python lockfile at this root, so
+          this is a point-in-time resolution rather than a reproducible locked
+          dependency attestation.
+
+          The result is not proof of vulnerability absence, compatibility,
+          source integrity, release readiness, deployment approval, or
+          publication authority.
+          EOF
+
   npm-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO npm-audit'
+      - name: Check out dependency manifests
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate deterministic Node audit readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! -f package.json ]]; then
+            echo "::error::Root package.json is missing."
+            exit 1
+          fi
+
+          if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
+            echo "::error::A root npm lockfile now exists. Graduate this lane to a real locked npm audit before accepting the change."
+            exit 1
+          fi
+
+          if [[ -f pnpm-lock.yaml || -f yarn.lock ]]; then
+            echo "::error::A non-npm root lockfile now exists. Confirm the package-manager contract and replace this npm-specific lane."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: npm-audit"
+          echo "WORKFLOW_HOLD: no committed root JavaScript lockfile"
+          echo "A nondeterministic --no-package-lock audit is intentionally not used."
+
+      - name: Record Node audit hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Node dependency audit status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no committed root JavaScript lockfile`
+
+          The root `package.json` declares workspaces and dependencies, but no
+          root `package-lock.json`, `npm-shrinkwrap.json`, `pnpm-lock.yaml`, or
+          `yarn.lock` is currently committed. This workflow intentionally does
+          not use npm's nondeterministic `--no-package-lock` mode.
+
+          Graduate this lane only after the repository records its package
+          manager and commits the authoritative lockfile. Then run the matching
+          locked audit with fail-closed severity policy and deterministic
+          fixtures or evidence where practical.
+
+          This hold does not establish dependency safety, compatibility,
+          release readiness, deployment approval, or publication authority.
+          EOF

--- a/data/receipts/generated/genrec-dependency-scan-workflow-743e95c5.json
+++ b/data/receipts/generated/genrec-dependency-scan-workflow-743e95c5.json
@@ -1,0 +1,53 @@
+{
+  "receipt_id": "genrec-dependency-scan-workflow-743e95c5",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "fdb3b9651828733364d8c257bfc6c0ef33280ae6",
+  "branch": "agent/dependency-scan-workflow-20260718",
+  "target_path": ".github/workflows/dependency-scan.yml",
+  "previous_blob": "e0437e5ae0e2941a4bc56f2e3d882d67cc504afe",
+  "new_blob": "df1de90d289ddfde3a0f505a703b55ededf6cc7d",
+  "sha256": "743e95c59546023f1c60408350c8b00b68980017a8a3e7e316d2fd2729a537cb",
+  "truth_labels": {
+    "confirmed": [
+      "The prior pip-audit and npm-audit jobs only executed TODO echo commands.",
+      "The root pyproject.toml declares Python dependencies and Python 3.11 support.",
+      "The root package.json declares JavaScript workspaces and devDependencies.",
+      "No root package-lock.json or pnpm-lock.yaml was found during this update.",
+      "Workflow name dependency-scan and job ids pip-audit and npm-audit are preserved."
+    ],
+    "proposed": [
+      "The pinned pip-audit project scan is the current executable Python vulnerability lane.",
+      "The explicit Node lockfile hold is safer than a nondeterministic unlocked npm audit."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Branch-protection dependencies.",
+      "Independent security review and vulnerability triage ownership.",
+      "Whether Python dependencies should be locked and audited with hashes.",
+      "The authoritative JavaScript package manager and committed lockfile.",
+      "Whether additional package manifests under apps, packages, pipelines, and connectors require separate audit lanes.",
+      "Whether action references should be pinned to immutable commit SHAs."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch and a weekly scheduled scan.",
+    "Added contents: read permission, concurrency cancellation, and job timeouts.",
+    "Added deterministic Python and pip environment settings.",
+    "Disabled persisted checkout credentials.",
+    "Pinned pip-audit to version 2.10.1 and audited the root Python project.",
+    "Converted npm-audit from a TODO success to an explicit lockfile readiness hold.",
+    "Added bounded always-run summaries."
+  ],
+  "authority_boundary": "A green or held result is CI evidence for the selected point-in-time checks only. It is not proof of dependency safety, compatibility, provenance completeness, release readiness, deployment approval, or publication authority.",
+  "rollback": {
+    "strategy": "Revert the receipt commit and workflow commit in reverse order or close the pull request without merge.",
+    "restores_blob": "e0437e5ae0e2941a4bc56f2e3d882d67cc504afe"
+  },
+  "human_review": {
+    "state": "pending"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/dependency-scan.yml` scaffold with a real Python vulnerability audit while keeping the Node lane explicitly fail-safe until the repository commits an authoritative JavaScript lockfile.

## Evidence status

- **CONFIRMED:** the prior `pip-audit` and `npm-audit` jobs only checked out the repository and echoed TODO messages.
- **CONFIRMED:** baseline run `29649242111` completed successfully without scanning dependencies.
- **CONFIRMED:** the root `pyproject.toml` declares Python 3.11 and root Python dependencies.
- **CONFIRMED:** the root `package.json` declares workspaces and JavaScript devDependencies.
- **CONFIRMED:** no root `package-lock.json` or `pnpm-lock.yaml` was found during this update.
- **PROPOSED:** the pinned root-project `pip-audit` invocation is the current executable Python vulnerability lane.
- **NEEDS VERIFICATION:** final-head CI, lockfile policy, subpackage coverage, branch-protection dependencies, and vulnerability triage ownership.

## What changed

- Preserved workflow name `dependency-scan`.
- Preserved job ids `pip-audit` and `npm-audit`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch` and a weekly scheduled scan.
- Added explicit `contents: read`, concurrency cancellation, deterministic Python settings, and job timeouts.
- Disabled persisted checkout credentials.
- Added Python 3.11 setup with pip caching.
- Pinned `pip-audit==2.10.1` and runs it against the root project.
- Converted `npm-audit` from a false-positive TODO success to an explicit `WORKFLOW_HOLD` because no authoritative root JavaScript lockfile is committed.
- Makes the Node lane fail when a root lockfile appears, requiring deliberate graduation to the matching locked audit rather than silently continuing the hold.
- Added bounded always-run summaries.
- Added generated receipt `data/receipts/generated/genrec-dependency-scan-workflow-743e95c5.json`.

## Authority boundary

A green Python audit means only that no known vulnerability was reported for the dependency resolution produced during that run. The Node job remains explicitly held. Neither outcome proves vulnerability absence, compatibility, provenance completeness, release readiness, deployment approval, or publication authority.

## Validation

| Check | Outcome |
|---|---|
| Base/target preflight | PASS |
| Workflow and job identities preserved | PASS |
| Root Python project audit wired | PASS |
| Node lockfile absence handled explicitly | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Exact changed paths | workflow + generated receipt only |
| Workflow SHA-256 | `743e95c59546023f1c60408350c8b00b68980017a8a3e7e316d2fd2729a537cb` |
| Remote Git blob | `df1de90d289ddfde3a0f505a703b55ededf6cc7d` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `2477ef0fbb36e5143277e1712c2b6082c39fd6d9` and `5e70595b4a1bf5cb52842735a171037c3907ddd4` in reverse order. This restores prior workflow blob `e0437e5ae0e2941a4bc56f2e3d882d67cc504afe` and removes the generated receipt.

## Open verification

- Final Python audit result and Node hold result.
- Authoritative JavaScript package manager and lockfile.
- Whether Python dependencies require a committed, hashed lock artifact.
- Audit coverage for manifests under `apps/`, `packages/`, `pipelines/`, and `connectors/`.
- Branch-protection references and independent security review.
- Vulnerability exception, expiry, and remediation ownership.

## CONTRACT_VERSION

`3.0.0`