### PR TITLE
ci(fauna): make domain readiness holds explicit

### DIFF
--- a/.github/workflows/domain-fauna.yml
+++ b/.github/workflows/domain-fauna.yml
@@ -1,25 +1,300 @@
-# KFM CI workflow stub: domain-fauna
-# Status: PROPOSED greenfield scaffold.
+# KFM Fauna domain CI readiness workflow.
+# Status: PROPOSED explicit holds; executable Fauna validation, proof, and
+# release-dry-run producers are not established in current repository evidence.
+#
+# Authority boundary:
+# - This workflow inspects repository maturity without opening restricted Fauna
+#   payloads or exposing exact or reverse-engineerable sensitive locations.
+# - It does not validate Fauna truth, make taxonomic or stewardship decisions,
+#   build an EvidenceBundle or ProofPack, admit sources, apply policy, perform a
+#   geoprivacy transform, promote lifecycle artifacts, approve release, write
+#   published data, deploy, or publish.
 name: domain-fauna
 
-on:
+"on":
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: domain-fauna-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: UTC
+  PYTHONUNBUFFERED: "1"
 
 jobs:
   validate-fauna:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO validate-fauna'
+      - name: Check out Fauna boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Evaluate Fauna validation readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "docs/domains/fauna/README.md"
+            "contracts/domains/fauna/README.md"
+            "schemas/contracts/v1/domains/fauna/README.md"
+            "fixtures/domains/fauna/README.md"
+            "policy/domains/fauna/README.md"
+            "policy/sensitivity/fauna/README.md"
+            "tests/domains/fauna/README.md"
+            "tools/validators/fauna/README.md"
+            "tools/validators/domains/fauna/README.md"
+            "data/registry/sources/fauna/README.md"
+            "release/candidates/fauna/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Fauna boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          test_root = Path("tests/domains/fauna")
+          collected = []
+
+          for path in sorted(test_root.rglob("test_*.py")):
+              tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+              for node in ast.walk(tree):
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+                      collected.append(f"{path}:{node.name}")
+                  elif isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+                      if any(
+                          isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                          and child.name.startswith("test_")
+                          for child in node.body
+                      ):
+                          collected.append(f"{path}:{node.name}")
+
+          if collected:
+              raise SystemExit(
+                  "Executable Fauna tests surfaced. Graduate validate-fauna "
+                  "to the accepted deterministic no-network suite:\n" + "\n".join(collected)
+              )
+
+          print("No collected Fauna test functions or classes were found.")
+          PY
+
+          validator_roots=(
+            "tools/validators/fauna"
+            "tools/validators/domains/fauna"
+            "tools/validators/geoprivacy/habitat-fauna"
+            "tools/validators/habitat_fauna"
+            "tools/validators/habitat/fauna-geoprivacy"
+            "tools/validators/habitat-fauna"
+          )
+
+          for validator_root in "${validator_roots[@]}"; do
+            if [[ -d "$validator_root" ]]; then
+              validator_file="$(find "$validator_root" -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+              if [[ -n "$validator_file" ]]; then
+                echo "::error::Fauna validator implementation surfaced at $validator_file. Resolve validator ownership and wire the accepted command."
+                exit 1
+              fi
+            fi
+          done
+
+          if grep -Eq '^(fauna-validate|validate-fauna):' Makefile; then
+            echo "::error::A Fauna validation target now exists. Wire and verify it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: validate-fauna"
+          echo "WORKFLOW_HOLD: executable Fauna validation is not established"
+
+      - name: Record Fauna validation hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Fauna validation status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: executable Fauna validation is not established`
+
+          Current repository evidence is documentation-heavy: sampled Fauna test
+          modules are placeholders, and the inspected per-domain, broad, and
+          cross-domain Fauna validator lanes are README-backed rather than
+          accepted executable validators.
+
+          This check does not establish taxonomic identity, occurrence validity,
+          source-role closure, rights, sensitivity, geoprivacy, public-safe
+          geometry, evidence closure, policy approval, stewardship approval,
+          release readiness, or safe public use.
+          EOF
+
   build-proof-fauna:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO build-proof-fauna'
+      - name: Check out Fauna proof boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Fauna proof readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "data/proofs/fauna/README.md"
+            "data/registry/sources/fauna/README.md"
+            "release/candidates/fauna/README.md"
+            "tests/domains/fauna/README.md"
+            "policy/sensitivity/fauna/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Fauna proof boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "**Status:** draft / PROPOSED" "data/proofs/fauna/README.md"; then
+            echo "::error::The Fauna proof posture changed. Review proof schemas, geoprivacy controls, producers, access controls, receipts, and release linkage before accepting this workflow."
+            exit 1
+          fi
+
+          proof_artifact="$(find data/proofs/fauna -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$proof_artifact" ]]; then
+            echo "::error::Fauna proof material surfaced at $proof_artifact. Replace this hold with the governed proof validator and manifest path."
+            exit 1
+          fi
+
+          if grep -Eq '^(fauna-proof|proof-fauna):' Makefile; then
+            echo "::error::A Fauna proof target now exists. Wire and validate it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          proof_implementation="$(find . -path './.git' -prune -o -type f \( -iname '*fauna*proof*.py' -o -iname '*proof*fauna*.py' -o -iname '*fauna*proof*.mjs' -o -iname '*proof*fauna*.mjs' \) -print -quit)"
+          if [[ -n "$proof_implementation" ]]; then
+            echo "::error::Potential Fauna proof implementation surfaced at $proof_implementation. Establish its contract, public-safe fixtures, geoprivacy controls, receipts, access controls, and rollback before wiring CI."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: build-proof-fauna"
+          echo "WORKFLOW_HOLD: no accepted Fauna proof producer or deterministic proof command"
+
+      - name: Record Fauna proof hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Fauna proof status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Fauna proof producer or deterministic proof command`
+
+          The Fauna proof lane is documented, but concrete proof inventory,
+          EvidenceRef-to-EvidenceBundle resolution, schemas, validators,
+          public-safe fixtures, access controls, geoprivacy proof, review
+          binding, receipt linkage, and release linkage remain unverified.
+
+          A green held result is readiness evidence only. It is not an
+          EvidenceBundle, ProofPack, ValidationReport, RedactionReceipt,
+          AggregationReceipt, stewardship decision, hunting or legal guidance,
+          release decision, or publication authority.
+          EOF
+
   publish-dry-run-fauna:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO publish-dry-run-fauna'
