### PR TITLE
ci(geology): make domain readiness holds explicit

### DIFF
--- a/.github/workflows/domain-geology.yml
+++ b/.github/workflows/domain-geology.yml
@@ -1,25 +1,297 @@
-# KFM CI workflow stub: domain-geology
-# Status: PROPOSED greenfield scaffold.
+# KFM Geology domain CI readiness workflow.
+# Status: PROPOSED explicit holds; executable Geology validation, proof, and
+# release-dry-run producers are not established in current repository evidence.
+#
+# Authority boundary:
+# - This workflow inspects repository maturity without opening restricted
+#   subsurface, private-well, well-log, parcel, operator, or resource payloads.
+# - It does not validate Geology truth, certify reserves or engineering claims,
+#   build an EvidenceBundle or ProofPack, admit sources, apply policy, perform a
+#   public-safe geometry transform, promote lifecycle artifacts, approve release,
+#   write published data, deploy, or publish.
 name: domain-geology
 
-on:
+"on":
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: domain-geology-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: UTC
+  PYTHONUNBUFFERED: "1"
 
 jobs:
   validate-geology:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO validate-geology'
+      - name: Check out Geology boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Evaluate Geology validation readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "docs/domains/geology/README.md"
+            "contracts/domains/geology/README.md"
+            "schemas/contracts/v1/domains/geology/README.md"
+            "fixtures/domains/geology/README.md"
+            "policy/domains/geology/README.md"
+            "tests/domains/geology/README.md"
+            "tools/validators/domains/geology/README.md"
+            "tools/validators/geology/README.md"
+            "data/registry/sources/geology/README.md"
+            "data/registry/sensitivity/geology/README.md"
+            "release/candidates/geology/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Geology boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          test_root = Path("tests/domains/geology")
+          collected = []
+
+          for path in sorted(test_root.rglob("test_*.py")):
+              tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+              for node in ast.walk(tree):
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+                      collected.append(f"{path}:{node.name}")
+                  elif isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+                      if any(
+                          isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                          and child.name.startswith("test_")
+                          for child in node.body
+                      ):
+                          collected.append(f"{path}:{node.name}")
+
+          if collected:
+              raise SystemExit(
+                  "Executable Geology tests surfaced. Graduate validate-geology "
+                  "to the accepted deterministic no-network suite:\n" + "\n".join(collected)
+              )
+
+          print("No collected Geology test functions or classes were found.")
+          PY
+
+          validator_roots=(
+            "tools/validators/domains/geology"
+            "tools/validators/geology"
+          )
+
+          for validator_root in "${validator_roots[@]}"; do
+            validator_file="$(find "$validator_root" -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+            if [[ -n "$validator_file" ]]; then
+              echo "::error::Geology validator implementation surfaced at $validator_file. Resolve validator ownership and wire the accepted command."
+              exit 1
+            fi
+          done
+
+          if grep -Eq '^(geology-validate|validate-geology):' Makefile; then
+            echo "::error::A Geology validation target now exists. Wire and verify it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: validate-geology"
+          echo "WORKFLOW_HOLD: executable Geology validation is not established"
+
+      - name: Record Geology validation hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Geology validation status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: executable Geology validation is not established`
+
+          Current repository evidence is documentation-heavy: sampled Geology
+          test modules are placeholders, and the inspected per-domain and broad
+          Geology validator lanes are README-backed rather than accepted
+          executable validators.
+
+          This check does not establish geologic interpretation, resource class,
+          reserve or estimate validity, permit or production status, mineral or
+          property rights, exact subsurface safety, evidence closure, policy
+          approval, engineering suitability, or release readiness.
+          EOF
+
   build-proof-geology:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO build-proof-geology'
+      - name: Check out Geology proof boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Geology proof readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "data/proofs/geology/README.md"
+            "data/registry/sources/geology/README.md"
+            "data/registry/sensitivity/geology/README.md"
+            "release/candidates/geology/README.md"
+            "tests/domains/geology/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Geology proof boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "**Status:** draft / PROPOSED" "data/proofs/geology/README.md"; then
+            echo "::error::The Geology proof posture changed. Review proof schemas, claim-class controls, producers, access controls, receipts, and release linkage before accepting this workflow."
+            exit 1
+          fi
+
+          proof_artifact="$(find data/proofs/geology -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$proof_artifact" ]]; then
+            echo "::error::Geology proof material surfaced at $proof_artifact. Replace this hold with the governed proof validator and manifest path."
+            exit 1
+          fi
+
+          if grep -Eq '^(geology-proof|proof-geology):' Makefile; then
+            echo "::error::A Geology proof target now exists. Wire and validate it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          proof_implementation="$(find . -path './.git' -prune -o -type f \( -iname '*geology*proof*.py' -o -iname '*proof*geology*.py' -o -iname '*geology*proof*.mjs' -o -iname '*proof*geology*.mjs' \) -print -quit)"
+          if [[ -n "$proof_implementation" ]]; then
+            echo "::error::Potential Geology proof implementation surfaced at $proof_implementation. Establish its contract, synthetic fixtures, sensitivity controls, receipts, access controls, and rollback before wiring CI."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: build-proof-geology"
+          echo "WORKFLOW_HOLD: no accepted Geology proof producer or deterministic proof command"
+
+      - name: Record Geology proof hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Geology proof status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Geology proof producer or deterministic proof command`
+
+          The Geology proof lane is documented, but concrete proof inventory,
+          EvidenceRef-to-EvidenceBundle resolution, schemas, validators,
+          synthetic fixtures, access controls, occurrence/deposit/estimate/
+          permit/production/reserve anti-collapse proof, review binding, receipt
+          linkage, and release linkage remain unverified.
+
+          A green held result is readiness evidence only. It is not an
+          EvidenceBundle, ProofPack, ValidationReport, reserve estimate,
+          mineral-rights record, property-rights record, engineering
+          certification, extraction recommendation, release decision, or
+          publication authority.
+          EOF
+
   publish-dry-run-geology:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO publish-dry-run-geology'
