### PR TITLE
ci(settlements-infrastructure): add bounded readiness checks and explicit holds

### DIFF
--- a/.github/workflows/domain-settlements-infrastructure.yml
+++ b/.github/workflows/domain-settlements-infrastructure.yml
@@ -1,25 +1,408 @@
-# KFM CI workflow stub: domain-settlements-infrastructure
-# Status: PROPOSED greenfield scaffold.
+# KFM Settlements/Infrastructure domain CI readiness workflow.
+# Status: PROPOSED bounded static readiness checks plus explicit holds; accepted
+# executable semantic validation, proof, and release-dry-run producers are not
+# established in current repository evidence.
+#
+# Authority boundary:
+# - This workflow performs no live source requests and does not provide legal
+#   municipal-status, facility-condition, service-availability, dependency,
+#   emergency, safety, security, planning, or regulatory guidance.
+# - It does not create settlement or infrastructure truth, EvidenceBundles,
+#   proofs, policy decisions, lifecycle promotion, release approval, or
+#   published artifacts.
 name: domain-settlements-infrastructure
 
-on:
+"on":
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: domain-settlements-infrastructure-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: UTC
+  PYTHONUNBUFFERED: "1"
 
 jobs:
   validate-settlements-infrastructure:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO validate-settlements-infrastructure'
