### PR TITLE
ci(agriculture): make domain readiness holds explicit

### DIFF
--- a/.github/workflows/domain-agriculture.yml
+++ b/.github/workflows/domain-agriculture.yml
@@ -1,25 +1,253 @@
-# KFM CI workflow stub: domain-agriculture
-# Status: PROPOSED greenfield scaffold.
+# KFM Agriculture domain CI readiness workflow.
+# Status: PROPOSED explicit holds; executable Agriculture validation, proof, and
+# release-dry-run producers are not established in current repository evidence.
+#
+# Authority boundary:
+# - This workflow inspects repository state and reports whether Agriculture CI
+#   lanes are ready to graduate from documentation-backed scaffolds.
+# - It does not validate Agriculture truth, build an EvidenceBundle or ProofPack,
+#   admit sources, apply policy, promote lifecycle artifacts, approve release,
+#   write published data, deploy, or publish.
 name: domain-agriculture
 
-on:
+"on":
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: domain-agriculture-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: UTC
 
 jobs:
   validate-agriculture:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO validate-agriculture'
+      - name: Check out Agriculture boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Agriculture validation readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "docs/domains/agriculture/DOMAIN.md"
+            "contracts/domains/agriculture/README.md"
+            "schemas/contracts/v1/domains/agriculture/README.md"
+            "fixtures/domains/agriculture/README.md"
+            "policy/domains/agriculture/README.md"
+            "tests/domains/agriculture/README.md"
+            "tools/validators/agriculture/README.md"
+            "release/agriculture/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Agriculture boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          placeholder="tests/domains/agriculture/test_nass_aggregate_only.py"
+          if [[ ! -f "$placeholder" ]]; then
+            echo "::error::Expected documented Agriculture placeholder is missing: $placeholder"
+            exit 1
+          fi
+
+          if ! grep -Fq "PROPOSED placeholder" "$placeholder"; then
+            echo "::error::The Agriculture placeholder changed. Replace this readiness hold with the accepted executable test lane."
+            exit 1
+          fi
+
+          implemented_test="$(find tests/domains/agriculture -type f -name 'test_*.py' ! -path "$placeholder" -print -quit)"
+          if [[ -n "$implemented_test" ]]; then
+            echo "::error::Executable Agriculture test surfaced at $implemented_test. Graduate validate-agriculture to the accepted deterministic suite."
+            exit 1
+          fi
+
+          validator_file="$(find tools/validators/agriculture -type f ! -name 'README.md' -print -quit)"
+          if [[ -n "$validator_file" ]]; then
+            echo "::error::Agriculture validator implementation surfaced at $validator_file. Resolve validator topology and wire the accepted command."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: validate-agriculture"
+          echo "WORKFLOW_HOLD: Agriculture executable validation is not established"
+
+      - name: Record Agriculture validation hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Agriculture validation status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: Agriculture executable validation is not established`
+
+          Current repository evidence is documentation-heavy: the inspected
+          Agriculture test lane contains a placeholder rather than a collected
+          pytest test, and the direct Agriculture validator lane is README-only.
+
+          This result confirms only that the known boundaries still match that
+          maturity posture. It does not validate Agriculture contracts, schemas,
+          source roles, rights, sensitivity, evidence, policy, lifecycle state,
+          cross-domain joins, public aggregation, or release readiness.
+          EOF
+
   build-proof-agriculture:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO build-proof-agriculture'
+      - name: Check out Agriculture proof boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Agriculture proof readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "data/proofs/README.md"
+            "release/agriculture/README.md"
+            "release/candidates/agriculture/county_year_panel_v0/README.md"
+            "tests/domains/agriculture/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Agriculture proof boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "BLOCKED_FOR_EVIDENCE_AND_VALIDATION" "release/agriculture/README.md"; then
+            echo "::error::The documented Agriculture candidate posture changed. Review proof and release gates before accepting this workflow."
+            exit 1
+          fi
+
+          if ! grep -Fq 'Candidate status:** `PROPOSED`' "release/candidates/agriculture/county_year_panel_v0/README.md"; then
+            echo "::error::The Agriculture candidate is no longer documented as PROPOSED. Replace this hold with the governed proof path before proceeding."
+            exit 1
+          fi
+
+          if grep -Eq '^(agriculture-proof|proof-agriculture):' Makefile; then
+            echo "::error::An Agriculture proof target now exists. Wire and validate it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          proof_implementation="$(find . -path './.git' -prune -o -type f \( -iname '*agriculture*proof*.py' -o -iname '*proof*agriculture*.py' -o -iname '*agriculture*proof*.mjs' -o -iname '*proof*agriculture*.mjs' \) -print -quit)"
+          if [[ -n "$proof_implementation" ]]; then
+            echo "::error::Potential Agriculture proof implementation surfaced at $proof_implementation. Establish its contract, tests, receipts, and rollback before wiring CI."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: build-proof-agriculture"
+          echo "WORKFLOW_HOLD: no accepted Agriculture proof producer or deterministic proof command"
+
+      - name: Record Agriculture proof hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Agriculture proof status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Agriculture proof producer or deterministic proof command`
+
+          The inspected county-year candidate remains proposed and blocked for
+          evidence and validation. No accepted Agriculture proof builder,
+          deterministic fixture-backed command, EvidenceRef-to-EvidenceBundle
+          closure, proof manifest, or rollback-tested proof path is established.
+
+          A green held result is readiness evidence only. It is not a ProofPack,
+          EvidenceBundle, validation receipt, promotion decision, release
+          approval, scientific endorsement, or publication authority.
+          EOF
+
   publish-dry-run-agriculture:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO publish-dry-run-agriculture'