+      - name: Check out Fauna release boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Fauna release dry-run readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "release/candidates/fauna/README.md"
+            "docs/domains/fauna/RELEASE_INDEX.md"
+            "data/published/fauna/README.md"
+            ".github/workflows/release-dry-run.yml"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Fauna release boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "A candidate is not a release." "release/candidates/fauna/README.md"; then
+            echo "::error::The documented Fauna candidate posture changed. Re-evaluate source, evidence, rights, sensitivity, geoprivacy, policy, review, correction, and rollback gates."
+            exit 1
+          fi
+
+          candidate_record="$(find release/candidates/fauna -mindepth 1 -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$candidate_record" ]]; then
+            echo "::error::A Fauna candidate record surfaced at $candidate_record. Replace this hold with the independently reviewed domain dry-run path."
+            exit 1
+          fi
+
+          if grep -Eq '^(fauna-release-dry-run|release-dry-run-fauna):' Makefile; then
+            echo "::error::A Fauna release dry-run target now exists. Wire the accepted fail-closed command instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: publish-dry-run-fauna"
+          echo "WORKFLOW_HOLD: no accepted Fauna release dry-run command or candidate manifest contract"
+
+      - name: Record Fauna release dry-run hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Fauna release dry-run status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Fauna release dry-run command or candidate manifest contract`
+
+          This lane performs no source access, geoprivacy transform, release,
+          promotion, manifest assembly, deployment, publication, or write to
+          processed, catalog, proof, receipt, release, or published stores.
+
+          Graduate it only after candidate identity, immutable artifact pointer,
+          source and EvidenceBundle closure, rights, sensitivity, public-safe
+          transformation, policy result, steward review, validation receipts,
+          independent approval, correction path, withdrawal path, and rollback
+          target are accepted.
+
+          A green held result does not mean Fauna data is accurate, legally or
+          ethically releasable, safe for species or site exposure, approved,
+          released, or published.
+          EOF

--- a/data/receipts/generated/genrec-domain-fauna-workflow-4c8931f9.json
+++ b/data/receipts/generated/genrec-domain-fauna-workflow-4c8931f9.json
@@ -1,0 +1,69 @@
+{
+  "receipt_id": "genrec-domain-fauna-workflow-4c8931f9",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "3c0b8f0fa2d9d2a490701d72a5a5b3bc448b02e0",
+  "branch": "agent/domain-fauna-workflow-20260718",
+  "target_path": ".github/workflows/domain-fauna.yml",
+  "previous_blob": "53e6b038f72772d7f38fb0968339548c23b1db69",
+  "new_blob": "981a6554d38cacd3b528dea45ae7e2834f55934b",
+  "sha256": "4c8931f9b589374b6998f441a723651ed212ee364a7e33a42096592045a34189",
+  "truth_labels": {
+    "confirmed": [
+      "The prior validate-fauna, build-proof-fauna, and publish-dry-run-fauna jobs only executed TODO echo commands.",
+      "Baseline workflow run 29650601349 completed successfully without Fauna validation, proof construction, or release dry-run execution.",
+      "Sampled Fauna test modules contain only PROPOSED placeholder docstrings.",
+      "The broad and per-domain Fauna validator indexes record executable behavior as unverified and README-backed.",
+      "The Fauna proof lane is draft and PROPOSED, with concrete proof inventory and enforcement unresolved.",
+      "The Fauna release-candidate lane is pre-publication and states that a candidate is not a release.",
+      "Workflow name domain-fauna and all three job ids are preserved."
+    ],
+    "proposed": [
+      "Explicit fail-closed readiness holds are the safest current CI behavior until accepted executable Fauna lanes exist.",
+      "AST-based test detection and implementation-presence checks are appropriate graduation signals for the current scaffold maturity."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Accepted Fauna validator ownership and deterministic no-network suite.",
+      "Concrete EvidenceBundle and proof producer contracts, schemas, public-safe fixtures, geoprivacy controls, access controls, manifests, and receipts.",
+      "Accepted Fauna candidate, release dry-run, sensitivity, stewardship, correction, withdrawal, and rollback contracts.",
+      "Branch-protection dependencies, independent review ownership, and immutable action pinning."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch, contents: read permission, concurrency cancellation, deterministic Python setup, and job timeouts.",
+    "Disabled persisted checkout credentials.",
+    "Converted all three TODO-only jobs into explicit WORKFLOW_SKIPPED_EXPLICIT and WORKFLOW_HOLD readiness checks.",
+    "Added required-boundary checks across Fauna docs, contracts, schemas, fixtures, policy, tests, validators, registry, proofs, release candidates, and published lanes.",
+    "Added AST-based detection for newly executable Fauna tests.",
+    "Added fail-closed graduation checks for validators, proof artifacts or producers, candidate records, Make targets, and changed release posture.",
+    "Added bounded summaries preserving sensitive-species, exact-occurrence, stewardship, geoprivacy, rights, release, correction, and rollback boundaries."
+  ],
+  "authority_boundary": "A green held result is repository-readiness evidence only. It is not Fauna validation, taxonomic or occurrence confirmation, stewardship approval, geoprivacy approval, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, hunting or legal guidance, or publication authority.",
+  "directory_rules_basis": [
+    ".github/workflows remains the existing CI orchestration location.",
+    "tests and fixtures remain the test and bounded test-data roots.",
+    "tools remains the validator and helper root.",
+    "data/proofs remains the proof-support root.",
+    "release remains the release-decision root.",
+    "data/published remains the released-payload root.",
+    "data/receipts/generated remains the existing generated process-memory lane."
+  ],
+  "validation": {
+    "workflow_yaml_parse": "PASS",
+    "workflow_and_job_identities_preserved": "PASS",
+    "exact_changed_paths": [
+      ".github/workflows/domain-fauna.yml",
+      "data/receipts/generated/genrec-domain-fauna-workflow-4c8931f9.json"
+    ],
+    "final_head_ci": "PENDING",
+    "human_review": "PENDING"
+  },
+  "rollback": {
+    "strategy": "Close the pull request without merge or revert the receipt commit and workflow commit in reverse order.",
+    "restores_blob": "53e6b038f72772d7f38fb0968339548c23b1db69"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/domain-fauna.yml` scaffold with explicit, fail-closed readiness holds until executable Fauna validation, proof, and release-dry-run contracts are accepted.