+      - name: Check out Geology release boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Geology release dry-run readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "release/candidates/geology/README.md"
+            "docs/domains/geology/RELEASE_INDEX.md"
+            "data/published/geology/README.md"
+            ".github/workflows/release-dry-run.yml"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Geology release boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "A candidate is not a release." "release/candidates/geology/README.md"; then
+            echo "::error::The documented Geology candidate posture changed. Re-evaluate source, evidence, rights, sensitivity, claim class, policy, review, correction, and rollback gates."
+            exit 1
+          fi
+
+          candidate_record="$(find release/candidates/geology -mindepth 1 -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$candidate_record" ]]; then
+            echo "::error::A Geology candidate record surfaced at $candidate_record. Replace this hold with the independently reviewed domain dry-run path."
+            exit 1
+          fi
+
+          if grep -Eq '^(geology-release-dry-run|release-dry-run-geology):' Makefile; then
+            echo "::error::A Geology release dry-run target now exists. Wire the accepted fail-closed command instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: publish-dry-run-geology"
+          echo "WORKFLOW_HOLD: no accepted Geology release dry-run command or candidate manifest contract"
+
+      - name: Record Geology release dry-run hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Geology release dry-run status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Geology release dry-run command or candidate manifest contract`
+
+          This lane performs no source access, geometry transform, resource
+          classification, release, promotion, manifest assembly, deployment,
+          publication, or write to processed, catalog, proof, receipt, release,
+          or published stores.
+
+          Graduate it only after candidate identity, immutable artifact pointer,
+          source and EvidenceBundle closure, rights, sensitivity, public-safe
+          geometry, claim-class separation, policy result, steward review,
+          validation receipts, independent approval, correction path,
+          withdrawal path, and rollback target are accepted.
+
+          A green held result does not mean Geology data is accurate, complete,
+          suitable for engineering, investment, extraction, legal, regulatory,
+          emergency, or operational use, approved, released, or published.
+          EOF

--- a/data/receipts/generated/genrec-domain-geology-workflow-5ee8b062.json
+++ b/data/receipts/generated/genrec-domain-geology-workflow-5ee8b062.json
@@ -1,0 +1,70 @@
+{
+  "receipt_id": "genrec-domain-geology-workflow-5ee8b062",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "ede1d1f2dc4dc7d8409fa5c1da0d98b469d973f9",
+  "branch": "agent/domain-geology-workflow-20260718",
+  "target_path": ".github/workflows/domain-geology.yml",
+  "previous_blob": "dd0342a39e165f32e0b8a3346ddc44c091423464",
+  "new_blob": "b66ea88f245e2c598a5bca21d24de4006bb8b26a",
+  "sha256": "5ee8b0620e8cbdf3ae1d6c7da727865812242d595510830a12819716a4332b95",
+  "truth_labels": {
+    "confirmed": [
+      "The prior validate-geology, build-proof-geology, and publish-dry-run-geology jobs only executed TODO echo commands.",
+      "Baseline workflow run 29651476200 completed successfully without Geology validation, proof construction, or release dry-run execution.",
+      "Sampled Geology test modules contain only PROPOSED placeholder docstrings.",
+      "The per-domain and broad Geology validator indexes record executable behavior as unverified and README-backed.",
+      "The Geology proof lane is draft and PROPOSED, with concrete proof inventory and enforcement unresolved.",
+      "The Geology release-candidate lane is pre-publication and states that a candidate is not a release.",
+      "Workflow name domain-geology and all three job ids are preserved."
+    ],
+    "proposed": [
+      "Explicit fail-closed readiness holds are the safest current CI behavior until accepted executable Geology lanes exist.",
+      "AST-based test detection and implementation-presence checks are appropriate graduation signals for the current scaffold maturity."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Accepted Geology validator ownership and deterministic no-network suite.",
+      "Concrete EvidenceBundle and proof producer contracts, schemas, synthetic fixtures, claim-class controls, access controls, manifests, and receipts.",
+      "Accepted Geology candidate, release dry-run, rights, sensitivity, public-safe geometry, correction, withdrawal, and rollback contracts.",
+      "Branch-protection dependencies, independent review ownership, and immutable action pinning."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch, contents: read permission, concurrency cancellation, deterministic Python setup, and job timeouts.",
+    "Disabled persisted checkout credentials.",
+    "Converted all three TODO-only jobs into explicit WORKFLOW_SKIPPED_EXPLICIT and WORKFLOW_HOLD readiness checks.",
+    "Added required-boundary checks across Geology docs, contracts, schemas, fixtures, policy, tests, validators, source and sensitivity registries, proofs, release candidates, and published lanes.",
+    "Added AST-based detection for newly executable Geology tests.",
+    "Added fail-closed graduation checks for validators, proof artifacts or producers, candidate records, Make targets, and changed release posture.",
+    "Added bounded summaries preserving subsurface-location, private-well, resource-class, rights, evidence, policy, correction, withdrawal, and rollback boundaries."
+  ],
+  "authority_boundary": "A green held result is repository-readiness evidence only. It is not Geology validation, geologic or resource confirmation, reserve or estimate certification, rights determination, public-safe geometry approval, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, engineering or extraction guidance, or publication authority.",
+  "directory_rules_basis": [
+    ".github/workflows remains the existing CI orchestration location.",
+    "tests and fixtures remain the test and bounded test-data roots.",
+    "tools remains the validator and helper root.",
+    "data/registry remains the source and sensitivity registry root.",
+    "data/proofs remains the proof-support root.",
+    "release remains the release-decision root.",
+    "data/published remains the released-payload root.",
+    "data/receipts/generated remains the existing generated process-memory lane."
+  ],
+  "validation": {
+    "workflow_yaml_parse": "PASS",
+    "workflow_and_job_identities_preserved": "PASS",
+    "exact_changed_paths": [
+      ".github/workflows/domain-geology.yml",
+      "data/receipts/generated/genrec-domain-geology-workflow-5ee8b062.json"
+    ],
+    "final_head_ci": "PENDING",
+    "human_review": "PENDING"
+  },
+  "rollback": {
+    "strategy": "Close the pull request without merge or revert the receipt commit and workflow commit in reverse order.",
+    "restores_blob": "dd0342a39e165f32e0b8a3346ddc44c091423464"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/domain-geology.yml` scaffold with explicit, fail-closed readiness holds until executable Geology validation, proof, and release-dry-run contracts are accepted.

