### PR TITLE
ci(habitat): make domain readiness holds explicit

### DIFF
--- a/.github/workflows/domain-habitat.yml
+++ b/.github/workflows/domain-habitat.yml
@@ -1,25 +1,330 @@
-# KFM CI workflow stub: domain-habitat
-# Status: PROPOSED greenfield scaffold.
+# KFM Habitat domain CI readiness workflow.
+# Status: PROPOSED explicit holds; executable Habitat validation, proof, and
+# release-dry-run producers are not established in current repository evidence.
+#
+# Authority boundary:
+# - This workflow inspects repository maturity without opening restricted or
+#   reverse-engineerable Fauna, Flora, archaeology, stewardship, private-land,
+#   infrastructure, or other sensitive joined payloads.
+# - It does not validate Habitat truth, establish species presence, issue legal
+#   or regulatory interpretations, build an EvidenceBundle or ProofPack, admit
+#   sources, apply policy, perform geoprivacy transforms, promote lifecycle
+#   artifacts, approve release, write published data, deploy, or publish.
 name: domain-habitat
 
-on:
+"on":
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: domain-habitat-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: UTC
+  PYTHONUNBUFFERED: "1"
 
 jobs:
   validate-habitat:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO validate-habitat'
+      - name: Check out Habitat boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Evaluate Habitat validation readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "docs/domains/habitat/README.md"
+            "docs/domains/habitat/SENSITIVITY_POLICY.md"
+            "contracts/domains/habitat/README.md"
+            "schemas/contracts/v1/domains/habitat/README.md"
+            "fixtures/domains/habitat/README.md"
+            "policy/domains/habitat/README.md"
+            "tests/domains/habitat/README.md"
+            "tools/validators/domains/habitat/README.md"
+            "tools/validators/habitat/README.md"
+            "data/registry/sources/habitat/README.md"
+            "data/quarantine/habitat/over_precise_geometry/README.md"
+            "release/candidates/habitat/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Habitat boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          test_root = Path("tests/domains/habitat")
+          collected = []
+
+          for path in sorted(test_root.rglob("test_*.py")):
+              tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+              for node in ast.walk(tree):
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+                      collected.append(f"{path}:{node.name}")
+                  elif isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+                      if any(
+                          isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                          and child.name.startswith("test_")
+                          for child in node.body
+                      ):
+                          collected.append(f"{path}:{node.name}")
+
+          if collected:
+              raise SystemExit(
+                  "Executable Habitat tests surfaced. Graduate validate-habitat "
+                  "to the accepted deterministic no-network suite:\n" + "\n".join(collected)
+              )
+
+          print("No collected Habitat test functions or classes were found.")
+          PY
+
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          validator_roots = (
+              Path("tools/validators/domains/habitat"),
+              Path("tools/validators/habitat"),
+              Path("tools/validators/habitat_fauna"),
+              Path("tools/validators/habitat-fauna"),
+              Path("tools/validators/geoprivacy/habitat-fauna"),
+              Path("tools/validators/habitat/fauna-geoprivacy"),
+          )
+          implementations = []
+
+          for root in validator_roots:
+              if not root.exists():
+                  continue
+
+              for path in sorted(root.rglob("*.py")):
+                  tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+                  for node in tree.body:
+                      if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                          implementations.append(f"{path}:{getattr(node, 'name', type(node).__name__)}")
+                          break
+
+              for suffix in ("*.js", "*.mjs", "*.ts", "*.sh"):
+                  for path in sorted(root.rglob(suffix)):
+                      text = path.read_text(encoding="utf-8").strip()
+                      meaningful = [
+                          line.strip()
+                          for line in text.splitlines()
+                          if line.strip() and not line.lstrip().startswith(("#", "//"))
+                      ]
+                      if meaningful:
+                          implementations.append(str(path))
+
+          if implementations:
+              raise SystemExit(
+                  "Executable Habitat validator implementation surfaced. Resolve "
+                  "validator ownership and wire the accepted command:\n"
+                  + "\n".join(implementations)
+              )
+
+          print("No executable Habitat validator implementation was detected.")
+          PY
+
+          if grep -Eq '^(habitat-validate|validate-habitat):' Makefile; then
+            echo "::error::A Habitat validation target now exists. Wire and verify it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: validate-habitat"
+          echo "WORKFLOW_HOLD: executable Habitat validation is not established"
+
+      - name: Record Habitat validation hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Habitat validation status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: executable Habitat validation is not established`
+
+          Current repository evidence is documentation-heavy: sampled Habitat
+          test modules are placeholders, and inspected per-domain, broad, and
+          Habitat/Fauna geoprivacy validator lanes are README-backed rather than
+          accepted executable validators.
+
+          This check does not establish Habitat truth, species presence,
+          critical-habitat legal status, model-as-observation validity,
+          public-safe geometry, evidence closure, policy approval, stewardship
+          approval, or release readiness.
+          EOF
+
   build-proof-habitat:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO build-proof-habitat'
+      - name: Check out Habitat proof boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Habitat proof readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "data/proofs/habitat/README.md"
+            "data/registry/sources/habitat/README.md"
+            "fixtures/domains/habitat/README.md"
+            "release/candidates/habitat/README.md"
+            "tests/domains/habitat/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Habitat proof boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "Implementation depth remains UNKNOWN" "data/proofs/habitat/README.md"; then
+            echo "::error::The Habitat proof posture changed. Review proof schemas, producers, access controls, policy bindings, receipts, and release linkage before accepting this workflow."
+            exit 1
+          fi
+
+          proof_artifact="$(find data/proofs/habitat -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$proof_artifact" ]]; then
+            echo "::error::Habitat proof material surfaced at $proof_artifact. Replace this hold with the governed proof validator and manifest path."
+            exit 1
+          fi
+
+          if grep -Eq '^(habitat-proof|proof-habitat):' Makefile; then
+            echo "::error::A Habitat proof target now exists. Wire and validate it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          proof_implementation="$(find . -path './.git' -prune -o -type f \( -iname '*habitat*proof*.py' -o -iname '*proof*habitat*.py' -o -iname '*habitat*proof*.mjs' -o -iname '*proof*habitat*.mjs' \) -print -quit)"
+          if [[ -n "$proof_implementation" ]]; then
+            echo "::error::Potential Habitat proof implementation surfaced at $proof_implementation. Establish its contract, synthetic fixtures, sensitivity controls, receipts, access controls, and rollback before wiring CI."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: build-proof-habitat"
+          echo "WORKFLOW_HOLD: no accepted Habitat proof producer or deterministic proof command"
+
+      - name: Record Habitat proof hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Habitat proof status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Habitat proof producer or deterministic proof command`
+
+          The Habitat proof lane is documented, but proof schemas, emitted proof
+          inventory, EvidenceRef-to-EvidenceBundle resolution, validators,
+          public-safe fixtures, sensitive-join controls, access controls, policy
+          binding, receipt linkage, and release linkage remain unverified.
+
+          A green held result is readiness evidence only. It is not an
+          EvidenceBundle, ProofPack, ValidationReport, critical-habitat
+          determination, species-occurrence proof, stewardship decision,
+          restoration decision, release decision, or publication authority.
+          EOF
+
   publish-dry-run-habitat:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO publish-dry-run-habitat'