+      - name: Check out Agriculture release boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Agriculture release dry-run readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "release/agriculture/README.md"
+            "release/candidates/agriculture/county_year_panel_v0/README.md"
+            "data/published/agriculture/README.md"
+            ".github/workflows/release-dry-run.yml"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Agriculture release boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "BLOCKED_FOR_EVIDENCE_AND_VALIDATION" "release/agriculture/README.md"; then
+            echo "::error::The documented Agriculture release posture changed. Re-evaluate candidate, manifest, policy, evidence, review, correction, and rollback gates."
+            exit 1
+          fi
+
+          if ! grep -Fq "No concrete Agriculture release approval" "release/agriculture/README.md"; then
+            echo "::error::Concrete Agriculture release evidence may now exist. Replace this hold with an independently reviewed dry-run implementation."
+            exit 1
+          fi
+
+          if grep -Eq '^(agriculture-release-dry-run|release-dry-run-agriculture):' Makefile; then
+            echo "::error::An Agriculture release dry-run target now exists. Wire the accepted fail-closed command instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: publish-dry-run-agriculture"
+          echo "WORKFLOW_HOLD: no accepted Agriculture release dry-run command or manifest assembly contract"
+
+      - name: Record Agriculture release dry-run hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Agriculture release dry-run status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Agriculture release dry-run command or manifest assembly contract`
+
+          This lane performs no release, promotion, publication, deployment,
+          manifest generation, source access, network acquisition, or write to
+          processed, catalog, proof, receipt, release, or published stores.
+
+          Graduate it only after an accepted candidate identity, immutable
+          artifact pointer, evidence closure, rights and sensitivity review,
+          policy result, validation receipts, release manifest contract,
+          separation of duties, correction path, and rollback target exist.
+
+          A green held result does not mean Agriculture data is safe, approved,
+          released, published, or suitable for operational or agronomic use.
+          EOF

--- a/data/receipts/generated/genrec-domain-agriculture-workflow-f3486cf8.json
+++ b/data/receipts/generated/genrec-domain-agriculture-workflow-f3486cf8.json
@@ -1,0 +1,62 @@
+{
+  "receipt_id": "genrec-domain-agriculture-workflow-f3486cf8",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T10:33:19-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "3442a813cd51261dfc8b3239348e72e459f5302e",
+  "branch": "agent/domain-agriculture-workflow-20260718",
+  "target_path": ".github/workflows/domain-agriculture.yml",
+  "previous_blob": "a9f5f212ef61d72fdc209d9f8b173bbf87fb1803",
+  "new_blob": "1dd9938b92de61c7d905f30170cf6394e6c06ea1",
+  "sha256": "f3486cf8ca13c1f632d1a3e0549d5edb204323537979af0cbffb73a56f995674",
+  "truth_labels": {
+    "confirmed": [
+      "The prior validate-agriculture, build-proof-agriculture, and publish-dry-run-agriculture jobs only executed TODO echo commands.",
+      "Baseline run 29649918701 completed successfully without Agriculture validation, proof construction, or release dry-run execution.",
+      "The inspected Agriculture test lane contains only a placeholder Python file and no collected Agriculture pytest test.",
+      "The direct tools/validators/agriculture lane is README-only in bounded repository evidence.",
+      "The inspected county_year_panel_v0 candidate is PROPOSED and the Agriculture release index records BLOCKED_FOR_EVIDENCE_AND_VALIDATION.",
+      "The current Makefile has no Agriculture validation, Agriculture proof, or Agriculture release dry-run target.",
+      "Workflow name domain-agriculture and job ids validate-agriculture, build-proof-agriculture, and publish-dry-run-agriculture are preserved."
+    ],
+    "proposed": [
+      "Explicit fail-closed readiness holds are the safest current implementation until executable Agriculture validation, proof, and release-dry-run contracts are accepted.",
+      "The graduation detectors should be replaced by repository-owned deterministic commands when implementation evidence appears."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Accepted Agriculture validator topology and executable no-network test suite.",
+      "Canonical Agriculture proof producer, EvidenceRef-to-EvidenceBundle closure, proof manifest, fixtures, and rollback-tested command.",
+      "Accepted Agriculture release dry-run manifest assembly, policy, rights, sensitivity, review, correction, and rollback contracts.",
+      "Branch-protection dependencies and independent Agriculture, policy, evidence, security, and release review ownership.",
+      "Whether action references should be pinned to immutable commit SHAs."
+    ]
+  },
+  "changes": [
+    "Preserved workflow and three job identities.",
+    "Added workflow_dispatch, contents: read, concurrency cancellation, and five-minute timeouts.",
+    "Disabled persisted checkout credentials.",
+    "Replaced validate-agriculture TODO success with an explicit maturity and boundary hold.",
+    "Replaced build-proof-agriculture TODO success with an explicit candidate and proof-producer hold.",
+    "Replaced publish-dry-run-agriculture TODO success with an explicit release-readiness hold.",
+    "Added fail-closed graduation checks that require deliberate CI wiring when implementation or release posture changes.",
+    "Added bounded always-run summaries for all three jobs."
+  ],
+  "directory_rules_basis": [
+    ".github/workflows remains the existing CI orchestration location.",
+    "tests and tools remain the test and validator responsibility roots.",
+    "data/proofs remains the proof support root; release remains the release-decision root; data/published remains the released-payload root.",
+    "data/receipts/generated remains the existing generated process-memory lane.",
+    "No new schema, contract, policy, validator, proof, release, publication, or root-level authority is created."
+  ],
+  "authority_boundary": "A green held result is repository-readiness evidence only. It is not Agriculture validation, proof, source admission, EvidenceBundle resolution, policy approval, lifecycle promotion, release approval, publication, scientific endorsement, or agronomic advice.",
+  "rollback": {
+    "strategy": "Revert the receipt commit and workflow commit in reverse order or close the pull request without merge.",
+    "restores_blob": "a9f5f212ef61d72fdc209d9f8b173bbf87fb1803"
+  },
+  "human_review": {
+    "state": "pending"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/domain-agriculture.yml` scaffold with explicit, fail-closed readiness holds until executable Agriculture validation, proof, and release-dry-run contracts are accepted.

