### PR TITLE
ci(flora): make domain readiness holds explicit

### DIFF
--- a/.github/workflows/domain-flora.yml
+++ b/.github/workflows/domain-flora.yml
@@ -1,25 +1,304 @@
-# KFM CI workflow stub: domain-flora
-# Status: PROPOSED greenfield scaffold.
+# KFM Flora domain CI readiness workflow.
+# Status: PROPOSED explicit holds; executable Flora validation, proof, and
+# release-dry-run producers are not established in current repository evidence.
+#
+# Authority boundary:
+# - This workflow inspects repository maturity without opening restricted Flora
+#   payloads or exposing exact or reverse-engineerable rare-plant locations.
+# - It does not validate botanical truth, make stewardship decisions, execute a
+#   geoprivacy transform, build an EvidenceBundle or ProofPack, admit sources,
+#   apply policy, promote lifecycle artifacts, approve release, write published
+#   data, deploy, or publish.
 name: domain-flora
 
-on:
+"on":
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: domain-flora-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: UTC
+  PYTHONUNBUFFERED: "1"
 
 jobs:
   validate-flora:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO validate-flora'
+      - name: Check out Flora boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Evaluate Flora validation readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "docs/domains/flora/README.md"
+            "contracts/domains/flora/README.md"
+            "schemas/contracts/v1/domains/flora/README.md"
+            "fixtures/domains/flora/README.md"
+            "policy/domains/flora/README.md"
+            "policy/sensitivity/flora/README.md"
+            "tests/domains/flora/README.md"
+            "tools/validators/domains/flora/README.md"
+            "packages/domains/flora/geoprivacy_transformer/README.md"
+            "data/registry/sources/flora/README.md"
+            "release/candidates/flora/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Flora boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          test_root = Path("tests/domains/flora")
+          collected = []
+
+          for path in sorted(test_root.rglob("test_*.py")):
+              tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+              for node in ast.walk(tree):
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+                      collected.append(f"{path}:{node.name}")
+                  elif isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+                      if any(
+                          isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                          and child.name.startswith("test_")
+                          for child in node.body
+                      ):
+                          collected.append(f"{path}:{node.name}")
+
+          if collected:
+              raise SystemExit(
+                  "Executable Flora tests surfaced. Graduate validate-flora "
+                  "to the accepted deterministic no-network suite:\n" + "\n".join(collected)
+              )
+
+          print("No collected Flora test functions or classes were found.")
+          PY
+
+          validator_roots=(
+            "tools/validators/domains/flora"
+            "tools/validators/geoprivacy"
+            "tools/validators/geoprivacy_transform"
+          )
+
+          for validator_root in "${validator_roots[@]}"; do
+            if [[ -d "$validator_root" ]]; then
+              validator_file="$(find "$validator_root" -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+              if [[ -n "$validator_file" ]]; then
+                echo "::error::Flora validator implementation surfaced at $validator_file. Resolve validator ownership and wire the accepted command."
+                exit 1
+              fi
+            fi
+          done
+
+          transformer_file="$(find packages/domains/flora/geoprivacy_transformer -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$transformer_file" ]]; then
+            echo "::error::Flora geoprivacy implementation surfaced at $transformer_file. Wire its accepted contract, fixtures, receipts, policy, tests, and rollback path deliberately."
+            exit 1
+          fi
+
+          if grep -Eq '^(flora-validate|validate-flora):' Makefile; then
+            echo "::error::A Flora validation target now exists. Wire and verify it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: validate-flora"
+          echo "WORKFLOW_HOLD: executable Flora validation is not established"
+
+      - name: Record Flora validation hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Flora validation status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: executable Flora validation is not established`
+
+          Current repository evidence is documentation-heavy: sampled Flora tests
+          are placeholders, the domain validator is an index without accepted
+          executables, and the geoprivacy transformer is a proposed package
+          contract rather than verified implementation.
+
+          This check does not establish botanical identity, occurrence validity,
+          rights, rare-plant sensitivity, geoprivacy, public-safe geometry,
+          EvidenceBundle closure, policy approval, stewardship approval, release
+          readiness, or safe public use.
+          EOF
+
   build-proof-flora:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO build-proof-flora'
+      - name: Check out Flora proof boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Flora proof readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "data/proofs/flora/README.md"
+            "data/proofs/evidence_bundle/flora/README.md"
+            "data/proofs/citation_validation/flora/README.md"
+            "data/registry/sources/flora/README.md"
+            "release/candidates/flora/README.md"
+            "policy/sensitivity/flora/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Flora proof boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "**Status:** draft / PROPOSED" "data/proofs/flora/README.md"; then
+            echo "::error::The Flora proof posture changed. Review proof schemas, redaction controls, producers, access controls, receipts, and release linkage before accepting this workflow."
+            exit 1
+          fi
+
+          proof_artifact="$(find data/proofs/flora -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$proof_artifact" ]]; then
+            echo "::error::Flora proof material surfaced at $proof_artifact. Replace this hold with the governed proof validator and manifest path."
+            exit 1
+          fi
+
+          if grep -Eq '^(flora-proof|proof-flora):' Makefile; then
+            echo "::error::A Flora proof target now exists. Wire and validate it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          proof_implementation="$(find . -path './.git' -prune -o -type f \( -iname '*flora*proof*.py' -o -iname '*proof*flora*.py' -o -iname '*flora*proof*.mjs' -o -iname '*proof*flora*.mjs' \) -print -quit)"
+          if [[ -n "$proof_implementation" ]]; then
+            echo "::error::Potential Flora proof implementation surfaced at $proof_implementation. Establish its contract, public-safe fixtures, redaction controls, receipts, access controls, and rollback before wiring CI."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: build-proof-flora"
+          echo "WORKFLOW_HOLD: no accepted Flora proof producer or deterministic proof command"
+
+      - name: Record Flora proof hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Flora proof status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Flora proof producer or deterministic proof command`
+
+          Flora proof, EvidenceBundle, and citation-validation lanes are
+          documented, but concrete proof inventory, schemas, validators,
+          public-safe fixtures, access controls, redaction/generalization proof,
+          review binding, receipt linkage, and release linkage remain unverified.
+
+          A green held result is readiness evidence only. It is not an
+          EvidenceBundle, ProofPack, ValidationReport, RedactionReceipt,
+          stewardship decision, collection or access guidance, release decision,
+          or publication authority.
+          EOF
+
   publish-dry-run-flora:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO publish-dry-run-flora'