+      - name: Check out Settlements Infrastructure boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Evaluate Settlements Infrastructure validation readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "docs/domains/settlements-infrastructure/README.md"
+            "docs/domains/settlements-infrastructure/CANONICAL_PATHS.md"
+            "docs/domains/settlements-infrastructure/IDENTITY_MODEL.md"
+            "docs/domains/settlements-infrastructure/SENSITIVITY.md"
+            "contracts/domains/settlements-infrastructure/README.md"
+            "schemas/contracts/v1/domains/settlements-infrastructure/README.md"
+            "fixtures/domains/settlements-infrastructure/README.md"
+            "fixtures/domains/settlements-infrastructure/valid/PLACEHOLDER.md"
+            "fixtures/domains/settlements-infrastructure/invalid/PLACEHOLDER.md"
+            "fixtures/domains/settlements-infrastructure/golden/PLACEHOLDER.md"
+            "policy/domains/settlements-infrastructure/README.md"
+            "tests/domains/settlements-infrastructure/README.md"
+            "tests/domains/settlements-infrastructure/identity/README.md"
+            "tools/validators/domains/settlements-infrastructure/README.md"
+            "tools/validators/facilities/README.md"
+            "tools/validators/hazard-exposure/README.md"
+            "data/registry/sources/settlements-infrastructure/README.md"
+            "release/candidates/settlements-infrastructure/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Settlements/Infrastructure boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          python - <<'PY'
+          import ast
+          import json
+          from collections import Counter
+          from pathlib import Path
+
+          test_root = Path("tests/domains/settlements-infrastructure")
+          substantive_tests = []
+          placeholder_modules = 0
+
+          for path in sorted(test_root.rglob("test_*.py")):
+              tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+              tests = []
+              for node in ast.walk(tree):
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+                      tests.append(f"{path}:{node.name}")
+                  elif isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+                      if any(
+                          isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                          and child.name.startswith("test_")
+                          for child in node.body
+                      ):
+                          tests.append(f"{path}:{node.name}")
+              if tests:
+                  substantive_tests.extend(tests)
+              else:
+                  placeholder_modules += 1
+
+          if substantive_tests:
+              raise SystemExit(
+                  "Executable Settlements/Infrastructure tests surfaced. Graduate "
+                  "this job to the accepted deterministic no-network suite:\n" +
+                  "\n".join(substantive_tests)
+              )
+
+          schema_root = Path("schemas/contracts/v1/domains/settlements-infrastructure")
+          schemas = sorted(schema_root.glob("*.schema.json"))
+          if not schemas:
+              raise SystemExit("No Settlements/Infrastructure JSON Schema files were found.")
+
+          schema_statuses = Counter()
+          for path in schemas:
+              payload = json.loads(path.read_text(encoding="utf-8"))
+              if not isinstance(payload, dict):
+                  raise SystemExit(f"Schema root must be an object: {path}")
+              dialect = payload.get("$schema")
+              if not isinstance(dialect, str) or "json-schema.org" not in dialect:
+                  raise SystemExit(f"Missing or unrecognized JSON Schema dialect: {path}")
+              schema_id = payload.get("$id")
+              if not isinstance(schema_id, str) or not schema_id.endswith(path.name):
+                  raise SystemExit(f"Schema $id does not end with its filename: {path}")
+              schema_statuses[str(payload.get("x-kfm", {}).get("status", "UNSPECIFIED"))] += 1
+
+          fixture_root = Path("fixtures/domains/settlements-infrastructure")
+          json_fixtures = sorted(fixture_root.rglob("*.json"))
+          fixture_statuses = Counter()
+          for path in json_fixtures:
+              payload = json.loads(path.read_text(encoding="utf-8"))
+              if not isinstance(payload, (dict, list)):
+                  raise SystemExit(f"Fixture root must be an object or array: {path}")
+              if isinstance(payload, dict):
+                  declared_path = payload.get("path")
+                  if declared_path is not None and declared_path != path.as_posix():
+                      raise SystemExit(f"Fixture path declaration does not match location: {path}")
+                  fixture_statuses[str(payload.get("status", "UNSPECIFIED"))] += 1
+              else:
+                  fixture_statuses["ARRAY"] += 1
+
+          def is_not_implemented_scaffold(tree: ast.Module) -> bool:
+              body = [
+                  node
+                  for node in tree.body
+                  if not (
+                      isinstance(node, ast.Expr)
+                      and isinstance(node.value, ast.Constant)
+                      and isinstance(node.value.value, str)
+                  )
+              ]
+              if len(body) != 1 or not isinstance(body[0], (ast.FunctionDef, ast.AsyncFunctionDef)):
+                  return False
+              function = body[0]
+              if function.name != "main" or function.decorator_list or function.args.args:
+                  return False
+              if len(function.body) != 1 or not isinstance(function.body[0], ast.Raise):
+                  return False
+              exc = function.body[0].exc
+              if isinstance(exc, ast.Name):
+                  return exc.id == "NotImplementedError"
+              return (
+                  isinstance(exc, ast.Call)
+                  and isinstance(exc.func, ast.Name)
+                  and exc.func.id == "NotImplementedError"
+              )
+
+          validator_roots = (
+              Path("tools/validators/domains/settlements-infrastructure"),
+              Path("tools/validators/facilities"),
+              Path("tools/validators/hazard-exposure"),
+          )
+          validator_scaffolds = []
+          executable_validators = []
+
+          for root in validator_roots:
+              if not root.exists():
+                  continue
+              for path in sorted(root.rglob("*")):
+                  if not path.is_file() or path.name in {"README.md", ".gitkeep"}:
+                      continue
+                  if any(part in {"fixtures", "schemas", "policy"} for part in path.parts):
+                      continue
+                  suffix = path.suffix.lower()
+                  text = path.read_text(encoding="utf-8", errors="replace")
+                  if suffix == ".py":
+                      tree = ast.parse(text, filename=str(path))
+                      if is_not_implemented_scaffold(tree):
+                          validator_scaffolds.append(str(path))
+                      else:
+                          executable_validators.append(str(path))
+                  elif suffix in {".sh", ".bash", ".js", ".mjs", ".cjs", ".ts"}:
+                      meaningful_lines = [
+                          line.strip()
+                          for line in text.splitlines()
+                          if line.strip()
+                          and not line.lstrip().startswith(("#", "//", "/*", "*", "*/"))
+                      ]
+                      if meaningful_lines:
+                          executable_validators.append(str(path))
+
+          if executable_validators:
+              raise SystemExit(
+                  "Settlements/Infrastructure validator implementation surfaced. "
+                  "Resolve ownership, slug topology, policy binding, fixtures, and "
+                  "report semantics before wiring CI:\n" +
+                  "\n".join(executable_validators)
+              )
+
+          print(f"Inspected {placeholder_modules} non-executable domain test modules.")
+          print(f"Parsed {len(schemas)} Settlements/Infrastructure schemas; statuses={dict(schema_statuses)}")
+          print(f"Parsed {len(json_fixtures)} JSON fixtures; statuses={dict(fixture_statuses)}")
+          print(f"Recognized {len(validator_scaffolds)} main/NotImplementedError validator scaffolds.")
+          print("No accepted executable validator body was detected in inspected lanes.")
+          PY
+
+          if ! grep -Fq "PROPOSED (greenfield scaffold)" "policy/domains/settlements-infrastructure/README.md"; then
+            echo "::error::The Settlements/Infrastructure policy posture changed. Verify executable rules, sensitivity topology, fixtures, tests, ownership, and activation before accepting this workflow."
+            exit 1
+          fi
+
+          if grep -Eq '^(settlements-infrastructure-validate|validate-settlements-infrastructure):' Makefile; then
+            echo "::error::A Settlements/Infrastructure validation target now exists. Wire and verify it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_CHECK_EXECUTED: settlements-infrastructure-readiness"
+          echo "WORKFLOW_HOLD: semantic Settlements/Infrastructure validation is not established"
+
+      - name: Record Settlements Infrastructure validation hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Settlements/Infrastructure validation status
+
+          `WORKFLOW_CHECK_EXECUTED: settlements-infrastructure-readiness`
+
+          `WORKFLOW_HOLD: semantic Settlements/Infrastructure validation is not established`
+
+          This job verifies responsibility boundaries, parses current JSON Schemas
+          and any JSON fixtures for structural integrity, recognizes docstring-only
+          tests and exact `main(): raise NotImplementedError` validator scaffolds,
+          and fails closed when substantive tests or validator bodies appear.
+
+          It does not establish place, municipal, census, townsite, facility,
+          operator, condition, service-area, dependency, critical-infrastructure,
+          EvidenceBundle, policy, legal, safety, emergency, or release truth.
+          EOF
+
   build-proof-settlements-infrastructure:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO build-proof-settlements-infrastructure'