## Evidence status

- **CONFIRMED:** the prior `validate-agriculture`, `build-proof-agriculture`, and `publish-dry-run-agriculture` jobs only checked out the repository and echoed TODO messages.
- **CONFIRMED:** baseline run `29649918701` completed successfully without Agriculture validation, proof construction, or release dry-run execution.
- **CONFIRMED:** the inspected Agriculture test lane contains a placeholder Python file rather than a collected pytest test.
- **CONFIRMED:** the direct `tools/validators/agriculture/` lane is README-only in bounded repository evidence.
- **CONFIRMED:** `county_year_panel_v0` remains `PROPOSED`, and the Agriculture release index records `BLOCKED_FOR_EVIDENCE_AND_VALIDATION` with no concrete release approval established.
- **CONFIRMED:** the current Makefile has no Agriculture validation, proof, or release dry-run command.
- **PROPOSED:** explicit readiness holds are the safest current CI behavior until accepted executable lanes exist.
- **NEEDS VERIFICATION:** final-head CI, accepted validator topology, proof contract, release dry-run contract, branch protection, and independent review ownership.

## What changed

- Preserved workflow name `domain-agriculture`.
- Preserved job ids `validate-agriculture`, `build-proof-agriculture`, and `publish-dry-run-agriculture`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch`.
- Added `contents: read`, concurrency cancellation, and five-minute timeouts.
- Disabled persisted checkout credentials.
- Replaced all three false-positive TODO successes with explicit `WORKFLOW_SKIPPED_EXPLICIT` / `WORKFLOW_HOLD` outcomes.
- Added required-boundary checks for Agriculture docs, contracts, schemas, fixtures, policy, tests, validators, proof, release, and published lanes.
- Added fail-closed graduation detectors when executable tests, validator files, proof implementations, Make targets, or release posture changes appear.
- Added bounded always-run summaries for every lane.
- Added generated receipt `data/receipts/generated/genrec-domain-agriculture-workflow-f3486cf8.json`.

## Directory Rules basis

- `.github/workflows/` remains the existing CI orchestration location.
- `tests/` and `tools/` remain the test and validator responsibility roots.
- `data/proofs/` remains the proof-support root.
- `release/` remains the release-decision root.
- `data/published/` remains the released-payload root.
- `data/receipts/generated/` remains the existing generated process-memory lane.
- No new schema, contract, policy, validator, proof, release, publication, or root-level authority is created.

## Authority boundary

A green held result is repository-readiness evidence only. It is not Agriculture validation, proof, source admission, EvidenceBundle resolution, policy approval, lifecycle promotion, release approval, publication, scientific endorsement, or agronomic advice.

## Validation

| Check | Outcome |
|---|---|
| Base/target/overlap preflight | PASS |
| Workflow and three job identities preserved | PASS |
| Validation maturity hold wired | PASS |
| Proof maturity hold wired | PASS |
| Release dry-run maturity hold wired | PASS |
| Fail-closed graduation checks added | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Directory Rules placement review | PASS |
| Exact changed paths | workflow + generated receipt only |
| Workflow YAML parse | PASS |
| Workflow SHA-256 | `f3486cf8ca13c1f632d1a3e0549d5edb204323537979af0cbffb73a56f995674` |
| Remote Git blob | `1dd9938b92de61c7d905f30170cf6394e6c06ea1` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `6b26cbebb88745dbc93193fe165eb3a7da2b3a5c` and `520fc9468ab5ac76e56b02839a7792c9a8fecdcc` in reverse order. This restores prior workflow blob `a9f5f212ef61d72fdc209d9f8b173bbf87fb1803` and removes the generated receipt.

## Open verification

- Accepted Agriculture validator topology and deterministic no-network test suite.
- Canonical Agriculture proof producer, EvidenceBundle closure, proof manifest, fixtures, and rollback-tested command.
- Accepted Agriculture release dry-run manifest assembly, policy, rights, sensitivity, review, correction, and rollback contracts.
- Branch-protection references, immutable action pinning, and independent Agriculture, policy, evidence, security, and release review ownership.

## CONTRACT_VERSION

`3.0.0`