### PR TITLE
docs(policy): update agriculture domain policy README

### DIFF
--- a/data/receipts/generated/genrec-agriculture-policy-readme-f90f3e11.json
+++ b/data/receipts/generated/genrec-agriculture-policy-readme-f90f3e11.json
@@ -1,0 +1,164 @@
+{
+  "receipt_id": "genrec-agriculture-policy-readme-f90f3e11",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    "policy/domains/agriculture/README.md"
+  ],
+  "artifact_hashes": {
+    "policy/domains/agriculture/README.md": "sha256:f90f3e114eb2c57db63cb374d2f3806033b358eb69aef58aa93125be26d07f24"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "GPT-5.6 Thinking",
+    "version": "2026-07-19"
+  },
+  "prompt_or_contract": "sha256:dc080e5e6327630fc8c055e254e44a6c4020a59d7c76967ceded296fff852523",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "repository evidence inspection",
+      "Directory Rules",
+      "KFM AI Build Operating Contract",
+      "local Markdown structure and hash validation"
+    ]
+  },
+  "inputs": {
+    "attached_docs": [
+      "Directory Rules.pdf",
+      "Kansas Frontier Matrix — AI Build Operating Contract.md",
+      "KFM Unified Doctrine Synthesis.md"
+    ],
+    "evidence_refs": [
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/domains/agriculture/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/domains/agriculture/deny_unpublished.rego",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/domains/agriculture/abstain_on_ambiguous.rego",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/domains/agriculture/deny-field-level.rego",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/domains/agriculture/redaction_profiles.yaml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/domains/agriculture/aggregation_thresholds/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/sensitivity/agriculture/aggregation_thresholds.yaml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/sensitivity/agriculture/farm_operator_join.rego",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/docs/domains/agriculture/POLICY.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/docs/domains/agriculture/SENSITIVITY.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/tests/domains/agriculture/policy_deny/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/tests/domains/agriculture/aggregate_only/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/tests/domains/agriculture/test_nass_aggregate_only.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/tools/validators/agriculture/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/.github/workflows/policy-test.yml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/.github/workflows/domain-agriculture.yml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/packages/policy-runtime/src/policy_runtime/core.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/bundles/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/compare/25c0a66f3a722926828b32189802442d40b9b5fd...66adcd917bc77232f6eac2218849f812019631dd"
+    ]
+  },
+  "truth_labels": {
+    "policy/domains/agriculture/README.md": "PROPOSED"
+  },
+  "validation_gates": [
+    {
+      "gate": "repository-and-authority-preflight",
+      "outcome": "PASS",
+      "reason": "Verified repository identity, target path, current parent-policy blob, branch base, and authenticated write permission."
+    },
+    {
+      "gate": "directory-rules-placement",
+      "outcome": "PASS",
+      "reason": "The existing README remains in the canonical singular policy responsibility root and creates no parallel policy authority."
+    },
+    {
+      "gate": "repository-inventory-grounding",
+      "outcome": "PASS",
+      "reason": "Inspected the direct Agriculture Rego and YAML scaffolds, aggregation-threshold child, sensitivity scaffolds, doctrine, test boundaries, validator boundary, policy runtime placeholder, bundle boundary, and readiness workflows."
+    },
+    {
+      "gate": "policy-non-activation",
+      "outcome": "PASS",
+      "reason": "The revision explicitly distinguishes file presence and readiness holds from accepted bundle identity, evaluator binding, policy decisions, release approval, and production enforcement."
+    },
+    {
+      "gate": "conflict-surfacing",
+      "outcome": "PASS",
+      "reason": "The README surfaces inconsistent defaults, namespaces, decision vocabularies, placement overlap, and missing bundle/evaluator contracts without resolving them by assertion."
+    },
+    {
+      "gate": "markdown-structure",
+      "outcome": "PASS",
+      "reason": "Authored candidate has one H1, complete KFM Meta Block markers, required README boundary sections, Mermaid flow, evidence ledger, changelog, definition of done, open verification, correction, and rollback sections."
+    },
+    {
+      "gate": "remote-readback",
+      "outcome": "PASS",
+      "reason": "GitHub returned blob SHA 9fd3762577e6804ed69e6ac278cd3252a50bb75e; beginning and terminal sections were read back and matched the intended structure."
+    },
+    {
+      "gate": "remote-content-sha256-recomputation",
+      "outcome": "SKIPPED",
+      "reason": "The connector exposed the Git blob SHA and bounded readback but did not provide a separate byte-complete SHA-256 computation in this session; the artifact_hash records the locally authored candidate content hash and requires reviewer verification before merge."
+    },
+    {
+      "gate": "base-drift-review",
+      "outcome": "PASS",
+      "reason": "Main advanced from 25c0a66 to 66adcd9 only through unrelated apps/packages documentation and generated-receipt changes; no target or cited Agriculture policy evidence path changed."
+    },
+    {
+      "gate": "executable-policy-and-tests",
+      "outcome": "SKIPPED",
+      "reason": "No accepted Agriculture policy bundle, evaluator, rule test suite, fixture payload set, validator executable, obligation handler, emitted decision, or release integration was established; the README documents those gaps."
+    },
+    {
+      "gate": "human-review",
+      "outcome": "SKIPPED",
+      "reason": "Human review remains pending on the draft pull request."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "agriculture-parent-policy-prior-state",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/domains/agriculture/README.md"
+    },
+    {
+      "id": "agriculture-rego-default-conflict",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/tree/25c0a66f3a722926828b32189802442d40b9b5fd/policy/domains/agriculture"
+    },
+    {
+      "id": "agriculture-policy-test-readiness-hold",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/.github/workflows/policy-test.yml"
+    },
+    {
+      "id": "agriculture-domain-readiness-hold",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/.github/workflows/domain-agriculture.yml"
+    },
+    {
+      "id": "policy-runtime-placeholder",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/packages/policy-runtime/src/policy_runtime/core.py"
+    },
+    {
+      "id": "policy-bundle-boundary",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/25c0a66f3a722926828b32189802442d40b9b5fd/policy/bundles/README.md"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-19T16:41:00Z",
+  "emitter": "openai/gpt-5.6-thinking",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "AI-authored repository-grounded parent policy README revision on a scoped review branch. This receipt is provenance, not approval. No policy source, rule value, numeric threshold, bundle, evaluator, schema, contract, fixture, test, validator, workflow, receipt instance, release artifact, data object, deployment, or public behavior was changed. Human review and exact remote SHA-256 verification remain pending."
+}

--- a/policy/domains/agriculture/README.md
+++ b/policy/domains/agriculture/README.md
@@ -1,337 +1,1120 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://policy/domains/agriculture
 title: Agriculture Domain Policy README
-type: policy-readme
-version: v0.1
-status: draft
-owners: OWNER_TBD — Agriculture steward · Policy steward · Sensitivity steward · Rights steward · Docs steward
+type: readme; directory-readme; domain-policy-boundary; policy-index
+version: v0.2
+status: draft; repository-grounded; policy-scaffolds; evaluator-unimplemented; fail-closed; non-authoritative-for-release
+owners: OWNER_TBD — Agriculture steward · Policy steward · Sensitivity and rights steward · Privacy reviewer · Source steward · Contract/schema steward · Validator/test steward · Runtime steward · Release steward · Security steward · Docs steward
 created: 2026-06-15
-updated: 2026-06-15
-policy_label: restricted
+updated: 2026-07-19
+supersedes: v0.1 Agriculture domain policy guide
+policy_label: restricted-review; policy; agriculture; rights; sensitivity; aggregation; redaction; finite-outcomes; no-public-authority
+current_path: policy/domains/agriculture/README.md
+owning_root: policy/
+responsibility: >
+  Agriculture-specific policy boundary and repository index. It records which policy questions
+  belong here, the current policy-source inventory and maturity, the required input and decision
+  contracts, finite outcomes and obligations, cross-lane composition rules, test and review
+  burdens, and the smallest safe implementation sequence without treating scaffolds, READMEs,
+  schemas, workflow holds, or file presence as executable enforcement.
+truth_posture: >
+  CONFIRMED target README and canonical singular policy root; three direct Agriculture Rego
+  sources are present but are PROPOSED stubs/scaffolds with inconsistent package namespaces and
+  default semantics; redaction_profiles.yaml is a PROPOSED placeholder; the aggregation-threshold
+  child README is repository-grounded documentation only; a separate sensitivity Agriculture lane
+  contains a placeholder threshold YAML and farm-operator-join scaffold; policy-test and
+  domain-agriculture workflows are readiness/drift guards rather than policy evaluation; the policy
+  runtime remains a comment-only placeholder; Agriculture policy-deny and aggregate-only test lanes
+  are README-led and do not establish executable enforcement /
+  PROPOSED bounded Agriculture policy architecture, policy-family map, normalized decision contract,
+  reason-code and obligation families, public-surface boundary, review model, validation matrix,
+  and implementation sequence /
+  CONFLICTED deny-named and abstain-named Rego packages defaulting deny to false versus deny-field
+  and farm-operator scaffolds defaulting allow to false; abstain_on_ambiguous exposing a deny relation
+  rather than an abstain result; multiple Rego namespace conventions; domain-policy versus
+  sensitivity-policy placement; engine-native ALLOW/RESTRICT/HOLD vocabulary versus the current
+  PolicyDecision schema's ANSWER/ABSTAIN/DENY/ERROR vocabulary; documentation claims of canonical
+  policy artifacts versus unaccepted bundle/evaluator activation /
+  UNKNOWN accepted policy bundle, manifest, evaluator, selection rule, deployment binding, real
+  Agriculture policy tests, fixture payloads, validator implementation, emitted PolicyDecision
+  records, reason-code registry, obligation registry, production consumers, branch-protection
+  significance, monitoring, and release-gate adoption /
+  NEEDS VERIFICATION owners and CODEOWNERS, accepted package namespace, default-result semantics,
+  canonical child placement, policy input contract, source-specific rights rules, sensitive join
+  composition, bundle identity and digest, evaluator compatibility, deterministic fixtures,
+  no-network tests, API/UI/map/AI obligation handling, correction propagation, and rollback drills.
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  repository_id: "1059091169"
+  visibility: public
+  base_ref: main
+  base_commit: 25c0a66f3a722926828b32189802442d40b9b5fd
+  prior_blob: ba73c387e16f70895f32444e489d6d55dd577b75
+  policy_root_blob: 09cd966ab188d5e831960869117522a98274cb7f
+  deny_unpublished_blob: 35c813606f37d3578230092fc526430e256b134d
+  abstain_on_ambiguous_blob: 7733c0d6389e5e159346ab0bbd118b300970d728
+  deny_field_level_blob: dc626a6975309e1356876715385c748bc30c18c2
+  redaction_profiles_blob: f13fbb93fb4b0b53f764c1d21b8189f81cfc0304
+  aggregation_thresholds_readme_blob: b5482dc8306c225e718e64fe6d5d879742e93654
+  sensitivity_threshold_placeholder_blob: 31947ca3e468a967aed3fc5d44699130b7d588fd
+  farm_operator_join_blob: 1b6128c4e2470f198edb6464424c6effc9d246dd
+  agriculture_policy_doc_blob: be42d02fae601f4b90a220f336ec36a848d2e51a
+  agriculture_sensitivity_doc_blob: 9d25f63d471af78899d8db2ad39a3921c4f11fac
+  policy_deny_test_readme_blob: 07f3dcb643e49ce54bae06a17399ee3829d72d1c
+  aggregate_only_test_readme_blob: e872e11c71840cb806717bf1199c74c4a01d4e37
+  aggregate_only_placeholder_test_blob: 97939b939122f029f35ecf12c81f5989df00ae63
+  agriculture_validator_readme_blob: 40d268b425d9939ab6a8cda7bd197ba758572d3f
+  policy_test_workflow_blob: 003192e1adb3be65e727b58c3414c7ce0f8cceed
+  agriculture_workflow_blob: 1dd9938b92de61c7d905f30170cf6394e6c06ea1
+  policy_runtime_core_blob: e7e14cf39ae6919fbbc80f1b471de6b907292edb
+  policy_bundles_readme_blob: 77f59c399fbce668c916cbbc385009121d6169f4
 related:
   - ../README.md
+  - ../../README.md
   - ../../../docs/domains/agriculture/POLICY.md
   - ../../../docs/domains/agriculture/SENSITIVITY.md
-  - ../../../docs/domains/agriculture/README.md
-  - ../../../docs/domains/agriculture/DOMAIN.md
-  - ../../../docs/domains/agriculture/OBJECTS.md
-  - ../../../docs/domains/agriculture/OBJECT_FAMILIES.md
   - ../../../docs/domains/agriculture/PIPELINE.md
   - ../../../docs/domains/agriculture/CROSS_LANE.md
-  - ../../../policy/sensitivity/
-  - ../../../policy/rights/
-  - ../../../policy/release/
-  - ../../../schemas/contracts/v1/domains/agriculture/
-  - ../../../contracts/domains/agriculture/
-  - ../../../packages/policy-runtime/README.md
-  - ../../../tests/domains/agriculture/
+  - ../../../docs/domains/agriculture/OBJECTS.md
+  - ../../../docs/domains/agriculture/OBJECT_FAMILIES.md
+  - ../../../docs/domains/agriculture/policy/README.md
+  - ./aggregation_thresholds/README.md
+  - ./deny_unpublished.rego
+  - ./abstain_on_ambiguous.rego
+  - ./deny-field-level.rego
+  - ./redaction_profiles.yaml
+  - ../../sensitivity/agriculture/aggregation_thresholds.yaml
+  - ../../sensitivity/agriculture/farm_operator_join.rego
+  - ../../../contracts/policy/policy_input_bundle.md
+  - ../../../contracts/policy/policy_decision.md
+  - ../../../schemas/contracts/v1/policy/policy_input_bundle.schema.json
+  - ../../../schemas/contracts/v1/policy/policy_decision.schema.json
+  - ../../../tests/domains/agriculture/policy_deny/README.md
+  - ../../../tests/domains/agriculture/aggregate_only/README.md
   - ../../../fixtures/domains/agriculture/
-tags: [kfm, policy, domains, agriculture, admissibility, sensitivity, rights, release, redaction, aggregation, fail-closed]
+  - ../../../tools/validators/agriculture/README.md
+  - ../../../packages/policy-runtime/README.md
+  - ../../../policy/bundles/README.md
+  - ../../../data/receipts/aggregation/README.md
+  - ../../../release/agriculture/README.md
+  - ../../../docs/doctrine/directory-rules.md
+  - ../../../docs/doctrine/ai-build-operating-contract.md
+  - ../../../.github/workflows/policy-test.yml
+  - ../../../.github/workflows/domain-agriculture.yml
+tags:
+  - kfm
+  - policy
+  - agriculture
+  - domain-policy
+  - fail-closed
+  - policy-input
+  - policy-decision
+  - source-role
+  - rights
+  - sensitivity
+  - aggregation
+  - redaction
+  - field-level-deny
+  - farm-operator-join
+  - evidence
+  - finite-outcomes
+  - obligations
+  - no-network
+  - release-gated
+  - correction
+  - rollback
 notes:
-  - "Replaces the greenfield Agriculture policy stub with a bounded domain-policy README."
-  - "This directory is for Agriculture-specific executable policy materials or policy-lane documentation only; it is not a home for docs, contracts, schemas, tests, fixtures, packages, pipelines, registries, or lifecycle data."
-  - "Agriculture policy intent is described in docs/domains/agriculture/POLICY.md; this lane is the proposed executable/bundle-side policy home."
-  - "Concrete policy files, bundle syntax, tests, fixtures, CI binding, and runtime enforcement remain NEEDS VERIFICATION."
+  - "This revision changes only policy/domains/agriculture/README.md plus the required AI-generated provenance receipt."
+  - "No policy rule, numeric threshold, bundle, evaluator, schema, contract, fixture, test, validator, workflow, receipt instance, release artifact, data object, deployment, or public behavior is created or changed."
+  - "A policy file's presence is not activation; a green readiness hold is not policy enforcement."
+  - "The most restrictive applicable source, rights, sensitivity, audience, join, lifecycle, and release rule wins."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-<div align="center">
-
 # Agriculture Domain Policy
 
-`policy/domains/agriculture/`
+> **One-line purpose.** Govern Agriculture-specific allow, deny, restrict, abstain, review, redaction, aggregation, and release-adjacent decisions while keeping evidence, rights, sensitivity, validation, receipts, release authority, and public serving boundaries explicit and separate.
 
-**Agriculture-specific admissibility policy lane for field/operator exposure, aggregate-release posture, rights, sensitivity, redaction, aggregation, review, and release-adjacent gates.**
-
-![status](https://img.shields.io/badge/status-draft-blue)
-![owner](https://img.shields.io/badge/owner-OWNER__TBD-lightgrey)
-![domain](https://img.shields.io/badge/domain-agriculture-2e7d32)
-![truth](https://img.shields.io/badge/truth-NEEDS__VERIFICATION-yellow)
-![default](https://img.shields.io/badge/default-deny__exact__exposure-d62728)
-
-[Scope](#1-scope) · [Repo fit](#2-repo-fit) · [Boundary](#3-authority-boundary) · [Inputs](#5-inputs) · [Exclusions](#6-exclusions) · [Policy families](#7-policy-families) · [Definition of done](#14-definition-of-done)
-
-</div>
-
----
+<p>
+  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
+  <img alt="Version: v0.2" src="https://img.shields.io/badge/version-v0.2-informational">
+  <img alt="Root: policy" src="https://img.shields.io/badge/root-policy%2F-blue">
+  <img alt="Domain: agriculture" src="https://img.shields.io/badge/domain-agriculture-2e7d32">
+  <img alt="Inventory: scaffolds" src="https://img.shields.io/badge/inventory-scaffolds-orange">
+  <img alt="Runtime: unimplemented" src="https://img.shields.io/badge/runtime-unimplemented-critical">
+  <img alt="Default: fail closed" src="https://img.shields.io/badge/default-fail__closed-critical">
+</p>
 
 > [!IMPORTANT]
-> **Status:** draft / `NEEDS VERIFICATION`  
-> **Owners:** `OWNER_TBD` — Agriculture steward · Policy steward · Sensitivity steward · Rights steward · Docs steward  
-> **Path:** `policy/domains/agriculture/README.md`  
-> **Responsibility root:** `policy/` — policy-as-code and policy documentation  
-> **Truth posture:** CONFIRMED file path / PROPOSED Agriculture policy-lane contract / UNKNOWN runtime enforcement
+> **This directory is policy authority only after its exact rule set, input contract, bundle identity, evaluator, tests, and review state are accepted.** Today it contains policy documentation and proposed source scaffolds. It does not establish production enforcement.
 
 > [!CAUTION]
-> Field-level, operator-resolved, private parcel-adjacent, NASS-confidential, or quarantine-adjacent Agriculture material must fail closed for public exact exposure unless a reviewed policy path explicitly allows a transformed, aggregated, redacted, generalized, or restricted output.
+> **Current Rego defaults are not coherent enough to activate.** Two packages named for denial or abstention default `deny := false`; two other Agriculture-related scaffolds default `allow := false`; package namespaces differ; and the ambiguous-input file exposes no abstain result. Do not infer a safe engine contract from filenames.
+
+> [!WARNING]
+> **Agriculture aggregation does not erase sensitivity.** Field, operator, person, parcel, ownership, proprietary yield, pesticide/application, well-to-field, and restricted-source joins remain deny/restrict/review candidates even when some inputs are aggregated.
+
+**Quick links:** [Purpose](#purpose) · [Authority](#authority-level) · [Status](#status-and-repository-evidence) · [Belongs](#what-belongs-here) · [Does not](#what-does-not-belong-here) · [Inventory](#confirmed-policy-inventory) · [Families](#policy-family-map) · [Inputs](#minimum-policy-input-contract) · [Decisions](#decision-vocabulary-and-normalization) · [Obligations](#obligation-families) · [Cross-lane](#cross-lane-composition) · [Public surfaces](#public-surface-contract) · [Validation](#validation-tests-and-ci) · [Review](#review-burden-and-separation-of-duties) · [Related](#related-folders) · [Conflicts](#adrs-and-conflict-register) · [Sequence](#smallest-sound-implementation-sequence) · [Done](#definition-of-done) · [Open](#open-verification-register) · [Rollback](#maintenance-correction-and-rollback)
 
 ---
 
-## Quick jump
+## Purpose
 
-- [1. Scope](#1-scope)
-- [2. Repo fit](#2-repo-fit)
-- [3. Authority boundary](#3-authority-boundary)
-- [4. Default posture](#4-default-posture)
-- [5. Inputs](#5-inputs)
-- [6. Exclusions](#6-exclusions)
-- [7. Policy families](#7-policy-families)
-- [8. Diagram](#8-diagram)
-- [9. Decision vocabulary](#9-decision-vocabulary)
-- [10. Agriculture obligations](#10-agriculture-obligations)
-- [11. Child-file contract](#11-child-file-contract)
-- [12. Inspection path](#12-inspection-path)
-- [13. Validation expectations](#13-validation-expectations)
-- [14. Definition of done](#14-definition-of-done)
-- [15. Open verification items](#15-open-verification-items)
+`policy/domains/agriculture/` is the Agriculture domain segment under KFM's canonical singular `policy/` responsibility root.
 
----
+Its durable question is:
 
-## 1. Scope
+> Given a fully declared Agriculture operation and governed context, what bounded action is permitted, refused, narrowed, held for review, or left unanswered—and which obligations must downstream systems preserve?
 
-`policy/domains/agriculture/` is the proposed executable and bundle-side policy lane for Agriculture domain admissibility.
+A complete Agriculture policy implementation should decide only after it knows:
 
-It should hold Agriculture policy modules, bundle manifests, rule documentation, fixtures pointers, or lane READMEs that enforce the intent described by `docs/domains/agriculture/POLICY.md` and `docs/domains/agriculture/SENSITIVITY.md`.
+1. the requested operation and audience;
+2. the Agriculture object family and source role;
+3. spatial and temporal precision;
+4. rights, license, confidentiality, consent, and source-use posture;
+5. sensitivity and re-identification risk;
+6. EvidenceRef/EvidenceBundle support;
+7. validation and lifecycle state;
+8. aggregation, redaction, review, and receipt state;
+9. release, correction, withdrawal, and rollback context;
+10. the exact policy bundle, evaluator profile, and decision contract being used.
 
-In scope:
+### In scope
 
-- Agriculture sensitivity, rights, promotion, runtime, release, and redaction policy material
-- field/operator exposure and private parcel-adjacent joins
-- aggregate-only and public-safe materialization gates
-- source-role, evidence, validation, receipt, and review prerequisites
-- finite policy outcomes and safe reason codes
-- obligations such as aggregation, redaction, generalization, audience restriction, review, delay, or rollback
+- public, reviewer, restricted, and denied Agriculture audience decisions;
+- exact-field, operator, parcel-adjacent, and private-party exposure controls;
+- source-role and evidence prerequisites;
+- rights, confidentiality, sensitivity, and consent inheritance;
+- aggregation, redaction, generalization, delay, and review obligations;
+- unpublished, superseded, withdrawn, stale, quarantine-adjacent, or rollback-blocked material;
+- cross-lane Agriculture joins;
+- finite decisions, safe reason codes, and obligation propagation;
+- policy-bundle selection and replay requirements once accepted;
+- policy tests and negative cases;
+- policy-change correction and rollback posture.
 
-Out of scope:
+### Out of scope
 
-- Agriculture doctrine and scope documents
-- Agriculture semantic contracts
-- Agriculture JSON Schemas
-- Agriculture package helper code
-- Agriculture executable pipelines
-- source acquisition jobs
-- lifecycle data and registry records
-- release approval or rollback authority
-- public UI or API implementation
+- Agriculture domain meaning or object definitions;
+- machine-shape authority;
+- data acquisition, storage, normalization, or transformation;
+- evidence creation or proof closure;
+- source registry authority;
+- release approval;
+- application serving, map rendering, exports, or AI generation;
+- numeric aggregation thresholds that lack accepted authority;
+- agronomic, financial, legal, safety, or operational advice.
 
 [Back to top](#top)
 
 ---
 
-## 2. Repo fit
+## Authority level
 
-| Concern | Owning root | Expected relationship |
+**Canonical policy responsibility / non-authoritative for adjacent concerns.**
+
+| Concern | Authority home | Agriculture policy role |
 |---|---|---|
-| Agriculture domain policy | `policy/domains/agriculture/` | This README and future Agriculture policy files, if accepted |
-| Domain policy parent | `policy/domains/` | Shared domain-policy root contract |
-| Agriculture policy intent | `docs/domains/agriculture/POLICY.md` | Human-readable policy reference; not itself executable bundle |
-| Agriculture sensitivity posture | `docs/domains/agriculture/SENSITIVITY.md` | Human-readable sensitivity, rights, and release posture |
-| Agriculture doctrine and scope | `docs/domains/agriculture/` | Domain docs; not executable policy authority |
-| Agriculture contracts | `contracts/domains/agriculture/` | Object meaning and field intent |
-| Agriculture schemas | `schemas/contracts/v1/domains/agriculture/` | Machine-readable shape |
-| Tests and fixtures | `tests/domains/agriculture/`, `fixtures/domains/agriculture/` | Enforceability proof; presence remains `NEEDS VERIFICATION` |
-| Runtime policy evaluation | `packages/policy-runtime/` | Evaluator helper code; not policy authority |
+| Agriculture policy rule source | Accepted lanes under `policy/` | Owns reviewed decision logic after acceptance. |
+| Agriculture policy intent | [`docs/domains/agriculture/POLICY.md`](../../../docs/domains/agriculture/POLICY.md) | Implements and cites intent; does not silently contradict it. |
+| Agriculture sensitivity doctrine | [`docs/domains/agriculture/SENSITIVITY.md`](../../../docs/domains/agriculture/SENSITIVITY.md) | Applies the most restrictive relevant row. |
+| Object meaning | [`contracts/domains/agriculture/`](../../../contracts/domains/agriculture/) | Consumes semantic meaning; does not redefine it. |
+| Machine shape | [`schemas/contracts/v1/`](../../../schemas/contracts/v1/) | Consumes schemas; policy source is not a schema home. |
+| Source identity and rights facts | Governed `data/registry/` lanes and review records | Evaluates supplied facts; does not invent them. |
+| Evidence | EvidenceRef/EvidenceBundle and `data/proofs/` families | Requires support; cannot create evidence closure. |
+| Transformation | `pipelines/`, `packages/`, or accepted tools | Emits obligations; does not perform hidden transformation. |
+| Validation | `tools/validators/` and `tests/` | Is validated and tested; a validator is not policy authority. |
+| Receipt instances | `data/receipts/` | May require receipts; does not store instances here. |
+| Release, correction, rollback | `release/` | Supplies a policy input; cannot approve publication. |
+| Policy execution | Accepted policy runtime/evaluator | Executes the exact accepted bundle; helper code does not own rule values. |
+| Public API, UI, map, export, AI | Governed applications and released artifacts | Must preserve decisions and obligations; cannot choose policy ad hoc. |
+| CI | `.github/workflows/` | Orchestrates checks; a green hold is not policy enforcement. |
 
-> [!NOTE]
-> The prior stub claimed this folder could hold docs, contracts, schemas, fixtures, tests, packages, pipelines, registries, or data artifacts. This README narrows the lane to policy responsibility only.
+### Governing order
 
-## 3. Authority boundary
+When Agriculture policy sources conflict, resolve in this order:
 
-This lane may decide Agriculture-specific admissibility. It must not become Agriculture doctrine, schema authority, contract authority, lifecycle storage, pipeline code, release authority, or public serving code.
+1. KFM core invariants and operating law.
+2. Accepted ADRs that explicitly change policy or placement.
+3. Sensitive-domain and most-restrictive-row rules.
+4. Agriculture policy and sensitivity doctrine.
+5. source-specific rights, confidentiality, consent, and use restrictions;
+6. accepted policy contract/schema/bundle definitions;
+7. this README;
+8. current proposed scaffolds and examples.
+
+A lower-ranked artifact must not weaken a higher-ranked denial, restriction, review, or rollback obligation.
+
+[Back to top](#top)
+
+---
+
+## Status and repository evidence
+
+### Confirmed direct inventory
+
+At `main@25c0a66f3a722926828b32189802442d40b9b5fd`, bounded repository inspection establishes:
 
 ```text
-policy/domains/agriculture/               = Agriculture admissibility policy
-docs/domains/agriculture/                 = Agriculture doctrine, scope, status, policy intent
-contracts/domains/agriculture/            = Agriculture object meaning
-schemas/contracts/v1/domains/agriculture/ = Agriculture machine shape
-packages/domains/agriculture/             = Agriculture helper code, if present
-pipelines/domains/agriculture/            = Agriculture transformations, if present
-data/                                     = lifecycle artifacts, receipts, proofs, registry
-release/                                  = publication, correction, rollback control
+policy/domains/agriculture/
+├── README.md
+├── abstain_on_ambiguous.rego
+├── aggregation_thresholds/
+│   └── README.md
+├── deny-field-level.rego
+├── deny_unpublished.rego
+└── redaction_profiles.yaml
 ```
 
-## 4. Default posture
-
-Agriculture policy should fail closed when support is missing.
-
-A policy gate should return `DENY`, `RESTRICT`, `HOLD`, or `ABSTAIN` when any of these are unresolved:
-
-- object family or domain slug
-- source role and provenance
-- rights or license posture
-- sensitivity tier
-- field/operator or parcel-adjacent exposure risk
-- cross-lane People, Land, Soil, Hydrology, Habitat, or Infrastructure joins
-- EvidenceRef / EvidenceBundle support
-- validation report
-- redaction or aggregation receipt
-- release state and rollback target
-- required steward review
-
-## 5. Inputs
-
-| Input family | Examples | Required posture |
+| Surface | Confirmed state | Safe conclusion |
 |---|---|---|
-| Agriculture object context | `OF-AG-*` family, field/crop/irrigation/production/derived layer reference | Explicit and domain-owned or marked `NEEDS VERIFICATION` |
-| Source context | NASS, NRCS, USDA, remote-sensing, local upload, manual curation | Source role and rights must be explicit |
-| Spatial context | field, parcel-adjacent, county, watershed, generalized tile, aggregate layer | Most restrictive precision rule wins |
-| Evidence context | EvidenceRef, EvidenceBundle status, citation validation | Required for claim-bearing outputs |
-| Sensitivity context | aggregate public, field-level, operator-resolved, private-parcel-adjacent, quarantine-adjacent | Fail closed when unresolved |
-| Rights context | public-domain, licensed, restricted, unclear, attribution required | Required before release or render |
-| Release context | candidate, released, superseded, withdrawn, rollback requested | Explicit; never inferred from path alone |
-| Audit context | policy version, reason code, reviewer, receipt refs | Required for consequential decisions |
+| This README | Existing v0.1 draft | Parent policy documentation exists but predates the detailed child and workflow evidence. |
+| `deny_unpublished.rego` | Fourteen-line `PROPOSED` stub; package `kfm.agriculture_deny_unpublished`; `default deny := false`; only a commented example | Filename and package suggest denial, but no active denial rule exists. |
+| `abstain_on_ambiguous.rego` | Fourteen-line `PROPOSED` stub; package `kfm.agriculture_abstain_on_ambiguous`; `default deny := false`; commented example writes `deny[reason]` | No machine-level abstain outcome is implemented. |
+| `deny-field-level.rego` | Six-line `PROPOSED` scaffold; generated namespace; `default allow := false` | Fail-closed-looking default exists, but no input contract, reason, obligation, or test is established. |
+| `redaction_profiles.yaml` | Seven-line `PROPOSED` placeholder | No redaction profile values or transform contract are implemented. |
+| `aggregation_thresholds/README.md` | Repository-grounded v0.2 documentation; no numeric thresholds accepted | Disclosure-control policy expectations exist; executable threshold enforcement does not. |
 
-## 6. Exclusions
+### Adjacent Agriculture policy surfaces
 
-| Does not belong here | Correct home |
+| Surface | Confirmed state | Boundary consequence |
+|---|---|---|
+| `policy/sensitivity/agriculture/aggregation_thresholds.yaml` | Eight-line `PROPOSED` placeholder | Placement overlaps the domain child; no numeric values exist. |
+| `policy/sensitivity/agriculture/farm_operator_join.rego` | Six-line generated scaffold; `default allow := false` | Sensitive-join intent exists without active decision logic. |
+| `policy/sensitivity/README.md` | Five-line greenfield stub | Cross-cutting sensitivity bundle architecture is not established. |
+| `policy/bundles/` | README-only in bounded evidence | No accepted bundle artifact, manifest, lock, selector, or active deployment is established. |
+| `packages/policy-runtime/.../core.py` | Comment-only greenfield placeholder | No policy evaluator is implemented. |
+| `tools/validators/agriculture/` | Repository-grounded README; direct lane remains README-only | No Agriculture validator executable is established. |
+| `tests/domains/agriculture/policy_deny/` | README-only test contract | Negative policy expectations exist without collected lane-local tests. |
+| `tests/domains/agriculture/aggregate_only/` | README-only test contract | Aggregate-preservation expectations exist without lane-local executable proof. |
+| `tests/domains/agriculture/test_nass_aggregate_only.py` | Docstring-only placeholder | No pytest assertion is defined. |
+| `.github/workflows/policy-test.yml` | Readiness/drift guard | It confirms absence of an accepted evaluator/test lane; it evaluates no policy. |
+| `.github/workflows/domain-agriculture.yml` | Agriculture readiness holds | It emits no Agriculture PolicyDecision, proof, release, or publication authority. |
+
+### Current maturity determination
+
+**CONFIRMED:** Agriculture policy source scaffolds and substantial documentation exist.
+
+**UNKNOWN:** executable coverage, active bundle selection, evaluator compatibility, deployed enforcement, production callers, current decision receipts, and release-gate use.
+
+**NEEDS VERIFICATION:** whether the direct inventory is byte-complete; current branch protection; CODEOWNERS; source-specific terms; owners; and current workflow run results.
+
+> [!NOTE]
+> Repository presence is not policy activation. A Rego file, YAML file, schema-valid input, passing readiness workflow, or documentation page cannot be cited as evidence that an Agriculture request would be safely denied or allowed at runtime.
+
+[Back to top](#top)
+
+---
+
+## What belongs here
+
+Accepted Agriculture policy material may include:
+
+- reviewed Rego or equivalent decision modules;
+- Agriculture policy data documents whose values are policy authority;
+- package-local policy documentation;
+- references to accepted shared policy inputs and decisions;
+- Agriculture-specific reason-code and obligation mappings;
+- bundle inclusion metadata where the canonical bundle design requires it;
+- policy-local tests only if the repository's accepted convention places engine-native tests beside rule source;
+- a child README for a coherent policy sublane;
+- migration, deprecation, correction, and rollback notes for Agriculture policy source.
+
+Every material policy file should identify:
+
+- package or module identity;
+- policy family;
+- supported operation and object families;
+- input contract/version;
+- canonical output or normalization contract;
+- default behavior;
+- reason codes;
+- obligations;
+- rights and sensitivity dependencies;
+- evidence, validation, lifecycle, and release prerequisites;
+- fixtures and tests;
+- bundle/manifest inclusion;
+- change and rollback procedure.
+
+[Back to top](#top)
+
+---
+
+## What does not belong here
+
+| Material | Correct authority home |
 |---|---|
-| Agriculture domain docs | `docs/domains/agriculture/` |
-| Agriculture semantic contracts | `contracts/domains/agriculture/` |
-| Agriculture schemas | `schemas/contracts/v1/domains/agriculture/` |
-| Agriculture helper libraries | `packages/domains/agriculture/` |
-| Agriculture pipelines | `pipelines/domains/agriculture/` |
-| Agriculture pipeline specs | `pipeline_specs/` or verified spec home |
-| Source records, registry, receipts, proofs, tiles, catalog, triplets | `data/` lifecycle roots |
-| Release manifests and rollback cards | `release/` |
-| Public API or UI surfaces | `apps/` and governed UI/API packages |
-| Secrets, API keys, private source material | Secret manager / deployment config, not repo docs |
+| Agriculture doctrine, architecture, object descriptions, and human policy rationale | `docs/domains/agriculture/` |
+| Semantic object contracts | `contracts/` |
+| JSON Schemas and machine-shape definitions | `schemas/` |
+| Source descriptors and source-rights records | `data/registry/` and governed review records |
+| Raw, work, quarantine, processed, catalog, triplet, or published data | Corresponding `data/` lifecycle lane |
+| AggregationReceipt, RedactionReceipt, RunReceipt, or PolicyDecision instances | Accepted `data/receipts/` lane |
+| EvidenceBundle, ProofPack, or citation proof | `data/proofs/` and evidence families |
+| Transform implementation | `pipelines/`, `packages/`, or `tools/` according to responsibility |
+| Synthetic fixtures | `fixtures/` |
+| Enforceability tests | `tests/` unless an accepted policy-engine convention requires colocated native tests |
+| General policy runtime/evaluator code | `packages/policy-runtime/` or accepted runtime boundary |
+| ReleaseManifest, PromotionDecision, CorrectionNotice, WithdrawalNotice, RollbackCard | `release/` |
+| Governed API, UI, map, export, or AI response code | `apps/` and shared packages |
+| Credentials, private source payloads, operator identities, parcel joins, or restricted coordinates | Governed private storage—not repository policy docs |
+| Generic agronomic advice or thresholds unsupported by accepted evidence/authority | Nowhere in this lane |
 
-## 7. Policy families
+[Back to top](#top)
 
-The Agriculture policy reference names these policy families as intent; implementation remains `NEEDS VERIFICATION` until files, bundles, tests, and CI are inspected.
+---
 
-| Family | Policy question | Default posture |
+## Default posture
+
+Agriculture policy must fail closed when required context is missing, contradictory, stale, unsupported, or unavailable.
+
+The default public posture is:
+
+```text
+exact field / operator / person / parcel / private-party detail
+  → DENY or HOLD
+  → apply reviewed aggregation / redaction / generalization only when authorized
+  → require evidence, rights, validation, receipt, review, release, correction, rollback
+  → serve only through governed interfaces
+```
+
+### Conditions that block an affirmative public result
+
+- unknown operation or object family;
+- unknown or collapsed source role;
+- unclear rights, confidentiality, consent, or license;
+- unresolved sensitivity tier or audience;
+- field-, operator-, person-, parcel-, ownership-, irrigation-, or private-party adjacency;
+- NASS-confidential or source-restricted detail;
+- unsupported spatial, temporal, or attribute precision;
+- missing EvidenceRef/EvidenceBundle support;
+- missing validation report;
+- missing required aggregation, redaction, transform, or review receipt;
+- candidate, quarantine, superseded, withdrawn, stale, or rollback-blocked state;
+- missing correction path or rollback target;
+- missing or mismatched policy bundle identity;
+- evaluator failure, input-contract failure, or obligation-handler failure;
+- untested policy change.
+
+### Anti-collapse rules
+
+Agriculture policy must not collapse:
+
+- aggregate statistics into field-level truth;
+- remotely sensed or modeled context into observed truth;
+- a schema-valid object into an allowed object;
+- a validator pass into a PolicyDecision;
+- a PolicyDecision into evidence or release approval;
+- an AggregationReceipt into proof;
+- a public-safe transform into permission for the source detail;
+- a reviewer-only object into a public object;
+- one source's permissive license into permission for a restricted join;
+- a green readiness workflow into runtime enforcement;
+- generated prose into policy authority.
+
+[Back to top](#top)
+
+---
+
+## Policy family map
+
+| Family | Policy question | Default posture | Candidate outputs |
+|---|---|---|---|
+| `source_admission` | May this source/object enter the Agriculture lane for this use? | Hold or deny if role, rights, provenance, or terms are unresolved. | Deny/abstain/hold with safe reason. |
+| `sensitivity` | May this object be exposed at the requested precision and audience? | Most restrictive row wins; exact private detail denied. | Deny/restrict/review obligations. |
+| `rights` | Do source terms permit processing, derivation, display, export, and retention? | Hold or deny when unclear. | Rights review, attribution, no-export, or deny. |
+| `aggregation` | Is the product sufficiently aggregated and resistant to reconstruction? | No numeric threshold is assumed; hold until an accepted profile applies. | Aggregate, suppress, generalize, delay, or deny. |
+| `redaction` | Which fields, geometries, attributes, labels, or citations must be withheld? | Redact only under an accepted profile with receipt. | Redaction/generalization obligations. |
+| `cross_lane_join` | Does a join increase identifiability or authority beyond either input? | Most restrictive input and derived-risk row wins. | Deny, review, de-identify, aggregate, or abstain. |
+| `promotion` | May a candidate cross a lifecycle gate? | Hold without evidence, validation, receipts, policy, review, and rollback support. | Gate denial or bounded readiness. |
+| `runtime_access` | May a governed caller answer, render, export, or compare this material? | Abstain/deny on unresolved evidence/policy/release state. | Canonical PolicyDecision plus obligations. |
+| `release` | May a released public state transition be requested? | Policy may recommend/deny; `release/` remains the authority. | Policy input to release review. |
+| `correction_rollback` | What must happen when source, rights, policy, or release state changes? | Re-evaluate affected outputs; fail closed during uncertainty. | Correct, supersede, withdraw, or rollback request. |
+
+These family names are documentation vocabulary until a contract/schema/bundle makes them normative.
+
+[Back to top](#top)
+
+---
+
+## Minimum policy input contract
+
+A consequential Agriculture decision should receive one immutable, explicit `PolicyInputBundle` or equivalent bounded input. It should not fetch hidden facts during evaluation.
+
+| Input group | Minimum content | Failure posture |
 |---|---|---|
-| Sensitivity | Can this Agriculture object be exposed at the requested precision? | Deny exact sensitive exposure; allow only reviewed transforms |
-| Rights | Does source/license posture permit use and display? | Hold or deny when rights are unclear |
-| Promotion | Can candidate Agriculture data cross a lifecycle gate? | Hold without validation, receipts, and steward review |
-| Runtime | Can a governed runtime answer or render from this material? | Abstain when evidence or policy support is unresolved |
-| Release | Can public-safe materialization proceed? | Requires release authority and rollback target |
-| Redaction / aggregation | Which transform is required before exposure? | Preserve obligations and receipts |
+| Decision identity | request id, policy family, operation, caller/audience, evaluation time | `ERROR` or `ABSTAIN` if missing |
+| Policy identity | bundle id, version, digest, evaluator profile, input-contract version | `ERROR` / `HOLD` on mismatch |
+| Object identity | object id/family, domain, source version, candidate/release refs | `ABSTAIN` if unresolved |
+| Source context | source id, role, authority class, rights/terms, citation obligations | `HOLD` / `DENY` |
+| Spatial context | geometry class, precision, support unit, public/generalized geometry ref | `RESTRICT` / `DENY` |
+| Temporal context | valid/source/observed/retrieval/release/correction times as material | `ABSTAIN` / stale restriction |
+| Sensitivity context | tier, privacy/re-identification flags, restricted joins, audience | Most restrictive row |
+| Evidence context | EvidenceRef resolution, EvidenceBundle/review/proof status | `ABSTAIN` / `DENY` |
+| Validation context | schema, semantic, geometry, source-role, cross-lane validation status | `HOLD` / `ERROR` |
+| Transform context | aggregation/redaction/generalization profile and receipt refs | `HOLD` / `DENY` |
+| Lifecycle context | RAW/WORK/QUARANTINE/PROCESSED/CATALOG/PUBLISHED state and candidate status | Public access denied before release |
+| Release context | release id/state, policy/review refs, correction path, rollback target | `HOLD` / `DENY` |
+| Prior decision context | superseded decisions, overrides, expiry, correction refs | Re-evaluate or hold |
 
-## 8. Diagram
+### Input invariants
+
+- Inputs must be sufficient to replay the decision without live source access.
+- Policy must not dereference private payloads merely to decide public exposure.
+- Absence of a fact must not be treated as a permissive fact.
+- Derived join risk must be represented explicitly.
+- Overrides must be scoped, attributable, reviewable, expiring where appropriate, and separately auditable.
+- The bundle digest and evaluator profile must be pinned for consequential decisions.
+
+[Back to top](#top)
+
+---
+
+## Decision vocabulary and normalization
+
+Current repository surfaces use more than one vocabulary:
+
+- the current shared `PolicyDecision` schema permits `ANSWER`, `ABSTAIN`, `DENY`, and `ERROR`;
+- Agriculture documentation also uses `ALLOW`, `RESTRICT`, and `HOLD`;
+- Rego scaffolds expose `allow` or `deny` booleans/sets;
+- `abstain_on_ambiguous.rego` currently exposes a `deny` relation rather than an abstain relation.
+
+This is **CONFLICTED** and must be normalized before runtime adoption.
+
+### Recommended separation
+
+| Layer | Purpose | Example vocabulary |
+|---|---|---|
+| Engine-native result | Internal evaluator output | `allow`, `deny`, `restrict`, `hold`, `abstain`, engine error |
+| Canonical policy result | Stable cross-system envelope | Accepted `PolicyDecision` outcome enum |
+| Obligations | Required downstream transforms/actions | aggregate, redact, generalize, review, no-export, cite, rollback |
+| Runtime response | User-facing finite outcome | ANSWER, ABSTAIN, DENY, ERROR or accepted equivalent |
+| Release decision | Publication state transition | separately governed promotion/release outcome |
+
+### Documentation mapping—non-normative
+
+| Agriculture intent | Canonical meaning | Typical obligations |
+|---|---|---|
+| `ALLOW` | Policy has no blocking rule for the declared operation; adjacent gates still apply. | citation, audit, release checks |
+| `RESTRICT` | Operation may proceed only under explicit constraints. | aggregate, redact, generalize, audience restrict, no export |
+| `HOLD` | Required human/release/evidence/right/sensitivity state is pending. | review, delayed evaluation, no public surface |
+| `ABSTAIN` | Policy lacks sufficient governed context to decide. | retrieve/resolve context; do not guess |
+| `DENY` | Policy blocks the requested operation/exposure. | no public output; safe reason only |
+| `ERROR` | Evaluation could not complete safely. | fail closed; emit diagnostic without protected data |
+
+This README does not amend the machine enum. An accepted contract/ADR must do that.
+
+### Reason-code requirements
+
+Reason codes should be:
+
+- stable and machine-readable;
+- safe to expose at the intended audience;
+- specific enough for remediation;
+- free of protected payload data;
+- versioned or registry-bound;
+- paired with obligations where applicable.
+
+Candidate Agriculture reason families include:
+
+- `object_context_unresolved`;
+- `source_role_unresolved`;
+- `rights_unresolved`;
+- `source_terms_restrict_use`;
+- `sensitivity_unresolved`;
+- `field_level_public_denied`;
+- `farm_operator_join_denied`;
+- `private_parcel_adjacency`;
+- `restricted_source_detail`;
+- `evidence_unresolved`;
+- `validation_incomplete`;
+- `aggregation_profile_missing`;
+- `redaction_profile_missing`;
+- `small_cell_or_reconstruction_risk`;
+- `unpublished_or_candidate_only`;
+- `release_state_invalid`;
+- `rollback_target_missing`;
+- `policy_bundle_mismatch`;
+- `evaluator_unavailable`.
+
+These are `PROPOSED` until a shared registry is accepted.
+
+[Back to top](#top)
+
+---
+
+## Obligation families
+
+| Obligation | Required downstream behavior |
+|---|---|
+| `aggregate_required` | Use only an accepted aggregate profile and record the method/profile. |
+| `small_cell_suppression_required` | Suppress unsafe cells and apply complementary suppression where needed. |
+| `redaction_required` | Remove protected fields/geometry/labels under a reviewed profile. |
+| `generalization_required` | Reduce spatial, temporal, or attribute precision. |
+| `source_role_badge_required` | Preserve observed/modeled/aggregate/context/restricted character. |
+| `citation_required` | Preserve safe source and evidence citations. |
+| `rights_review_required` | Route unclear or restrictive source use to a rights reviewer. |
+| `sensitivity_review_required` | Route exact, joined, or reconstruction-prone output to sensitivity/privacy review. |
+| `human_review_required` | Require an independently recorded review before the next governed transition. |
+| `aggregation_receipt_required` | Emit a receipt recording method, profile, inputs, digest, and affected outputs. |
+| `redaction_receipt_required` | Record what transform class was applied and why without leaking protected detail. |
+| `no_public_render` | Block public API/UI/map/tile/report/export/AI surfaces. |
+| `no_export` | Permit bounded in-app review but deny download or external dissemination. |
+| `audience_restriction_required` | Restrict to named reviewer/research/steward roles. |
+| `delay_required` | Delay exposure until time/source/sensitivity conditions are satisfied. |
+| `correction_path_required` | Link a correction/supersession process before exposure. |
+| `rollback_required` | Require a prior known-good target and tested rollback route. |
+| `audit_receipt_required` | Record policy bundle/input/decision identity for replay. |
+
+Downstream systems must reject obligations they cannot enforce. Silently dropping an obligation is a policy failure.
+
+[Back to top](#top)
+
+---
+
+## Confirmed policy inventory
+
+### Direct rule/source surfaces
+
+| Path | Package / form | Current default | Current maturity | Activation posture |
+|---|---|---:|---|---|
+| [`deny_unpublished.rego`](deny_unpublished.rego) | `kfm.agriculture_deny_unpublished` | `deny := false` | Commented example only | **DENY activation** |
+| [`abstain_on_ambiguous.rego`](abstain_on_ambiguous.rego) | `kfm.agriculture_abstain_on_ambiguous` | `deny := false` | No abstain relation; commented deny example | **DENY activation** |
+| [`deny-field-level.rego`](deny-field-level.rego) | `kfm.generated.policy.domains.agriculture.deny_field_level` | `allow := false` | Generated scaffold only | **DENY activation** |
+| [`redaction_profiles.yaml`](redaction_profiles.yaml) | Placeholder YAML | none | No profile values | **DENY activation** |
+| [`aggregation_thresholds/README.md`](aggregation_thresholds/README.md) | Human-readable child policy contract | none | Documentation only; no numeric thresholds | Not executable |
+
+### Cross-cutting sensitivity surfaces
+
+| Path | Package / form | Current default | Current maturity | Conflict |
+|---|---|---:|---|---|
+| [`../../sensitivity/agriculture/aggregation_thresholds.yaml`](../../sensitivity/agriculture/aggregation_thresholds.yaml) | Placeholder YAML | none | No threshold values | Overlaps child sublane |
+| [`../../sensitivity/agriculture/farm_operator_join.rego`](../../sensitivity/agriculture/farm_operator_join.rego) | generated sensitivity package | `allow := false` | Scaffold only | Separate namespace/root |
+
+### Activation preconditions
+
+No Agriculture policy source should be activated until:
+
+- a canonical package namespace is accepted;
+- default-result semantics are harmonized;
+- input and decision contracts are accepted;
+- a bundle/manifest includes the exact sources and digest;
+- a reviewed evaluator profile exists;
+- all rules have deterministic positive and negative fixtures;
+- engine-native results normalize to the canonical PolicyDecision;
+- obligations have tested handlers;
+- reason codes are registry-bound;
+- no-network and failure tests pass;
+- public-surface denial tests pass;
+- policy change correction and rollback are tested;
+- owners and independent reviewers approve.
+
+[Back to top](#top)
+
+---
+
+## Agriculture policy flow
 
 ```mermaid
 flowchart TD
-    req["Agriculture operation"] --> obj{"Object family + source role known?"}
-    obj -->|no| abstain["ABSTAIN / HOLD"]
-    obj -->|yes| exposure{"Exact field / operator / parcel-adjacent exposure?"}
-    exposure -->|yes| transform{"Aggregation / redaction / review receipt?"}
-    exposure -->|no| rights{"Rights and evidence resolved?"}
-    transform -->|no| deny["DENY exact exposure"]
-    transform -->|yes| rights
-    rights -->|no| hold["HOLD / ABSTAIN"]
-    rights -->|yes| release{"Lifecycle + release state valid?"}
-    release -->|no| hold2["HOLD"]
-    release -->|yes| allow["ALLOW or RESTRICT with obligations"]
-
-    allow --> audit["PolicyDecision metadata"]
-    deny --> audit
-    hold --> audit
-    hold2 --> audit
-    abstain --> audit
+    R["Agriculture request"] --> I{"Complete immutable policy input?"}
+    I -->|no| A["ABSTAIN / ERROR<br/>fail closed"]
+    I -->|yes| B{"Accepted bundle + evaluator match?"}
+    B -->|no| H["HOLD / ERROR"]
+    B -->|yes| S{"Source role, rights, sensitivity resolved?"}
+    S -->|no| D["DENY / HOLD / ABSTAIN"]
+    S -->|yes| X{"Exact field, operator, parcel, restricted join, or reconstruction risk?"}
+    X -->|yes| T{"Reviewed transform + receipt + audience restriction?"}
+    T -->|no| D
+    T -->|yes| E{"Evidence + validation + lifecycle support?"}
+    X -->|no| E
+    E -->|no| A
+    E -->|yes| P{"Released state + correction + rollback valid?"}
+    P -->|no| H
+    P -->|yes| C["Canonical PolicyDecision"]
+    C --> O["Obligations"]
+    O --> G{"Caller can enforce every obligation?"}
+    G -->|no| D
+    G -->|yes| U["Bounded governed operation"]
+    U --> Q["Decision/audit receipt"]
 ```
 
-## 9. Decision vocabulary
+The flow produces a bounded policy result. It does not publish data, create evidence, or approve release.
 
-| Decision | Meaning | Required behavior |
+[Back to top](#top)
+
+---
+
+## Cross-lane composition
+
+Agriculture frequently composes with other domains. The join is a new risk-bearing operation, not a neutral lookup.
+
+| Related lane | Common relation | Primary risk | Default composition rule |
+|---|---|---|---|
+| People / Land | operator, owner, parcel, residence, title, private party | re-identification and living-person/private-land exposure | Exact joins denied for public use; most restrictive row wins. |
+| Hydrology | irrigation well, withdrawal, drought, watershed | private well-to-field/operator linkage; source-role collapse | Generalize/de-identify; retain hydrology authority and policy. |
+| Soil | map unit, suitability, moisture | modeled suitability presented as field fact | Preserve soil/source role; do not infer operator condition. |
+| Atmosphere | weather, smoke, drought, stress | modeled/forecast context presented as observed field impact | Label model/context; abstain from unsupported causal claims. |
+| Habitat / Flora / Fauna | habitat, wetlands, rare species/plants | sensitive biological locations exposed via farm/field joins | Apply biological geoprivacy and Agriculture restrictions together. |
+| Infrastructure | storage, processing, energy, transport | critical facility or private business exposure | Restrict/generalize according to infrastructure and rights policy. |
+| Hazards | flood, fire, drought, storm | operational advice or precise private impact inference | KFM is not an alert authority; preserve official-source context. |
+| Geology | groundwater/resource/parent material | unsupported causality or private extraction linkage | Preserve geology authority; require evidence for derived claims. |
+
+### Composition invariants
+
+- The join may be more sensitive than either input.
+- Aggregation on one side does not make exact detail on the other side safe.
+- Source role and valid time remain attached to each contributing record.
+- Policy decisions should cite all controlling policies or a composed bundle identity.
+- A downstream transform must not reverse an upstream redaction.
+- Public clients receive only released, obligation-compliant derivatives.
+- AI may explain a resolved decision; it cannot relax it.
+
+[Back to top](#top)
+
+---
+
+## Public-surface contract
+
+Agriculture policy decisions may affect:
+
+- governed API responses;
+- MapLibre layers and feature details;
+- Evidence Drawer payloads;
+- Focus Mode answers;
+- compare views;
+- exports and reports;
+- stories and screenshots;
+- graph/search/vector retrieval;
+- AI-generated summaries.
+
+Every caller must:
+
+1. validate the PolicyDecision shape and bundle identity;
+2. preserve the outcome, reasons, obligations, audience, scope, and expiry;
+3. verify required evidence/release references;
+4. enforce every obligation before rendering or exporting;
+5. avoid leaking protected data in denial/error messages;
+6. prevent recombination/reconstruction across layers, times, or exports;
+7. record correction/withdrawal/rollback state;
+8. fail closed if the policy service, bundle, or obligation handler is unavailable.
+
+### Forbidden shortcuts
+
+- UI loads policy files directly.
+- Client chooses a more permissive bundle.
+- API treats missing policy as allow.
+- Map tile exposure bypasses feature-level obligations.
+- Export removes redaction/audience metadata.
+- AI receives restricted source detail to decide whether it should be restricted.
+- A receipt or validator result is treated as release approval.
+- A cached prior allow decision survives a policy, rights, source, or release change without re-evaluation.
+
+[Back to top](#top)
+
+---
+
+## Validation, tests, and CI
+
+### Required test families
+
+| Family | Minimum negative case | Minimum positive/control case |
 |---|---|---|
-| `ALLOW` | Operation may proceed under supplied Agriculture context | Scope to object, source, precision, audience, and version |
-| `DENY` | Policy blocks exact exposure or unsafe action | Return safe reason code and do not expose protected detail |
-| `RESTRICT` | Operation may proceed with aggregation, redaction, generalization, audience restriction, delay, or review | Preserve obligations downstream |
-| `HOLD` | Steward review, validation, receipt, proof, or release gate is pending | Do not promote or render publicly |
-| `ABSTAIN` | Evidence, source, rights, or policy support is unresolved | Preserve unresolved handles where safe |
-| `ERROR` | Policy machinery, schema, runtime, or repository support failed | Fail closed and record failure |
+| Policy input | missing source role/evidence/release context fails closed | complete synthetic bundle evaluates deterministically |
+| Unpublished | candidate/quarantine material denied from public path | released safe fixture passes adjacent gate checks |
+| Ambiguity | conflicting source role or missing context abstains/holds | resolved context normalizes correctly |
+| Field precision | exact field/operator/parcel request denied | accepted generalized derivative carries obligations |
+| Farm/operator join | identifiable private join denied | synthetic de-identified reviewer case remains restricted |
+| Rights | unclear or restrictive terms hold/deny | explicit permitted use preserves attribution obligations |
+| Aggregation | missing profile or reconstruction risk blocks release | accepted synthetic profile produces receipt requirement |
+| Redaction | missing profile/receipt blocks output | redacted fixture cannot reconstruct protected fields |
+| Cross-lane | most restrictive policy is inherited | safe bounded join preserves both source roles |
+| Lifecycle | RAW/WORK/QUARANTINE/candidate cannot serve publicly | released fixture includes correction/rollback refs |
+| Bundle integrity | digest/version/evaluator mismatch errors | pinned bundle/input replays same result |
+| Obligation handling | unsupported obligation blocks caller | caller proves every obligation applied |
+| Error safety | evaluator failure leaks no protected input | safe diagnostic emitted |
+| Correction/rollback | withdrawn policy/output no longer answers | prior known-good release can be restored |
 
-## 10. Agriculture obligations
+### Confirmed current limitations
 
-| Obligation | Example effect |
-|---|---|
-| `aggregate_required` | Publish county/region/authorized aggregate, not operator or field detail |
-| `redaction_required` | Withhold operator, private parcel-adjacent, or restricted source detail |
-| `generalization_required` | Reduce spatial or attribute precision |
-| `rights_review_required` | Route unclear or restricted source material to rights review |
-| `sensitivity_review_required` | Route exact or joined Agriculture material to sensitivity review |
-| `receipt_required` | Require AggregationReceipt, RedactionReceipt, TransformReceipt, or equivalent |
-| `citation_required` | Preserve safe source/evidence citation where display is allowed |
-| `rollback_required` | Require rollback target before public-impacting release |
+- No Rego test modules are confirmed.
+- `policy-test.yml` is a readiness/drift guard and emits no PolicyDecision.
+- The Agriculture policy-deny and aggregate-only child lanes are README-led.
+- `test_nass_aggregate_only.py` contains no assertion.
+- No accepted Agriculture evaluator or bundle selection is confirmed.
+- No Agriculture validator executable is confirmed in the direct validator lane.
+- No current run proves Agriculture policy enforcement.
 
-## 11. Child-file contract
+### Local-parity target—PROPOSED
 
-Future files under this lane should state:
+A future accepted command should be narrow and deterministic, for example:
 
-- policy family and Agriculture object families covered
-- inputs and required context
-- finite outcomes
-- obligations and reason codes
-- rights and sensitivity assumptions
-- required receipts and review records
-- fixtures and tests
-- rollback and correction expectations
-- links to `docs/domains/agriculture/POLICY.md` and `SENSITIVITY.md`
-
-## 12. Inspection path
-
-Concrete Agriculture policy files, bundles, fixtures, tests, validators, and CI remain `NEEDS VERIFICATION`.
-
-```bash
-find policy/domains/agriculture -maxdepth 4 -type f | sort
-find docs/domains/agriculture contracts/domains/agriculture schemas/contracts/v1/domains/agriculture -maxdepth 4 -type f 2>/dev/null | sort
-find tests/domains/agriculture fixtures/domains/agriculture -maxdepth 5 -type f 2>/dev/null | sort
+```text
+make policy-agriculture-test
 ```
 
-## 13. Validation expectations
+The command name is `PROPOSED`. It should:
 
-Useful validation for this lane should cover:
+- run no-network by default;
+- validate policy source and bundle manifest;
+- execute engine-native tests;
+- validate normalized PolicyDecision outputs;
+- exercise synthetic valid and invalid fixtures;
+- verify obligation handlers;
+- produce machine-readable test reports;
+- avoid emitting protected payloads;
+- return non-zero on missing coverage or unsafe defaults.
 
-- field/operator exact exposure without transform returns `DENY`
-- unresolved source role returns `ABSTAIN` or `HOLD`
-- unclear rights returns `HOLD` or `DENY`
-- missing EvidenceBundle support returns `ABSTAIN`
-- missing aggregation/redaction receipt blocks promotion
-- cross-lane joins inherit the most restrictive policy row
-- public renders use governed APIs and released/public-safe artifacts only
-- policy decisions emit stable safe reason codes and receipt-ready metadata
+[Back to top](#top)
 
-## 14. Definition of done
+---
 
-- [ ] Owners are confirmed and `OWNER_TBD` is replaced.
-- [ ] Agriculture policy files and bundle structure are inventoried.
-- [ ] Runtime policy language and bundle location are confirmed.
-- [ ] Fixtures cover allow, deny, restrict, hold, abstain, and error outcomes.
-- [ ] Rights, sensitivity, aggregation, redaction, and release obligations are tested.
-- [ ] Cross-lane join policy is linked or implemented.
-- [ ] Receipt requirements are linked to accepted schemas or contracts.
-- [ ] Public API bypass checks are covered by tests or policy fixtures.
-- [ ] Release and rollback requirements remain separate from policy allow decisions.
+## Security, privacy, and log minimization
 
-## 15. Open verification items
+Policy evaluation and testing must not log or return:
+
+- operator or living-person identifiers;
+- exact private parcel geometry;
+- proprietary yield or production values;
+- pesticide/application detail;
+- restricted well-to-field/operator joins;
+- restricted source payloads;
+- secrets, tokens, private endpoints, or agreement terms;
+- exact sensitive biological/cultural/infrastructure joins;
+- hidden policy data that would enable bypass or reconstruction.
+
+Safe outputs should prefer:
+
+- stable decision id;
+- outcome;
+- bounded reason code;
+- obligations;
+- policy bundle id/version/digest;
+- input digest rather than payload;
+- source/evidence/release references safe for the audience;
+- reviewer and correction references where authorized.
+
+A denial that leaks the protected fact is a policy failure.
+
+[Back to top](#top)
+
+---
+
+## Review burden and separation of duties
+
+Changes to Agriculture policy are trust-bearing even when syntactically small.
+
+| Change | Required review roles |
+|---|---|
+| Documentation-only boundary/index change | Agriculture steward + policy/docs review |
+| Rego/YAML policy logic or value | Agriculture + policy + sensitivity/rights + test/validator review |
+| Field/operator/parcel or private join rule | Privacy/sensitivity + People/Land + Agriculture review |
+| Source-specific terms | Rights/source steward + Agriculture review |
+| Aggregation/redaction profile | Privacy/sensitivity + policy + transform/receipt + Agriculture review |
+| Policy input/decision schema | Contract/schema + runtime + policy + affected caller review |
+| Bundle/evaluator/selection change | Policy-runtime + security + supply-chain + policy review |
+| Release-affecting change | Release steward + independent policy reviewer + rollback owner |
+| Public API/UI/map/AI obligation behavior | Governed API/UI/AI owner + policy + security review |
+
+### Separation rules
+
+- Policy author must not be the sole approver for a policy-significant release.
+- Validation success is separate from policy approval.
+- Policy approval is separate from release approval.
+- Release approval is separate from publication execution.
+- Correction, withdrawal, and rollback remain independently authorized.
+- Emergency override, if ever supported, must be scoped, expiring, signed, and auditable.
+
+[Back to top](#top)
+
+---
+
+## Child-file contract
+
+Every child README or policy file under this lane should state:
+
+- purpose and policy family;
+- authority and non-authority;
+- current implementation status;
+- package/module identity;
+- input contract and version;
+- output/normalization contract;
+- default behavior;
+- reason codes and obligations;
+- source-role, rights, sensitivity, evidence, validation, lifecycle, and release inputs;
+- tests, fixtures, and no-network posture;
+- bundle/manifest inclusion;
+- public-surface implications;
+- review roles;
+- correction, supersession, withdrawal, rollback, and deprecation path;
+- open conflicts and verification items.
+
+A child must not claim a threshold, policy value, or enforcement path solely because a planning document named it.
+
+[Back to top](#top)
+
+---
+
+## Related folders
+
+| Path | Relationship |
+|---|---|
+| [`policy/`](../../README.md) | Canonical singular policy root; current root README remains a short proposed scaffold. |
+| [`policy/domains/`](../README.md) | Parent domain-policy grouping. |
+| [`aggregation_thresholds/`](aggregation_thresholds/README.md) | Aggregation/disclosure-control documentation; no numeric thresholds or enforcement. |
+| [`policy/sensitivity/`](../../sensitivity/README.md) | Cross-cutting sensitivity policy lane; current parent README is a greenfield stub. |
+| [`policy/bundles/`](../../bundles/README.md) | Future immutable bundle/manifest boundary; no accepted bundle instance confirmed. |
+| [`docs/domains/agriculture/POLICY.md`](../../../docs/domains/agriculture/POLICY.md) | Agriculture policy intent. |
+| [`docs/domains/agriculture/SENSITIVITY.md`](../../../docs/domains/agriculture/SENSITIVITY.md) | Sensitivity, rights, and public-release posture. |
+| [`docs/domains/agriculture/policy/README.md`](../../../docs/domains/agriculture/policy/README.md) | Human-facing policy aspect index; contains older proposed-path assumptions that need periodic reconciliation. |
+| [`contracts/policy/`](../../../contracts/policy/) | Shared policy input/decision meaning. |
+| [`schemas/contracts/v1/policy/`](../../../schemas/contracts/v1/policy/) | Shared policy input/decision shapes. |
+| [`contracts/domains/agriculture/`](../../../contracts/domains/agriculture/) | Agriculture object and receipt meaning. |
+| [`schemas/contracts/v1/domains/agriculture/`](../../../schemas/contracts/v1/domains/agriculture/) | Agriculture machine-shape scaffolds. |
+| [`fixtures/domains/agriculture/`](../../../fixtures/domains/agriculture/) | Synthetic Agriculture inputs. |
+| [`tests/domains/agriculture/policy_deny/`](../../../tests/domains/agriculture/policy_deny/README.md) | Negative policy test contract; README-only in bounded evidence. |
+| [`tests/domains/agriculture/aggregate_only/`](../../../tests/domains/agriculture/aggregate_only/README.md) | Aggregate-preservation test contract; README-only in bounded evidence. |
+| [`tools/validators/agriculture/`](../../../tools/validators/agriculture/README.md) | Agriculture validation profile; no direct executable established. |
+| [`packages/policy-runtime/`](../../../packages/policy-runtime/README.md) | Proposed evaluator/helper boundary; current core is a placeholder. |
+| [`data/receipts/aggregation/`](../../../data/receipts/aggregation/README.md) | Aggregation process-memory boundary; receipt subroot authority remains unresolved. |
+| [`release/agriculture/`](../../../release/agriculture/README.md) | Agriculture release/correction/rollback boundary. |
+| [`policy-test.yml`](../../../.github/workflows/policy-test.yml) | Policy readiness/drift guard; does not evaluate policy. |
+| [`domain-agriculture.yml`](../../../.github/workflows/domain-agriculture.yml) | Agriculture validation/proof/release readiness holds. |
+
+[Back to top](#top)
+
+---
+
+## ADRs and conflict register
+
+| Conflict / decision | Current status | Required resolution |
+|---|---|---|
+| Canonical singular `policy/` root | Repository-present; doctrine supports it | Preserve; do not create parallel `policies/`. |
+| Agriculture package namespace | `kfm.agriculture_*` and `kfm.generated.policy.domains.agriculture.*` coexist | Accept one namespace/versioning convention and migrate with tests. |
+| Default result semantics | `deny := false` versus `allow := false` | Define fail-closed engine contract and explicit system-error behavior. |
+| Ambiguity result | `abstain_on_ambiguous` currently defines a deny relation | Define canonical abstain/hold normalization. |
+| Domain policy vs sensitivity policy | Agriculture rules split across `policy/domains/` and `policy/sensitivity/` | Accept composition/ownership and bundle precedence. |
+| Aggregation threshold placement | Child README and separate sensitivity YAML overlap | Decide canonical source/value home without duplicating authority. |
+| Decision vocabulary | ALLOW/RESTRICT/HOLD intent versus ANSWER/ABSTAIN/DENY/ERROR schema | Accept normalized PolicyDecision contract or amend via ADR/schema migration. |
+| Bundle format and selection | No accepted manifest, bundle artifact, selector, or evaluator binding | Define deterministic bundle and activation contract. |
+| Reason/obligation registries | Documentation vocabularies only | Create shared contract/schema/registry and migration rules. |
+| Receipt layout | Domain AggregationReceipt versus broader receipt-family paths | Resolve through receipt-layout ADR/migration. |
+| Policy change effect on release | No confirmed correction cascade | Define re-evaluation, withdrawal, correction, and rollback triggers. |
+
+Do not resolve these conflicts by prose alone. Use an accepted ADR, contract/schema change, migration note, tests, and rollback plan as appropriate.
+
+[Back to top](#top)
+
+---
+
+## Smallest sound implementation sequence
+
+1. **Inventory and freeze the current source set.**
+   - byte-complete policy inventory;
+   - hashes, package names, owners, and stated status;
+   - no activation.
+
+2. **Accept shared input and decision contracts.**
+   - immutable PolicyInputBundle;
+   - canonical PolicyDecision;
+   - reason and obligation registries;
+   - explicit normalization from engine-native results.
+
+3. **Resolve namespace and placement conflicts.**
+   - domain versus sensitivity composition;
+   - package naming;
+   - aggregation/redaction profile ownership;
+   - receipt linkage.
+
+4. **Define deterministic synthetic fixtures.**
+   - public aggregate;
+   - exact field attempt;
+   - farm/operator join;
+   - rights unclear;
+   - evidence unresolved;
+   - unpublished candidate;
+   - valid transformed reviewer case;
+   - evaluator/bundle mismatch.
+
+5. **Implement fail-closed rules and native tests.**
+   - no hidden fetches;
+   - safe diagnostics;
+   - explicit defaults;
+   - complete negative coverage.
+
+6. **Build and validate one immutable bundle.**
+   - manifest, digest, dependency lock;
+   - evaluator profile;
+   - test receipt;
+   - human review;
+   - no deployment yet.
+
+7. **Implement runtime adapter and obligation handlers.**
+   - validate input/output;
+   - reject unknown obligations;
+   - emit replay/audit record;
+   - no public caller yet.
+
+8. **Prove public-boundary denial and safe narrow success.**
+   - governed API tests;
+   - UI/map/export/AI obligation tests;
+   - reconstruction and differencing tests.
+
+9. **Integrate with release dry-run.**
+   - evidence, validation, rights, policy, review, correction, rollback;
+   - independent release review;
+   - no automatic publication.
+
+10. **Run correction and rollback drill before activation.**
+
+Each step should be independently reviewable and reversible.
+
+[Back to top](#top)
+
+---
+
+## Definition of done
+
+This Agriculture policy lane is not implementation-complete until:
+
+- [ ] owners and independent reviewers are confirmed;
+- [ ] byte-complete source inventory is recorded;
+- [ ] package namespace and placement conflicts are resolved;
+- [ ] default behavior is explicitly fail-closed and tested;
+- [ ] PolicyInputBundle and PolicyDecision contracts/schemas are accepted;
+- [ ] engine-native results normalize deterministically;
+- [ ] reason-code and obligation registries are accepted;
+- [ ] source-role, rights, sensitivity, evidence, validation, lifecycle, and release inputs are mandatory where material;
+- [ ] aggregation/redaction profiles are reviewed and versioned;
+- [ ] no numeric threshold is invented or exposed without authority;
+- [ ] deterministic valid and invalid fixtures exist;
+- [ ] Rego/equivalent native tests exist;
+- [ ] Agriculture policy-deny and aggregate-only executable tests exist;
+- [ ] bundle manifest, digest, dependency lock, and evaluator profile are accepted;
+- [ ] policy runtime is implemented and tested;
+- [ ] obligation handlers fail closed on unsupported obligations;
+- [ ] public API/UI/map/export/AI tests prevent bypass and reconstruction;
+- [ ] policy decisions emit auditable, replayable records;
+- [ ] release integration preserves separation of duties;
+- [ ] correction, withdrawal, supersession, and rollback are tested;
+- [ ] CI runs real commands rather than only readiness holds;
+- [ ] branch-protection/check significance is documented;
+- [ ] documentation and generated receipts are synchronized.
+
+[Back to top](#top)
+
+---
+
+## Open verification register
 
 | Item | Why it matters |
 |---|---|
-| Confirm actual child files under `policy/domains/agriculture/` | Prevents stale stub claims |
-| Confirm Rego/OPA or equivalent policy language | Prevents non-runnable guidance |
-| Confirm policy bundle manifest path | Required for runtime use |
-| Confirm tests and fixtures | Required before enforcement claims |
-| Confirm Agriculture object-family register | Required for object-specific gates |
-| Confirm aggregation/redaction receipt schemas | Required for public-safe transforms |
-| Confirm cross-lane join composition | Prevents private parcel/operator leakage |
-| Confirm release-gate integration | Required before publication claims |
+| Byte-complete Agriculture policy inventory | Bounded search is not a full checkout proof. |
+| Owner and CODEOWNERS enforcement | Trust-bearing changes need accountable review. |
+| Accepted Rego/equivalent namespace | Prevents parallel packages and ambiguous imports. |
+| Default semantics | Current stubs mix permissive-deny and restrictive-allow defaults. |
+| Canonical decision enum | Callers cannot safely consume conflicting vocabularies. |
+| PolicyInputBundle completeness | Hidden/missing facts can turn policy into guessing. |
+| Bundle format, manifest, digest, selector | File presence must not become activation. |
+| Evaluator implementation and version | Runtime behavior is currently unproved. |
+| Reason-code and obligation registries | Prevents caller-specific interpretation drift. |
+| Source-specific rights/confidentiality rules | Agriculture sources may differ materially. |
+| Aggregation/redaction authority and values | Prevents invented or inconsistent disclosure controls. |
+| Sensitive cross-lane join composition | Joins can create new re-identification risk. |
+| Deterministic fixture payloads | Required for no-network replay. |
+| Agriculture validator implementation | Needed for input/output/profile/receipt checks. |
+| Real policy test coverage | README contracts are not executable proof. |
+| Public caller obligation support | A decision is unsafe if obligations are ignored. |
+| Decision/audit receipt home | Needed for replay without collapsing receipt/proof/release. |
+| Release re-evaluation triggers | Policy/source/rights changes may invalidate published outputs. |
+| Correction and rollback automation | Required before policy activation affects public state. |
+| Current workflow run results and branch protection | Workflow files alone do not prove enforcement. |
 
-<details>
-<summary>Appendix A — no-loss preservation note</summary>
+[Back to top](#top)
 
-The previous file was a greenfield scaffold that over-broadened this directory by saying docs, contracts, schemas, fixtures, tests, packages, pipelines, registries, and data lifecycle artifacts could belong here. This README narrows the lane to Agriculture policy only and routes other materials back to their owning roots.
+---
 
-It preserves the Agriculture policy intent already documented in `docs/domains/agriculture/POLICY.md` while keeping executable policy, tests, fixtures, runtime enforcement, and CI status marked `NEEDS VERIFICATION`.
+## Maintenance, correction, and rollback
 
-</details>
+### Maintenance triggers
 
-## Status summary
+Review this README when:
 
-`policy/domains/agriculture/` should define Agriculture-specific admissibility policy only when it remains subordinate to Agriculture doctrine, contracts, schemas, lifecycle, evidence, release, correction, and rollback boundaries.
+- any file is added, removed, moved, or renamed under this lane;
+- a package namespace or decision enum changes;
+- a policy bundle/manifest/evaluator is accepted;
+- a reason or obligation registry lands;
+- an Agriculture policy test becomes executable;
+- aggregation/redaction values are accepted;
+- source terms or sensitivity posture change;
+- a public caller begins consuming Agriculture decisions;
+- a release, correction, withdrawal, or rollback path uses this policy.
 
-It should keep Agriculture policy fail-closed, reason-coded, obligation-preserving, fixture-tested, and routed through governed interfaces without becoming domain doctrine, schema authority, lifecycle storage, package code, pipeline code, or release authority.
+### Correction rule
+
+If this README overstates implementation:
+
+1. mark the affected claim `CONFLICTED` or `NEEDS VERIFICATION`;
+2. narrow or remove the claim;
+3. link the correcting evidence;
+4. update generated provenance;
+5. notify affected policy/runtime/release reviewers;
+6. re-evaluate any release that relied on the incorrect claim.
+
+### Rollback
+
+For this documentation revision:
+
+- restore prior blob `ba73c387e16f70895f32444e489d6d55dd577b75`;
+- remove the paired generated receipt if the change is reverted;
+- no policy source, data, runtime, release, deployment, or public state requires restoration.
+
+For future policy behavior changes:
+
+- roll back by accepted bundle/version/digest;
+- invalidate or supersede affected decisions;
+- block new public use during uncertainty;
+- correct, withdraw, or roll back affected releases through `release/`;
+- preserve prior decision and receipt lineage.
+
+[Back to top](#top)
+
+---
+
+## Changelog
+
+| Date | Version | Change | Status |
+|---|---|---|---|
+| 2026-06-15 | v0.1 | Replaced a broad greenfield stub with a bounded Agriculture policy README. | Draft; implementation largely unverified. |
+| 2026-07-19 | v0.2 | Rebuilt the parent lane as a repository-grounded policy index; inventoried current Rego/YAML/child surfaces; surfaced namespace/default/output/placement conflicts; added input, decision, obligation, cross-lane, public-surface, test, review, implementation, correction, and rollback contracts. | Documentation update only; enforcement remains unimplemented. |
+
+[Back to top](#top)
+
+---
+
+## Evidence ledger
+
+| Evidence | Confirmed observation | Limitation |
+|---|---|---|
+| Prior parent README | Existing v0.1 boundary and intended Agriculture obligations | Predates detailed current inventory and workflow readiness changes. |
+| `deny_unpublished.rego` | Proposed stub with `default deny := false` | No active rule or test. |
+| `abstain_on_ambiguous.rego` | Proposed stub with `default deny := false` and deny example | No abstain result or test. |
+| `deny-field-level.rego` | Generated scaffold with `default allow := false` | No decision shape, reason, or test. |
+| `redaction_profiles.yaml` | Placeholder exists | No profile values. |
+| Aggregation-threshold child README | Detailed fail-closed disclosure-control contract | Documentation only; no accepted numeric threshold. |
+| Sensitivity Agriculture scaffolds | Placeholder threshold YAML and farm/operator default-deny scaffold | Separate placement/namespace remains unresolved. |
+| Agriculture policy/sensitivity docs | Deny-exact/private-join and most-restrictive-row doctrine | Draft doctrine; not runtime proof. |
+| Policy-deny/aggregate-only test READMEs | Comprehensive test expectations | README-only maturity; no lane-local executable proof. |
+| NASS aggregate placeholder test | Docstring only | No assertions. |
+| Agriculture validator README | Broad validation contract and conflicts | Direct lane remains README-only. |
+| `policy-test.yml` | Readiness/drift guard with explicit holds | Evaluates no policy and emits no PolicyDecision. |
+| `domain-agriculture.yml` | Agriculture readiness holds | No validation/proof/release authority. |
+| Policy runtime core | Comment-only placeholder | No evaluator. |
+| Policy bundle README | Bundle/manifest boundary documented | No accepted bundle artifact or active selection. |
+
+---
+
+KFM rule: Agriculture policy may decide only from explicit governed context, must fail closed when that context or enforcement path is incomplete, and must never let a scaffold, aggregation, receipt, validator, workflow, map, export, or AI answer substitute for evidence, rights, review, release, correction, or rollback.
 
 <p align="right"><a href="#top">Back to top</a></p>


### PR DESCRIPTION
## Goal:

Update `policy/domains/agriculture/README.md` into a repository-grounded v0.2 parent policy index without changing policy behavior or presenting scaffolds as active enforcement.

## Status labels:

- **CONFIRMED:** current Rego/YAML sources, aggregation-threshold child, sensitivity scaffolds, Agriculture doctrine, test/validator boundaries, policy runtime placeholder, bundle boundary, and readiness workflows were inspected.
- **PROPOSED:** parent policy architecture, normalized input/decision/obligation model, reason-code families, validation matrix, and implementation sequence.
- **CONFLICTED:** Rego defaults and namespaces, ambiguity output semantics, domain-vs-sensitivity placement, and engine-native vs shared `PolicyDecision` vocabulary.
- **UNKNOWN / NEEDS VERIFICATION:** accepted bundle/evaluator, executable tests, runtime enforcement, emitted decisions, public consumers, release integration, owners, and rollback drills.

## Evidence highlights:

| Surface | Confirmed state |
|---|---|
| `deny_unpublished.rego` | `PROPOSED` stub; `default deny := false`; no active rule |
| `abstain_on_ambiguous.rego` | `PROPOSED` stub; no abstain relation; commented deny example |
| `deny-field-level.rego` | generated scaffold; `default allow := false` |
| `redaction_profiles.yaml` | placeholder; no profile values |
| `aggregation_thresholds/README.md` | merged v0.2 documentation; no numeric thresholds |
| sensitivity Agriculture policy files | placeholder/scaffold, separate placement and namespace |
| policy-deny / aggregate-only tests | README-led; no established executable lane |
| `test_nass_aggregate_only.py` | docstring-only placeholder |
| Agriculture validator lane | README-only in direct bounded evidence |
| `policy-test.yml` | readiness/drift guard; evaluates no policy |
| `domain-agriculture.yml` | readiness holds; no policy/proof/release authority |
| policy runtime core | comment-only placeholder |
| policy bundles | README boundary; no accepted bundle or selector |

## Directory Rules basis:

- `policy/domains/agriculture/README.md` remains under the canonical singular `policy/` decision root.
- `data/receipts/generated/genrec-agriculture-policy-readme-f90f3e11.json` records AI provenance under the existing receipt lane.
- No path moved, no parallel authority home was created, and no ADR is activated by this documentation-only revision.

## What changed:

- Added a pinned evidence snapshot and direct/adjacent policy inventory.
- Added authority and anti-collapse boundaries, fail-closed defaults, policy-family map, minimum immutable input contract, decision normalization, reason-code and obligation families.
- Added cross-lane and public API/UI/map/export/AI constraints.
- Added test matrix, log minimization, review/separation duties, conflict register, reversible implementation sequence, definition of done, open verification, correction/rollback, changelog, and evidence ledger.
- Added the required generated receipt.

## What did not change:

No Rego/YAML rule, numeric threshold, bundle, evaluator, schema, contract, fixture, test, validator, workflow, receipt instance, release artifact, data object, deployment, or public behavior changed. No policy was evaluated and no `PolicyDecision`, release, or publication action was emitted.

## Validation:

- **PASS:** one H1, complete KFM Meta Block, remote beginning/end readback, direct inventory checks, and declared changed-path set.
- **PASS / bounded:** main advanced by three unrelated `apps/packages/README.md` and generated-receipt commits; no cited Agriculture policy path changed.
- **NOT RUN:** OPA tests, runtime evaluation, bundle validation, public obligation tests, and release/rollback drills because those implementation surfaces are not accepted.
- **NEEDS VERIFICATION:** exact remote SHA-256; GitHub returned blob `9fd3762577e6804ed69e6ac278cd3252a50bb75e`, while the receipt records the locally authored candidate hash and marks remote SHA-256 recomputation skipped.

## Rollback:

Restore prior target blob `ba73c387e16f70895f32444e489d6d55dd577b75` and remove the paired generated receipt, or close this PR. No policy source, value, data, runtime, release, deployment, or public state requires restoration.

## Open verification:

Package namespace/default semantics; canonical policy decision vocabulary; domain/sensitivity composition; aggregation/redaction authority; reason/obligation registries; bundle/evaluator/selector; deterministic fixtures and executable tests; validator/runtime integration; public obligation handlers; correction/withdrawal/rollback; branch protection and reviewers.

## GENERATED_RECEIPT:

`data/receipts/generated/genrec-agriculture-policy-readme-f90f3e11.json` — human review pending.

## Release posture:

No release or publication action. `CONTRACT_VERSION = "3.0.0"`.
