### PR TITLE
docs(fixtures): ground spec_hash invalid fixture lane

### DIFF
--- a/data/receipts/generated/genrec-spec-hash-invalid-readme-ce1f57a2.json
+++ b/data/receipts/generated/genrec-spec-hash-invalid-readme-ce1f57a2.json
@@ -1,0 +1,121 @@
+{
+  "receipt_id": "genrec-spec-hash-invalid-readme-ce1f57a2",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    "fixtures/contracts/v1/common/spec_hash/invalid/README.md"
+  ],
+  "artifact_hashes": {
+    "fixtures/contracts/v1/common/spec_hash/invalid/README.md": "sha256:ce1f57a2205dd8adf6853351030e0b545a48c785d8218074fe3e029a7b4047b8"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "GPT-5.6 Thinking",
+    "version": "2026-07-19"
+  },
+  "prompt_or_contract": "sha256:026bda2c782f6bb26d2ceb879f9c54236863628460abc5b86543b57063975e19",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "python"
+    ]
+  },
+  "inputs": {
+    "evidence_hashes": [
+      "sha256:026bda2c782f6bb26d2ceb879f9c54236863628460abc5b86543b57063975e19"
+    ],
+    "attached_docs": [],
+    "evidence_refs": [
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:fixtures/contracts/v1/common/spec_hash/invalid/README.md",
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:fixtures/contracts/v1/common/spec_hash/invalid/invalid_1.json",
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:fixtures/contracts/v1/common/spec_hash/invalid/invalid_1.expected_error.txt",
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:fixtures/contracts/v1/common/spec_hash/valid/README.md",
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:fixtures/contracts/v1/common/spec_hash/README.md",
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:fixtures/contracts/v1/common/README.md",
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:schemas/contracts/v1/common/spec_hash.schema.json",
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:contracts/common/spec_hash.md",
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:tools/validators/validate_spec_hash.py",
+      "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:tests/schemas/test_common_contracts.py"
+    ]
+  },
+  "truth_labels": {
+    "fixtures/contracts/v1/common/spec_hash/invalid/README.md": "PROPOSED"
+  },
+  "validation_gates": [
+    {
+      "gate": "directory-rules-placement",
+      "outcome": "PASS",
+      "reason": "Existing fixture path retained under the fixtures/contracts/v1/common/spec_hash/invalid responsibility lane; no authority root or path moved."
+    },
+    {
+      "gate": "repository-evidence-and-maturity",
+      "outcome": "PASS",
+      "reason": "README distinguishes one confirmed invalid fixture, executable generic pytest harness, proposed schema status, and placeholder dedicated validator."
+    },
+    {
+      "gate": "fixture-schema-polarity",
+      "outcome": "PASS",
+      "reason": "The exact invalid fixture {} produces the expected missing-value Draft 2020-12 validation error."
+    },
+    {
+      "gate": "markdown-structure-and-links",
+      "outcome": "PASS",
+      "reason": "One H1, closed meta block, consecutive hierarchy, balanced fences, unique internal anchors, final newline, and no tabs or trailing whitespace."
+    },
+    {
+      "gate": "sensitive-content-and-secrets",
+      "outcome": "PASS",
+      "reason": "No production hash, credential, token, source payload, personal data, or restricted material was introduced."
+    },
+    {
+      "gate": "repository-native-pytest",
+      "outcome": "SKIPPED",
+      "reason": "No full repository checkout was available; exact schema/fixture polarity was executed locally and remote CI will provide repository-level evidence."
+    },
+    {
+      "gate": "remote-ci",
+      "outcome": "SKIPPED",
+      "reason": "To be observed after draft pull request creation."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "spec-hash-schema",
+      "validated": true,
+      "evidence_ref": "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:schemas/contracts/v1/common/spec_hash.schema.json"
+    },
+    {
+      "id": "generic-schema-harness",
+      "validated": true,
+      "evidence_ref": "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:tests/schemas/test_common_contracts.py"
+    },
+    {
+      "id": "dedicated-validator-placeholder",
+      "validated": true,
+      "evidence_ref": "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:tools/validators/validate_spec_hash.py"
+    },
+    {
+      "id": "invalid-fixture",
+      "validated": true,
+      "evidence_ref": "github:bartytime4life/Kansas-Frontier-Matrix@2783739bba744f560772388a9969ed3107d08930:fixtures/contracts/v1/common/spec_hash/invalid/invalid_1.json"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-19T17:30:00Z",
+  "emitter": "OpenAI GPT-5.6 Thinking via ChatGPT GitHub connector",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "Documentation-only update for the SpecHash invalid fixture lane. The receipt records provenance and bounded validation; it is not schema authority, contract meaning, validator proof, policy approval, release approval, or human review."
+}

--- a/fixtures/contracts/v1/common/spec_hash/invalid/README.md
+++ b/fixtures/contracts/v1/common/spec_hash/invalid/README.md
@@ -1,164 +1,425 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://fixture/contracts/v1/common/spec-hash/invalid/readme
-title: spec_hash invalid fixtures README
-type: fixture-readme
-version: v0.1.0
-status: draft
-owners: TODO(owner): schema steward; TODO(owner): common contracts steward; TODO(owner): fixture steward; TODO(owner): validator steward; TODO(owner): docs steward
-created: NEEDS VERIFICATION - blank file existed before 2026-06-30 expansion
-updated: 2026-06-30
-policy_label: public-review
-related: [../README.md, ../valid/valid_1.json, invalid_1.json, invalid_1.expected_error.txt, ../../../../../../schemas/contracts/v1/common/spec_hash.schema.json, ../../../../../../contracts/common/spec_hash.md, ../../../../../../tools/validators/validate_spec_hash.py, ../../../../../../tests/schemas/test_common_contracts.py]
-tags: [kfm, fixtures, contracts, v1, common, spec-hash, invalid-fixtures, json-schema, expected-error, negative-tests, non-authoritative]
-notes: ["This README replaces a blank file at `fixtures/contracts/v1/common/spec_hash/invalid/README.md`.", "Invalid fixtures are intentionally failing inputs for schema enforcement; they are not schema authority, contract authority, policy authority, proof authority, release authority, or production data.", "The active schema evidence for this lane is `schemas/contracts/v1/common/spec_hash.schema.json`; the fixture root is declared in that schema's `x-kfm.fixtures_root`.", "The dedicated `tools/validators/validate_spec_hash.py` file exists but is a greenfield placeholder; current fixture behavior is documented from `tests/schemas/test_common_contracts.py` and the JSON Schema shape."]
+title: fixtures/contracts/v1/common/spec_hash/invalid/ — SpecHash Negative Fixture Contract
+type: readme; directory-readme; invalid-contract-fixture-lane; common-contract; json-schema-negative-case; non-authoritative
+version: v0.2
+status: draft; repository-grounded; one-invalid-fixture-confirmed; generic-pytest-harness-confirmed; dedicated-validator-placeholder; partial-negative-coverage
+owners: OWNER_TBD — Schema steward · Common-contract steward · Fixture steward · Validator steward · Test/QA steward · Docs steward
+created: NEEDS VERIFICATION — file predates the 2026-06-30 v0.1 expansion
+updated: 2026-07-19
+supersedes: v0.1.0
+policy_label: public-review; fixtures; contracts; common; spec-hash; invalid; synthetic-only; non-authoritative
+owning_root: fixtures/
+current_path: fixtures/contracts/v1/common/spec_hash/invalid/README.md
+truth_posture: >
+  CONFIRMED target v0.1 README and prior blob; invalid_1.json content; expected-error
+  sidecar content; sibling valid fixture lane; parent fixture-family guidance; SpecHash
+  semantic contract; Draft 2020-12 schema shape, required value field, lowercase SHA-256
+  pattern, closed object shape, and x-kfm fixture/validator metadata; generic pytest
+  collection and expected-error matching; dedicated validator placeholder behavior /
+  PROPOSED broader negative matrix for missing value, wrong root type, wrong value type,
+  missing prefix, wrong digest length, uppercase hex, non-hex characters, extra properties,
+  and stable reason-token coverage / UNKNOWN exhaustive fixture inventory outside the
+  inspected direct lane, dynamic consumers, branch-protection significance, current
+  repository-wide pass state, production producers, canonicalization behavior, and release
+  use / NEEDS VERIFICATION accepted owners, CODEOWNERS, dedicated validator implementation,
+  complete negative coverage, exact collected case count, CI requirement, and downstream
+  correction obligations
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  repository_id: "1059091169"
+  visibility: public
+  base_ref: main
+  base_commit: 2783739bba744f560772388a9969ed3107d08930
+  prior_blob: bf9fa6f13c0b93e7f64d70885e64a60275e69500
+  invalid_fixture_blob: 0967ef424bce6791893e9a57bb952f80fd536e93
+  expected_error_blob: cb128ae0e4af3f627f25520854312fef678d50e5
+  schema_blob: 80b496b01b8de8c0e8ba67bf020977e6b1f3c652
+  validator_blob: de69c6c7001082af29827a4b287a80b7c6a05af3
+  test_harness_blob: b04342cc034d7f1cc554e155fdd02d6e972976e6
+related:
+  - ../README.md
+  - ../valid/README.md
+  - ../valid/valid_1.json
+  - invalid_1.json
+  - invalid_1.expected_error.txt
+  - ../../../../../../schemas/contracts/v1/common/spec_hash.schema.json
+  - ../../../../../../contracts/common/spec_hash.md
+  - ../../../../../../tools/validators/validate_spec_hash.py
+  - ../../../../../../tests/schemas/test_common_contracts.py
+  - ../../../../../../docs/doctrine/directory-rules.md
+tags: [kfm, fixtures, contracts, v1, common, spec-hash, invalid-fixtures, json-schema, expected-error, negative-tests, fail-closed, non-authoritative]
+notes:
+  - "v0.2 replaces the v0.1 historical blank-file narrative with current repository evidence."
+  - "The direct lane contains one confirmed invalid JSON fixture and one expected-error sidecar."
+  - "The generic pytest harness is executable; the schema-declared dedicated validator remains a NotImplementedError placeholder."
+  - "This README changes documentation only. It creates no new fixture case and claims no broader negative coverage."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-# `spec_hash` invalid fixtures
+# SpecHash Negative Fixture Contract
 
-Intentional negative fixtures for the KFM `spec_hash` common contract.
+`fixtures/contracts/v1/common/spec_hash/invalid/`
+
+> **Purpose.** Hold deterministic JSON instances that must be rejected by the `spec_hash` schema, together with narrowly scoped expected-error text, without turning fixtures or test output into schema, contract, policy, proof, release, or production authority.
 
 <p>
   <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
+  <img alt="Version: v0.2" src="https://img.shields.io/badge/version-v0.2-informational">
   <img alt="Root: fixtures" src="https://img.shields.io/badge/root-fixtures%2F-6f42c1">
-  <img alt="Contract family: common" src="https://img.shields.io/badge/family-common-blue">
-  <img alt="Contract: spec_hash" src="https://img.shields.io/badge/contract-spec__hash-purple">
   <img alt="Fixture kind: invalid" src="https://img.shields.io/badge/fixture-invalid-critical">
+  <img alt="Coverage: one case" src="https://img.shields.io/badge/coverage-one__case-orange">
+  <img alt="Dedicated validator: placeholder" src="https://img.shields.io/badge/dedicated__validator-placeholder-red">
+  <img alt="Authority: fixture only" src="https://img.shields.io/badge/authority-fixture__only-success">
 </p>
 
-**Path:** `fixtures/contracts/v1/common/spec_hash/invalid/README.md`  
-**Fixture posture:** negative JSON Schema fixture lane  
-**Authority posture:** fixture only; schema authority lives in `schemas/contracts/v1/common/spec_hash.schema.json`  
-**Quick links:** [Purpose](#purpose) · [Current inventory](#current-inventory) · [Schema basis](#schema-basis) · [Test harness behavior](#test-harness-behavior) · [Accepted material](#accepted-material) · [Exclusions](#exclusions) · [Validation checklist](#validation-checklist) · [Status notes](#status-notes) · [Evidence ledger](#evidence-ledger)
-
 > [!IMPORTANT]
-> Files in this directory are expected to fail validation. They are not production spec hashes, source data, proof records, receipts, policy decisions, release decisions, or contract/schema authority.
+> Every `invalid_*.json` file in this directory is expected to fail the paired JSON Schema. A failure caused by a missing file, parser crash, unresolved schema, dependency error, or placeholder validator is **not** proof that the intended negative condition was enforced.
+
+> [!WARNING]
+> A rejected fixture proves only the tested machine-shape condition. It does not prove semantic correctness, canonicalization, evidence closure, policy admissibility, artifact integrity, release readiness, or publication safety.
+
+**Quick links:** [Status](#status-and-evidence-boundary) · [Purpose](#purpose-and-scope) · [Placement](#placement-and-authority) · [Inventory](#confirmed-inventory) · [Schema](#schema-and-contract-basis) · [Harness](#executable-test-harness) · [Failure contract](#negative-fixture-failure-contract) · [Coverage](#coverage-boundary) · [Authoring](#authoring-contract) · [Validation](#validation) · [Correction](#correction-and-rollback) · [Open items](#open-verification-register) · [Evidence](#evidence-ledger)
 
 ---
 
-## Purpose
+## Status and evidence boundary
 
-This directory holds invalid JSON fixtures for the `spec_hash` common contract.
-
-Use this lane to verify that the schema rejects malformed or incomplete `spec_hash` objects. Each invalid fixture should pair with an optional `.expected_error.txt` file when the test harness should assert a specific error message fragment.
-
----
-
-## Current inventory
-
-| Fixture | Invalid because | Expected error |
+| Surface | Status at the pinned snapshot | Safe conclusion |
 |---|---|---|
-| [`invalid_1.json`](invalid_1.json) | The object is `{}` and omits required property `value`. | [`invalid_1.expected_error.txt`](invalid_1.expected_error.txt): `'value' is a required property` |
+| This README | **CONFIRMED existing v0.1** | Revised in place; prior blob is pinned above. |
+| `invalid_1.json` | **CONFIRMED** | Contains an empty JSON object. |
+| `invalid_1.expected_error.txt` | **CONFIRMED** | Requires the missing-`value` message. |
+| Paired schema | **CONFIRMED file / `PROPOSED` metadata status** | Requires `value`, enforces a lowercase SHA-256 pattern, and rejects additional properties. |
+| Generic pytest harness | **CONFIRMED executable code** | Discovers this fixture family and checks invalid polarity plus expected-error text. |
+| Dedicated `validate_spec_hash.py` | **CONFIRMED placeholder** | Raises `NotImplementedError`; it is not usable validator enforcement. |
+| Current test result for this exact repository head | **NEEDS VERIFICATION** | File inspection is not an execution log. |
+| Complete negative-case coverage | **NOT ESTABLISHED** | One missing-required-field case is confirmed. |
+| Production or release use | **UNKNOWN** | Fixtures do not establish downstream consumers or authority. |
+
+### Truth labels
+
+- **CONFIRMED** — verified from repository files or local execution against the pinned content.
+- **PROPOSED** — recommended behavior or coverage not yet implemented.
+- **UNKNOWN** — not resolved from current evidence.
+- **NEEDS VERIFICATION** — checkable but not sufficiently proven for reliance.
+
+[Back to top](#top)
 
 ---
 
-## Schema basis
+## Purpose and scope
 
-The current schema evidence for this fixture lane is:
+This lane answers a narrow question:
+
+> Does the current `spec_hash` schema reject a deliberately invalid instance for the intended reason?
+
+### In scope
+
+- intentionally invalid JSON instances;
+- one failure concern per fixture when practical;
+- expected-error sidecars used by the repository schema test harness;
+- deterministic, synthetic, reviewable cases;
+- schema drift detection;
+- clear separation between fixture failure and infrastructure failure.
+
+### Out of scope
+
+- valid examples, which belong in [`../valid/`](../valid/README.md);
+- schema or semantic-contract definitions;
+- canonicalization algorithms;
+- hash generation;
+- validator implementation;
+- evidence, proof, policy, release, lifecycle, or publication records;
+- production digests or real artifact identifiers.
+
+[Back to top](#top)
+
+---
+
+## Placement and authority
+
+### Directory Rules basis
+
+`fixtures/` is an enforceability-input root adjacent to `tests/`. This path is further partitioned by contract version, family, object name, and polarity:
 
 ```text
-schemas/contracts/v1/common/spec_hash.schema.json
+fixtures/
+└── contracts/
+    └── v1/
+        └── common/
+            └── spec_hash/
+                ├── valid/
+                └── invalid/   # this lane
 ```
 
-Relevant shape:
+The path is correct for reusable contract-fixture inputs. Responsibility remains separated:
 
-| Field | Requirement |
+| Responsibility | Owning surface |
 |---|---|
-| Root type | object |
+| Semantic meaning | [`contracts/common/spec_hash.md`](../../../../../../contracts/common/spec_hash.md) |
+| Machine shape | [`schemas/contracts/v1/common/spec_hash.schema.json`](../../../../../../schemas/contracts/v1/common/spec_hash.schema.json) |
+| Invalid fixture inputs | This directory |
+| Positive fixture inputs | [`../valid/`](../valid/README.md) |
+| Generic executable test | [`tests/schemas/test_common_contracts.py`](../../../../../../tests/schemas/test_common_contracts.py) |
+| Dedicated validator implementation | [`tools/validators/validate_spec_hash.py`](../../../../../../tools/validators/validate_spec_hash.py) |
+| Policy, proofs, receipts, and release | Their separate authority roots |
+
+This README coordinates those references but owns none of their authority.
+
+[Back to top](#top)
+
+---
+
+## Confirmed inventory
+
+| Path | Content | Expected outcome |
+|---|---|---|
+| [`invalid_1.json`](invalid_1.json) | `{}` | Schema rejection because required property `value` is absent. |
+| [`invalid_1.expected_error.txt`](invalid_1.expected_error.txt) | `'value' is a required property` | The generic harness must find this normalized text in the combined schema errors. |
+
+No additional direct invalid fixture is claimed by this README.
+
+### Positive comparison
+
+[`../valid/valid_1.json`](../valid/valid_1.json) provides the sibling positive shape. The valid and invalid lanes are complementary inputs, not competing authority.
+
+[Back to top](#top)
+
+---
+
+## Schema and contract basis
+
+The schema requires this shape:
+
+```json
+{
+  "value": "sha256:<64 lowercase hexadecimal characters>"
+}
+```
+
+| Constraint | Current requirement |
+|---|---|
+| Root type | `object` |
 | Required property | `value` |
-| `value` type | string |
-| `value` pattern | `^sha256:[a-f0-9]{64}$` |
-| Additional properties | false |
-| Schema-declared fixtures root | `fixtures/contracts/v1/common/spec_hash/` |
-| Dedicated validator path | `tools/validators/validate_spec_hash.py` |
-| Dedicated validator maturity | `NEEDS VERIFICATION` — current file is a greenfield placeholder. |
+| `value` type | `string` |
+| Pattern | `^sha256:[a-f0-9]{64}$` |
+| Additional properties | rejected |
+| Schema metadata status | `PROPOSED` |
+| Declared fixture root | `fixtures/contracts/v1/common/spec_hash/` |
+| Declared validator | `tools/validators/validate_spec_hash.py` |
+
+The semantic contract further limits interpretation: a shape-valid `spec_hash` identifies a hashed specification representation. It does not prove correctness, authority, admissibility, freshness, evidence closure, or release state.
+
+[Back to top](#top)
 
 ---
 
-## Test harness behavior
+## Executable test harness
 
-`tests/schemas/test_common_contracts.py` discovers schema fixture families under:
+`tests/schemas/test_common_contracts.py`:
 
-```text
-fixtures/contracts/v1/<family>/<name>/
+1. includes `common` in its hard-coded family list;
+2. discovers immediate `*.schema.json` files under the common schema family;
+3. maps each schema name to `fixtures/contracts/v1/common/<name>/`;
+4. validates `invalid/invalid_*.json`;
+5. requires at least one JSON Schema error;
+6. reads the matching `.expected_error.txt` when present;
+7. normalizes and matches expected text against combined validator messages.
+
+For this fixture, the expected text is specific enough to distinguish the intended missing-field rejection from an unrelated schema failure.
+
+### Dedicated validator boundary
+
+`tools/validators/validate_spec_hash.py` currently raises:
+
+```python
+NotImplementedError("Greenfield placeholder")
 ```
 
-For each invalid fixture matching `invalid/invalid_*.json`, the test harness expects JSON Schema validation errors. When a sibling `.expected_error.txt` file exists, the harness lowercases the expected text and checks that each expected non-empty line appears in the combined JSON Schema error messages.
-
-For this directory, `invalid_1.expected_error.txt` is intentionally specific:
+Therefore:
 
 ```text
-'value' is a required property
+generic pytest harness = executable evidence path
+dedicated validator CLI = placeholder, not enforcement
 ```
 
-That expected line corresponds to `invalid_1.json` omitting the schema-required `value` field.
+A placeholder exception must never be counted as successful rejection of an invalid fixture.
+
+[Back to top](#top)
 
 ---
 
-## Accepted material
+## Negative fixture failure contract
 
-| Accepted item | Purpose |
+A case is acceptable only when all applicable conditions hold:
+
+| Condition | Required posture |
 |---|---|
-| `invalid_*.json` | JSON instances expected to fail `spec_hash` schema validation. |
-| `invalid_*.expected_error.txt` | Optional expected error fragment for the matching invalid JSON fixture. |
-| `README.md` | Local fixture boundary and inventory. |
+| Fixture parses as JSON | Yes |
+| Matching schema loads and resolves | Yes |
+| Validation returns one or more schema errors | Yes |
+| Expected-error sidecar exists when stable cause matching is needed | Preferred |
+| Expected text matches the intended cause | Yes |
+| Failure is caused by missing file, crash, import error, or placeholder validator | Reject the test result |
+| Fixture contains real production hash or restricted material | Reject the fixture |
 
----
+### Finite outcomes
 
-## Exclusions
-
-| Do not place here | Correct home |
+| Outcome | Meaning |
 |---|---|
-| Valid `spec_hash` examples | `../valid/` |
-| Parent contract fixture guidance | `../README.md` |
-| JSON Schema authority | `../../../../../../schemas/contracts/v1/common/spec_hash.schema.json` |
-| Semantic contract documentation | `../../../../../../contracts/common/spec_hash.md` |
-| Validator implementation | `../../../../../../tools/validators/validate_spec_hash.py` or accepted validator root |
-| Policy rules | `../../../../../../policy/common/` |
-| Runtime receipts, proofs, release records, source data, or published artifacts | Their canonical KFM roots, not fixtures |
+| `EXPECTED_REJECTION` | Fixture parsed, schema loaded, and the intended invalid condition was detected. |
+| `UNEXPECTED_PASS` | Fixture produced no schema errors; fail the test. |
+| `WRONG_REJECTION` | Fixture failed, but expected cause text did not match; fail the test. |
+| `FIXTURE_ERROR` | JSON or sidecar is malformed or missing; fail the test. |
+| `HARNESS_ERROR` | Schema, dependency, import, or runner failed; do not report expected rejection. |
+
+These labels are documentation vocabulary unless separately standardized by a contract.
+
+[Back to top](#top)
 
 ---
 
-## Validation checklist
+## Coverage boundary
 
-Before adding or changing invalid fixtures here:
+The current lane proves one negative dimension:
 
-- [ ] The fixture file name follows `invalid_<n>.json`.
-- [ ] The fixture is intentionally invalid under `spec_hash.schema.json`.
-- [ ] The failure reason is narrow and easy to understand.
-- [ ] The expected error file, when present, matches the JSON Schema error text closely enough for `tests/schemas/test_common_contracts.py`.
-- [ ] The fixture does not redefine the schema, contract, policy, or validator.
-- [ ] The fixture does not contain production hashes, secrets, source data, receipts, proofs, release records, or published artifacts.
-- [ ] New invalid cases are paired with a matching valid case only when that improves coverage and does not blur fixture purpose.
+- missing required `value`.
+
+It does **not** currently prove rejection of:
+
+- non-object roots;
+- non-string `value`;
+- missing `sha256:` prefix;
+- uppercase hexadecimal;
+- non-hexadecimal characters;
+- digest shorter or longer than 64 characters;
+- leading or trailing whitespace;
+- additional properties;
+- alternative hash algorithms;
+- canonicalization mismatch.
+
+These are sensible **PROPOSED** future cases, not current repository facts. Each added fixture should isolate one primary failure where practical.
+
+[Back to top](#top)
 
 ---
 
-## Status notes
+## Authoring contract
 
-| Item | Status | Notes |
-|---|---:|---|
-| Target path presence | CONFIRMED | `fixtures/contracts/v1/common/spec_hash/invalid/README.md` existed as a blank file before this update. |
-| Invalid fixture inventory | CONFIRMED | `invalid_1.json` exists and contains `{}`. |
-| Expected error inventory | CONFIRMED | `invalid_1.expected_error.txt` exists and contains `'value' is a required property`. |
-| Valid sibling example | CONFIRMED | `../valid/valid_1.json` contains a `sha256:` value with 64 lowercase hex characters. |
-| Schema authority | CONFIRMED | `schemas/contracts/v1/common/spec_hash.schema.json` defines the required `value` property and pattern. |
-| Dedicated validator implementation | NEEDS VERIFICATION | `tools/validators/validate_spec_hash.py` is present but currently a greenfield placeholder. |
-| Test harness behavior | CONFIRMED | `tests/schemas/test_common_contracts.py` validates invalid fixtures and expected error text. |
-| Runtime validation results | NOT RUN | This README update did not run tests. |
+Before adding or changing an invalid fixture:
+
+- use `invalid_<n>.json`;
+- keep the payload synthetic and minimal;
+- target one primary schema invariant;
+- ensure the JSON parses before schema validation;
+- add `invalid_<n>.expected_error.txt` when cause stability matters;
+- use expected text emitted by the actual Draft 2020-12 validator path;
+- avoid broad patterns that could match unrelated errors;
+- add or update the positive sibling only when needed to preserve polarity;
+- update this inventory and the parent README when coverage changes;
+- do not place production hashes, secrets, source payloads, receipts, proofs, or release records here;
+- do not edit schema or contract meaning inside fixture prose.
+
+### Naming and pairing
+
+```text
+invalid_<n>.json
+invalid_<n>.expected_error.txt
+```
+
+The sidecar is optional in the generic harness, but omission reduces cause-specific assurance.
+
+[Back to top](#top)
+
+---
+
+## Validation
+
+### Repository-native check
+
+The executable schema lane is:
+
+```bash
+python -m pytest -q tests/schemas/test_common_contracts.py
+```
+
+A narrower parametrized selector may be used only after collection names are verified.
+
+### Documentation checks
+
+For README-only changes, verify:
+
+- one H1;
+- a closed KFM Meta Block;
+- balanced code fences;
+- valid internal anchors;
+- repository-relative links resolve;
+- no tabs or trailing whitespace;
+- final newline;
+- no secret, production hash, or restricted payload;
+- generated receipt present when required.
+
+### Acceptance criteria
+
+A change is review-ready when:
+
+1. every listed fixture exists;
+2. each JSON fixture parses;
+3. each expected-error sidecar is non-empty;
+4. the schema rejects every invalid fixture;
+5. expected text matches the intended failure;
+6. the dedicated validator is not represented as implemented while it remains a placeholder;
+7. coverage gaps remain visible;
+8. no authority or lifecycle boundary is collapsed.
+
+[Back to top](#top)
+
+---
+
+## Correction and rollback
+
+If a fixture begins passing unexpectedly:
+
+1. determine whether the schema changed intentionally;
+2. check whether the fixture no longer expresses the intended invalid condition;
+3. update schema, contract, valid fixtures, invalid fixtures, expected errors, tests, and docs together when semantics changed;
+4. do not weaken expected-error matching merely to restore a green test;
+5. record compatibility and downstream correction obligations where the changed schema is consumed.
+
+For this README revision, rollback is mechanical: restore prior blob `bf9fa6f13c0b93e7f64d70885e64a60275e69500` and remove the paired generated receipt. No fixture or schema rollback is required because this change modifies documentation only.
+
+[Back to top](#top)
+
+---
+
+## Open verification register
+
+- **NEEDS VERIFICATION** — current pass result of `test_common_contracts.py` at the PR head.
+- **NEEDS VERIFICATION** — accepted owners and CODEOWNERS enforcement.
+- **NEEDS VERIFICATION** — complete invalid-case matrix and required coverage threshold.
+- **NEEDS VERIFICATION** — implementation and admission of the dedicated `spec_hash` validator.
+- **NEEDS VERIFICATION** — branch-protection status of schema-validation checks.
+- **UNKNOWN** — production consumers and canonicalization rules used by producers.
+- **UNKNOWN** — whether ignored, generated, branch-local, or external fixture cases exist.
+
+[Back to top](#top)
 
 ---
 
 ## Evidence ledger
 
-| Source | Status | Supports | Limits |
+| Evidence | Status | Supports | Limit |
 |---|---|---|---|
-| Previous target file | CONFIRMED | Target existed as a blank file. | Did not define fixture boundaries or inventory. |
-| [`invalid_1.json`](invalid_1.json) | CONFIRMED | Invalid fixture omits required `value`. | Only one invalid case is currently verified. |
-| [`invalid_1.expected_error.txt`](invalid_1.expected_error.txt) | CONFIRMED | Expected error asserts missing required `value`. | Depends on JSON Schema error wording remaining compatible with the test harness. |
-| [`../valid/valid_1.json`](../valid/valid_1.json) | CONFIRMED | Shows the positive fixture shape for comparison. | Does not prove all valid cases are covered. |
-| [`../../../../../../schemas/contracts/v1/common/spec_hash.schema.json`](../../../../../../schemas/contracts/v1/common/spec_hash.schema.json) | CONFIRMED | Schema shape, required field, pattern, additionalProperties rule, and declared fixtures root. | Schema status is `PROPOSED` in `x-kfm`. |
-| [`../../../../../../tools/validators/validate_spec_hash.py`](../../../../../../tools/validators/validate_spec_hash.py) | CONFIRMED | Dedicated validator path exists. | File is a greenfield placeholder, not implemented validator behavior. |
-| [`../../../../../../tests/schemas/test_common_contracts.py`](../../../../../../tests/schemas/test_common_contracts.py) | CONFIRMED | Test harness discovery and expected-error matching behavior. | Tests were not run during this README update. |
+| Prior README blob `bf9fa6f…` | **CONFIRMED** | Existing v0.1 scope and historical claims. | Prior-session history is not current implementation evidence. |
+| [`invalid_1.json`](invalid_1.json) | **CONFIRMED** | Empty-object negative case. | Covers one invariant only. |
+| [`invalid_1.expected_error.txt`](invalid_1.expected_error.txt) | **CONFIRMED** | Expected missing-field cause. | Coupled to validator wording. |
+| [`../valid/README.md`](../valid/README.md) | **CONFIRMED documentation** | Positive-lane boundary and sibling case. | Does not prove execution. |
+| [`../README.md`](../README.md) | **CONFIRMED documentation** | Fixture-family placement and schema linkage. | Contains older maturity wording. |
+| [`spec_hash.schema.json`](../../../../../../schemas/contracts/v1/common/spec_hash.schema.json) | **CONFIRMED schema file** | Shape, required field, pattern, closed object, metadata. | `x-kfm.status` remains `PROPOSED`. |
+| [`spec_hash.md`](../../../../../../contracts/common/spec_hash.md) | **CONFIRMED semantic contract** | Meaning and anti-overclaim boundary. | Canonicalization and producers remain unverified. |
+| [`validate_spec_hash.py`](../../../../../../tools/validators/validate_spec_hash.py) | **CONFIRMED placeholder** | Dedicated path exists. | Raises `NotImplementedError`. |
+| [`test_common_contracts.py`](../../../../../../tests/schemas/test_common_contracts.py) | **CONFIRMED executable code** | Discovery, invalid polarity, and sidecar matching. | Current run result is separate evidence. |
 
 [Back to top](#top)


### PR DESCRIPTION
## Goal

Update `fixtures/contracts/v1/common/spec_hash/invalid/README.md` so it reflects the current repository evidence for the negative fixture, expected-error sidecar, paired schema, semantic contract, generic pytest harness, and placeholder dedicated validator.

## Status

- **CONFIRMED** — one invalid fixture (`{}`), one expected-error sidecar, the paired Draft 2020-12 schema, the semantic contract, and executable generic pytest discovery/matching behavior.
- **CONFIRMED placeholder** — `tools/validators/validate_spec_hash.py` raises `NotImplementedError` and is not usable enforcement.
- **PROPOSED** — broader negative coverage for wrong types, prefix, digest length, uppercase/non-hex characters, whitespace, extra properties, and alternative algorithms.
- **NEEDS VERIFICATION** — current repository-wide test result, accepted owners, CODEOWNERS, branch-protection significance, and dedicated validator implementation.

## Directory Rules basis

The existing path remains under the canonical `fixtures/` responsibility root and follows the contract/version/family/object/polarity structure:

`fixtures/contracts/v1/common/spec_hash/invalid/`

No schema, contract, validator, test, policy, lifecycle, proof, receipt-schema, release, or public authority is moved or duplicated.

## What changed

- Replaced the v0.1 historical blank-file narrative with a commit-pinned current evidence snapshot.
- Documented the exact one-case inventory and its expected rejection.
- Separated executable generic pytest enforcement from the placeholder dedicated validator.
- Added explicit failure outcomes so crashes and infrastructure errors cannot be described as expected fixture rejection.
- Added the current coverage boundary and proposed missing negative dimensions.
- Added authoring, validation, correction, rollback, and open-verification contracts.
- Preserved the fixture/schema/contract/test/validator authority split.

## Changed paths

1. `fixtures/contracts/v1/common/spec_hash/invalid/README.md`
2. `data/receipts/generated/genrec-spec-hash-invalid-readme-ce1f57a2.json`

## Validation

| Check | Outcome |
|---|---:|
| Target/blob concurrency preflight | PASS |
| Markdown structure, anchors, fences, whitespace, final newline | PASS |
| Repository-relative link targets | PASS |
| Exact schema/fixture polarity | PASS — `{}` yields `"'value' is a required property"` |
| Dedicated-validator maturity check | PASS — placeholder accurately disclosed |
| Sensitive-content and secret scan | PASS |
| Generated receipt required fields, patterns, enums, pending review | PASS |
| Exact changed-path set | PASS — two files |
| Full repository pytest | SKIPPED — no full checkout available; remote CI supplies repository-level execution evidence |
| Human review | PENDING |

## Evidence snapshot

Base: `main@2783739bba744f560772388a9969ed3107d08930`

Key evidence:

- prior README blob `bf9fa6f13c0b93e7f64d70885e64a60275e69500`;
- invalid fixture blob `0967ef424bce6791893e9a57bb952f80fd536e93`;
- expected-error blob `cb128ae0e4af3f627f25520854312fef678d50e5`;
- schema blob `80b496b01b8de8c0e8ba67bf020977e6b1f3c652`;
- validator blob `de69c6c7001082af29827a4b287a80b7c6a05af3`;
- generic harness blob `b04342cc034d7f1cc554e155fdd02d6e972976e6`.

## Generated receipt

`data/receipts/generated/genrec-spec-hash-invalid-readme-ce1f57a2.json`

The receipt remains `pending` human review and is process memory only. It is not schema authority, contract meaning, validator proof, policy approval, release approval, or publication authority.

## Rollback

Before merge, close this draft PR. After merge, revert receipt commit `ff96d6c3ce33cdfbf1d90cca16cdfa5734f9dce9`, then README commit `467527dd6a2ddd9fc75444349c750a1b131d89b7`. The prior README blob is `bf9fa6f13c0b93e7f64d70885e64a60275e69500`.

No release, deployment, publication, lifecycle transition, or public behavior is authorized or performed by this PR.