### PR TITLE
docs(release): ground source envelope in repository state

### DIFF
--- a/data/receipts/generated/genrec-packages-release-src-readme-c5b2eb1d.json
+++ b/data/receipts/generated/genrec-packages-release-src-readme-c5b2eb1d.json
@@ -1,0 +1,179 @@
+{
+  "receipt_id": "genrec-packages-release-src-readme-c5b2eb1d",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    "packages/release/src/README.md"
+  ],
+  "artifact_hashes": {
+    "packages/release/src/README.md": "sha256:c5b2eb1d581b3f55de28f351d873687a4c2586b167247954f1e9baf34d87855c"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "GPT-5.6 Thinking",
+    "version": "2026-07-19"
+  },
+  "prompt_or_contract": "sha256:39447e9d5b36b2a10df734d1367b9b980ee37edbd287395dc25df886a871f675",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "repository code search",
+      "repository file reads",
+      "remote branch and contents writes",
+      "local deterministic content validation"
+    ]
+  },
+  "inputs": {
+    "evidence_hashes": [
+      "sha256:39447e9d5b36b2a10df734d1367b9b980ee37edbd287395dc25df886a871f675"
+    ],
+    "attached_docs": [
+      "Current user request — update packages/release/src/README.md",
+      "Directory Rules.pdf",
+      "Kansas Frontier Matrix — AI Build Operating Contract.md"
+    ],
+    "evidence_refs": [
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/packages/release/src/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/packages/release/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/packages/release/pyproject.toml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/packages/release/src/release/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/packages/release/src/release/__init__.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/packages/release/src/release/core.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/docs/doctrine/directory-rules.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/release/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/contracts/release/release_manifest.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/schemas/contracts/v1/release/release_manifest.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/contracts/release/promotion_decision.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/schemas/contracts/v1/release/promotion_decision.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/tools/validators/release/validate_promotion_decision.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/tests/release/test_promotion_decision_schema.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/contracts/release/rollback_card.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/schemas/contracts/v1/release/rollback_card.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/tools/validators/validate_rollback_card.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/contracts/correction/correction_notice.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/schemas/contracts/v1/correction/correction_notice.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/docs/adr/ADR-0018-promotion-gate-sequence.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/docs/standards/SIGNING.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/.github/workflows/release-dry-run.yml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/10707dae52320dd453135e2840bdfd5917e46f46",
+      "attachment://Directory Rules.pdf",
+      "attachment://Kansas Frontier Matrix — AI Build Operating Contract.md"
+    ]
+  },
+  "truth_labels": {
+    "packages/release/src/README.md": "CONFIRMED"
+  },
+  "validation_gates": [
+    {
+      "gate": "task-contract-and-authority-preflight",
+      "outcome": "PASS",
+      "reason": "Repository, immutable base, target blob, existing source path, review-branch route, two-file change budget, and non-goals were resolved before mutation."
+    },
+    {
+      "gate": "directory-authority-and-duplicate-preflight",
+      "outcome": "PASS",
+      "reason": "Existing packages/release/src placement and document identity were retained. Directory Rules, package/source/namespace layers, release authority, open pull requests, and matching branches were checked; no parallel authority or ADR trigger was introduced."
+    },
+    {
+      "gate": "base-drift-reconciliation",
+      "outcome": "PASS",
+      "reason": "Main advanced to 7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd through an unrelated Agriculture pipeline README and generated receipt. The target blob remained 38f2122cec30f2194ccd5b8ffdcabdafeb52ab44."
+    },
+    {
+      "gate": "repository-inventory-and-no-overclaim",
+      "outcome": "PASS",
+      "reason": "Direct reads confirmed kfm-release version 0.0.0, incomplete package metadata, merged namespace README v1.1, empty __init__.py, and comment-only core.py. Bounded search established no functional namespace consumer import or package-local test reference."
+    },
+    {
+      "gate": "release-object-maturity-separation",
+      "outcome": "PASS",
+      "reason": "The README separates concrete PROPOSED PromotionDecision shape validation from thin ReleaseManifest, RollbackCard, and CorrectionNotice enforcement, absent or placeholder validators, proposed gate naming, draft signing, and explicit dry-run holds."
+    },
+    {
+      "gate": "source-contract-completeness",
+      "outcome": "PASS",
+      "reason": "The README defines source admission, allowed classes, explicit exclusions, object maturity, candidate/persistence boundaries, outcome separation, lifecycle, dependencies, effects, signing/key custody, replay, telemetry, consumers, tests, staged implementation, definition of done, verification, compatibility, correction, and rollback."
+    },
+    {
+      "gate": "markdown-meta-anchor-and-structure",
+      "outcome": "PASS",
+      "reason": "The final README has one H1, 63 headings with no hierarchy jumps or duplicate slugs, 58 resolved internal links, balanced code fences, no trailing whitespace, a parseable KFM Meta Block, and a final newline."
+    },
+    {
+      "gate": "repository-relative-reference-validation",
+      "outcome": "PASS",
+      "reason": "All twenty-nine repository-relative paths listed in the KFM Meta Block were verified in this session or directly inherited from commit-pinned repository evidence inspected in this conversation."
+    },
+    {
+      "gate": "security-privacy-signing-and-sensitive-content",
+      "outcome": "PASS",
+      "reason": "The change contains no credentials, private keys, protected data, release payloads, trust-artifact instances, or publication action; key custody and authoritative writes remain external."
+    },
+    {
+      "gate": "remote-readback-and-content-hash",
+      "outcome": "PASS",
+      "reason": "GitHub returned blob 8318fc5aeee6856391487a80c1e623a62e6fd510 on commit 10707dae52320dd453135e2840bdfd5917e46f46, matching the locally recomputed Git blob and SHA-256 artifact hash."
+    },
+    {
+      "gate": "multi-file-atomicity",
+      "outcome": "SKIPPED",
+      "reason": "The connector exposes serialized Contents API writes. README and receipt are written sequentially on a scoped review branch with remote read-back and final diff verification."
+    },
+    {
+      "gate": "repository-native-package-execution",
+      "outcome": "SKIPPED",
+      "reason": "The release package remains a greenfield placeholder and exposes no package-native implementation to execute. Pull-request workflows are observed separately."
+    },
+    {
+      "gate": "human-review",
+      "outcome": "SKIPPED",
+      "reason": "Human review remains pending and separate from generation, merge, signing, release, and publication."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "user-request",
+      "validated": true,
+      "evidence_ref": "conversation://current#update-packages-release-src-readme"
+    },
+    {
+      "id": "directory-rules-doctrine",
+      "validated": true,
+      "evidence_ref": "attachment://Directory Rules.pdf"
+    },
+    {
+      "id": "ai-build-operating-contract",
+      "validated": true,
+      "evidence_ref": "attachment://Kansas Frontier Matrix — AI Build Operating Contract.md"
+    },
+    {
+      "id": "release-source-baseline",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd/packages/release/src/README.md"
+    },
+    {
+      "id": "release-source-remote-readback",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/commit/10707dae52320dd453135e2840bdfd5917e46f46"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-19T12:16:40-05:00",
+  "emitter": "OpenAI GPT-5.6 Thinking via ChatGPT GitHub connector",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "Task kfm-packages-release-src-readme-v1-1-20260719. Documentation-only source-envelope revision. This receipt is provenance, not factual proof, policy approval, human review, signing authority, release approval, or publication authority."
+}

--- a/packages/release/src/README.md
+++ b/packages/release/src/README.md
@@ -1,327 +1,1135 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://doc/NEEDS-VERIFICATION/packages-release-src-readme
-title: Release Package Source README
+title: packages/release/src/ — Python Source Envelope and Governed Release-Candidate Boundary
 type: readme
-version: v1
+version: v1.1
+prior_version: v1
 status: draft
-owners: OWNER_TBD
-created: NEEDS VERIFICATION — target file existed before this repair but contained only placeholder text
-updated: 2026-06-15
-policy_label: public
-related: [packages/release/README.md, packages/hashing/README.md, packages/identity/README.md, packages/pipelines-core/README.md, packages/policy-runtime/README.md, packages/envelopes/README.md, packages/README.md, docs/doctrine/directory-rules.md, docs/architecture/release-model.md, docs/architecture/release-discipline.md, docs/architecture/publication/release-state-machine.md, docs/architecture/publication/release-objects.md, docs/architecture/publication/RELEASE_GATES.md, docs/architecture/publication/rollback-and-correction.md, docs/standards/RELEASE_MANIFEST.md, docs/standards/SIGNING.md, docs/adr/ADR-0018-promotion-gate-sequence.md, docs/adr/ADR-0015-data-published-_domain_-current-alias-is-governed-by-rollback_card.md, release/, contracts/, schemas/contracts/v1/, policy/, data/receipts/, data/proofs/]
-tags: [kfm, packages, release, src, release-manifest, promotion, signing, rollback, correction, publication, audit, replay]
-notes: ["Source-directory guide for release-support helper code.", "This directory may contain source code for release manifest candidate assembly, release preflight, signing-envelope metadata, signature verification helpers, rollback/correction helpers, receipt-ready metadata, replay, validation, and synthetic fixtures only.", "It must not own release decisions, release records, lifecycle data, policy rules, schemas, contracts, receipts, proofs, signing keys, API routes, UI surfaces, source records, or AI truth claims."]
+owners: OWNER_TBD — Release steward · Promotion steward · Rollback/correction steward · Contracts steward · Schema steward · Policy steward · Evidence steward · Security/signing steward · Validation steward · Package steward · Runtime/API steward · CI steward · Docs steward
+created: NEEDS VERIFICATION — target file existed before this evidence-grounded revision
+updated: 2026-07-19
+policy_label: "public-doctrine; package-source-boundary; python-source-envelope; greenfield-placeholder; no-supported-api; explicit-inputs; no-hidden-fetches; no-network-by-default; deterministic-candidate-mechanics; fail-closed; release-authority-external; signing-key-external; receipt-proof-external; no-publication-authority; correction-aware; rollback-aware"
+current_path: packages/release/src/README.md
+truth_posture: >
+  CONFIRMED target README v1, repository-present packages/release/src source envelope,
+  merged child namespace README v1.1, kfm-release distribution metadata version 0.0.0,
+  empty release/__init__.py, comment-only release/core.py greenfield placeholder,
+  packages responsibility-root doctrine, authoritative release-governance root, draft
+  ReleaseManifest, PromotionDecision, RollbackCard, and CorrectionNotice contracts,
+  uneven PROPOSED schema/validator/test maturity, draft signing standard, proposed
+  promotion-gate ADR, and explicit release-dry-run holds / PROPOSED a small reusable
+  Python source envelope for deterministic candidate normalization, injected validation,
+  public verification result handling, replay-safe comparison, and sanitized test support /
+  CONFLICTED prior README implications that proposed modules, imports, and custom helper
+  outcomes were usable implementation; competing draft A–G gate vocabularies;
+  CorrectionNotice release-vs-correction family placement / UNKNOWN accepted import name,
+  public API, build backend, Python support, package discovery, dependencies, source-module
+  decomposition, signer integration, first consumer, package-local test home, CI enforcement,
+  deployment, operational health, and release use / NEEDS VERIFICATION owners, package
+  metadata completion, API approval, contract/schema/policy acceptance, validators,
+  fixtures, security review, compatibility policy, correction process, and rollback drills
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  repository_id: "1059091169"
+  visibility: public
+  base_ref: main
+  base_commit: 7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd
+  prior_blob: 38f2122cec30f2194ccd5b8ffdcabdafeb52ab44
+  package_readme_blob: e0f2aad3f3b1e70b15bd1f1b410c60852c9d41dd
+  package_metadata_blob: b50731922626e9eb12b69f62dd8e71b11f00068b
+  namespace_readme_blob: 1fc83f7549c1258da3f121ba3b364db9877ca333
+  namespace_init_blob: e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  namespace_core_blob: 1c98feb4fb83b956decc0f55171a732d4a3233c0
+  directory_rules_blob: 2affb080e6f0043867c64c7f06c1ca52030fbd55
+  release_root_blob: 089c4a394c5cbf3b9e5a2a1963e68e16be485dce
+  release_manifest_contract_blob: 9ca1c9d4a5b247196aa84a31a158fe734c8a6720
+  release_manifest_schema_blob: 727db0a781900aa3816dcdce723fe355fec2e786
+  promotion_decision_contract_blob: 42295bfc83a621cf125d33aa821912b426f70bd2
+  promotion_decision_schema_blob: a2d087a46772cf60e4b9dfb394892690e8a88b31
+  promotion_decision_validator_blob: ead33d6c5c073f319627ee42d99c5933c0e370d1
+  promotion_decision_test_blob: 495c76aa9d3a016b7a60831e47c15d3a21efaa0c
+  rollback_card_contract_blob: 72ab9e148491243cc8a374556350ab94c2557ab4
+  rollback_card_schema_blob: 779ffcf282201ba4dba9689e622f92723db55b4e
+  rollback_validator_placeholder_blob: b80dd40e93733c7fa76f8f9a78e9ec55b6090b4b
+  correction_notice_contract_blob: 4716f2bc6e714ad2ab873d95144417d7855f5beb
+  correction_notice_schema_blob: 8f260eb5a5adba0b4966adfeffebfbcf6960277d
+  promotion_gate_adr_blob: d7604ab92b915abaec8d7d9bac3da5d40d51e7f3
+  signing_standard_blob: b719251e5f7d0abb954da4f043f8ea5d95e6283f
+  release_dry_run_workflow_blob: c91e794ae68a99edf6b618e9e3992c30ab0e4fe5
+  bounded_path_checks:
+    - packages/release/src/README.md existed at version v1 before this revision
+    - packages/release/pyproject.toml declares only project name kfm-release and version 0.0.0
+    - package metadata declares no build system, Python requirement, package discovery, dependencies, scripts, entry points, license, authors, or test configuration
+    - packages/release/src/release/README.md exists at version v1.1 on main
+    - packages/release/src/release/__init__.py is empty
+    - packages/release/src/release/core.py is a comment-only greenfield placeholder
+    - bounded repository search surfaced no functional release namespace consumer import or package-local test reference
+    - PromotionDecision has a concrete PROPOSED schema, validator, and repository fixture test
+    - ReleaseManifest, RollbackCard, and CorrectionNotice enforcement remains thin, incomplete, or conflicted
+    - release-dry-run workflow explicitly emits holds and no release or publication artifact
+related:
+  - ../README.md
+  - ../pyproject.toml
+  - release/README.md
+  - release/__init__.py
+  - release/core.py
+  - ../../README.md
+  - ../../../pyproject.toml
+  - ../../../docs/doctrine/directory-rules.md
+  - ../../../docs/doctrine/trust-membrane.md
+  - ../../../docs/doctrine/lifecycle-law.md
+  - ../../../docs/architecture/release-discipline.md
+  - ../../../docs/architecture/publication/RELEASE_GATES.md
+  - ../../../docs/adr/ADR-0018-promotion-gate-sequence.md
+  - ../../../docs/standards/SIGNING.md
+  - ../../../contracts/release/release_manifest.md
+  - ../../../contracts/release/promotion_decision.md
+  - ../../../contracts/release/rollback_card.md
+  - ../../../contracts/correction/correction_notice.md
+  - ../../../schemas/contracts/v1/release/release_manifest.schema.json
+  - ../../../schemas/contracts/v1/release/promotion_decision.schema.json
+  - ../../../schemas/contracts/v1/release/rollback_card.schema.json
+  - ../../../schemas/contracts/v1/correction/correction_notice.schema.json
+  - ../../../tools/validators/release/validate_promotion_decision.py
+  - ../../../tools/validators/validate_rollback_card.py
+  - ../../../tests/release/test_promotion_decision_schema.py
+  - ../../../release/README.md
+  - ../../../.github/workflows/release-dry-run.yml
+  - ../../../data/receipts/generated/README.md
+  - ../../../schemas/contracts/v1/receipts/generated_receipt.schema.json
+tags: [kfm, packages, release, src, python, source-envelope, scaffold, release-candidate, promotion-decision, release-manifest, rollback-card, correction-notice, signing, fail-closed, compatibility, correction, rollback]
+notes:
+  - "v1.1 replaces proposed source modules, imports, and custom helper outcomes with the directly verified source inventory and delegates namespace/API detail to release/README.md."
+  - "This README governs what may enter packages/release/src; it does not install the package, establish a supported API, accept a release-gate vocabulary, implement release mechanics, hold signing keys, write trust artifacts, mutate release state, authorize publication, or prove operational safety."
+  - "The source envelope remains a greenfield placeholder at the recorded evidence snapshot."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-# Release Package Source
+# Release Python Source Envelope and Governed Release-Candidate Boundary
 
-Source-code envelope for KFM release-support helpers: release manifest candidate assembly, promotion preflight checks, signing-envelope helpers, rollback/correction application helpers, receipt-ready metadata, validation, replay, and synthetic fixtures.
+`packages/release/src/`
 
-<p>
-  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
-  <img alt="Implementation: proposed" src="https://img.shields.io/badge/implementation-PROPOSED-orange">
-  <img alt="Root: packages" src="https://img.shields.io/badge/root-packages-blue">
-  <img alt="Path: src" src="https://img.shields.io/badge/path-src-lightgrey">
-  <img alt="Publication: governed transition" src="https://img.shields.io/badge/publication-governed__transition-blue">
-  <img alt="Authority: helper only" src="https://img.shields.io/badge/authority-helper__only-lightgrey">
-</p>
+> Source-placement and governance boundary for a future reusable Python release-support library. Current evidence establishes one evidence-grounded child namespace README, an empty package initializer, and a comment-only `core.py` placeholder—not an installable distribution, supported API, release runner, policy evaluator, signer, rollback executor, correction publisher, receipt writer, release ledger, or publication authority.
+
+![status](https://img.shields.io/badge/status-draft-yellow)
+![version](https://img.shields.io/badge/version-v1.1-informational)
+![maturity](https://img.shields.io/badge/maturity-greenfield__placeholder-lightgrey)
+![root](https://img.shields.io/badge/root-packages-blue)
+![namespace](https://img.shields.io/badge/namespace-release-blue)
+![exports](https://img.shields.io/badge/exports-none-orange)
+![tests](https://img.shields.io/badge/tests-not__established-orange)
+![authority](https://img.shields.io/badge/publication__authority-none-red)
+
+**Quick links:** [Purpose](#purpose-and-audience) · [Evidence](#status-and-evidence) · [Placement](#directory-rules-and-authority) · [Inventory](#confirmed-source-inventory) · [Layers](#package-source-and-namespace-layers) · [Packaging](#packaging-import-api-and-ownership-status) · [Admission](#source-admission-rules) · [Allowed files](#allowed-source-file-classes) · [Exclusions](#explicit-non-responsibilities) · [Objects](#release-object-maturity-boundary) · [Inputs](#input-and-semantic-completeness-boundary) · [Outputs](#candidate-output-and-persistence-boundary) · [Outcomes](#outcome-vocabularies-and-fail-closed-behavior) · [Lifecycle](#lifecycle-and-trust-membrane) · [Dependencies](#dependency-direction) · [Effects](#side-effects-network-and-determinism) · [Security](#security-signing-and-key-custody) · [Replay](#identity-hashing-replay-and-freshness) · [Telemetry](#logging-telemetry-and-error-hygiene) · [Consumers](#consumer-runtime-and-public-surface-contract) · [Testing](#testing-fixtures-and-ci) · [Implementation](#smallest-sound-implementation-sequence) · [Done](#definition-of-done) · [Open](#verification-register) · [Drift](#drift-and-conflicts) · [Maintenance](#maintenance-and-change-review) · [Compatibility](#versioning-compatibility-deprecation-and-correction) · [Evidence ledger](#evidence-ledger) · [Rollback](#rollback)
 
 > [!IMPORTANT]
-> **Status:** PROPOSED source-directory README  
-> **Path:** `packages/release/src/README.md`  
-> **Owning responsibility root:** `packages/`  
-> **Package lane:** `packages/release/`  
-> **Import/package layout:** NEEDS VERIFICATION  
-> **Release authority:** `release/`, not this source tree  
-> **Schema authority:** `schemas/contracts/v1/`, not this source tree  
-> **Contract authority:** `contracts/`, not this source tree  
-> **Policy authority:** `policy/`, not this source tree  
-> **Receipt/proof authority:** `data/receipts/` and `data/proofs/`, not this source tree  
-> **Key-management authority:** external key-management/signing infrastructure or repo-confirmed security root, not this source tree  
-> **Repo implementation depth:** UNKNOWN for package metadata, import style, tests, CI workflows, release bindings, emitted receipts, proof packs, release manifests, signing infrastructure, branch protections, and runtime behavior.
+> **This README is not implementation evidence.** It does not establish installation, import success, exports, accepted release objects, gate behavior, signing, rollback, correction publication, receipt/proof persistence, release mutation, consumers, tests, CI enforcement, deployment, or operational health.
 
-## Scope
+> [!CAUTION]
+> **Release-support code is not release authority.** A schema-valid candidate, signature, PromotionDecision, workflow result, pull request, merge, copied artifact, or generated summary cannot create evidence, satisfy release closure, or silently change `PUBLISHED` state.
 
-`packages/release/src/` is the proposed source-code root for the Release package.
+---
 
-This directory is for importable helper code used by pipelines, validators, release gates, signing workflows, rollback tools, governed APIs, receipts, proof builders, replay tools, and tests when they need deterministic release-support semantics.
+## Purpose and audience
 
-This source tree may support helpers for:
+This README governs source placement under:
 
-- assembling release manifest candidates from explicit artifact refs, manifest refs, evidence refs, policy refs, receipt refs, proof refs, hashes, version ids, audience metadata, and rollback refs;
-- validating release candidate completeness before a governed release workflow makes a release decision;
-- checking promotion-gate inputs such as schema validation, policy decision, EvidenceBundle closure, hash consistency, source rights, sensitivity posture, receipt/proof presence, review state, and rollback target presence;
-- preparing signing-envelope inputs, signature verification inputs, and signature-result metadata without storing private keys or becoming signing authority;
-- applying rollback-card logic to compute candidate alias/current pointers from explicit rollback records;
-- preparing correction, supersession, tombstone, deprecation, and withdrawal metadata from explicit caller inputs;
-- mapping release helper outcomes into finite envelope-ready states such as `READY`, `INVALID`, `DENIED`, `HOLD`, `ABSTAIN`, `SIGNED`, `ROLLBACK_READY`, `DRIFT`, and `ERROR`;
-- supporting deterministic replay of release manifests, signatures, rollback cards, and correction metadata;
-- building synthetic no-network fixtures for release, rollback, correction, signature, drift, and gate-failure paths.
+```text
+packages/release/src/
+```
 
-This source tree must not approve release, publish artifacts, mutate `release/`, change `data/published`, write receipts, write proofs, store signing keys, decide policy, resolve evidence as truth, fetch source data, expose public routes, render UI, or generate truth claims.
+It is written for:
+
+- package implementers deciding what source code may enter the package;
+- release, promotion, rollback, correction, policy, evidence, rights, sensitivity, privacy, security, and signing reviewers;
+- contract, schema, validator, fixture, test, and CI maintainers;
+- pipeline, worker, validator, runtime, governed API, map, export, and review-console consumers;
+- receipt, proof, release, correction, rollback, compatibility, and documentation stewards.
+
+The intended future role is a **small reusable source envelope** for deterministic candidate mechanics shared by more than one governed caller.
+
+The current role is narrower:
+
+- this README exists;
+- `release/README.md` is merged at v1.1;
+- `release/__init__.py` is empty;
+- `release/core.py` is a comment-only placeholder;
+- `../pyproject.toml` declares only `kfm-release` version `0.0.0`;
+- no build backend, Python support policy, package discovery, dependency set, script, or entry point is established;
+- no functional module, supported export, consumer import, package-local test suite, signer binding, release mutation, deployment, or runtime behavior was established by bounded inspection;
+- the release-object, signing, and promotion-gate surfaces have uneven draft or PROPOSED maturity.
+
+This README therefore records the **CONFIRMED placeholder state**, defines **PROPOSED source-admission rules**, and keeps release authority, contracts, schemas, policy, evidence, validation, signing, receipts, proofs, review, correction, and rollback visible before adoption.
+
+[Back to top](#top)
+
+---
+
+## Status and evidence
+
+| Surface | Status | Safe conclusion |
+|---|---:|---|
+| Target README | **CONFIRMED v1 before revision** | The prior source guide over-described implementation. |
+| Source envelope | **CONFIRMED present** | `packages/release/src/` exists. |
+| Child namespace README | **CONFIRMED v1.1** | The namespace boundary is current and evidence-grounded. |
+| Subpackage metadata | **CONFIRMED placeholder** | `kfm-release`, version `0.0.0`. |
+| Subpackage build/discovery | **NOT DECLARED** | Build, install, and import are unproved. |
+| `release/__init__.py` | **CONFIRMED empty** | No supported exports. |
+| `release/core.py` | **CONFIRMED comment-only** | No release-support behavior. |
+| Functional source modules | **NOT ESTABLISHED by bounded inspection** | Prior proposed module names are not facts. |
+| Consumer imports | **NOT ESTABLISHED by bounded search** | No package adoption or integration behavior is proved. |
+| Package-local tests | **NOT ESTABLISHED by bounded search** | No source behavior is proved. |
+| `ReleaseManifest` | **DRAFT / PROPOSED / thin schema** | Rich semantics exist; machine closure is not enforced. |
+| `PromotionDecision` | **DRAFT / PROPOSED / concrete schema** | Shape validator and fixture test exist; authorization is not proved. |
+| `RollbackCard` | **DRAFT / PROPOSED / thin schema** | Schema-declared validator is absent; another validator is placeholder-only. |
+| `CorrectionNotice` | **DRAFT / thin schema / placement conflicted** | Validator and canonical family remain unresolved. |
+| Signing standard | **DRAFT** | Production key custody, trust roots, and verification binding are unproved. |
+| Promotion-gate ADR | **PROPOSED** | Competing draft A–G vocabularies remain unresolved. |
+| Release dry run | **CONFIRMED explicit hold** | Bounded checks run; no candidate, release, or publication artifact is emitted. |
+| Runtime health | **UNKNOWN** | No operational package is proved. |
+
+### Corrections from v1
+
+| Prior implication | Current evidence | v1.1 correction |
+|---|---|---|
+| Source root and namespace were only proposed | Both paths exist | Mark placement CONFIRMED. |
+| Proposed modules are expected implementation | Only README, empty initializer, and placeholder core surfaced | Remove fictional module tree. |
+| `from release...` examples are usable | Build/import support is absent; import name may collide | Remove import examples and keep namespace decision open. |
+| Custom helper outcomes are package contracts | No runtime type exists; KFM vocabularies differ by object family | Require accepted mapping before export. |
+| Broad callers use the package | No functional consumer import surfaced | Consumer set remains UNKNOWN. |
+| Release gate names are settled | ADR-0018 remains proposed and draft docs conflict | Do not encode gate vocabulary as API. |
+| Signing verification can be local helper behavior | Keys, trust roots, verifier protocol, and revocation are unproved | Limit future code to injected public verification context after review. |
+| Checklist prose indicates readiness | No package behavior exists | Add staged gates, definition of done, and verification register. |
+
+Open items must not be upgraded to implementation facts without new repository evidence.
+
+[Back to top](#top)
+
+---
+
+## Directory Rules and authority
+
+Directory Rules state that placement encodes ownership and governance. The source path remains appropriate because `packages/` owns shared reusable libraries.
+
+| Path or responsibility | Owning root | Rule |
+|---|---|---|
+| Package metadata and reusable implementation | `packages/release/` | Package boundary and build metadata. |
+| Python source admission | `packages/release/src/` | This README. |
+| Namespace/API design | `packages/release/src/release/` | Child namespace README and reviewed source. |
+| Authoritative release records | `release/` | Release governance, decisions, manifests, corrections, rollback, signatures, and history. |
+| Semantic meaning | `contracts/` | Object meaning. |
+| Machine shape | `schemas/contracts/v1/` | JSON Schema and machine contracts. |
+| Policy and admissibility | `policy/` | Release, promotion, rights, sensitivity, and access decisions. |
+| Evidence authority | EvidenceRef/EvidenceBundle homes | Evidence closure. |
+| Receipts and proofs | `data/receipts/`, `data/proofs/` | Auditable trust artifacts. |
+| Lifecycle artifacts | `data/<phase>/` | RAW through PUBLISHED state. |
+| One-off release execution | `tools/`, `pipelines/`, or accepted runtime lanes | Operational orchestration, not shared source. |
+| Keys and trust roots | Security/KMS/signing infrastructure | Private key custody and issuer policy. |
+| Public delivery | Governed API/UI/map/AI roots | Downstream released surfaces only. |
+
+No path is moved or renamed by this revision. No parallel release, contract, schema, policy, source, registry, receipt, proof, signing, or publication authority is created. No ADR is required for this documentation-only in-place correction.
+
+[Back to top](#top)
+
+---
+
+## Confirmed source inventory
+
+Bounded direct reads and repository search surfaced:
+
+```text
+packages/release/src/
+├── README.md
+└── release/
+    ├── README.md
+    ├── __init__.py
+    └── core.py
+```
+
+| Path | Verified state | Safe interpretation |
+|---|---|---|
+| `README.md` | This source-envelope guide | Documentation only. |
+| `release/README.md` | v1.1 namespace boundary | Design and governance, not implementation proof. |
+| `release/__init__.py` | Empty | No exports. |
+| `release/core.py` | Comment-only greenfield placeholder | No behavior. |
+
+No additional functional release-source module, supported export, test module, or consumer import surfaced in the bounded inspection. This is not a claim that no hidden or future branch content exists.
+
+[Back to top](#top)
+
+---
+
+## Package, source, and namespace layers
+
+The three documentation layers are complementary.
+
+| Layer | Owns | Must not duplicate |
+|---|---|---|
+| `../README.md` | Package purpose, packaging, adoption, compatibility, and package-level rollback | Source-file admission or detailed API semantics |
+| This README | Source-root admission, dependency direction, side-effect rules, source-level testing burden | Package installation promises or namespace exports |
+| `release/README.md` | Namespace concepts, candidate API boundary, object maturity, consumer contract | Package build policy or source-root placement doctrine |
+
+The package README remains v1 and overstates current implementation. This source revision does not silently rewrite it; parent reconciliation is recorded as a separate verification item.
+
+[Back to top](#top)
+
+---
+
+## Packaging, import, API, and ownership status
+
+The subpackage manifest currently declares only:
+
+```toml
+[project]
+name = "kfm-release"
+version = "0.0.0"
+```
+
+It does not establish:
+
+- a build backend;
+- supported Python versions;
+- source-layout discovery;
+- dependencies or optional dependencies;
+- scripts or entry points;
+- package data;
+- typing support;
+- license, authors, or maintainers;
+- test, lint, formatting, or type-check configuration;
+- the accepted import name;
+- a supported API or compatibility promise.
+
+The source tree must not add API-bearing code until package metadata and ownership are reviewed together.
+
+### Import-name risk
+
+`release` is generic and collision-prone. The current directory name does not prove that `import release` is accepted. Before consumer adoption, maintainers must decide whether to:
+
+- retain `release`;
+- use a project-qualified namespace such as `kfm_release`;
+- nest under another accepted package;
+- or choose another reviewed convention.
+
+That decision belongs in package metadata and, if compatibility or architecture significance warrants, an ADR or migration note.
+
+### Ownership minimum
+
+Before functional code lands, identify:
+
+- package steward;
+- release and promotion stewards;
+- contract/schema/policy owners;
+- security/signing reviewer;
+- validation and CI owner;
+- first consumer owner;
+- correction and rollback owner;
+- compatibility/deprecation owner.
+
+CODEOWNERS routing alone is not independent approval or release authorization.
+
+[Back to top](#top)
+
+---
+
+## Source-admission rules
+
+A source file may enter this envelope only when all applicable rules are satisfied.
+
+1. **Reusable responsibility.** More than one governed caller needs the mechanics, or a clear shared-library reason is documented.
+2. **Explicit inputs.** The file does not discover authority from hidden globals, environment state, current working directory, mutable aliases, UI state, logs, or operator memory.
+3. **Candidate-only behavior.** It may compute or validate candidates; it does not approve or persist authoritative release state.
+4. **No hidden fetches.** Network, database, object-store, KMS, source-system, and lifecycle-store access are excluded from the deterministic core.
+5. **Determinism.** Deterministic claims are backed by canonicalization rules and tests.
+6. **Fail closed.** Unknown, stale, conflicted, invalid, unsupported, or unverifiable inputs produce explicit non-success results.
+7. **Authority separation.** Contracts, schemas, policy, evidence, review, receipts, proofs, release records, and key custody remain external.
+8. **Safe telemetry.** Logs and exceptions do not leak payloads, keys, tokens, evidence bodies, protected locations, or personal data.
+9. **Bounded resources.** Size, count, nesting, algorithmic complexity, memory, and time limits are explicit.
+10. **Test-first burden.** Positive, negative, replay, privacy, authority-boundary, and resource-limit tests accompany behavior.
+11. **Compatibility discipline.** API, object-version, and result-vocabulary changes carry migration and rollback.
+12. **Documentation parity.** Package, source, namespace, contracts, schemas, policy, tests, workflows, and runbooks are updated together where behavior changes.
+
+README prose, file presence, or a merged PR does not satisfy these gates.
+
+[Back to top](#top)
+
+---
+
+## Allowed source-file classes
+
+The source envelope may eventually contain reviewed files in these responsibility classes.
+
+| Class | Permitted purpose | Required boundary |
+|---|---|---|
+| Candidate data carriers | Typed immutable input/result candidates | No authoritative release records |
+| Manifest normalization | Normalize explicit refs, versions, digests, and metadata | No persistence or closure claim |
+| Shape-validation adapters | Call injected accepted validators | Schema validity is not release readiness |
+| Promotion input assembly | Assemble explicit `PromotionDecision` inputs | Must not decide `APPROVE`, `DENY`, or `ABSTAIN` |
+| Public verification adapters | Normalize explicit public-key verification results | No private-key, KMS, issuer, or trust-root authority |
+| Rollback metadata normalization | Normalize affected state, target, invalidation, restoration refs | No alias movement or rollback execution |
+| Correction lineage helpers | Preserve correction, withdrawal, supersession, and revocation refs | No notice publication or silent mutation |
+| Canonicalization and hashing adapters | Apply accepted deterministic profiles | No ad hoc hash authority |
+| Replay and drift comparison | Compare expected and observed explicit state | No certification or warning-only drift |
+| Reason and obligation carriers | Preserve accepted safe codes and obligations | No policy evaluation |
+| Synthetic test builders | Build deterministic sanitized examples | No production or sensitive payloads |
+
+Concrete module names remain **PROPOSED** until the accepted API and decomposition are reviewed. Do not recreate the v1 fictional tree as empty files merely to satisfy documentation.
+
+[Back to top](#top)
+
+---
+
+## Explicit non-responsibilities
+
+Do not place these responsibilities in `packages/release/src/`.
+
+| Excluded responsibility | Correct authority |
+|---|---|
+| Release approval, denial, abstention, withdrawal, correction approval | Governed policy/release workflow |
+| Authoritative manifests, decisions, rollback cards, notices, signatures, release records | `release/` |
+| Contract meaning | `contracts/` |
+| JSON Schemas and API schemas | `schemas/` |
+| Policy logic or bundle activation | `policy/` |
+| Evidence resolution or evidence truth | Evidence subsystem |
+| Receipt/proof storage | `data/receipts/`, `data/proofs/` |
+| RAW, WORK, QUARANTINE, PROCESSED, CATALOG, TRIPLET, PUBLISHED payloads | `data/<phase>/` |
+| Source retrieval | `connectors/` or governed pipeline inputs |
+| Release execution, publication, alias movement, cache invalidation | Release-owned tooling/pipelines/runtime |
+| Private keys, KMS clients, OIDC credentials, issuer policy, trust roots | Security/signing infrastructure |
+| Public API routes, UI, map rendering, AI answer generation | Governed downstream apps |
+| Real release payloads, protected coordinates, personal/DNA data, secrets | Never in package source or fixtures |
+
+The package may preserve safe references to external authority objects. A reference carrier does not inherit the authority of the referenced object.
+
+[Back to top](#top)
+
+---
+
+## Release-object maturity boundary
+
+### `ReleaseManifest`
+
+The semantic contract describes a rich release binding. The paired PROPOSED schema currently requires only `id` and permits additional properties.
+
+Source code may eventually normalize explicit manifest candidate fields, but it must not:
+
+- persist a manifest;
+- treat schema validity as release closure;
+- infer evidence, rights, sensitivity, policy, review, signature, receipt/proof, correction, or rollback completion;
+- publish or activate a release;
+- replace the authoritative release record.
+
+### `PromotionDecision`
+
+The PROPOSED schema is materially more concrete. It requires eleven fields, rejects additional properties, and uses:
+
+```text
+APPROVE | DENY | ABSTAIN
+```
+
+A repository validator and fixture test exist. This proves bounded **shape validation** only.
+
+Source code must not equate validation with:
+
+- policy evaluation;
+- EvidenceBundle closure;
+- accountable human review;
+- rollback readiness beyond supplied refs;
+- release approval;
+- publication.
+
+A future helper may assemble or validate explicit candidate inputs. The decision itself remains external.
+
+### `RollbackCard`
+
+The semantic contract is rich, while the paired schema is thin. The schema-declared validator path is absent, and a different validator is a `NotImplementedError` placeholder.
+
+Source code must not claim rollback validation or execute:
+
+- alias/current-pointer mutation;
+- cache, tile, graph, vector, search, API, map, or AI-cache invalidation;
+- restoration;
+- release withdrawal;
+- correction notice publication;
+- history erasure.
+
+### `CorrectionNotice`
+
+The semantic contract currently lives under `contracts/correction/`. Its paired schema is thin, its declared validator is absent, and the release-vs-correction family placement remains conflicted.
+
+Source code may preserve explicit lineage candidates only. It must not:
+
+- choose the canonical family;
+- silently replace prior records;
+- expose restricted correction details;
+- publish a notice;
+- authorize correction or withdrawal.
+
+### Signing and attestations
+
+The signing standard is draft. Production signer identity, trust roots, key custody, issuer policy, transparency-log requirements, media types, revocation, and verification protocol are not established here.
+
+The source envelope may eventually contain an adapter that consumes explicit public verification context. It must never hold or retrieve private signing material.
+
+[Back to top](#top)
+
+---
+
+## Input and semantic-completeness boundary
+
+Future functions must receive explicit, inspectable inputs.
+
+| Input family | Examples | Required posture |
+|---|---|---|
+| Identity | candidate id, release id, object version, spec hash, canonicalization profile | Stable and versioned |
+| Artifact | explicit artifact refs, digests, media types, sizes, manifest refs | Refs only; no hidden reads |
+| Evidence | EvidenceRef, EvidenceBundle ref, resolver status, freshness | Preserve; do not fabricate or resolve as truth |
+| Policy/review | PolicyDecision ref, PromotionDecision candidate, obligations, reviewer/ticket refs | External authority |
+| Rights/sensitivity | license, audience, redistribution, embargo, redaction/generalization posture | Unknown fails closed |
+| Receipts/proofs | run, validation, redaction, promotion, generated receipt, proof refs | Preserve; do not persist |
+| Signing | canonical payload digest, payload type, public identity, issuer, verification result, trust-policy version | Public verification context only |
+| Rollback/correction | affected release, target, invalidation, restoration, correction, withdrawal, supersession refs | Candidate metadata only |
+| Replay/freshness | expected hashes, versions, prior state, evaluated/published/valid time | Explicit comparison |
+| Limits | maximum bytes, fields, artifacts, nesting, runtime | Enforced before expensive work |
+
+### Semantic completeness is not schema validity
+
+A candidate can pass a permissive schema and still be release-incomplete.
+
+The source layer must distinguish:
+
+- machine shape;
+- semantic completeness;
+- evidence closure;
+- policy admissibility;
+- review completion;
+- signature integrity;
+- release authorization;
+- publication state.
+
+When required support is absent, the function must return an explicit bounded failure or abstention result defined by an accepted contract. It must not invent defaults that imply release readiness.
+
+[Back to top](#top)
+
+---
+
+## Candidate output and persistence boundary
+
+Allowed future outputs are **candidates** or **local validation/comparison results**.
+
+A candidate output may contain:
+
+- normalized safe fields;
+- explicit source object refs;
+- accepted reason codes;
+- validation findings;
+- deterministic hashes;
+- replay differences;
+- required follow-up obligations;
+- safe diagnostic metadata.
+
+It must not contain or imply:
+
+- authoritative release state;
+- public publication permission;
+- stored receipt/proof identity that was not actually persisted;
+- signer or reviewer approval;
+- evidence closure that was not resolved;
+- policy outcome that was not evaluated;
+- successful rollback or correction execution;
+- mutable `current` alias state;
+- secrets or restricted payloads.
+
+Persistence belongs to release-owned workflows and trust-artifact stores after their own validation, policy, review, integrity, and rollback gates.
+
+[Back to top](#top)
+
+---
+
+## Outcome vocabularies and fail-closed behavior
+
+Do not collapse distinct object-family vocabularies.
+
+| Vocabulary | Current use | Source-layer rule |
+|---|---|---|
+| `APPROVE | DENY | ABSTAIN` | `PromotionDecision` | Preserve only after external decision or validated candidate input |
+| `ANSWER | ABSTAIN | DENY | ERROR` | Runtime/policy envelopes | Do not invent package-specific substitutes |
+| `PASS | FAIL | SKIPPED` | Validation/workflow reporting | Report bounded checks, not release state |
+| `DRAFT | HELD | APPROVED | RELEASED | CORRECTED | SUPERSEDED | WITHDRAWN` and related states | Release governance records | Never emit as authority from local helper logic |
+| Proposed `READY`, `SIGNED`, `ROLLBACK_READY`, `DRIFT` | Prior README design lineage | Not compatibility commitments |
+
+Before exporting a result type:
+
+1. identify its authoritative contract;
+2. pin version and enum;
+3. define exhaustive mapping;
+4. reject unknown values;
+5. preserve safe reason codes and obligations;
+6. test every negative path;
+7. document consumer behavior;
+8. define correction and migration rules.
+
+Unknown, stale, conflicted, unsupported, unverifiable, revoked, or malformed inputs fail closed. Warning-only continuation is not acceptable where public or release safety is affected.
+
+[Back to top](#top)
+
+---
+
+## Lifecycle and trust membrane
+
+The KFM lifecycle remains:
 
 ```text
 RAW -> WORK / QUARANTINE -> PROCESSED -> CATALOG / TRIPLET -> PUBLISHED
 ```
 
-Publication is a governed state transition, not a file move. Release source code may prepare and validate candidates for that transition, but it does not own the transition.
+The source envelope may support deterministic candidate computation near a governed transition. It does not own any lifecycle phase or transition.
 
-[⬆ Back to top](#top)
+A valid release still requires, as applicable:
+
+- stable identity and content digests;
+- accepted contracts and schemas;
+- resolvable evidence;
+- rights and sensitivity closure;
+- policy evaluation;
+- accountable review and separation of duties;
+- receipts and proofs;
+- signing/integrity support;
+- ReleaseManifest and PromotionDecision linkage;
+- rollback and correction lineage;
+- authoritative release records;
+- governed downstream interfaces.
+
+Public clients and normal UI/map/AI surfaces must never call this source tree as an authority or read pre-publication stores through it.
+
+[Back to top](#top)
 
 ---
 
-## Repo fit
+## Dependency direction
+
+Preferred dependency direction:
 
 ```text
-packages/release/src/
+explicit accepted input objects
+        |
+        v
+pure candidate normalization / comparison
+        |
+        v
+local candidate result
+        |
+        v
+external schema + semantic + policy + evidence + review + signing gates
+        |
+        v
+release-owned persistence and governed publication
 ```
 
-`packages/` is the responsibility root for shared reusable code. `release/` is the package segment. `src/` is the source-code envelope.
+The source tree may depend on small accepted shared utilities when responsibility is clear, such as deterministic identity, hashing, canonicalization, or typed contract carriers.
 
-| Relationship | Expected home | Boundary rule |
-| --- | --- | --- |
-| Release source code | `packages/release/src/` | Manifest-candidate assembly, preflight checks, signing metadata, rollback/correction helpers only. |
-| Importable module | `packages/release/src/release/` or repo-confirmed namespace | Package namespace, subject to repo package convention verification. |
-| Package entry README | `packages/release/README.md` | Explains the package as a whole. |
-| Release authority records | `release/` | Owns release manifests, release decisions, rollback records, correction notices, and publication state. |
-| Lifecycle data and artifacts | `data/<phase>/` or repo-confirmed artifact homes | Owns RAW/WORK/QUARANTINE/PROCESSED/CATALOG/TRIPLET/PUBLISHED state and artifacts. |
-| Hash helpers | `packages/hashing/` | Computes and compares content/spec/artifact hashes and Merkle roots. |
-| Identity helpers | `packages/identity/` | Handles release ids, object ids, refs, aliases, and deterministic identity grammar. |
-| Pipeline helpers | `packages/pipelines-core/` | Supplies run-state, receipt metadata, replay, and lifecycle guardrail helpers. |
-| Policy runtime helpers | `packages/policy-runtime/` | Supplies policy decision outcomes and obligations. |
-| Runtime envelopes | `packages/envelopes/` | Maps helper results into finite governed response envelopes. |
-| Semantic contracts | `contracts/` | Defines meaning for release, rollback, correction, and signing objects. |
-| Machine schemas | `schemas/contracts/v1/` | Defines release manifest, rollback card, signature, receipt, and artifact shapes. |
-| Policy rules | `policy/` | Owns publication, rights, sensitivity, and release gate decisions. |
-| Receipts and proofs | `data/receipts/`, `data/proofs/` | Stores RunReceipt, PolicyDecision, RedactionReceipt, PromotionReceipt, proof packs, and validation records. |
-| Signing keys | security/KMS/signing infrastructure or repo-confirmed root | Private keys and key policy never belong in `packages/`. |
-| Public API and UI | `apps/`, `ui/`, `web/`, or repo-confirmed equivalents | Consume governed release status; source internals are not public authority. |
-| Tests and fixtures | `tests/packages/release/`, `fixtures/packages/release/`, or repo-confirmed equivalents | Proves deterministic behavior with synthetic public-safe fixtures. |
+It must not import:
 
-> [!WARNING]
-> A source-code directory is not an authoritative release ledger. Release records, rollback cards, correction notices, and publication state belong under the release/lifecycle governance roots.
+- connectors;
+- source clients;
+- release record writers;
+- policy engines as hidden authority;
+- receipt/proof stores;
+- public API routers;
+- UI/map components;
+- model providers;
+- credential or private-key stores;
+- mutable lifecycle repositories.
 
-[⬆ Back to top](#top)
+Adapters that cross an authority boundary belong outside the deterministic core and require explicit interfaces, limits, tests, and review.
+
+[Back to top](#top)
 
 ---
 
-## Accepted inputs
+## Side effects, network, and determinism
 
-Functions in this source tree should accept explicit values from governed callers. They should not fetch missing facts from source systems, raw stores, hidden globals, UI state, operator memory, or generated language.
+### No-network default
 
-| Input family | Accepted examples | Required handling |
-| --- | --- | --- |
-| Release context | release id, release type, version, audience, domain, release state, supersedes ref | Preserve explicit release identity and state. |
-| Artifact context | artifact refs, artifact hashes, tile/style/layer/source manifests, Merkle root, size/media metadata | Validate presence and integrity refs; do not read or publish artifacts. |
-| Evidence context | EvidenceRef, EvidenceBundle ref, resolver outcome, citation-validation ref | Carry evidence support; do not fabricate evidence. |
-| Policy context | policy decision ref, obligations, sensitivity posture, rights posture, release gate result | Consume supplied posture; do not evaluate policy. |
-| Receipt/proof context | run receipt ref, validation receipt ref, redaction receipt ref, promotion receipt ref, proof pack ref | Validate refs are present; do not store receipts/proofs. |
-| Signing context | signing profile, public key ref, signature envelope ref, signature verification result | Prepare/verify metadata only; do not store private keys. |
-| Rollback/correction context | rollback card ref, current alias, prior release ref, correction notice, tombstone/supersession reason | Compute candidate status and metadata; do not mutate release ledger. |
-| Replay context | prior manifest hash, expected artifact hashes, expected policy refs, drift policy | Compare explicit values; do not infer release success from names or logs. |
-| Fixture context | synthetic release, rollback, correction, signature, invalid, denied, drift examples | Keep fixtures deterministic and public-safe. |
+Production source code is no-network by default.
 
-[⬆ Back to top](#top)
+Any future networked verification adapter requires:
 
----
+- an accepted ADR or equivalent architecture decision;
+- explicit endpoint and trust policy;
+- timeout, retry, circuit-breaker, and response-size limits;
+- deterministic cache and freshness semantics;
+- no credential leakage;
+- offline/replay fixtures;
+- fail-closed handling;
+- audit-safe telemetry.
 
-## Exclusions
+### Forbidden hidden side effects
 
-| Do not put here | Correct home or owner | Reason |
-| --- | --- | --- |
-| Release manifests, rollback cards, correction notices as authoritative records | `release/` | Release state is governed and auditable. |
-| RAW, WORK, QUARANTINE, PROCESSED, CATALOG, TRIPLET, or PUBLISHED data | `data/<phase>/` | Lifecycle state must remain phase-visible. |
-| Source descriptors and source registries | `data/registry/` or repo-confirmed registry homes | Source authority, rights, cadence, and limitations are governance data. |
-| JSON Schemas | `schemas/contracts/v1/` | Schemas own machine shape. |
-| Semantic contracts | `contracts/` | Contracts own meaning. |
-| Policy rules | `policy/` | Policy owns publication, rights, and sensitivity decisions. |
-| Receipts, proof packs, validation reports | `data/receipts/`, `data/proofs/` | Trust artifacts must remain separately auditable. |
-| Signing private keys, secrets, credentials, key policies | Security/KMS/signing infrastructure | Packages must not store key material. |
-| Public API routes or serializers | `apps/` or repo-confirmed API app | Public clients must use governed APIs. |
-| UI components, dashboards, controls | `apps/`, `ui/`, `web/`, or observability roots | Presentation is downstream from governed status. |
-| AI-generated release claims or source interpretation | governed AI runtime plus evidence validation | AI output is interpretive and evidence-subordinate. |
-| Secrets, private source content, protected-location examples, real personal/DNA data | Nowhere in package fixtures | Fixtures must remain synthetic or public-safe. |
+Core functions must not:
 
-[⬆ Back to top](#top)
+- read or write release/lifecycle stores;
+- call KMS or signing services;
+- mutate aliases;
+- invalidate caches or derivatives;
+- persist receipts/proofs;
+- inspect environment variables for decision authority;
+- use wall-clock time or randomness without explicit injection;
+- depend on file ordering, locale, timezone, or current working directory;
+- make release decisions from logs or filenames.
 
----
+### Deterministic claims
 
-## Expected source layout
+A deterministic result must pin:
 
-> [!NOTE]
-> The tree below is PROPOSED. Confirm package metadata, language conventions, import namespace, test layout, and CI before committing code beyond README files.
+- canonicalization profile and version;
+- hash algorithm;
+- input version and digest;
+- policy/review/signing context versions where included;
+- explicit timestamp semantics;
+- randomness/nonce rules;
+- sorting and serialization rules;
+- resource-limit profile.
 
-```text
-packages/release/src/
-├── README.md                # This file: source-code boundary and trust rules
-└── release/
-    ├── README.md            # PROPOSED: importable namespace guide
-    ├── __init__.py          # PROPOSED export boundary
-    ├── manifests.py         # PROPOSED release manifest candidate helpers
-    ├── gates.py             # PROPOSED release preflight/gate helpers
-    ├── signing.py           # PROPOSED signing metadata and verification helpers
-    ├── rollback.py          # PROPOSED rollback-card application helpers
-    ├── corrections.py       # PROPOSED correction/supersession/tombstone helpers
-    ├── receipts.py          # PROPOSED release receipt-ready metadata carriers only
-    ├── replay.py            # PROPOSED replay/drift helpers
-    ├── validation.py        # PROPOSED manifest/output validation helpers
-    ├── fixtures.py          # PROPOSED synthetic fixtures
-    └── py.typed             # PROPOSED if typed package convention is confirmed
-```
+Same accepted input under the same pinned profile must produce byte-equivalent canonical output or an explicitly documented equivalent.
 
-Preferred import posture, subject to package verification:
-
-```python
-from release.manifests import build_release_manifest_candidate
-from release.gates import validate_release_preflight
-from release.rollback import apply_rollback_card_candidate
-```
-
-[⬆ Back to top](#top)
+[Back to top](#top)
 
 ---
 
-## Release helper outcomes
+## Security, signing, and key custody
 
-| Helper outcome | Use when | Runtime posture |
-| --- | --- | --- |
-| `READY` | Manifest candidate has required refs, hashes, and preflight support. | Candidate only; release workflow must still approve. |
-| `INVALID` | Manifest shape, ref set, hash, signature, or rollback metadata is malformed. | Fail closed with validation metadata. |
-| `DENIED` | Supplied policy posture blocks release or audience. | Deny with stable reason code. |
-| `HOLD` | Steward review, rights review, sensitivity review, proof review, or signature review is required. | Internal governance state; not public release. |
-| `ABSTAIN` | Required evidence, policy, receipt, proof, artifact, signature, or rollback support is missing. | Fail safe; do not publish. |
-| `SIGNED` | Signature metadata verifies for supplied manifest/hash and public-key context. | Integrity candidate only; not truth or release approval. |
-| `ROLLBACK_READY` | Rollback/correction candidate is locally coherent from explicit inputs. | Candidate only; release workflow must still apply. |
-| `DRIFT` | Replay or recompute differs from expected manifest, hashes, refs, or signature context. | Block promotion/release and require review. |
-| `ERROR` | Runtime or evaluator failure prevents a valid local helper result. | Fail closed with receipt-ready error metadata. |
+Private keys, KMS clients, OIDC credentials, certificate issuance, issuer policy, trust-root policy, and transparency-log authority remain outside this source tree.
 
-`READY` and `SIGNED` are not proof of truth, evidence closure, publication, or release. They only mean the local helper checks found the candidate coherent enough for the next governed gate.
+A future public-verification adapter must:
 
-[⬆ Back to top](#top)
+- accept canonical payload bytes or digest explicitly;
+- accept payload type and object-family version explicitly;
+- accept public identity, issuer, trust-policy version, and revocation context explicitly;
+- bind the verification result to the exact payload digest;
+- distinguish valid, invalid, unverifiable, stale, revoked, unsupported, and error states;
+- avoid network access in the deterministic core;
+- avoid exposing signatures or certificates where policy restricts them;
+- never treat a valid signature as factual truth, legal admissibility, evidence closure, or release approval.
 
----
+### Threat model
 
-## Trust-boundary flow
+| Threat | Required control |
+|---|---|
+| Package becomes release ledger | No authoritative writes |
+| Schema-valid but unsafe candidate | Separate shape validation from governance readiness |
+| Gate-vocabulary drift | Versioned mappings; no proposed enum hard-coding |
+| Signature treated as truth | Integrity-only semantics |
+| Key/token leakage | No secrets in source, fixtures, logs, or exceptions |
+| TOCTOU between check and release | Digest, version, authority, and time binding; reverify at persistence boundary |
+| Stale evidence/policy/review | Explicit freshness and version checks |
+| Rollback-target substitution | Digest-bound target and reviewed lineage |
+| Warning-only drift | Typed fail-closed result |
+| Dependency or parser attack | Minimal dependencies, locked versions, size/depth/count limits |
+| Sensitive payload leakage | Reference-only design and safe telemetry |
 
-```mermaid
-flowchart LR
-    A[Pipeline / release workflow caller] --> B[packages/release/src]
-    B --> C[Importable release helpers]
-    C --> D{Manifest / gate / signing / rollback check}
-    D -->|READY| E[Release candidate metadata]
-    D -->|SIGNED| F[Verified signature metadata]
-    D -->|ROLLBACK_READY| G[Rollback/correction candidate]
-    D -->|INVALID or ERROR| H[Fail-closed metadata]
-    D -->|DENIED| I[Deny result]
-    D -->|HOLD or ABSTAIN| J[Review or missing-support state]
-    E --> K[Schema + policy + evidence + receipt/proof checks]
-    F --> K
-    G --> K
-    K --> L[Governed release workflow]
-    L --> M[Authoritative release records]
-    M --> N[Governed API / publication / audit / replay]
-
-    C -. must not own .-> O[Release ledger]
-    C -. must not write .-> P[Lifecycle data]
-    C -. must not store .-> Q[Receipts / proofs]
-    C -. must not hold .-> R[Private signing keys]
-```
-
-[⬆ Back to top](#top)
+[Back to top](#top)
 
 ---
 
-## Source anti-collapse rules
+## Identity, hashing, replay, and freshness
 
-| Boundary | Preserve as | Never collapse into |
-| --- | --- | --- |
-| Release manifest candidate | Deterministic candidate from explicit refs/hashes | Authoritative release record |
-| Signing metadata | Verification/signature context | Release approval or private key storage |
-| Rollback candidate | Computed state from explicit rollback card | Mutation of current alias/release ledger |
-| Correction metadata | Explicit correction/supersession/tombstone context | Hidden content replacement |
-| Preflight result | Local gate support check | Policy decision, evidence closure, or release decision |
-| Receipt metadata | Receipt-ready carrier | Receipt store or proof authority |
-| Fixture release | Synthetic public-safe example | Production release or sensitive artifact record |
+Identity and hash fields are not decorative.
 
-[⬆ Back to top](#top)
+Future candidate mechanics must preserve:
+
+- object/candidate id;
+- object family and version;
+- canonicalization profile;
+- input and output digests;
+- referenced artifact digests;
+- expected and observed versions;
+- policy, evidence, review, receipt/proof, signing, rollback, and correction refs;
+- explicit time kinds.
+
+Replay must distinguish:
+
+- exact match;
+- semantically equivalent under an accepted profile;
+- changed input;
+- changed profile;
+- changed dependency;
+- changed policy/review/signing context;
+- stale support;
+- unverifiable prior state;
+- unsupported legacy state;
+- error.
+
+A replay comparison is not certification. Release-owned governance decides what drift means for continued service, correction, withdrawal, or rollback.
+
+[Back to top](#top)
 
 ---
 
-## Development rules
+## Logging, telemetry, and error hygiene
 
-1. Prefer pure functions with explicit input objects.
-2. Preserve release refs, artifact refs, evidence refs, policy refs, receipt refs, proof refs, hashes, signature refs, rollback refs, correction refs, review refs, and actor/timestamp metadata supplied by callers.
-3. Do not make network calls from `src` helpers unless a future ADR explicitly permits a constrained signing/verification call path.
-4. Do not read directly from RAW, WORK, QUARANTINE, unpublished candidates, source systems, source credentials, canonical stores, private keys, or model runtimes.
-5. Do not write lifecycle data, release records, receipts, proofs, policy rules, source registries, catalog records, API responses, UI components, or signing keys.
-6. Do not approve release, publish artifacts, resolve evidence as truth, decide policy, or generate public claims.
-7. Do not create schemas, contracts, policy source rules, source registries, pipeline DAGs, API routes, public answers, release decisions, key policies, or connector behavior from this source tree.
-8. Do not store raw provider payloads, secrets, private keys, credentials, private source records, sensitive-location examples, living-person identifiers, DNA/genomic context, or unrestricted sensitive context.
-9. Return typed finite outcomes instead of implicit release, warning-only drift, skipped signature validation, hidden rollback failure, or public exposure of unreleased outputs.
-10. Add deterministic tests for every behavior-changing helper and every negative path.
-11. Keep fixtures synthetic, sanitized, and public-safe.
-12. Preserve rollback and correction metadata supplied by callers when release output can affect downstream publication candidates.
+Allowed telemetry may include:
 
-[⬆ Back to top](#top)
+- safe candidate or run id;
+- object family/version;
+- result class;
+- safe reason code;
+- duration and bounded resource counts;
+- canonicalization/hash/verifier profile version;
+- caller component id where approved;
+- correlation id that reveals no sensitive data.
+
+Do not log:
+
+- release payloads;
+- evidence bodies;
+- private or unreleased artifact content;
+- keys, tokens, credentials, certificates where restricted;
+- full signatures;
+- protected coordinates;
+- personal or genomic data;
+- policy inputs containing restricted details;
+- stack traces containing secrets or payloads.
+
+Errors must be typed, safe, exhaustive, and separable from successful candidate results. Never convert an internal exception into a permissive release candidate.
+
+[Back to top](#top)
 
 ---
 
-## Validation checklist
+## Consumer, runtime, and public-surface contract
 
-- [ ] Confirm `packages/release/src/` exists in the mounted repo with this README as its source-directory guide.
-- [ ] Confirm package manager and import convention (`pyproject.toml`, package.json, workspace config, or equivalent).
-- [ ] Confirm whether this source tree is Python-only, TypeScript-only, or mixed-language.
-- [ ] Confirm import namespace and whether it is `release`, `kfm_release`, or repo-specific.
-- [ ] Confirm owners and CODEOWNERS path coverage.
-- [ ] Confirm release record homes under `release/`.
-- [ ] Confirm schema homes for ReleaseManifest, MapReleaseManifest, RollbackCard, CorrectionNotice, signature envelope, release receipt, and proof refs.
-- [ ] Confirm relationship with `packages/hashing/`, `packages/identity/`, `packages/pipelines-core/`, `packages/policy-runtime/`, `packages/envelopes/`, and receipt/proof homes.
-- [ ] Confirm validators and tests that exercise this source tree.
-- [ ] Confirm tests for `READY`, `INVALID`, `DENIED`, `HOLD`, `ABSTAIN`, `SIGNED`, `ROLLBACK_READY`, `DRIFT`, and `ERROR` paths.
-- [ ] Confirm tests for missing evidence, missing policy, missing rights, missing receipts/proofs, unsigned manifest, invalid signature, hash mismatch, rollback mismatch, correction mismatch, replay drift, and no-public-RAW/WORK/QUARANTINE exposure.
-- [ ] Confirm helpers do not access lifecycle stores, source systems, credentials, private keys, model runtimes, or unpublished candidate stores.
-- [ ] Confirm helpers do not write release records, lifecycle data, receipts, proofs, catalog records, API responses, credentials, permissions, UI state, or signing keys.
+The first consumer must be:
 
-Suggested inspection commands:
+- internal;
+- governed;
+- reviewable;
+- reversible;
+- narrow enough to disable safely.
 
-```bash
-find packages/release/src -maxdepth 5 -type f | sort
-git grep -n "ReleaseManifest\|MapReleaseManifest\|RollbackCard\|CorrectionNotice\|release_state\|rollback\|signature\|SIGNED\|DRIFT\|PromotionReceipt" -- packages docs contracts schemas policy tests fixtures pipelines connectors tools apps release 2>/dev/null || true
-git grep -n "from release\|import release\|packages/release/src" -- . 2>/dev/null || true
-```
+It must:
 
-[⬆ Back to top](#top)
+1. pin package/API/object versions;
+2. supply explicit validated inputs;
+3. preserve all evidence, policy, review, receipt/proof, signing, rollback, and correction refs;
+4. handle every negative and unknown result;
+5. avoid release/lifecycle mutation through the package;
+6. persist authoritative objects only through release-owned workflows;
+7. reverify authority-bound context before persistence;
+8. add replay, correction, revocation, and rollback tests;
+9. expose a kill switch;
+10. document compatibility and operational ownership.
+
+Public clients consume governed released state through approved APIs and release manifests. They must never import this package as release authority.
+
+[Back to top](#top)
+
+---
+
+## Testing, fixtures, and CI
+
+### Minimum test matrix
+
+| Test family | Minimum burden |
+|---|---|
+| Import boundary | Intentional imports succeed only after packaging; unknown exports fail |
+| Empty-state guard | Placeholder package cannot appear operational |
+| Candidate normalization | Stable input produces stable canonical output |
+| ReleaseManifest | Current thin schema and governance-incomplete cases remain distinct |
+| PromotionDecision | Valid and invalid shapes; eleven required fields; closed properties |
+| Outcome mapping | Exhaustive accepted values; unknown value rejection |
+| Evidence | Missing, unresolved, stale, conflicted refs fail closed |
+| Rights/sensitivity | Unknown or restricted posture blocks unsafe candidate |
+| Policy/review | Missing or stale policy/reviewer/ticket context fails closed |
+| Signing | Match, mismatch, wrong payload type, stale, revoked, unverifiable, unsupported, error |
+| Rollback | Missing affected state, target, invalidation, restoration, correction lineage |
+| Correction | Append-only history, supersession, withdrawal, public-summary safety |
+| Replay | Input, profile, dependency, policy, signing, and time drift |
+| Side effects | No network, store, KMS, alias, cache, receipt/proof writes |
+| Privacy | No secrets, keys, personal/DNA data, protected coordinates in logs/errors |
+| Resource bounds | Oversize, count, nesting, parser, memory, and timeout limits |
+| Compatibility | Old/new API and object versions; deprecation and migration |
+| Consumer | First integration handles every finite outcome and kill switch |
+| Authority | Helper cannot publish, approve, persist, or mutate lifecycle state |
+
+Fixtures must be deterministic, synthetic, sanitized, public-safe, and stored in an accepted fixture root—not hidden beside production source by default.
+
+### Current workflow boundary
+
+The current `release-dry-run.yml` confirms explicit holds:
+
+- no real candidate packet payload;
+- comment-only release helper;
+- TODO-only Make target;
+- thin ReleaseManifest schema with no declared validator/fixtures;
+- PromotionDecision shape testing only;
+- incomplete rollback support;
+- no candidate, decision, receipt, proof, manifest, rollback action, release, or publication artifact emitted.
+
+A successful dry-run workflow proves the documented hold behavior, not release readiness.
+
+[Back to top](#top)
+
+---
+
+## Smallest sound implementation sequence
+
+### Gate 0 — governance and naming
+
+Resolve owners, CODEOWNERS/rulesets, import name, package build policy, accepted gate vocabulary, CorrectionNotice family, and first consumer.
+
+### Gate 1 — package metadata
+
+Add reviewed build backend, Python support, discovery, dependency policy, licensing, authorship, typing, and test configuration.
+
+### Gate 2 — accepted candidate contracts
+
+Ratify minimal input/result types, object versions, reason codes, and exhaustive outcome mapping. Do not invent package-specific release states.
+
+### Gate 3 — pure deterministic core
+
+Implement normalization, canonicalization, hashing, comparison, and resource limits without network or authoritative writes.
+
+### Gate 4 — object enforcement
+
+Harden ReleaseManifest, RollbackCard, and CorrectionNotice schemas/validators/fixtures and keep PromotionDecision shape enforcement aligned.
+
+### Gate 5 — signing verification adapter
+
+After security review, add an injected public verification adapter with explicit trust policy, revocation, limits, and negative tests.
+
+### Gate 6 — first governed consumer
+
+Integrate one internal consumer that cannot mutate release state through the package and has a kill switch.
+
+### Gate 7 — governance handoff proof
+
+Prove evidence, policy, review, receipts/proofs, signing, release persistence, correction, revocation, and rollback separation.
+
+### Gate 8 — compatibility and operations
+
+Add changelog, migration, deprecation, correction, rollback drills, observability, incident response, and operational ownership.
+
+No stage may claim publication because the previous stage passed.
+
+[Back to top](#top)
+
+---
+
+## Definition of done
+
+The source envelope is not done until all applicable conditions are verified.
+
+- [ ] Owners and independent review controls are assigned.
+- [ ] Import name and package build are accepted.
+- [ ] Supported Python versions and dependencies are pinned.
+- [ ] Public API and object/result versions are ratified.
+- [ ] Contracts, schemas, policy, validators, and fixtures agree.
+- [ ] Functional source exists and contains no hidden authority.
+- [ ] Determinism and canonicalization are executable and tested.
+- [ ] Network and side-effect boundaries are enforced.
+- [ ] Signing verifier protocol and key custody are security-reviewed.
+- [ ] Positive, negative, replay, privacy, resource, and authority tests pass.
+- [ ] First consumer is governed, reversible, and kill-switch protected.
+- [ ] Receipt/proof and release persistence remain external.
+- [ ] Correction, revocation, supersession, withdrawal, and rollback paths are tested.
+- [ ] Compatibility, migration, deprecation, and changelog policy are active.
+- [ ] CI enforces package behavior without false-green placeholders.
+- [ ] Operational health is observed rather than inferred.
+- [ ] Human review is complete.
+- [ ] Release/publication approval remains a separate act.
+
+[Back to top](#top)
+
+---
+
+## Verification register
+
+| # | Question | Status |
+|---:|---|---|
+| 1 | Who owns package/source/namespace review? | NEEDS VERIFICATION |
+| 2 | Are branch rules and independent review enforced for `packages/release/`? | UNKNOWN |
+| 3 | Is `release` the accepted import name? | UNKNOWN |
+| 4 | Which build backend and Python versions are accepted? | UNKNOWN |
+| 5 | How is package discovery configured? | UNKNOWN |
+| 6 | Which runtime and development dependencies are approved? | UNKNOWN |
+| 7 | What is the accepted public API/version? | UNKNOWN |
+| 8 | Where do package-local tests and fixtures belong? | NEEDS VERIFICATION |
+| 9 | Which first governed consumer justifies the package? | UNKNOWN |
+| 10 | When will the parent package README be reconciled? | NEEDS VERIFICATION |
+| 11 | Which ReleaseManifest fields are required for production closure? | NEEDS VERIFICATION |
+| 12 | Where is the accepted ReleaseManifest validator and fixture set? | NEEDS VERIFICATION |
+| 13 | How is PromotionDecision connected to policy and accountable review? | NEEDS VERIFICATION |
+| 14 | Where is the schema-declared RollbackCard validator? | NEEDS VERIFICATION |
+| 15 | Which rollback fields and invalidation targets are mandatory? | NEEDS VERIFICATION |
+| 16 | Is CorrectionNotice canonical under correction, release, or compatibility paths? | CONFLICTED / NEEDS VERIFICATION |
+| 17 | Where is the accepted CorrectionNotice validator? | NEEDS VERIFICATION |
+| 18 | Which A–G gate vocabulary is accepted? | CONFLICTED / NEEDS VERIFICATION |
+| 19 | What canonicalization and hash profile is authoritative? | NEEDS VERIFICATION |
+| 20 | Which result/reason-code contract will the package export? | UNKNOWN |
+| 21 | What verifier protocol, trust roots, issuers, and media types are accepted? | UNKNOWN |
+| 22 | How are revocation, stale signatures, and transparency logs handled? | UNKNOWN |
+| 23 | Are no-network/no-store/no-KMS rules mechanically enforced? | NEEDS VERIFICATION |
+| 24 | What resource-limit profile is accepted? | NEEDS VERIFICATION |
+| 25 | What telemetry fields and retention policy are allowed? | NEEDS VERIFICATION |
+| 26 | How are EvidenceRef/EvidenceBundle freshness and conflicts represented? | NEEDS VERIFICATION |
+| 27 | How are policy/review decisions rebound at persistence time? | NEEDS VERIFICATION |
+| 28 | Which receipts/proofs are required for each candidate family? | NEEDS VERIFICATION |
+| 29 | How is release mutation kept outside package consumers? | NEEDS VERIFICATION |
+| 30 | What compatibility and deprecation policy applies? | NEEDS VERIFICATION |
+| 31 | What correction and revocation process applies to package defects? | NEEDS VERIFICATION |
+| 32 | Has a rollback drill exercised package and consumer reversal? | NEEDS VERIFICATION |
+| 33 | Which CI checks are required and non-vacuous? | UNKNOWN |
+| 34 | Is the package deployed or imported anywhere operationally? | UNKNOWN |
+| 35 | What is current runtime health? | UNKNOWN |
+
+[Back to top](#top)
+
+---
+
+## Drift and conflicts
+
+### Parent package documentation drift
+
+`../README.md` remains v1 and still lists proposed modules, imports, and helper outcomes. This README and the child namespace README classify those claims as design lineage, not implementation.
+
+Resolution should be a separate scoped revision of the package README so review remains inspectable.
+
+### Gate-vocabulary conflict
+
+`docs/architecture/publication/RELEASE_GATES.md` and proposed ADR-0018 describe different A–G mappings. This source tree must not freeze either mapping into code until the accepted authority resolves the conflict.
+
+### Correction family conflict
+
+CorrectionNotice appears in correction-family authority while release documentation also references it. This source tree must preserve refs without choosing a canonical family.
+
+### Validator-path drift
+
+RollbackCard and CorrectionNotice schema-declared validators are absent or do not match the placeholder validator that exists elsewhere. Source code must not compensate by inventing private validation semantics.
+
+[Back to top](#top)
+
+---
+
+## Maintenance and change review
+
+Any material source change should review:
+
+- package and namespace documentation;
+- package metadata;
+- contracts and schemas;
+- policy and review requirements;
+- validator and fixture coverage;
+- signing/key-custody implications;
+- consumer compatibility;
+- CI and runbooks;
+- receipts/proofs and release persistence boundaries;
+- correction, revocation, withdrawal, and rollback impact;
+- security, privacy, rights, sensitivity, and public-surface exposure;
+- generated-work receipt and human-review status.
+
+### Change classes
+
+| Change | Minimum review |
+|---|---|
+| Documentation-only clarification | Docs + responsible package/release steward |
+| New internal source file | Package + architecture + tests |
+| New export or result type | Contract/schema + package + consumers + compatibility |
+| New dependency | Package + supply-chain/security + CI |
+| Networked verifier | Security/signing + architecture/ADR + operations |
+| Release-object semantic change | Contract/schema/policy/release + migration |
+| Signing/trust policy change | Security/signing + policy + release + rollback |
+| Consumer integration | Consumer owner + package + release authority + tests |
+| Breaking change | Migration, deprecation, correction, rollback, and release review |
+
+Generation, review, merge, signing, release, and publication remain separate duties.
+
+[Back to top](#top)
+
+---
+
+## Versioning, compatibility, deprecation, and correction
+
+A supported API change must include:
+
+- API and object-version mapping;
+- contract/schema/policy impact;
+- consumer inventory and migration notes;
+- compatibility tests;
+- changelog entry;
+- deprecation window;
+- correction and revocation path;
+- rollback target and kill switch;
+- operational ownership;
+- documentation and generated receipt updates.
+
+### Package defect response
+
+If implemented package behavior emits incorrect candidate metadata:
+
+1. stop or disable affected consumers;
+2. identify affected package versions, runs, candidates, releases, and public derivatives;
+3. preserve prior records and evidence;
+4. issue governed correction, withdrawal, or revocation where public state was affected;
+5. invalidate derivatives through release authority;
+6. patch or revert through reviewed change control;
+7. rerun validation, replay, security, correction, and rollback drills;
+8. document impact and supersession.
+
+Do not silently rewrite release records or prior generated receipts.
+
+[Back to top](#top)
+
+---
+
+## Evidence ledger
+
+| Evidence | Finding | Limitation |
+|---|---|---|
+| Target README v1 | Proposed source tree and API claims | Not implementation proof |
+| Package metadata | `kfm-release` `0.0.0` only | No build/install/import support |
+| Source inventory | README, child README, empty init, placeholder core | Bounded inspection, not universal absence proof |
+| Child namespace README v1.1 | Current evidence-grounded API boundary | Still documentation, not code |
+| Parent package README v1 | Package intent | Stale relative to child/source evidence |
+| Release root | Governs release records | Lane conventions remain open |
+| ReleaseManifest contract/schema | Rich meaning, thin shape | No production closure |
+| PromotionDecision contract/schema/test | Concrete proposed shape and fixture validation | No policy/review/release authorization |
+| RollbackCard contract/schema/validator | Rich meaning, thin shape, placeholder validator | No rollback readiness |
+| CorrectionNotice contract/schema | Rich meaning, thin shape | Placement/validator unresolved |
+| Signing standard | Draft signing model | No production key/trust authority |
+| ADR-0018 | Proposed gate sequence | Not accepted |
+| Release dry-run workflow | Explicitly verifies holds and bounded shape tests | No candidate or release emitted |
+| Directory Rules | `packages/` is shared-library root | Does not prove package necessity |
+| CODEOWNERS | Review routing | Not independent approval |
+
+[Back to top](#top)
 
 ---
 
 ## Rollback
 
-Rollback is required if this source tree:
+### Before merge
 
-- creates a parallel authority home for release records, schemas, contracts, policy, registries, lifecycle data, receipts, proofs, API routes, UI surfaces, credentials, key-management, model runtimes, or source data;
-- approves release, writes release records, mutates current aliases, writes lifecycle outputs, writes receipts/proofs, or stores signing keys as a source helper;
-- lets public clients or normal UI surfaces access RAW, WORK, QUARANTINE, unpublished candidates, source systems, direct model outputs, or unreleased artifacts;
-- treats signing success, run success, policy allow, or manifest assembly as proof of truth, evidence closure, admissibility, public safety, or release;
-- hides rollback, correction, drift, missing receipt/proof, missing rights, or signature failure behind warning-only logs;
-- stores secrets, private keys, credentials, private source records, real living-person identifiers, DNA/genomic context, or protected-location examples in fixtures.
+Close the draft pull request and abandon the scoped branch.
 
-Rollback target: revert the release-source PR, keep any generated audit notes as review evidence, and file the affected behavior in `docs/registers/DRIFT_REGISTER.md` or `docs/registers/VERIFICATION_BACKLOG.md` if the mounted repo uses those registers.
+### After merge
 
-[⬆ Back to top](#top)
+Use a revert pull request. Preserve shared history and the generated receipt as review evidence.
 
----
+### Behavioral rollback
 
-## Evidence boundary
+This documentation revision changes no Python behavior, package metadata, release object, policy, schema, validator, fixture, test, workflow, signer, receipt/proof instance, release record, lifecycle artifact, public surface, or deployment.
 
-| Source | Status | Supports | Limits |
-| --- | --- | --- | --- |
-| Current target file | CONFIRMED | `packages/release/src/README.md` existed and required replacement from placeholder content. | Did not prove source implementation maturity. |
-| Parent package README | CONFIRMED repo doc | `packages/release/` is a shared helper-code package for release manifest assembly, signing, rollback, and correction support. | Does not prove source files, package metadata, tests, or CI. |
-| `packages/README.md` | CONFIRMED repo doc | `packages/` is for shared libraries used by apps, workers, pipelines, and tools. | Does not define this source namespace. |
-| `docs/architecture/release-model.md` | CONFIRMED repo search result | Release-model architecture exists as a repo doc. | Content was not re-read in full for this source README pass. |
-| `docs/standards/RELEASE_MANIFEST.md` and `docs/standards/SIGNING.md` | CONFIRMED repo search results | Release manifest and signing standards exist as repo docs. | Content was not re-read in full for this source README pass. |
-| Current file-generation pass | CONFIRMED request | User-requested target path and README repair/replacement. | Does not inspect package metadata, tests, CI logs, dashboards, deployment posture, runtime behavior, key-management posture, or branch protection. |
+If future source violates authority boundaries, rollback must:
 
-[⬆ Back to top](#top)
+- disable consumers;
+- revert or supersede the package version;
+- preserve affected records;
+- route correction/withdrawal through release authority;
+- revoke or distrust affected signatures where applicable;
+- invalidate public derivatives through governed release processes;
+- rerun replay and rollback tests.
+
+No merge, release, signing, or publication authority is granted by this README.
+
+[Back to top](#top)


### PR DESCRIPTION
<!-- KFM_AGENT_TASK: kfm-packages-release-src-readme-v1-1-20260719:BEGIN -->

## Goal

Revise `packages/release/src/README.md` so the source-envelope contract matches the verified greenfield repository state, delegates namespace/API detail to the merged child README, and defines source admission, authority, signing, testing, compatibility, correction, and rollback burdens without inventing implementation.

## Task contract

| Field | Value |
|---|---|
| Repository | `bartytime4life/Kansas-Frontier-Matrix` |
| Base | `main@7af75ca2b7c3bfe75325e41f4fbfca664bfcd7fd` |
| Head | `docs/release-source-readme-v1-1@bf0f25358e2ac96995849eddeaa52415169a029f` |
| Target paths | `packages/release/src/README.md`; generated receipt under `data/receipts/generated/` |
| Operation | Existing documentation revision |
| Authority | Implement on review branch only; no signing, release, or publication authority |
| Change budget | Exactly two files |
| Non-goals | No Python implementation, package metadata, dependencies, contracts, schemas, policy, validators, fixtures, tests, workflows, release records, signing, deployment, or publication |

## CONFIRMED repository state

- `packages/release/src/README.md` was v1 and over-described a proposed module/API surface.
- `packages/release/src/release/README.md` is merged at v1.1 and records a greenfield namespace boundary.
- `packages/release/pyproject.toml` declares only `kfm-release` version `0.0.0`.
- `release/__init__.py` is empty and `release/core.py` is comment-only.
- Bounded search surfaced no functional namespace consumer import or package-local test reference.
- `PromotionDecision` has a concrete PROPOSED schema, validator, and repository fixture test; this proves shape validation only.
- `ReleaseManifest`, `RollbackCard`, and `CorrectionNotice` enforcement remains thin, incomplete, or conflicted.
- ADR-0018 is proposed, the signing standard is draft, and `release-dry-run.yml` explicitly holds candidate assembly and publication.

## What changed

- Bumped the source README from v1 to v1.1 while preserving its document identity.
- Replaced the fictional module tree, import examples, and unratified helper outcomes with the verified four-file source inventory.
- Defined complementary package/source/namespace documentation responsibilities.
- Added package/import/API gates, source-admission rules, allowed file classes, explicit exclusions, object-maturity boundaries, candidate/persistence separation, outcome-vocabulary separation, lifecycle/trust-membrane rules, dependency direction, no-network and side-effect constraints, determinism, signing/key-custody requirements, replay/freshness, telemetry hygiene, consumer rules, and a comprehensive test matrix.
- Added a staged implementation sequence, definition of done, 35-item verification register, drift/conflict inventory, maintenance/change-review rules, compatibility/deprecation/correction requirements, evidence ledger, and rollback instructions.
- Added generated receipt `data/receipts/generated/genrec-packages-release-src-readme-c5b2eb1d.json`.

## Directory Rules basis

The existing path remains under `packages/`, the shared reusable implementation responsibility root. Authoritative release records remain under `release/`; meaning remains under `contracts/`; shape remains under `schemas/`; policy, evidence, review, receipts/proofs, key custody, lifecycle state, and public delivery remain in their owning roots. No parallel authority home or ADR-triggering path was created.

## Validation

| Check | Outcome |
|---|---:|
| One H1; 63 headings; no hierarchy jumps or duplicate slugs | PASS |
| 58 internal links resolve | PASS |
| Balanced code fences; zero trailing whitespace; final newline | PASS |
| KFM Meta Block parses | PASS |
| Repository-relative references | PASS — 29 paths verified in this session |
| Remote README read-back | PASS — blob `8318fc5aeee6856391487a80c1e623a62e6fd510` |
| README SHA-256 | `c5b2eb1d581b3f55de28f351d873687a4c2586b167247954f1e9baf34d87855c` |
| Final branch diff | PASS — exactly the README and receipt |
| Package-native execution | NOT RUN — no implementation exists |
| Human review | PENDING |

## Base drift

The initial evidence snapshot was prepared at `f73caa6…`. `main` advanced to `7af75ca2…` through an unrelated Agriculture pipeline README and generated receipt. The target blob and linked release authorities did not change, and the review branch was created from the newer head.

## Rollback

Before merge, close this draft PR and abandon the branch. After merge, use a revert PR and preserve shared history. This change does not mutate release state, data, trust-artifact instances, signatures, corrections, public artifacts, or deployment.

No merge, signing, release, or publication is authorized by this pull request.

<!-- KFM_AGENT_TASK: kfm-packages-release-src-readme-v1-1-20260719:END -->