### PR TITLE
ci(docs): make build and preview holds explicit

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,20 +1,145 @@
-# KFM CI workflow stub: docs-build
-# Status: PROPOSED greenfield scaffold.
+# KFM documentation build and preview readiness workflow.
+# Status: PROPOSED explicit hold until an accepted generator and preview contract exist.
+#
+# Authority boundary:
+# - This workflow may inspect repository documentation build readiness.
+# - It does not create authored doctrine, publish documentation, approve release,
+#   or make generated previews authoritative.
+# - Rendered documentation belongs only in a non-authoritative generated lane and
+#   requires an explicit publication handoff before public use.
 name: docs-build
 
 on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   mkdocs-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO mkdocs-build'
+      - name: Check out documentation sources
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate documentation generator readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! -d docs ]]; then
+            echo "::error::Canonical docs/ responsibility root is missing."
+            exit 1
+          fi
+
+          if [[ -f mkdocs.yml || -f mkdocs.yaml ]]; then
+            echo "::error::An MkDocs configuration now exists. Graduate this job to a pinned, strict build before accepting the change."
+            exit 1
+          fi
+
+          if [[ -f docusaurus.config.js || -f docusaurus.config.ts || -f docusaurus.config.mjs ]]; then
+            echo "::error::A Docusaurus configuration now exists. Confirm the generator contract and replace this MkDocs-specific readiness hold."
+            exit 1
+          fi
+
+          if [[ -f docs/requirements.txt || -f requirements-docs.txt ]]; then
+            echo "::error::Documentation build dependencies now exist. Wire the accepted generator and deterministic build command before accepting the change."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: mkdocs-build"
+          echo "WORKFLOW_HOLD: no accepted documentation generator configuration or build command"
+
+      - name: Record documentation build hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Documentation build status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted documentation generator configuration or build command`
+
+          Repository evidence currently establishes the canonical `docs/` source
+          root and the non-authoritative `artifacts/docs/` compatibility lane, but
+          does not establish `mkdocs.yml`, Docusaurus configuration, pinned docs
+          dependencies, a deterministic build command, or a generated-site
+          manifest.
+
+          Graduate this lane only after the generator, dependency pins, strict
+          build command, output directory, manifest/digest, no-network posture,
+          link/citation/accessibility responsibilities, and rollback behavior are
+          reviewed and recorded.
+
+          A green held result does not mean documentation was rendered, complete,
+          accessible, citation-valid, reproducible, release-approved, or published.
+          EOF
+
   publish-preview:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO publish-preview'
+      - name: Check out preview boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate preview publication readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! -d artifacts/docs ]]; then
+            echo "::error::The documented generated-preview compatibility lane artifacts/docs/ is missing."
+            exit 1
+          fi
+
+          if [[ -f artifacts/docs/docs-build-manifest.json ]]; then
+            echo "::error::A documentation build manifest now exists. Graduate this lane to explicit artifact validation and preview handoff before accepting the change."
+            exit 1
+          fi
+
+          if [[ -f .github/workflows/pages.yml || -f .github/workflows/deploy-docs.yml ]]; then
+            echo "::error::A documentation deployment workflow now exists. Confirm hosting, permissions, release, correction, and rollback contracts before accepting the change."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: publish-preview"
+          echo "WORKFLOW_HOLD: no built preview artifact, manifest, hosting target, or publication handoff"
+
+      - name: Record preview publication hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Documentation preview status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no built preview artifact, manifest, hosting target, or publication handoff`
+
+          `artifacts/docs/` is a transitional, non-authoritative staging lane. No
+          generated site, immutable build manifest, preview artifact upload,
+          hosting configuration, release binding, correction consumer, or rollback
+          target is established by the inspected repository evidence.
+
+          This job intentionally does not upload, deploy, expose, or publish
+          documentation. A future preview lane must remain separate from authored
+          `docs/` authority and from governed public-release decisions.
+
+          A green held result does not authorize hosting, release, deployment,
+          publication, or public reliance.
+          EOF