+      - name: Check out Flora release boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Flora release dry-run readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "release/candidates/flora/README.md"
+            "docs/domains/flora/RELEASE_INDEX.md"
+            "data/published/flora/README.md"
+            ".github/workflows/release-dry-run.yml"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Flora release boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "A candidate is not a release." "release/candidates/flora/README.md"; then
+            echo "::error::The documented Flora candidate posture changed. Re-evaluate source, evidence, rights, sensitivity, geoprivacy, policy, review, correction, and rollback gates."
+            exit 1
+          fi
+
+          candidate_record="$(find release/candidates/flora -mindepth 1 -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$candidate_record" ]]; then
+            echo "::error::A Flora candidate record surfaced at $candidate_record. Replace this hold with the independently reviewed domain dry-run path."
+            exit 1
+          fi
+
+          if grep -Eq '^(flora-release-dry-run|release-dry-run-flora):' Makefile; then
+            echo "::error::A Flora release dry-run target now exists. Wire the accepted fail-closed command instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: publish-dry-run-flora"
+          echo "WORKFLOW_HOLD: no accepted Flora release dry-run command or candidate manifest contract"
+
+      - name: Record Flora release dry-run hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Flora release dry-run status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Flora release dry-run command or candidate manifest contract`
+
+          This lane performs no source access, geoprivacy transform, release,
+          promotion, manifest assembly, deployment, publication, or write to
+          processed, catalog, proof, receipt, release, or published stores.
+
+          Graduate it only after candidate identity, immutable artifact pointer,
+          source and EvidenceBundle closure, rights, sensitivity, public-safe
+          transformation, policy result, steward review, validation receipts,
+          independent approval, correction path, withdrawal path, and rollback
+          target are accepted.
+
+          A green held result does not mean Flora data is botanically accurate,
+          legally or ethically releasable, safe for rare-plant location exposure,
+          approved, released, or published.
+          EOF

--- a/data/receipts/generated/genrec-domain-flora-workflow-231cb316.json
+++ b/data/receipts/generated/genrec-domain-flora-workflow-231cb316.json
@@ -1,0 +1,72 @@
+{
+  "receipt_id": "genrec-domain-flora-workflow-231cb316",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "d899c8507601cd5ca49221d7a767368fccd07033",
+  "branch": "agent/domain-flora-workflow-20260718",
+  "target_path": ".github/workflows/domain-flora.yml",
+  "previous_blob": "c7737001b3de3f0a1150ea467ef656a52c26b0fd",
+  "new_blob": "ab73dbf965db32bc294898de3eb89e9aab635808",
+  "sha256": "231cb316161016133bb6499a4b2f4e90bd6d666869edf84a5d91aff1c5299bea",
+  "truth_labels": {
+    "confirmed": [
+      "The prior validate-flora, build-proof-flora, and publish-dry-run-flora jobs only executed TODO echo commands.",
+      "Baseline workflow run 29650601340 completed successfully without Flora validation, proof construction, or release dry-run execution.",
+      "Sampled Flora test modules contain only PROPOSED placeholder docstrings.",
+      "The Flora validator index records executables and CI wiring as unverified.",
+      "The Flora geoprivacy transformer path is represented by a proposed package README, with no implementation file surfaced in bounded search.",
+      "The Flora proof lane is draft and PROPOSED, with concrete proof inventory and enforcement unresolved.",
+      "The Flora release-candidate lane is pre-publication and states that a candidate is not a release.",
+      "Workflow name domain-flora and all three job ids are preserved."
+    ],
+    "proposed": [
+      "Explicit fail-closed readiness holds are the safest current CI behavior until accepted executable Flora lanes exist.",
+      "AST-based test detection and implementation-presence checks are appropriate graduation signals for the current scaffold maturity."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Accepted Flora validator ownership and deterministic no-network suite.",
+      "Concrete geoprivacy transformer implementation, policies, public-safe fixtures, receipts, tests, and rollback behavior.",
+      "Concrete EvidenceBundle and proof producer contracts, schemas, access controls, manifests, and receipts.",
+      "Accepted Flora candidate, release dry-run, sensitivity, stewardship, correction, withdrawal, and rollback contracts.",
+      "Branch-protection dependencies, independent review ownership, and immutable action pinning."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch, contents: read permission, concurrency cancellation, deterministic Python setup, and job timeouts.",
+    "Disabled persisted checkout credentials.",
+    "Converted all three TODO-only jobs into explicit WORKFLOW_SKIPPED_EXPLICIT and WORKFLOW_HOLD readiness checks.",
+    "Added required-boundary checks across Flora docs, contracts, schemas, fixtures, policy, sensitivity, tests, validators, geoprivacy package, registry, proofs, release candidates, and published lanes.",
+    "Added AST-based detection for newly executable Flora tests.",
+    "Added fail-closed graduation checks for validators, geoprivacy implementation, proof artifacts or producers, candidate records, Make targets, and changed release posture.",
+    "Added bounded summaries preserving rare-plant location, geoprivacy, rights, stewardship, evidence, policy, correction, withdrawal, and rollback boundaries."
+  ],
+  "authority_boundary": "A green held result is repository-readiness evidence only. It is not Flora validation, botanical or occurrence confirmation, stewardship approval, geoprivacy approval, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, collection or access guidance, or publication authority.",
+  "directory_rules_basis": [
+    ".github/workflows remains the existing CI orchestration location.",
+    "tests and fixtures remain the test and bounded test-data roots.",
+    "tools remains the validator and helper root.",
+    "packages remains the reusable implementation root for the proposed geoprivacy transformer.",
+    "data/proofs remains the proof-support root.",
+    "release remains the release-decision root.",
+    "data/published remains the released-payload root.",
+    "data/receipts/generated remains the existing generated process-memory lane."
+  ],
+  "validation": {
+    "workflow_yaml_parse": "PASS",
+    "workflow_and_job_identities_preserved": "PASS",
+    "exact_changed_paths": [
+      ".github/workflows/domain-flora.yml",
+      "data/receipts/generated/genrec-domain-flora-workflow-231cb316.json"
+    ],
+    "final_head_ci": "PENDING",
+    "human_review": "PENDING"
+  },
+  "rollback": {
+    "strategy": "Close the pull request without merge or revert the receipt commit and workflow commit in reverse order.",
+    "restores_blob": "c7737001b3de3f0a1150ea467ef656a52c26b0fd"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/domain-flora.yml` scaffold with explicit, fail-closed readiness holds until executable Flora validation, proof, and release-dry-run contracts are accepted.