+      - name: Check out Habitat release boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Habitat release dry-run readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "release/candidates/habitat/README.md"
+            "docs/domains/habitat/RELEASE_INDEX.md"
+            "data/published/habitat/README.md"
+            ".github/workflows/release-dry-run.yml"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Habitat release boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "A candidate is not a release." "release/candidates/habitat/README.md"; then
+            echo "::error::The documented Habitat candidate posture changed. Re-evaluate source, evidence, rights, sensitivity, geoprivacy, model role, policy, review, correction, and rollback gates."
+            exit 1
+          fi
+
+          candidate_record="$(find release/candidates/habitat -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$candidate_record" ]]; then
+            echo "::error::A Habitat candidate record surfaced at $candidate_record. Replace this hold with the independently reviewed domain dry-run path."
+            exit 1
+          fi
+
+          if grep -Eq '^(habitat-release-dry-run|release-dry-run-habitat):' Makefile; then
+            echo "::error::A Habitat release dry-run target now exists. Wire the accepted fail-closed command instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: publish-dry-run-habitat"
+          echo "WORKFLOW_HOLD: no accepted Habitat release dry-run command or candidate manifest contract"
+
+      - name: Record Habitat release dry-run hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Habitat release dry-run status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Habitat release dry-run command or candidate manifest contract`
+
+          This lane performs no live source access, geoprivacy transform, model
+          execution, release, promotion, manifest assembly, deployment,
+          publication, or write to lifecycle, proof, receipt, release, or
+          published stores.
+
+          Graduate it only after candidate identity, immutable artifact pointer,
+          source and EvidenceBundle closure, rights, sensitivity, public-safe
+          geometry, model/observation/regulatory separation, policy result,
+          steward review, validation receipts, independent approval, correction
+          path, withdrawal path, and rollback target are accepted.
+
+          A green held result does not mean Habitat data is accurate, current,
+          legally authoritative, safe for sensitive joins, approved, released,
+          or published.
+          EOF

--- a/data/receipts/generated/genrec-domain-habitat-workflow-edf20c99.json
+++ b/data/receipts/generated/genrec-domain-habitat-workflow-edf20c99.json
@@ -1,0 +1,73 @@
+{
+  "receipt_id": "genrec-domain-habitat-workflow-edf20c99",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "0c28949d97cc718bd25b9cfa2a6470d46dc67f8d",
+  "branch": "agent/domain-habitat-workflow-20260718",
+  "target_path": ".github/workflows/domain-habitat.yml",
+  "previous_blob": "5fbc81145fe0c85026c9235dc5c5c79c72d17e6c",
+  "new_blob": "edf20c9916d880aab833e6acf23799b633c4d1af",
+  "truth_labels": {
+    "confirmed": [
+      "The prior validate-habitat, build-proof-habitat, and publish-dry-run-habitat jobs only executed TODO echo commands.",
+      "Baseline workflow run 29651765936 completed successfully without Habitat validation, proof construction, or release dry-run execution.",
+      "A sampled Habitat test module contains only a PROPOSED placeholder docstring.",
+      "The Habitat test index describes executable tests, validators, policy runtime, release integration, CI coverage, and pass rates as unverified.",
+      "The per-domain and broad Habitat validator indexes record executable behavior as unverified and README-backed.",
+      "The Habitat proof lane records implementation depth as UNKNOWN.",
+      "The Habitat candidate lane is pre-publication and states that a candidate is not a release.",
+      "Workflow name domain-habitat and all three job ids are preserved."
+    ],
+    "proposed": [
+      "Explicit fail-closed readiness holds are the safest current CI behavior until accepted executable Habitat lanes exist.",
+      "AST-based test detection and executable-body detection are appropriate graduation signals for the current scaffold maturity."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Accepted Habitat validator ownership and deterministic no-network suite.",
+      "Accepted machine policy and sensitivity topology for join-induced and derivation-induced Habitat risk.",
+      "Concrete EvidenceBundle and proof producer contracts, schemas, synthetic fixtures, sensitive-join controls, access controls, manifests, and receipts.",
+      "Accepted Habitat candidate, release dry-run, public-safe geometry, correction, withdrawal, and rollback contracts.",
+      "Branch-protection dependencies, independent review ownership, and immutable action pinning."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch, contents: read permission, concurrency cancellation, deterministic Python setup, and job timeouts.",
+    "Disabled persisted checkout credentials.",
+    "Converted all three TODO-only jobs into explicit WORKFLOW_SKIPPED_EXPLICIT and WORKFLOW_HOLD readiness checks.",
+    "Added required-boundary checks across Habitat docs, contracts, schemas, fixtures, policy, tests, validators, source registry, quarantine, proofs, release candidates, and published lanes.",
+    "Added AST-based detection for newly executable Habitat tests.",
+    "Added executable-body detection across Habitat and Habitat-Fauna validator lanes without treating README or fixture inventories as code.",
+    "Added fail-closed graduation checks for validators, proof artifacts or producers, candidate records, Make targets, and changed release posture.",
+    "Added bounded summaries preserving species-authority, model-role, sensitive-join, geoprivacy, evidence, policy, correction, withdrawal, and rollback boundaries."
+  ],
+  "authority_boundary": "A green held result is repository-readiness evidence only. It is not Habitat validation, species-presence confirmation, regulatory or legal determination, geoprivacy approval, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, restoration or stewardship decision authority, or publication authority.",
+  "directory_rules_basis": [
+    ".github/workflows remains the existing CI orchestration location.",
+    "tests and fixtures remain the test and bounded test-data roots.",
+    "tools remains the validator and helper root.",
+    "data/registry remains the source-registry root.",
+    "data/quarantine remains the fail-closed holding root.",
+    "data/proofs remains the proof-support root.",
+    "release remains the release-decision root.",
+    "data/published remains the released-payload root.",
+    "data/receipts/generated remains the existing generated process-memory lane."
+  ],
+  "validation": {
+    "workflow_and_job_identities_preserved": "PASS",
+    "remote_git_blob": "edf20c9916d880aab833e6acf23799b633c4d1af",
+    "exact_changed_paths": [
+      ".github/workflows/domain-habitat.yml",
+      "data/receipts/generated/genrec-domain-habitat-workflow-edf20c99.json"
+    ],
+    "final_head_ci": "PENDING",
+    "human_review": "PENDING"
+  },
+  "rollback": {
+    "strategy": "Close the pull request without merge or revert the receipt commit and workflow commit in reverse order.",
+    "restores_blob": "5fbc81145fe0c85026c9235dc5c5c79c72d17e6c"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/domain-habitat.yml` scaffold with explicit, fail-closed readiness holds until executable Habitat validation, proof, and release-dry-run contracts are accepted.

