### PR TITLE
ci(docs): enforce control-plane register checks

### DIFF
--- a/.github/workflows/docs-control-plane.yml
+++ b/.github/workflows/docs-control-plane.yml
@@ -1,20 +1,168 @@
-# KFM CI workflow stub: docs-control-plane
-# Status: PROPOSED greenfield scaffold.
+# KFM machine control-plane validation workflow.
+# Status: PROPOSED executable YAML and register meta-contract checks.
+#
+# Authority boundary:
+# - This workflow validates repository syntax and the currently implemented
+#   control-plane register meta contract for the checked revision.
+# - It does not make register entries authoritative, resolve contradictions,
+#   approve policy, change release state, promote lifecycle artifacts, or publish.
 name: docs-control-plane
 
 on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-control-plane-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: UTC
+  PYTHONUNBUFFERED: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_NO_INPUT: "1"
 
 jobs:
   validate-control-plane-yaml:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO validate-control-plane-yaml'
+      - name: Check out control-plane sources
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install pinned YAML parser
+        run: python -m pip install "PyYAML==6.0.3"
+
+      - name: Parse every control-plane YAML file
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          import yaml
+          from yaml.constructor import ConstructorError
+          from yaml.resolver import BaseResolver
+
+
+          class UniqueKeyLoader(yaml.SafeLoader):
+              """Safe YAML loader that rejects duplicate mapping keys."""
+
+
+          def construct_unique_mapping(loader, node, deep=False):
+              mapping = {}
+              for key_node, value_node in node.value:
+                  key = loader.construct_object(key_node, deep=deep)
+                  if key in mapping:
+                      raise ConstructorError(
+                          "while constructing a mapping",
+                          node.start_mark,
+                          f"found duplicate key: {key!r}",
+                          key_node.start_mark,
+                      )
+                  mapping[key] = loader.construct_object(value_node, deep=deep)
+              return mapping
+
+
+          UniqueKeyLoader.add_constructor(
+              BaseResolver.DEFAULT_MAPPING_TAG,
+              construct_unique_mapping,
+          )
+
+          root = Path("control_plane")
+          if not root.is_dir():
+              raise SystemExit("control_plane/ is missing")
+
+          files = sorted(root.glob("*.yaml"))
+          if not files:
+              raise SystemExit("control_plane/ contains no .yaml files")
+
+          for path in files:
+              with path.open("r", encoding="utf-8") as handle:
+                  document = yaml.load(handle, Loader=UniqueKeyLoader)
+
+              if not isinstance(document, dict):
+                  raise SystemExit(f"{path} must have a mapping at the document root")
+
+              print(f"validated YAML syntax and unique keys: {path}")
+
+          print(f"validated {len(files)} control-plane YAML file(s)")
+          PY
+
+      - name: Record YAML validation boundary
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Control-plane YAML validation boundary
+
+          This lane parses every tracked `control_plane/*.yaml` file with
+          `PyYAML==6.0.3`, rejects duplicate mapping keys, and requires each
+          document root to be a mapping.
+
+          A green result does not prove that every field has the correct
+          semantics, that register entries agree with doctrine or implementation,
+          or that any entry is approved for policy, release, promotion, or
+          publication.
+          EOF
+
   registers-schema:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO registers-schema'
+      - name: Check out register contracts
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install repository test dependencies
+        run: python -m pip install -e ".[test]"
+
+      - name: Enforce register meta contract
+        run: >-
+          python -m pytest
+          tests/policy/test_control_plane_register_meta_contract.py
+          -q
+          --strict-config
+          --strict-markers
+
+      - name: Record register contract boundary
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Control-plane register contract boundary
+
+          This lane runs the repository-owned register meta-contract tests for
+          the required control-plane files. The current checks cover required
+          files, top-level metadata, entries presence, review dates, owner,
+          status vocabulary, and related-doctrine paths.
+
+          The preserved job id is `registers-schema`, but this lane does not
+          claim that a dedicated machine JSON Schema governs every register
+          field. A green result is bounded test evidence only; it is not policy,
+          release, lifecycle-promotion, or publication authority.
+          EOF