## Evidence status

- **CONFIRMED:** the prior `validate-flora`, `build-proof-flora`, and `publish-dry-run-flora` jobs only checked out the repository and echoed TODO messages.
- **CONFIRMED:** baseline run `29650601340` completed successfully without Flora validation, proof construction, or release dry-run execution.
- **CONFIRMED:** sampled Flora test modules contain only `PROPOSED` placeholder docstrings.
- **CONFIRMED:** the Flora validator index records executables, fixtures, policy bundles, receipts, runtime behavior, and CI wiring as unverified.
- **CONFIRMED:** the Flora geoprivacy transformer is documented as a proposed implementation package; bounded search surfaced only its README.
- **CONFIRMED:** the Flora proof lane is draft and `PROPOSED`; concrete proof inventory, schemas, validators, fixtures, access controls, and release linkage remain unresolved.
- **CONFIRMED:** the Flora release-candidate lane remains pre-publication and states that a candidate is not a release.
- **PROPOSED:** explicit readiness holds are the safest current CI behavior until accepted executable Flora lanes exist.
- **NEEDS VERIFICATION:** final-head CI, accepted validator/geoprivacy/proof/release contracts, branch protection, and independent stewardship/review ownership.

## What changed

- Preserved workflow name `domain-flora`.
- Preserved job ids `validate-flora`, `build-proof-flora`, and `publish-dry-run-flora`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch`.
- Added `contents: read`, concurrency cancellation, Python 3.11 setup where needed, and five-minute timeouts.
- Disabled persisted checkout credentials.
- Replaced all three false-positive TODO successes with explicit `WORKFLOW_SKIPPED_EXPLICIT` / `WORKFLOW_HOLD` outcomes.
- Added required-boundary checks across Flora docs, contracts, schemas, fixtures, policy, sensitivity, tests, validators, geoprivacy package, registry, proofs, release candidates, and published lanes.
- Added AST-based detection of newly executable Flora tests.
- Added fail-closed graduation detectors when validator implementations, geoprivacy code, proof artifacts or producers, candidate records, Make targets, or release posture changes appear.
- Added bounded summaries preserving rare-plant location, geoprivacy, rights, stewardship, evidence, policy, correction, withdrawal, and rollback boundaries.
- Added generated receipt `data/receipts/generated/genrec-domain-flora-workflow-231cb316.json`.

## Directory Rules basis

- `.github/workflows/` remains the CI orchestration location.
- `tests/` and `fixtures/` remain the test and bounded test-data roots.
- `tools/` remains the validator/helper root.
- `packages/` remains the reusable implementation root for the proposed geoprivacy transformer.
- `data/proofs/` remains the proof-support root.
- `release/` remains the release-decision root.
- `data/published/` remains the released-payload root.
- `data/receipts/generated/` remains the generated process-memory lane.
- No new schema, contract, policy, validator, proof, release, publication, or root-level authority is created.

## Authority boundary

A green held result is repository-readiness evidence only. It is not Flora validation, botanical or occurrence confirmation, stewardship approval, geoprivacy approval, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, collection or access guidance, or publication authority.

## Validation

| Check | Outcome |
|---|---|
| Base/target/overlap preflight | PASS |
| Workflow and three job identities preserved | PASS |
| Validation maturity hold wired | PASS |
| Proof maturity hold wired | PASS |
| Release dry-run maturity hold wired | PASS |
| Protected/sensitive payloads not opened | PASS |
| Fail-closed graduation checks added | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Directory Rules placement review | PASS |
| Exact changed paths | workflow + generated receipt only |
| Workflow YAML parse | PASS |
| Workflow SHA-256 | `231cb316161016133bb6499a4b2f4e90bd6d666869edf84a5d91aff1c5299bea` |
| Remote Git blob | `ab73dbf965db32bc294898de3eb89e9aab635808` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `5dd3705f7168505af67909777a3eb36705fc2d4c` and `912e8af6de1341b5a429452cfeff370f128a097c` in reverse order. This restores prior workflow blob `c7737001b3de3f0a1150ea467ef656a52c26b0fd` and removes the generated receipt.

## Open verification

- Accepted Flora validator ownership and deterministic no-network suite.
- Concrete geoprivacy transformer implementation, policies, public-safe fixtures, transform receipts, tests, and rollback behavior.
- Concrete EvidenceBundle/proof schemas, access controls, producer, manifest, receipts, and rollback-tested command.
- Accepted candidate dossier, release-manifest assembly, rights, sensitivity, stewardship review, policy decision, independent approval, correction, withdrawal, and rollback contracts.
- Branch-protection references, immutable action pinning, and independent Flora, geoprivacy, sensitivity, evidence, policy, security, and release review ownership.

## CONTRACT_VERSION

`3.0.0`