## Evidence status

- **CONFIRMED:** the prior `validate-habitat`, `build-proof-habitat`, and `publish-dry-run-habitat` jobs only checked out the repository and echoed TODO messages.
- **CONFIRMED:** baseline run `29651765936` completed successfully without Habitat validation, proof construction, or release dry-run execution.
- **CONFIRMED:** a sampled Habitat test module contains only a `PROPOSED` placeholder docstring.
- **CONFIRMED:** the Habitat test index records executable tests, validators, policy runtime, release integration, CI coverage, and pass rates as unverified.
- **CONFIRMED:** per-domain, broad, and Habitat/Fauna validator lanes are README-backed, with executable behavior unverified.
- **CONFIRMED:** the Habitat proof lane records implementation depth as `UNKNOWN`.
- **CONFIRMED:** the Habitat candidate lane remains pre-publication and states that a candidate is not a release.
- **CONFIRMED:** Habitat sensitivity can be join-induced or derivation-induced and must preserve neighboring-domain ownership and public-safe geometry controls.
- **PROPOSED:** explicit readiness holds are the safest current CI behavior until accepted executable Habitat lanes exist.
- **NEEDS VERIFICATION:** final-head CI, accepted validator/policy/proof/release contracts, branch protection, and independent stewardship/review ownership.