--- a/data/receipts/generated/genrec-docs-control-plane-workflow-8510e17e.json
+++ b/data/receipts/generated/genrec-docs-control-plane-workflow-8510e17e.json
@@ -1,0 +1,57 @@
+{
+  "receipt_id": "genrec-docs-control-plane-workflow-8510e17e",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "c2075168292f0a6490e524240c90c9eaf15df9da",
+  "branch": "agent/docs-control-plane-workflow-20260718",
+  "target_path": ".github/workflows/docs-control-plane.yml",
+  "previous_blob": "e50351863cce87a00df03356832b8deada56b325",
+  "new_blob": "0991c0f4b1b580071c9bd25e5353ac2ac746c254",
+  "sha256": "8510e17e05e5da09451e1ed907e7024a73ee0f125ec6eccee168322b3a5850d1",
+  "truth_labels": {
+    "confirmed": [
+      "The prior validate-control-plane-yaml and registers-schema jobs only executed TODO echo commands.",
+      "Baseline workflow run 29649697595 completed successfully without parsing YAML or running register contract tests.",
+      "The control_plane root contains machine-readable YAML registers.",
+      "tests/policy/test_control_plane_register_meta_contract.py is an executable repository-owned register contract.",
+      "Workflow name docs-control-plane and job ids validate-control-plane-yaml and registers-schema are preserved."
+    ],
+    "proposed": [
+      "Parsing all control_plane YAML with a duplicate-key-rejecting safe loader is the current syntax gate.",
+      "The repository-owned meta-contract test is the current executable register structure gate."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Branch-protection dependencies.",
+      "Independent documentation-governance and policy review.",
+      "Whether a dedicated machine JSON Schema should govern complete register shapes.",
+      "Whether action references should be pinned to immutable commit SHAs.",
+      "Ownership for contradiction, deprecation, and release-state register review."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch, contents: read, concurrency cancellation, deterministic environment settings, and timeouts.",
+    "Disabled persisted checkout credentials.",
+    "Pinned PyYAML 6.0.3 and parse all control_plane YAML documents.",
+    "Reject duplicate YAML mapping keys and non-mapping document roots.",
+    "Run the repository-owned control-plane register meta-contract test.",
+    "Added bounded always-run summaries for both jobs."
+  ],
+  "directory_rules_basis": [
+    ".github/workflows remains the existing CI orchestration location.",
+    "control_plane remains the machine-register authority root.",
+    "data/receipts/generated remains the existing generated process-memory lane.",
+    "No new authority root, schema home, policy home, release home, or publication home is created."
+  ],
+  "authority_boundary": "A green result is bounded CI evidence for YAML syntax and the selected register meta-contract only. It does not make register entries authoritative, resolve contradictions, approve policy, change release state, promote lifecycle artifacts, or publish.",
+  "rollback": {
+    "strategy": "Revert the receipt commit and workflow commit in reverse order or close the pull request without merge.",
+    "restores_blob": "e50351863cce87a00df03356832b8deada56b325"
+  },
+  "human_review": {
+    "state": "pending"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/docs-control-plane.yml` scaffold with executable YAML parsing and repository-owned control-plane register contract checks while preserving compatibility-sensitive workflow and job identities.

## Evidence status

- **CONFIRMED:** the prior `validate-control-plane-yaml` and `registers-schema` jobs only checked out the repository and echoed TODO messages.
- **CONFIRMED:** baseline run `29649697595` completed successfully without parsing YAML or executing register contract tests.
- **CONFIRMED:** `control_plane/` contains machine-readable YAML registers.
- **CONFIRMED:** `tests/policy/test_control_plane_register_meta_contract.py` enforces required register files, metadata, entries presence, date bounds, owner, status vocabulary, and related-doctrine paths.
- **PROPOSED:** the duplicate-key-rejecting YAML parser and current repository meta-contract test are the present executable control-plane gates.
- **NEEDS VERIFICATION:** final-head CI, branch-protection dependencies, complete machine-schema coverage, independent governance review, and register review ownership.

## What changed

- Preserved workflow name `docs-control-plane`.
- Preserved job ids `validate-control-plane-yaml` and `registers-schema`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch`.
- Added explicit `contents: read`, concurrency cancellation, deterministic Python settings, and ten-minute timeouts.
- Disabled persisted checkout credentials.
- Pinned `PyYAML==6.0.3` and parses every tracked `control_plane/*.yaml` file.
- Rejects duplicate YAML mapping keys and non-mapping document roots.
- Runs `tests/policy/test_control_plane_register_meta_contract.py` with strict pytest configuration.
- Added bounded always-run summaries for both jobs.
- Added generated receipt `data/receipts/generated/genrec-docs-control-plane-workflow-8510e17e.json`.

## Directory Rules basis

- `.github/workflows/` remains the existing CI orchestration location.
- `control_plane/` remains the machine-register authority root.
- `docs/` remains the human control plane and doctrine root.
- `data/receipts/generated/` remains the existing generated process-memory lane.
- No new schema home, policy home, register home, release home, publication home, or root-level authority is created.

## Authority boundary

A green result is bounded CI evidence for YAML syntax and the selected register meta-contract only. It does not make register entries authoritative, resolve contradictions, approve policy, change release state, promote lifecycle artifacts, release data, or publish.

## Validation

| Check | Outcome |
|---|---|
| Base/target/overlap preflight | PASS |
| Workflow and job identities preserved | PASS |
| All root control-plane YAML parsed | PASS — workflow wiring |
| Duplicate mapping keys rejected | PASS — workflow wiring |
| Repository register meta-contract wired | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Directory Rules placement review | PASS |
| Exact changed paths | workflow + generated receipt only |
| Workflow SHA-256 | `8510e17e05e5da09451e1ed907e7024a73ee0f125ec6eccee168322b3a5850d1` |
| Remote Git blob | `0991c0f4b1b580071c9bd25e5353ac2ac746c254` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `b378fc2ee73f710cdafe1ad6affee7ccd3f6af51` and `5b95ba6690019849789f9e8b22c156e343141673` in reverse order. This restores prior workflow blob `e50351863cce87a00df03356832b8deada56b325` and removes the generated receipt.

## Open verification

- Final YAML and register-contract job conclusions.
- Whether a dedicated JSON Schema should govern complete register shapes.
- Whether register entry identities and cross-register references need separate validators.
- Contradiction, deprecation, verification-backlog, and release-state review ownership.
- Branch-protection references and immutable action pinning.

## CONTRACT_VERSION

`3.0.0`