## Evidence status

- **CONFIRMED:** the prior `validate-fauna`, `build-proof-fauna`, and `publish-dry-run-fauna` jobs only checked out the repository and echoed TODO messages.
- **CONFIRMED:** baseline run `29650601349` completed successfully without Fauna validation, proof construction, or release dry-run execution.
- **CONFIRMED:** sampled Fauna test modules contain only `PROPOSED` placeholder docstrings.
- **CONFIRMED:** broad and per-domain Fauna validator indexes are README-backed, with executable behavior unverified.
- **CONFIRMED:** the Fauna proof lane is draft and `PROPOSED`; concrete proof inventory, schemas, validators, fixtures, access controls, and release linkage remain unresolved.
- **CONFIRMED:** the Fauna release-candidate lane remains pre-publication and states that a candidate is not a release.
- **CONFIRMED:** Fauna sensitive taxa, exact occurrences, nests, dens, roosts, hibernacula, spawning sites, telemetry, steward-controlled records, and reverse-engineerable derivatives are deny-by-default without governed geoprivacy, review, evidence, policy, release, correction, and rollback support.
- **PROPOSED:** explicit readiness holds are the safest current CI behavior until accepted executable lanes exist.
- **NEEDS VERIFICATION:** final-head CI, accepted validator/proof/release contracts, branch protection, and independent stewardship/review ownership.