--- a/data/receipts/generated/genrec-docs-build-workflow-931289e9.json
+++ b/data/receipts/generated/genrec-docs-build-workflow-931289e9.json
@@ -1,0 +1,57 @@
+{
+  "receipt_id": "genrec-docs-build-workflow-931289e9",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "ecbf3d7110559ce59f1a0afda7772bd543a0f6c3",
+  "branch": "agent/docs-build-workflow-20260718",
+  "target_path": ".github/workflows/docs-build.yml",
+  "previous_blob": "3841ed36c0af0a41621992aff1d932cfca9ac082",
+  "new_blob": "202360a8bee431b50633e78c442cc70ca939206a",
+  "sha256": "931289e9db571fba73bbd22eaddaec9185ddbb82617d6ae0f87f065036298f11",
+  "directory_rules_basis": {
+    "responsibility_root": ".github/workflows for CI orchestration; data/receipts for canonical process memory",
+    "receipt_lane": "data/receipts/generated",
+    "status": "CONFIRMED existing repository lane; no new root or parallel receipt authority created",
+    "adr_required": false
+  },
+  "truth_labels": {
+    "confirmed": [
+      "The prior mkdocs-build and publish-preview jobs only executed TODO echo commands.",
+      "Baseline run 29649485395 completed successfully without building or publishing documentation.",
+      "The repository has a canonical docs/ source root and an artifacts/docs/ transitional compatibility lane.",
+      "No mkdocs.yml, mkdocs.yaml, Docusaurus configuration, documentation dependency manifest, documentation build manifest, or established preview deployment contract was found.",
+      "Workflow name docs-build and job ids mkdocs-build and publish-preview are preserved."
+    ],
+    "proposed": [
+      "Explicit readiness holds are safer than inventing a documentation generator, dependency set, output contract, or hosting target."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Branch-protection dependencies.",
+      "Accepted documentation generator and package-manager contract.",
+      "Pinned documentation dependencies and deterministic strict build command.",
+      "Generated-site manifest, digest, retention, and artifact upload contract.",
+      "Preview hosting, permissions, release handoff, correction, withdrawal, and rollback ownership.",
+      "Whether action references should be pinned to immutable commit SHAs."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch, contents: read permission, concurrency cancellation, and timeouts.",
+    "Disabled persisted checkout credentials.",
+    "Converted mkdocs-build from a TODO success to an explicit generator-readiness hold.",
+    "Converted publish-preview from a TODO success to an explicit preview-publication hold.",
+    "Added fail-closed graduation checks when generator, dependency, manifest, or deployment files appear.",
+    "Added bounded always-run summaries for both jobs."
+  ],
+  "authority_boundary": "A green held result is readiness evidence only. It does not mean documentation was rendered, validated, hosted, released, or published and does not authorize public reliance.",
+  "rollback": {
+    "strategy": "Revert the receipt commit and workflow commit in reverse order or close the pull request without merge.",
+    "restores_blob": "3841ed36c0af0a41621992aff1d932cfca9ac082"
+  },
+  "human_review": {
+    "state": "pending"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/docs-build.yml` scaffold with explicit, fail-safe readiness holds until the repository establishes an accepted documentation generator, deterministic build contract, preview artifact, and publication handoff.

## Evidence status

- **CONFIRMED:** the prior `mkdocs-build` and `publish-preview` jobs only checked out the repository and echoed TODO messages.
- **CONFIRMED:** baseline run `29649485395` completed successfully without building or publishing documentation.
- **CONFIRMED:** `docs/` is the canonical authored-documentation responsibility root.
- **CONFIRMED:** `artifacts/docs/` is a transitional, non-authoritative generated-preview compatibility lane.
- **CONFIRMED:** no `mkdocs.yml`, `mkdocs.yaml`, Docusaurus configuration, documentation dependency manifest, generated-site manifest, or established preview deployment contract was found.
- **PROPOSED:** explicit readiness holds are safer than inventing a generator, dependency set, output contract, or hosting target.
- **NEEDS VERIFICATION:** final-head CI, branch-protection dependencies, accepted generator and package manager, deterministic build and manifest contract, preview hosting, and correction/rollback ownership.

## What changed

- Preserved workflow name `docs-build`.
- Preserved job ids `mkdocs-build` and `publish-preview`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch`.
- Added `contents: read`, concurrency cancellation, and five-minute job timeouts.
- Disabled persisted checkout credentials.
- Converted `mkdocs-build` from a false-positive TODO success to an explicit `WORKFLOW_HOLD`.
- Converted `publish-preview` from a false-positive TODO success to an explicit `WORKFLOW_HOLD`.
- Added fail-closed graduation checks: if generator config, docs dependency files, a docs build manifest, or a docs deployment workflow appears, the relevant lane fails until deliberately implemented.
- Added bounded always-run summaries for both jobs.
- Added generated receipt `data/receipts/generated/genrec-docs-build-workflow-931289e9.json`.

## Directory Rules basis

- `.github/workflows/` remains the existing CI orchestration location.
- `docs/` remains the authored human control plane.
- `artifacts/docs/` remains a transitional, non-authoritative generated-preview lane and is not promoted to authority.
- The generated receipt remains under the existing canonical process-memory root `data/receipts/generated/`.
- No new root, parallel documentation authority, receipt authority, release home, or publication home is created.
- No ADR is required for this bounded in-place workflow edit and receipt addition.

## Authority boundary

A green held result is readiness evidence only. It does not mean documentation was rendered, complete, accessible, citation-valid, reproducible, hosted, released, or published and does not authorize public reliance.

## Validation

| Check | Outcome |
|---|---|
| Base/target/overlap preflight | PASS |
| Workflow and job identities preserved | PASS |
| Generator absence handled explicitly | PASS |
| Preview/publication absence handled explicitly | PASS |
| Fail-closed graduation checks added | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Directory Rules placement review | PASS |
| Exact changed paths | workflow + generated receipt only |
| Workflow YAML parse | PASS |
| Workflow SHA-256 | `931289e9db571fba73bbd22eaddaec9185ddbb82617d6ae0f87f065036298f11` |
| Remote Git blob | `202360a8bee431b50633e78c442cc70ca939206a` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `f368e9b3302cc0cb7a72f9d40efa172e676dfeda` and `cdd147f2733a9cb8586dbb25e16236dc63f9c6fd` in reverse order. This restores prior workflow blob `3841ed36c0af0a41621992aff1d932cfca9ac082` and removes the generated receipt.

## Open verification

- Accepted documentation generator and package-manager contract.
- Pinned documentation dependencies and strict deterministic build command.
- Output directory, generated-site manifest, digest, retention, and artifact upload contract.
- No-network posture and source-to-output mapping.
- Link, citation, accessibility, security, rights, and sensitivity validation responsibilities.
- Preview hosting permissions and release/publication handoff.
- Correction, withdrawal, supersession, and rollback consumers.
- Branch-protection references and immutable action pinning.

## CONTRACT_VERSION

`3.0.0`