+      - name: Check out Settlements Infrastructure proof boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Settlements Infrastructure proof readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "data/proofs/settlements-infrastructure/README.md"
+            "data/registry/sources/settlements-infrastructure/README.md"
+            "release/candidates/settlements-infrastructure/README.md"
+            "tests/domains/settlements-infrastructure/README.md"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Settlements/Infrastructure proof boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "NEEDS VERIFICATION for emitted proof objects" "data/proofs/settlements-infrastructure/README.md"; then
+            echo "::error::The Settlements/Infrastructure proof posture changed. Review proof schemas, producers, sensitivity controls, access controls, receipts, and release linkage."
+            exit 1
+          fi
+
+          proof_artifact="$(find data/proofs/settlements-infrastructure -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$proof_artifact" ]]; then
+            echo "::error::Settlements/Infrastructure proof material surfaced at $proof_artifact. Replace this hold with the governed proof validator and manifest path."
+            exit 1
+          fi
+
+          if grep -Eq '^(settlements-infrastructure-proof|proof-settlements-infrastructure):' Makefile; then
+            echo "::error::A Settlements/Infrastructure proof target now exists. Wire and validate it deliberately instead of retaining this hold."
+            exit 1
+          fi
+
+          proof_implementation="$(find tools pipelines packages scripts -type f \( -iname '*settlements*infrastructure*proof*.py' -o -iname '*proof*settlements*infrastructure*.py' -o -iname '*settlements*infrastructure*proof*.mjs' -o -iname '*proof*settlements*infrastructure*.mjs' \) -print -quit 2>/dev/null || true)"
+          if [[ -n "$proof_implementation" ]]; then
+            echo "::error::Potential Settlements/Infrastructure proof implementation surfaced at $proof_implementation. Establish its contract, public-safe fixtures, sensitivity controls, receipts, access controls, and rollback before wiring CI."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: build-proof-settlements-infrastructure"
+          echo "WORKFLOW_HOLD: no accepted Settlements/Infrastructure proof producer or deterministic proof command"
+
+      - name: Record Settlements Infrastructure proof hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Settlements/Infrastructure proof status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Settlements/Infrastructure proof producer or deterministic proof command`
+
+          The proof lane is documented, but emitted proof objects, proof schemas,
+          deterministic identity proof, critical-asset review, dependency-graph
+          controls, cultural/sovereignty review, validators, access controls,
+          receipt linkage, release linkage, and rollback drills remain unverified.
+
+          A green held result is not an EvidenceBundle, ProofPack, municipal-status
+          determination, infrastructure condition finding, service guarantee,
+          dependency disclosure approval, emergency/planning decision, release
+          decision, or publication authority.
+          EOF
+
   publish-dry-run-settlements-infrastructure:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v7
-      - run: 'echo TODO publish-dry-run-settlements-infrastructure'
+      - name: Check out Settlements Infrastructure release boundaries
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Evaluate Settlements Infrastructure release dry-run readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "release/candidates/settlements-infrastructure/README.md"
+            "docs/domains/settlements-infrastructure/RELEASE_INDEX.md"
+            "data/published/settlements-infrastructure/README.md"
+            ".github/workflows/release-dry-run.yml"
+          )
+
+          for required_path in "${required_paths[@]}"; do
+            if [[ ! -e "$required_path" ]]; then
+              echo "::error::Required Settlements/Infrastructure release boundary is missing: $required_path"
+              exit 1
+            fi
+          done
+
+          if ! grep -Fq "A candidate is not a release." "release/candidates/settlements-infrastructure/README.md"; then
+            echo "::error::The documented Settlements/Infrastructure candidate posture changed. Re-evaluate evidence, rights, source role, time, sensitivity, policy, review, correction, and rollback gates."
+            exit 1
+          fi
+
+          candidate_record="$(find release/candidates/settlements-infrastructure -mindepth 1 -type f ! -name 'README.md' ! -name '.gitkeep' -print -quit)"
+          if [[ -n "$candidate_record" ]]; then
+            echo "::error::A Settlements/Infrastructure candidate record surfaced at $candidate_record. Replace this hold with the independently reviewed domain dry-run path."
+            exit 1
+          fi
+
+          if grep -Eq '^(settlements-infrastructure-release-dry-run|release-dry-run-settlements-infrastructure):' Makefile; then
+            echo "::error::A Settlements/Infrastructure release dry-run target now exists. Wire the accepted fail-closed command instead of retaining this hold."
+            exit 1
+          fi
+
+          echo "WORKFLOW_SKIPPED_EXPLICIT: publish-dry-run-settlements-infrastructure"
+          echo "WORKFLOW_HOLD: no accepted Settlements/Infrastructure release dry-run command or candidate manifest contract"
+
+      - name: Record Settlements Infrastructure release dry-run hold
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Settlements/Infrastructure release dry-run status
+
+          `WORKFLOW_SKIPPED_EXPLICIT`
+
+          `WORKFLOW_HOLD: no accepted Settlements/Infrastructure release dry-run command or candidate manifest contract`
+
+          This lane performs no live fetch, source admission, facility or dependency
+          exposure, emergency/planning output, release, promotion, manifest
+          assembly, deployment, publication, or write to lifecycle, graph, proof,
+          receipt, release, cache, or published stores.
+
+          Graduate it only after candidate identity, immutable artifact pointer,
+          source and EvidenceBundle closure, rights, time validity, object-family
+          separation, critical-infrastructure and cultural/sovereignty review,
+          public-safe transformation, policy result, validation receipts,
+          independent approval, correction, withdrawal, and rollback targets are
+          accepted.
+
+          A green held result does not mean Settlements/Infrastructure material is
+          accurate, current, legally authoritative, operationally safe, approved,
+          released, or published.
+          EOF

--- a/data/receipts/generated/genrec-domain-settlements-infrastructure-workflow-70c56c0e.json
+++ b/data/receipts/generated/genrec-domain-settlements-infrastructure-workflow-70c56c0e.json
@@ -1,0 +1,88 @@
+{
+  "receipt_id": "genrec-domain-settlements-infrastructure-workflow-70c56c0e",
+  "contract_version": "3.0.0",
+  "receipt_type": "GenerationReceipt",
+  "status": "PROPOSED",
+  "generated_at": "2026-07-18T00:00:00-05:00",
+  "repository": "bartytime4life/Kansas-Frontier-Matrix",
+  "base_commit": "14a0be53f8fde399e20888b8fbf18174d41a8376",
+  "branch": "agent/domain-settlements-infrastructure-workflow-20260718",
+  "target_path": ".github/workflows/domain-settlements-infrastructure.yml",
+  "previous_blob": "f1005588b56c5aa103af254accd5d33ab7152fa6",
+  "new_blob": "70c56c0e3938f059e546e39897acb1fe7f54ad30",
+  "content_digest": {
+    "algorithm": "git-blob-sha1",
+    "value": "70c56c0e3938f059e546e39897acb1fe7f54ad30"
+  },
+  "truth_labels": {
+    "confirmed": [
+      "The prior validate-settlements-infrastructure, build-proof-settlements-infrastructure, and publish-dry-run-settlements-infrastructure jobs only executed TODO echo commands.",
+      "Baseline workflow run 29654753583 completed successfully without Settlements/Infrastructure validation, proof construction, or release dry-run execution.",
+      "The Settlements/Infrastructure test index records executable tests, fixture shapes, schema bindings, validators, CI coverage, release integration, and pass rates as needing verification.",
+      "Sampled Settlements/Infrastructure test modules contain only PROPOSED placeholder docstrings.",
+      "The per-domain validator index records executables, schemas, fixtures, policy bundles, and CI wiring as unverified.",
+      "Sampled domain validator files use a main function that raises NotImplementedError and therefore do not establish executable validation.",
+      "Concrete JSON Schema files exist under the domain schema root, while fixture lanes currently contain placeholder marker files rather than JSON payloads.",
+      "The domain policy README remains a PROPOSED greenfield scaffold.",
+      "The proof lane is draft and records emitted proof objects, schemas, validators, fixtures, CI workflows, source descriptors, release gates, and rollback drills as needing verification.",
+      "The release-candidate lane is pre-publication and states that a candidate is not a release.",
+      "Published artifacts remain downstream public-safe carriers with live artifact maturity and release approval unverified.",
+      "Workflow name domain-settlements-infrastructure and all three job ids are preserved."
+    ],
+    "proposed": [
+      "Bounded structural validation plus explicit semantic-validation, proof, and release holds are the safest current CI behavior.",
+      "Docstring-only tests and exact main/NotImplementedError validator modules should be recognized as scaffolds without being represented as enforceability proof."
+    ],
+    "needs_verification": [
+      "Final-head GitHub Actions conclusions.",
+      "Accepted settlements-infrastructure versus settlement schema, contract, package, pipeline, and published-layer topology.",
+      "Accepted Settlements/Infrastructure validator ownership and deterministic no-network semantic test suite.",
+      "Executable policy and sensitivity controls for critical assets, condition and vulnerability data, dependency graphs, cultural and sovereignty review, living-person proximity, and public-safe geometry.",
+      "Concrete EvidenceBundle and proof producer contracts, schemas, fixtures, manifests, access controls, and receipts.",
+      "Accepted candidate, ReleaseManifest, correction, withdrawal, graph or cache invalidation, and rollback contracts.",
+      "Branch-protection dependencies, independent infrastructure-sensitivity review ownership, and immutable action pinning."
+    ]
+  },
+  "changes": [
+    "Added workflow_dispatch, contents: read permission, concurrency cancellation, deterministic Python setup, and five-minute job timeouts.",
+    "Disabled persisted checkout credentials.",
+    "Converted the validation TODO into a bounded structural readiness check with an explicit WORKFLOW_HOLD outcome.",
+    "Added required-boundary checks across domain doctrine, contracts, schemas, fixtures, policy, tests, validators, source registry, proofs, release candidates, and published lanes.",
+    "Added AST-based detection for substantive Settlements/Infrastructure tests while recognizing docstring-only test modules as scaffolds.",
+    "Added deterministic JSON Schema parsing and structural identity checks without treating schema status as semantic acceptance.",
+    "Added parsing for any future JSON fixtures while preserving the current placeholder-marker fixture posture.",
+    "Added AST recognition for exact main/NotImplementedError validator scaffolds and fail-closed detection for substantive validator bodies.",
+    "Added a policy-posture check for the current domain scaffold.",
+    "Converted proof and release TODO jobs into explicit WORKFLOW_SKIPPED_EXPLICIT and WORKFLOW_HOLD readiness checks.",
+    "Added fail-closed detection for proof artifacts, proof producers, candidate records, Make targets, and changed candidate posture.",
+    "Added bounded summaries preserving municipal-status, census-vintage, critical-asset, operator, condition, service-area, dependency, cultural, sovereignty, safety, emergency, correction, withdrawal, and rollback boundaries."
+  ],
+  "authority_boundary": "A green held result is repository-readiness evidence only. It is not settlement, municipality, census-place, facility, operator, condition, service-area, dependency, critical-infrastructure, legal-status, safety, emergency, EvidenceBundle, proof, lifecycle promotion, release, or publication authority.",
+  "directory_rules_basis": [
+    ".github/workflows remains the existing CI orchestration location.",
+    "contracts and schemas remain separate meaning and shape roots.",
+    "tests and fixtures remain the enforceability and bounded synthetic-input roots.",
+    "tools remains the validator and helper root.",
+    "policy remains the admissibility and sensitivity root.",
+    "data/registry remains the source-admission and registry root.",
+    "data/proofs remains the proof-support root.",
+    "release remains the release-decision root.",
+    "data/published remains the released-payload root.",
+    "data/receipts/generated remains the existing generated process-memory lane."
+  ],
+  "validation": {
+    "workflow_yaml_parse": "PASS",
+    "workflow_and_job_identities_preserved": "PASS",
+    "schema_fixture_test_validator_runtime_checks": "PENDING_FINAL_HEAD_CI",
+    "exact_changed_paths": [
+      ".github/workflows/domain-settlements-infrastructure.yml",
+      "data/receipts/generated/genrec-domain-settlements-infrastructure-workflow-70c56c0e.json"
+    ],
+    "final_head_ci": "PENDING",
+    "human_review": "PENDING"
+  },
+  "rollback": {
+    "strategy": "Close the pull request without merge or revert the single atomic workflow-and-receipt commit.",
+    "restores_blob": "f1005588b56c5aa103af254accd5d33ab7152fa6"
+  }
+}


### PR DESCRIPTION
## Summary

Updates `.github/workflows/domain-settlements-infrastructure.yml` from TODO-only jobs to bounded structural readiness checks and explicit holds.

- Preserves workflow name and all three job IDs.
- Adds read-only permissions, concurrency cancellation, five-minute timeouts, and disabled persisted checkout credentials.
- Parses current domain JSON Schemas and any JSON fixtures for structural integrity.
- Recognizes docstring-only test modules and exact `main(): raise NotImplementedError` validator files as scaffolds, not enforceability proof.
- Fails closed when substantive tests, validator bodies, proof artifacts, proof producers, candidate records, or domain Make targets appear without deliberate workflow graduation.
- Holds semantic validation, proof generation, and release dry-run until accepted policy, sensitivity, evidence, review, correction, withdrawal, and rollback contracts exist.
- Adds `data/receipts/generated/genrec-domain-settlements-infrastructure-workflow-70c56c0e.json`.

**CONFIRMED:** baseline run `29654753583` passed while all three former jobs only echoed TODO.

**PROPOSED:** this patch provides repository-readiness evidence only. It does not establish settlement, municipal, census, facility, operator, condition, dependency, critical-infrastructure, safety, proof, release, or publication authority.

**NEEDS VERIFICATION:** final-head CI, slug topology, executable tests/validators/policy, proof and release contracts, and independent infrastructure-sensitivity review.

Workflow Git blob: `70c56c0e3938f059e546e39897acb1fe7f54ad30`

Rollback: close without merge, or revert atomic commit `42275c21928a84a22c55c100eb3235edd152d0b7`.