## What changed

- Preserved workflow name `domain-fauna`.
- Preserved job ids `validate-fauna`, `build-proof-fauna`, and `publish-dry-run-fauna`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch`.
- Added `contents: read`, concurrency cancellation, Python 3.11 setup where needed, and five-minute timeouts.
- Disabled persisted checkout credentials.
- Replaced all three false-positive TODO successes with explicit `WORKFLOW_SKIPPED_EXPLICIT` / `WORKFLOW_HOLD` outcomes.
- Added required-boundary checks across Fauna docs, contracts, schemas, fixtures, policy, sensitivity, tests, validators, registry, proofs, release candidates, and published lanes.
- Added AST-based detection of newly executable Fauna tests.
- Added fail-closed graduation detectors when validator implementations, proof artifacts or producers, candidate records, Make targets, or release posture changes appear.
- Added bounded summaries preserving sensitive-location, geoprivacy, rights, stewardship, evidence, policy, correction, withdrawal, and rollback boundaries.
- Added generated receipt `data/receipts/generated/genrec-domain-fauna-workflow-4c8931f9.json`.

## Directory Rules basis

- `.github/workflows/` remains the CI orchestration location.
- `tests/` and `fixtures/` remain the test and bounded test-data roots.
- `tools/` remains the validator/helper root.
- `data/proofs/` remains the proof-support root.
- `release/` remains the release-decision root.
- `data/published/` remains the released-payload root.
- `data/receipts/generated/` remains the generated process-memory lane.
- No new schema, contract, policy, validator, proof, release, publication, or root-level authority is created.

## Authority boundary

A green held result is repository-readiness evidence only. It is not Fauna validation, taxonomic or occurrence confirmation, stewardship approval, geoprivacy approval, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, hunting or legal guidance, or publication authority.

## Validation

| Check | Outcome |
|---|---|
| Base/target/overlap preflight | PASS |
| Workflow and three job identities preserved | PASS |
| Validation maturity hold wired | PASS |
| Proof maturity hold wired | PASS |
| Release dry-run maturity hold wired | PASS |
| Protected/sensitive payloads not opened | PASS |
| Fail-closed graduation checks added | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Directory Rules placement review | PASS |
| Exact changed paths | workflow + generated receipt only |
| Workflow YAML parse | PASS |
| Workflow SHA-256 | `4c8931f9b589374b6998f441a723651ed212ee364a7e33a42096592045a34189` |
| Remote Git blob | `981a6554d38cacd3b528dea45ae7e2834f55934b` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `99d4a935f3191d99e5e25bbecb0910e253647d43` and `bd2ea1c1d53e7b137bcfc58eba6b8501ad95b348` in reverse order. This restores prior workflow blob `53e6b038f72772d7f38fb0968339548c23b1db69` and removes the generated receipt.

## Open verification

- Accepted Fauna validator ownership and deterministic no-network suite.
- Concrete EvidenceBundle/proof schemas, public-safe fixtures, geoprivacy controls, access controls, producer, manifest, receipts, and rollback-tested command.
- Accepted candidate dossier, release-manifest assembly, rights, sensitivity, stewardship review, policy decision, independent approval, correction, withdrawal, and rollback contracts.
- Branch-protection references, immutable action pinning, and independent Fauna, geoprivacy, sensitivity, evidence, policy, security, and release review ownership.

## CONTRACT_VERSION

`3.0.0`