## What changed

- Preserved workflow name `domain-habitat`.
- Preserved job ids `validate-habitat`, `build-proof-habitat`, and `publish-dry-run-habitat`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch`.
- Added `contents: read`, concurrency cancellation, Python 3.11 setup where needed, and five-minute timeouts.
- Disabled persisted checkout credentials.
- Replaced all three false-positive TODO successes with explicit `WORKFLOW_SKIPPED_EXPLICIT` / `WORKFLOW_HOLD` outcomes.
- Added required-boundary checks across Habitat docs, contracts, schemas, fixtures, policy, tests, validators, source registry, quarantine, proofs, release candidates, and published lanes.
- Added AST-based detection of newly executable Habitat tests.
- Added executable-body detection across Habitat and Habitat/Fauna validator lanes without treating README or fixture inventories as executable code.
- Added fail-closed graduation detectors when validator implementations, proof artifacts or producers, candidate records, Make targets, or release posture changes appear.
- Added bounded summaries preserving species-authority, model-role, critical-habitat, sensitive-join, geoprivacy, evidence, policy, correction, withdrawal, and rollback boundaries.
- Added generated receipt `data/receipts/generated/genrec-domain-habitat-workflow-edf20c99.json`.

## Directory Rules basis

- `.github/workflows/` remains the CI orchestration location.
- `tests/` and `fixtures/` remain the test and bounded test-data roots.
- `tools/` remains the validator/helper root.
- `data/registry/` remains the source-registry root.
- `data/quarantine/` remains the fail-closed holding root.
- `data/proofs/` remains the proof-support root.
- `release/` remains the release-decision root.
- `data/published/` remains the released-payload root.
- `data/receipts/generated/` remains the generated process-memory lane.
- No new schema, contract, policy, validator, proof, release, publication, or root-level authority is created.

## Authority boundary

A green held result is repository-readiness evidence only. It is not Habitat validation, species-presence confirmation, regulatory or legal determination, geoprivacy approval, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, restoration or stewardship decision authority, or publication authority.

## Validation

| Check | Outcome |
|---|---|
| Base/target/overlap preflight | PASS |
| Workflow and three job identities preserved | PASS |
| Validation maturity hold wired | PASS |
| Proof maturity hold wired | PASS |
| Release dry-run maturity hold wired | PASS |
| Protected/restricted payloads not opened | PASS |
| README and fixture inventories not treated as code | PASS |
| Fail-closed graduation checks added | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Directory Rules placement review | PASS |
| Exact changed paths | workflow + generated receipt only |
| Remote Git blob | `edf20c9916d880aab833e6acf23799b633c4d1af` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `fbfa9b33c35c1d4d005a014029e7d9cfef6ba211` and `2790372fa0a63884eee55c8764b300169bef9fe0` in reverse order. This restores prior workflow blob `5fbc81145fe0c85026c9235dc5c5c79c72d17e6c` and removes the generated receipt.

## Open verification

- Accepted Habitat validator ownership and deterministic no-network suite.
- Accepted machine policy and sensitivity topology for join-induced and derivation-induced Habitat risk.
- Concrete EvidenceBundle/proof schemas, synthetic fixtures, sensitive-join controls, access controls, producer, manifest, receipts, and rollback-tested command.
- Accepted candidate dossier, release-manifest assembly, rights, public-safe geometry, model/observation/regulatory separation, independent review, correction, withdrawal, and rollback contracts.
- Branch-protection references, immutable action pinning, and independent Habitat, ecology, geoprivacy, sensitivity, evidence, policy, security, and release review ownership.

## CONTRACT_VERSION

`3.0.0`