## Evidence status

- **CONFIRMED:** the prior `validate-geology`, `build-proof-geology`, and `publish-dry-run-geology` jobs only checked out the repository and echoed TODO messages.
- **CONFIRMED:** baseline run `29651476200` completed successfully without Geology validation, proof construction, or release dry-run execution.
- **CONFIRMED:** sampled Geology test modules contain only `PROPOSED` placeholder docstrings.
- **CONFIRMED:** the per-domain and broad Geology validator indexes are README-backed, with executable behavior unverified.
- **CONFIRMED:** the Geology proof lane is draft and `PROPOSED`; concrete proof inventory, schemas, validators, fixtures, access controls, and release linkage remain unresolved.
- **CONFIRMED:** the Geology release-candidate lane remains pre-publication and states that a candidate is not a release.
- **CONFIRMED:** exact borehole, core, well-log, private-well, sample, operator/parcel, sensitive-resource, and extraction-targetable locations require restrictive or public-safe handling before exposure.
- **PROPOSED:** explicit readiness holds are the safest current CI behavior until accepted executable Geology lanes exist.
- **NEEDS VERIFICATION:** final-head CI, accepted validator/proof/release contracts, branch protection, and independent stewardship/review ownership.

## What changed

- Preserved workflow name `domain-geology`.
- Preserved job ids `validate-geology`, `build-proof-geology`, and `publish-dry-run-geology`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch`.
- Added `contents: read`, concurrency cancellation, Python 3.11 setup where needed, and five-minute timeouts.
- Disabled persisted checkout credentials.
- Replaced all three false-positive TODO successes with explicit `WORKFLOW_SKIPPED_EXPLICIT` / `WORKFLOW_HOLD` outcomes.
- Added required-boundary checks across Geology docs, contracts, schemas, fixtures, policy, tests, validators, source and sensitivity registries, proofs, release candidates, and published lanes.
- Added AST-based detection of newly executable Geology tests.
- Added fail-closed graduation detectors when validator implementations, proof artifacts or producers, candidate records, Make targets, or release posture changes appear.
- Added bounded summaries preserving exact-subsurface, private-well, source-role, resource-claim, rights, evidence, policy, correction, withdrawal, and rollback boundaries.
- Added generated receipt `data/receipts/generated/genrec-domain-geology-workflow-5ee8b062.json`.

## Directory Rules basis

- `.github/workflows/` remains the CI orchestration location.
- `tests/` and `fixtures/` remain the test and bounded test-data roots.
- `tools/` remains the validator/helper root.
- `data/registry/` remains the source and sensitivity registry root.
- `data/proofs/` remains the proof-support root.
- `release/` remains the release-decision root.
- `data/published/` remains the released-payload root.
- `data/receipts/generated/` remains the generated process-memory lane.
- No new schema, contract, policy, validator, proof, release, publication, or root-level authority is created.

## Authority boundary

A green held result is repository-readiness evidence only. It is not Geology validation, geologic or resource confirmation, reserve or estimate certification, rights determination, public-safe geometry approval, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, engineering or extraction guidance, or publication authority.

## Validation

| Check | Outcome |
|---|---|
| Base/target/overlap preflight | PASS |
| Workflow and three job identities preserved | PASS |
| Validation maturity hold wired | PASS |
| Proof maturity hold wired | PASS |
| Release dry-run maturity hold wired | PASS |
| Protected/restricted payloads not opened | PASS |
| Fail-closed graduation checks added | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Directory Rules placement review | PASS |
| Exact changed paths | workflow + generated receipt only |
| Workflow YAML parse | PASS |
| Workflow SHA-256 | `5ee8b0620e8cbdf3ae1d6c7da727865812242d595510830a12819716a4332b95` |
| Remote Git blob | `b66ea88f245e2c598a5bca21d24de4006bb8b26a` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `846b16ea4be3ac638575b42287765328f720829d` and `53431557715e22f6fa44f33901e575c2acaa543c` in reverse order. This restores prior workflow blob `dd0342a39e165f32e0b8a3346ddc44c091423464` and removes the generated receipt.

## Open verification

- Accepted Geology validator ownership and deterministic no-network suite.
- Concrete EvidenceBundle/proof schemas, synthetic fixtures, claim-class controls, access controls, producer, manifest, receipts, and rollback-tested command.
- Accepted candidate dossier, release-manifest assembly, rights, sensitivity, public-safe geometry, independent review, correction, withdrawal, and rollback contracts.
- Branch-protection references, immutable action pinning, and independent Geology, natural-resources, rights, sensitivity, evidence, policy, security, and release review ownership.

## CONTRACT_VERSION

`3.0.0`