### PR TITLE
ci(hazards): make domain readiness holds explicit

### DIFF
--- a/.github/workflows/domain-hazards.yml
+++ b/.github/workflows/domain-hazards.yml
@@ -1,25 +1,320 @@
-# KFM CI workflow stub: domain-hazards
-# Status: PROPOSED greenfield scaffold.
+# KFM Hazards domain CI readiness workflow.
+# Status: PROPOSED explicit holds; executable Hazards validation, proof, and
+# release-dry-run producers are not established in current repository evidence.
+#
+# Authority boundary:
+# - This workflow inspects repository maturity without consuming live hazard
+#   feeds or issuing warnings, evacuation instructions, regulatory decisions,
+#   emergency guidance, or other life-safety direction.
+# - It does not validate current conditions, build an EvidenceBundle or
+#   ProofPack, admit sources, apply policy, promote lifecycle artifacts, approve
+#   release, write published data, deploy, or publish.
 name: domain-hazards
 
-on:
+"on":
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: domain-hazards-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: UTC
+  PYTHONUNBUFFERED: "1"
 
 jobs:
   validate-hazards:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO validate-hazards'
+      - name: Check out Hazards boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Evaluate Hazards validation readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "docs/domains/hazards/README.md"
+            "docs/domains/hazards/LIFE_SAFETY_BOUNDARY.md"
+            "docs/domains/hazards/PUBLICATION_AND_BOUNDARY.md"
+            "contracts/domains/hazards/README.md"
+            "schemas/contracts/v1/domains/hazards/README.md"
+            "fixtures/domains/hazards/README.md"
+            "policy/domains/hazards/README.md"
+            "tests/domains/hazards/README.md"
+            "tools/validators/domains/hazards/README.md"
+            "data/registry/sources/hazards/README.md"
+            "release/candidates/hazards/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Hazards boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          test_root = Path("tests/domains/hazards")
+          collected = []
+
+          for path in sorted(test_root.rglob("test_*.py")):
+              tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+              for node in ast.walk(tree):
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+                      collected.append(f"{path}:{node.name}")
+                  elif isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+                      if any(
+                          isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                          and child.name.startswith("test_")
+                          for child in node.body
+                      ):
+                          collected.append(f"{path}:{node.name}")
+
+          if collected:
+              raise SystemExit(
+                  "Executable Hazards tests surfaced. Graduate validate-hazards "
+                  "to the accepted deterministic no-network suite:\n" + "\n".join(collected)
+              )
+
+          validator_roots = [
+              Path("tools/validators/domains/hazards"),
+              Path("tools/validators/air-hazards"),
+              Path("tools/validators/atmosphere_hazards"),
+              Path("tools/validators/hydrology-hazards"),
+          ]
+
+          implementations = []
+          for root in validator_roots:
+              if not root.exists():
+                  continue
+              for path in sorted(root.rglob("*")):
+                  if not path.is_file() or path.name in {"README.md", ".gitkeep"}:
+                      continue
+                  if path.suffix == ".py":
+                      tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+                      if any(
+                          isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+                          for node in ast.walk(tree)
+                      ):
+                          implementations.append(str(path))
+                  elif path.suffix in {".js", ".mjs", ".cjs", ".ts", ".tsx", ".sh"}:
+                      meaningful = [
+                          line.strip()
+                          for line in path.read_text(encoding="utf-8").splitlines()
+                          if line.strip()
+                          and not line.lstrip().startswith(("#", "//", "/*", "*", "*/"))
+                      ]
+                      if meaningful:
+                          implementations.append(str(path))
+
+          if implementations:
+              raise SystemExit(
+                  "Hazards validator implementation surfaced. Resolve ownership and wire "
+                  "the accepted command:\n" + "\n".join(implementations)
+              )
+
+          print("No collected Hazards tests or executable Hazards validator bodies were found.")
+          PY
+
+          if grep -Eq '^(hazards-validate|validate-hazards):' Makefile; then
+            echo "::error::A Hazards validation target now exists. Wire and verify it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: validate-hazards"
+          echo "WORKFLOW_HOLD: executable Hazards validation is not established"
+
+      - name: Record Hazards validation hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Hazards validation status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: executable Hazards validation is not established`
+
+          Current repository evidence is documentation-heavy: sampled Hazards
+          test modules are placeholders, and the inspected per-domain and
+          cross-domain validator lanes are README-backed rather than accepted
+          executable validators.
+
+          This check does not establish current hazard conditions, warning
+          validity, regulatory status, source freshness, EvidenceBundle closure,
+          policy approval, release readiness, or emergency/life-safety authority.
+          EOF
+
   build-proof-hazards:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO build-proof-hazards'
+      - name: Check out Hazards proof boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Hazards proof readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "data/proofs/hazards/README.md"
+            "data/registry/sources/hazards/README.md"
+            "release/candidates/hazards/README.md"
+            "tests/domains/hazards/README.md"
+            "docs/domains/hazards/LIFE_SAFETY_BOUNDARY.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Hazards proof boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "Implementation depth remains UNKNOWN" "data/proofs/hazards/README.md"; then
+            echo "::error::The Hazards proof maturity statement changed. Review proof schemas, freshness/expiry controls, producers, access controls, receipts, and release linkage before accepting this workflow."
+            exit 1
+          fi
+
+          proof_artifact="$(find data/proofs/hazards -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$proof_artifact" ]]; then
+            echo "::error::Hazards proof material surfaced at $proof_artifact. Replace this hold with the governed proof validator and manifest path."
+            exit 1
+          fi
+
+          if grep -Eq '^(hazards-proof|proof-hazards):' Makefile; then
+            echo "::error::A Hazards proof target now exists. Wire and validate it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          proof_implementation="$(find . -path './.git' -prune -o -type f \( -iname '*hazards*proof*.py' -o -iname '*proof*hazards*.py' -o -iname '*hazards*proof*.mjs' -o -iname '*proof*hazards*.mjs' \) -print -quit)"
+          if [[ -n "$proof_implementation" ]]; then
+            echo "::error::Potential Hazards proof implementation surfaced at $proof_implementation. Establish its contract, synthetic fixtures, time/freshness controls, receipts, access controls, and rollback before wiring CI."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: build-proof-hazards"
+          echo "WORKFLOW_HOLD: no accepted Hazards proof producer or deterministic proof command"
+
+      - name: Record Hazards proof hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Hazards proof status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Hazards proof producer or deterministic proof command`
+
+          The Hazards proof lane is documented, but concrete proof inventory,
+          EvidenceRef-to-EvidenceBundle resolution, source-role checks,
+          freshness/expiry proof, official-referral proof, life-safety-boundary
+          proof, schemas, validators, fixtures, access controls, receipt linkage,
+          and release linkage remain unverified.
+
+          A green held result is readiness evidence only. It is not an
+          EvidenceBundle, ProofPack, ValidationReport, warning, alert, regulatory
+          decision, emergency instruction, release decision, or publication
+          authority.
+          EOF
+
   publish-dry-run-hazards:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO publish-dry-run-hazards'
+      - name: Check out Hazards release boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Hazards release dry-run readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "release/candidates/hazards/README.md"
+            "docs/domains/hazards/RELEASE_INDEX.md"
+            "docs/domains/hazards/LIFE_SAFETY_BOUNDARY.md"
+            "data/published/hazards/README.md"
+            ".github/workflows/release-dry-run.yml"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Hazards release boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "A candidate is not a release." "release/candidates/hazards/README.md"; then
+            echo "::error::The documented Hazards candidate posture changed. Re-evaluate source, evidence, rights, freshness, expiry, official referral, policy, review, correction, and rollback gates."
+            exit 1
+          fi
+
+          candidate_record="$(find release/candidates/hazards -mindepth 1 -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$candidate_record" ]]; then
+            echo "::error::A Hazards candidate record surfaced at $candidate_record. Replace this hold with the independently reviewed domain dry-run path."
+            exit 1
+          fi
+
+          if grep -Eq '^(hazards-release-dry-run|release-dry-run-hazards):' Makefile; then
+            echo "::error::A Hazards release dry-run target now exists. Wire the accepted fail-closed command instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: publish-dry-run-hazards"
+          echo "WORKFLOW_HOLD: no accepted Hazards release dry-run command or candidate manifest contract"
+
+      - name: Record Hazards release dry-run hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Hazards release dry-run status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Hazards release dry-run command or candidate manifest contract`
+
+          This lane performs no live-source access, alert ingestion, warning
+          issuance, release, promotion, manifest assembly, deployment,
+          publication, or write to processed, catalog, proof, receipt, release,
+          or published stores.
+
+          Graduate it only after candidate identity, immutable artifact pointer,
+          source and EvidenceBundle closure, source role, validity, expiry,
+          retrieval and release times, official-source referral, not-for-life-
+          safety policy result, validation receipts, independent review,
+          correction path, withdrawal path, and rollback target are accepted.
+
+          A green held result does not mean Hazards data is current, accurate,
+          operationally actionable, regulatory, safe for emergency use, approved,
+          released, or published.
+          EOF

--- a/data/receipts/generated/genrec-domain-hazards-workflow-79233e4d.json
+++ b/data/receipts/generated/genrec-domain-hazards-workflow-79233e4d.json
@@ -1,0 +1,72 @@
+{
+  "receipt_id": "genrec-domain-hazards-workflow-79233e4d",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "eaeebdafeea381ec5532acfd5cc43091f9e81b28",
+  "branch": "agent/domain-hazards-workflow-20260718",
+  "target_path": ".github/workflows/domain-hazards.yml",
+  "previous_blob": "ada4e42302667488316fd0ca96137c76e1d6d4f5",
+  "new_blob": "9dfc3e88c02ce69adcbf93b1d24acd08783672b4",
+  "sha256": "79233e4ddcf63ed452c6534d88dbea84d829c08008f814770c86fe81a3b25122",
+  "truth_labels": {
+    "confirmed": [
+      "The prior validate-hazards, build-proof-hazards, and publish-dry-run-hazards jobs only executed TODO echo commands.",
+      "Baseline workflow run 29652350877 completed successfully without Hazards validation, proof construction, or release dry-run execution.",
+      "A sampled Hazards test module contains only a PROPOSED placeholder docstring.",
+      "The Hazards test index records executable tests, validators, policy runtime, release integration, CI coverage, and pass rates as unverified.",
+      "The per-domain and related cross-domain Hazards validator lanes are README-backed, with executable behavior unverified.",
+      "The Hazards proof lane records implementation depth as UNKNOWN and prohibits alert or life-safety authority.",
+      "The Hazards release-candidate lane is pre-publication and states that a candidate is not a release.",
+      "Workflow name domain-hazards and all three job ids are preserved."
+    ],
+    "proposed": [
+      "Explicit fail-closed readiness holds are the safest current CI behavior until accepted executable Hazards lanes exist.",
+      "AST-based test detection and executable-body detection are appropriate graduation signals for the current scaffold maturity."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Accepted Hazards validator ownership and deterministic no-network suite.",
+      "Concrete EvidenceBundle and proof producer contracts, schemas, freshness and expiry controls, official-referral proof, life-safety-boundary proof, fixtures, access controls, manifests, and receipts.",
+      "Accepted Hazards candidate, release dry-run, time-validity, stale-state, correction, withdrawal, and rollback contracts.",
+      "Branch-protection dependencies, independent review ownership, and immutable action pinning."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch, contents: read permission, concurrency cancellation, deterministic Python setup, and job timeouts.",
+    "Disabled persisted checkout credentials.",
+    "Converted all three TODO-only jobs into explicit WORKFLOW_SKIPPED_EXPLICIT and WORKFLOW_HOLD readiness checks.",
+    "Added required-boundary checks across Hazards docs, contracts, schemas, fixtures, policy, tests, validators, source registry, proofs, release candidates, and published lanes.",
+    "Added AST-based detection for newly executable Hazards tests.",
+    "Added executable-body detection for per-domain and related cross-domain Hazards validator lanes without treating README files as code.",
+    "Added fail-closed graduation checks for proof artifacts or producers, candidate records, Make targets, and changed release posture.",
+    "Added bounded summaries preserving source role, freshness, expiry, official referral, not-for-life-safety, evidence, policy, correction, withdrawal, and rollback boundaries."
+  ],
+  "authority_boundary": "A green held result is repository-readiness evidence only. It is not Hazards validation, current-condition confirmation, alert or warning authority, regulatory determination, emergency guidance, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, or publication authority.",
+  "directory_rules_basis": [
+    ".github/workflows remains the existing CI orchestration location.",
+    "tests and fixtures remain the test and bounded test-data roots.",
+    "tools remains the validator and helper root.",
+    "data/registry remains the source-registry root.",
+    "data/proofs remains the proof-support root.",
+    "release remains the release-decision root.",
+    "data/published remains the released-payload root.",
+    "data/receipts/generated remains the existing generated process-memory lane."
+  ],
+  "validation": {
+    "workflow_yaml_parse": "PASS",
+    "workflow_and_job_identities_preserved": "PASS",
+    "exact_changed_paths": [
+      ".github/workflows/domain-hazards.yml",
+      "data/receipts/generated/genrec-domain-hazards-workflow-79233e4d.json"
+    ],
+    "final_head_ci": "PENDING",
+    "human_review": "PENDING"
+  },
+  "rollback": {
+    "strategy": "Close the pull request without merge or revert the receipt commit and workflow commit in reverse order.",
+    "restores_blob": "ada4e42302667488316fd0ca96137c76e1d6d4f5"
+  }
+}


### PR DESCRIPTION
## Goal

Replace the TODO-only `.github/workflows/domain-hazards.yml` scaffold with explicit, fail-closed readiness holds until executable Hazards validation, proof, and release-dry-run contracts are accepted.

## Evidence status

- **CONFIRMED:** the prior `validate-hazards`, `build-proof-hazards`, and `publish-dry-run-hazards` jobs only checked out the repository and echoed TODO messages.
- **CONFIRMED:** baseline run `29652350877` completed successfully without Hazards validation, proof construction, or release dry-run execution.
- **CONFIRMED:** a sampled Hazards test module contains only a `PROPOSED` placeholder docstring.
- **CONFIRMED:** the Hazards test index records executable tests, validators, policy runtime, release integration, CI coverage, and pass rates as unverified.
- **CONFIRMED:** the per-domain and related cross-domain Hazards validator lanes are README-backed, with executable behavior unverified.
- **CONFIRMED:** the Hazards proof lane records implementation depth as `UNKNOWN` and preserves the not-for-life-safety boundary.
- **CONFIRMED:** the Hazards candidate lane remains pre-publication and states that a candidate is not a release.
- **CONFIRMED:** KFM Hazards is not an emergency alert, warning, evacuation, regulatory-determination, or life-safety instruction authority.
- **PROPOSED:** explicit readiness holds are the safest current CI behavior until accepted executable Hazards lanes exist.
- **NEEDS VERIFICATION:** final-head CI, accepted validator/policy/proof/release contracts, branch protection, and independent safety/review ownership.

## What changed

- Preserved workflow name `domain-hazards`.
- Preserved job ids `validate-hazards`, `build-proof-hazards`, and `publish-dry-run-hazards`.
- Preserved pull-request and push-to-`main` triggers; added `workflow_dispatch`.
- Added `contents: read`, concurrency cancellation, Python 3.11 setup where needed, and five-minute timeouts.
- Disabled persisted checkout credentials.
- Replaced all three false-positive TODO successes with explicit `WORKFLOW_SKIPPED_EXPLICIT` / `WORKFLOW_HOLD` outcomes.
- Added required-boundary checks across Hazards doctrine, life-safety and publication boundaries, contracts, schemas, fixtures, policy, tests, validators, source registry, proofs, release candidates, and published lanes.
- Added AST-based detection of newly executable Hazards tests.
- Added executable-body detection across per-domain and related cross-domain Hazards validator lanes without treating README files as executable code.
- Added fail-closed graduation detectors when proof artifacts or producers, candidate records, Make targets, or release posture changes appear.
- Added bounded summaries preserving source-role, freshness, expiry, official-source referral, not-for-life-safety, evidence, policy, correction, withdrawal, and rollback boundaries.
- Added generated receipt `data/receipts/generated/genrec-domain-hazards-workflow-79233e4d.json`.

## Directory Rules basis

- `.github/workflows/` remains the CI orchestration location.
- `tests/` and `fixtures/` remain the test and bounded test-data roots.
- `tools/` remains the validator/helper root.
- `data/registry/` remains the source-registry root.
- `data/proofs/` remains the proof-support root.
- `release/` remains the release-decision root.
- `data/published/` remains the released-payload root.
- `data/receipts/generated/` remains the generated process-memory lane.
- No new schema, contract, policy, validator, proof, release, publication, or root-level authority is created.

## Authority boundary

A green held result is repository-readiness evidence only. It is not Hazards validation, current-condition confirmation, alert or warning authority, regulatory determination, emergency guidance, EvidenceBundle resolution, proof construction, lifecycle promotion, release approval, or publication authority.

## Validation

| Check | Outcome |
|---|---|
| Base/target/overlap preflight | PASS |
| Workflow and three job identities preserved | PASS |
| Validation maturity hold wired | PASS |
| Proof maturity hold wired | PASS |
| Release dry-run maturity hold wired | PASS |
| Live feeds and operational source access not added | PASS |
| README files not treated as executable code | PASS |
| Fail-closed graduation checks added | PASS |
| Least-privilege token posture | PASS |
| Persisted checkout credentials disabled | PASS |
| Directory Rules placement review | PASS |
| Exact changed paths | workflow + generated receipt only |
| Workflow YAML parse | PASS |
| Workflow SHA-256 | `79233e4ddcf63ed452c6534d88dbea84d829c08008f814770c86fe81a3b25122` |
| Remote Git blob | `9dfc3e88c02ce69adcbf93b1d24acd08783672b4` |
| Final-head GitHub Actions run | PENDING |
| Human review | PENDING |

## Rollback

Close this PR without merge, or revert commits `72e607f6c928c102d44b2ae6b8e13b3586bb4b6f` and `d27234389c1a1fd9f1dd2bcc83ac493907cea267` in reverse order. This restores prior workflow blob `ada4e42302667488316fd0ca96137c76e1d6d4f5` and removes the generated receipt.

## Open verification

- Accepted Hazards validator ownership and deterministic no-network suite.
- Accepted machine policy topology for not-for-life-safety, official-source referral, freshness, expiry, supersession, and stale-state handling.
- Concrete EvidenceBundle/proof schemas, synthetic fixtures, source-role controls, life-safety-boundary proof, official-referral proof, access controls, producer, manifest, receipts, and rollback-tested command.
- Accepted candidate dossier, release-manifest assembly, rights, time-validity, independent safety review, correction, withdrawal, and rollback contracts.
- Branch-protection references, immutable action pinning, and independent Hazards, safety, evidence, policy, security, and release review ownership.

## CONTRACT_VERSION

`3.0.0`