### PR TITLE
docs(archaeology): ground generalization boundary

### DIFF
--- a/data/receipts/generated/genrec-packages-domains-archaeology-generalization-readme-93901b3f.json
+++ b/data/receipts/generated/genrec-packages-domains-archaeology-generalization-readme-93901b3f.json
@@ -1,0 +1,207 @@
+{
+  "receipt_id": "genrec-packages-domains-archaeology-generalization-readme-93901b3f",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    "packages/domains/archaeology/generalization/README.md"
+  ],
+  "artifact_hashes": {
+    "packages/domains/archaeology/generalization/README.md": "sha256:93901b3ff8a0d7adbc74ad2f47922a3d5eb6bfa922167ce0b3b0c1220108c904"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "Codex",
+    "version": "2026-07-20-work-mode"
+  },
+  "prompt_or_contract": "sha256:b061d3d8b153af8083cd1f62f447b389c396b5a882e590328ede7c3e3ff25e85",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "container validation"
+    ]
+  },
+  "inputs": {
+    "attached_docs": [
+      "KFM GitHub Repository Documentation Implementation Agent - Full Operating Prompt v3.1",
+      "Directory Rules.pdf",
+      "Kansas Frontier Matrix - AI Build Operating Contract.md"
+    ],
+    "evidence_refs": [
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/4f46eaaa444bb66f1f37d5c83b8311375ce8e572",
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/18ee0ae794037659989ea7acc87fba711a1d12ff",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/packages/domains/archaeology/generalization/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/packages/domains/archaeology/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/packages/domains/archaeology/evidence-projection/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/packages/redaction/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/docs/doctrine/directory-rules.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/docs/domains/archaeology/SENSITIVITY.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/docs/domains/archaeology/PRESERVATION_MATRIX.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/docs/domains/archaeology/MAP_UI_CONTRACTS.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/contracts/domains/archaeology/sensitivity_transform.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/contracts/domains/archaeology/publication_transform_receipt.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/contracts/shared/redaction_receipt.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/schemas/contracts/v1/domains/archaeology/sensitivity_transform.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/schemas/contracts/v1/domains/archaeology/publication_transform_receipt.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/schemas/contracts/v1/receipts/redaction_receipt.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/policy/redaction/profiles.yaml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/policy/domains/archaeology/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/docs/standards/REDACTION_DETERMINISM.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/tests/domains/archaeology/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/fixtures/domains/archaeology/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/.github/workflows/domain-archaeology.yml",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/.github/PULL_REQUEST_TEMPLATE.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/schemas/contracts/v1/receipts/generated_receipt.schema.json",
+      "attached://Pasted text(61).txt"
+    ]
+  },
+  "truth_labels": {
+    "packages/domains/archaeology/generalization/README.md": "PROPOSED"
+  },
+  "validation_gates": [
+    {
+      "gate": "repository-preflight",
+      "outcome": "PASS",
+      "reason": "Repository identity, immutable main snapshot, target blob, duplicate pull-request search, Directory Rules, pull-request contract, generated-receipt schema, and relevant Archaeology/generalization surfaces were inspected."
+    },
+    {
+      "gate": "base-drift-and-target-concurrency",
+      "outcome": "PASS",
+      "reason": "Main advanced after authoring from 4f46eaaa444bb66f1f37d5c83b8311375ce8e572 to 18ee0ae794037659989ea7acc87fba711a1d12ff. The intervening compare changed only fixtures/contracts/README.md and its generated receipt; the Archaeology generalization target remained at blob 3874ba04fb174c59a28b024bb74599252109943f."
+    },
+    {
+      "gate": "directory-rules-placement",
+      "outcome": "PASS",
+      "reason": "The target remains reusable domain-adapter documentation while shared mechanics, contracts, schemas, profiles, policy, restricted data, evidence, receipts, pipelines, tests, fixtures, release, API, map, UI, and AI stay in their owning roots."
+    },
+    {
+      "gate": "bounded-package-inventory",
+      "outcome": "PASS",
+      "reason": "The target and shared redaction package were read directly; common manifest, initializer, source, selected module, and stale package-specific test/fixture README paths were checked explicitly. Absence claims remain bounded."
+    },
+    {
+      "gate": "transform-receipt-schema-grounding",
+      "outcome": "PASS",
+      "reason": "SensitivityTransform, PublicationTransformReceipt, and shared RedactionReceipt contracts and schemas were inspected. Their semantic roles remain draft, schemas permissive scaffolds, and role/home conflicts visible."
+    },
+    {
+      "gate": "profile-and-precision-conflicts",
+      "outcome": "PASS",
+      "reason": "The placeholder redaction profile registry, proposed determinism standard, H3-r7 lane guidance, and county/region operating floor were inspected. No profile, algorithm, seed rule, or public precision is declared canonical."
+    },
+    {
+      "gate": "test-fixture-workflow-grounding",
+      "outcome": "PASS",
+      "reason": "The current Archaeology test and fixture roots, placeholder-heavy test maturity, and read-only readiness-hold workflow were inspected; no generalization test pass, validator, receipt flow, or runtime claim is made."
+    },
+    {
+      "gate": "authority-and-anti-collapse",
+      "outcome": "PASS",
+      "reason": "The README separates source classification, profile selection, transform mechanics, domain adaptation, receipt candidate, validation, evidence, review, policy, lifecycle, release, and public delivery."
+    },
+    {
+      "gate": "sensitive-content-review",
+      "outcome": "PASS",
+      "reason": "No real location, identifier, access route, cultural detail, reviewer identity, protected payload, profile secret, seed, credential, private endpoint, or reconstructive example is introduced; exact and inferable Archaeology detail remains fail-closed."
+    },
+    {
+      "gate": "markdown-structure",
+      "outcome": "PASS",
+      "reason": "One H1, balanced fences, KFM meta block, internal anchors, final newline, no trailing whitespace or tabs, and repository-relative links were checked."
+    },
+    {
+      "gate": "secret-pattern-review",
+      "outcome": "PASS",
+      "reason": "The README and receipt were checked for common private-key and token prefixes; no credential material was introduced."
+    },
+    {
+      "gate": "generated-receipt-structure",
+      "outcome": "PASS",
+      "reason": "Required fields, allowed properties, artifact hash closure, truth labels, validation outcomes, citations, timestamp, and pending human-review state were checked against the generated-receipt schema."
+    },
+    {
+      "gate": "runtime-and-executable-tests",
+      "outcome": "SKIPPED",
+      "reason": "Documentation and provenance only; no generalizer, shared mechanics, profile, dependency, schema, contract, policy, receipt, proof, test, fixture payload, workflow, lifecycle record, release, API route, tile, map, UI, or runtime is changed."
+    },
+    {
+      "gate": "remote-readback",
+      "outcome": "SKIPPED",
+      "reason": "Remote branch, commit, changed-path, and pull-request verification occurs after branch publication and is reported in pull-request metadata."
+    },
+    {
+      "gate": "repository-native-ci",
+      "outcome": "SKIPPED",
+      "reason": "GitHub Actions checks are observed after draft pull-request creation and were unavailable at receipt emission time."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "KFM-DOCUMENTATION-PROMPT-V3.1",
+      "validated": true,
+      "evidence_ref": "attached://Pasted text(61).txt"
+    },
+    {
+      "id": "KFM-DIRECTORY-RULES",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/docs/doctrine/directory-rules.md"
+    },
+    {
+      "id": "ARCHAEOLOGY-SENSITIVITY-TRANSFORM",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/contracts/domains/archaeology/sensitivity_transform.md"
+    },
+    {
+      "id": "ARCHAEOLOGY-PUBLICATION-TRANSFORM-RECEIPT",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/contracts/domains/archaeology/publication_transform_receipt.md"
+    },
+    {
+      "id": "SHARED-REDACTION-RECEIPT",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/contracts/shared/redaction_receipt.md"
+    },
+    {
+      "id": "REDACTION-PROFILE-PLACEHOLDER",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/policy/redaction/profiles.yaml"
+    },
+    {
+      "id": "ARCHAEOLOGY-SENSITIVITY-GUIDANCE",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/docs/domains/archaeology/SENSITIVITY.md"
+    },
+    {
+      "id": "ARCHAEOLOGY-TEST-BOUNDARY",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/tests/domains/archaeology/README.md"
+    },
+    {
+      "id": "ARCHAEOLOGY-READINESS-WORKFLOW",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/.github/workflows/domain-archaeology.yml"
+    },
+    {
+      "id": "GENERATED-RECEIPT-SCHEMA",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/4f46eaaa444bb66f1f37d5c83b8311375ce8e572/schemas/contracts/v1/receipts/generated_receipt.schema.json"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-20T16:18:08Z",
+  "emitter": "ai-builder/openai-codex",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "AI-authored documentation-only revision on a scoped review branch. It records bounded package absence, shared/domain transform-package overlap, scaffold transform and receipt schemas, placeholder profile posture, public-precision conflict, non-disclosure and cumulative-release threats, and sensitive-domain fail-closed rules. It introduces no generalizer, profile, shared mechanic, schema, contract, policy, receipt, proof, fixture payload, executable test, workflow, sensitive data, lifecycle artifact, release record, deployment, public route, tile, map, UI, or runtime behavior. Human review remains pending; this receipt records provenance and does not authorize merge, transform use, release, or publication."
+}

--- a/packages/domains/archaeology/generalization/README.md
+++ b/packages/domains/archaeology/generalization/README.md
@@ -1,375 +1,697 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://doc/packages-domains-archaeology-generalization-readme
-title: Archaeology Generalization Package README
+title: Governed Archaeology Generalization Helper Boundary
 type: readme
-version: v0.1
-status: draft
+version: v0.2
+status: draft; repository-grounded; bounded-readme-surface; generalizer-not-implemented; profiles-not-accepted; sensitive-domain; non-authoritative
 owners:
-  - <package-owner>
-  - <archaeology-domain-steward>
-  - <cultural-review-steward>
-  - <evidence-steward>
-  - <policy-steward>
-  - <release-steward>
-  - <docs-steward>
+  - OWNER_TBD - Archaeology package/domain steward
+  - OWNER_TBD - Cultural/sensitivity/sovereignty review steward
+  - OWNER_TBD - Geospatial/privacy/policy steward
+  - OWNER_TBD - Evidence/contract/schema/validation/release/docs steward
 created: 2026-06-13
-updated: 2026-06-13
-policy_label: public
+updated: 2026-07-20
+supersedes: v0.1
+policy_label: public-review; packages; archaeology; generalization; no-network; exact-location-deny-by-default; non-authoritative
 path: packages/domains/archaeology/generalization/README.md
+truth_posture: CONFIRMED target and prior blob, packages responsibility root, bounded absent package/runtime paths, draft SensitivityTransform and PublicationTransformReceipt contracts with permissive scaffold schemas, shared RedactionReceipt draft with scaffold schema, placeholder redaction-profile registry, shared redaction package scaffold, domain test/fixture roots, and Archaeology readiness-hold workflow / PROPOSED future explicit-input deterministic domain adapters, local application-result vocabulary, transform-profile binding, inference-risk validation, and no-network tests / CONFLICTED stale package-specific test and fixture paths, shared-redaction versus domain-generalization ownership, RedactionReceipt versus PublicationTransformReceipt roles, county/region public floor versus lane-local H3-r7 refinement, and proposed deterministic-jitter recipe versus unresolved secret/seed custody / UNKNOWN complete recursive inventory, runtime language, exports, consumers, accepted transform profile, canonical public precision, transform implementation, validator behavior, production release use, and public non-disclosure effectiveness / NEEDS VERIFICATION owners, boundary ADRs, profile registry authority, cultural and sovereignty review, contract/schema expansion, policy binding, correction cascade, cumulative-release attack controls, rollback execution, and public safety proof
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  repository_id: "1059091169"
+  base_ref: main
+  base_commit: 4f46eaaa444bb66f1f37d5c83b8311375ce8e572
+  prior_blob: 3874ba04fb174c59a28b024bb74599252109943f
+  directory_rules_blob: 2affb080e6f0043867c64c7f06c1ca52030fbd55
+  sensitivity_transform_contract_blob: 5de68a7e2223d14128157792fcb415cc66d1cc5f
+  sensitivity_transform_schema_blob: f72aa3c4504afa6c2c7ce669ad06fb5de514862e
+  publication_transform_receipt_contract_blob: fee559d492c3d0145edc30a7ab39369ae7716dd8
+  publication_transform_receipt_schema_blob: 379621207697fb9ad2bd16254cc96f6f7d230aae
+  shared_redaction_receipt_contract_blob: c686cdf5c79a8b99ac66d4b01cd30d2f450f645f
+  redaction_receipt_schema_blob: 6251119ecc2293cd219e4ddfa5bbde8b9d6f8f24
+  redaction_profile_registry_blob: e928e91ccf278fe42ac0cd83f571ba323787573d
+  shared_redaction_package_blob: c100eb332db3aba02395c1423b108005cb9bd5ed
+  redaction_determinism_standard_blob: 9b3f54f23fc835d4c589c0edbeada72f88766f4d
+  archaeology_sensitivity_blob: ca7888f2d43f022faeef5e1a6e16ab00526cf7aa
+  archaeology_map_ui_blob: e9c15dbc71086dded7afca18a3b5a1a8f915be28
+  archaeology_tests_blob: 229113afacc6acc0839e92318082ccce9e2ceab3
+  archaeology_fixtures_blob: ab348d4a5345d52cb0999072138e7c0feb63e8f1
+  archaeology_workflow_blob: 41e377f50ca310eccdc4b716ba8374c4fa8181db
 related:
-  - packages/README.md
-  - packages/domains/README.md
-  - packages/domains/archaeology/README.md
-  - docs/domains/archaeology/README.md
-  - pipelines/domains/archaeology/README.md
-  - pipeline_specs/archaeology/README.md
-  - contracts/domains/archaeology/
-  - schemas/contracts/v1/domains/archaeology/
-  - policy/domains/archaeology/
-  - data/proofs/evidence_bundle/
-  - release/manifests/
-  - tests/packages/domains/archaeology/generalization/
-  - fixtures/packages/domains/archaeology/generalization/
-tags: [kfm, packages, domains, archaeology, generalization, redaction, sensitivity-transform, public-safe, exact-location-denial, cultural-review, governance]
+  - ../README.md
+  - ../../README.md
+  - ../../../README.md
+  - ../../../redaction/README.md
+  - ../../../../docs/doctrine/directory-rules.md
+  - ../../../../docs/domains/archaeology/README.md
+  - ../../../../docs/domains/archaeology/SENSITIVITY.md
+  - ../../../../docs/domains/archaeology/PRESERVATION_MATRIX.md
+  - ../../../../docs/domains/archaeology/MAP_UI_CONTRACTS.md
+  - ../../../../docs/domains/archaeology/PUBLICATION_AND_POLICY.md
+  - ../../../../contracts/domains/archaeology/sensitivity_transform.md
+  - ../../../../contracts/domains/archaeology/publication_transform_receipt.md
+  - ../../../../contracts/shared/redaction_receipt.md
+  - ../../../../schemas/contracts/v1/domains/archaeology/sensitivity_transform.schema.json
+  - ../../../../schemas/contracts/v1/domains/archaeology/publication_transform_receipt.schema.json
+  - ../../../../schemas/contracts/v1/receipts/redaction_receipt.schema.json
+  - ../../../../policy/redaction/profiles.yaml
+  - ../../../../policy/domains/archaeology/README.md
+  - ../../../../tests/domains/archaeology/README.md
+  - ../../../../fixtures/domains/archaeology/README.md
+tags: [kfm, archaeology, generalization, redaction, sensitivity-transform, geoprivacy, inference-risk, trust-membrane, governance]
 notes:
-  - "This README fills the empty archaeology generalization package file with a governed helper-package contract."
-  - "generalization is a shared helper package for public-safe transformation support; it is not a policy engine, sensitivity decision authority, or release authority."
-  - "Generalization helpers must preserve exact-source refs, sensitivity-transform refs, evidence refs, review refs, and release refs without exposing restricted detail."
-  - "Exact archaeological locations and sensitive cultural context fail closed for public use unless governed review, transform, and release controls are satisfied elsewhere."
-  - "Concrete code exports, language runtime, package manifest, tests, and CI coverage remain NEEDS VERIFICATION until repository evidence proves them."
+  - "v0.2 replaces planning-only package claims with commit-pinned repository evidence and bounded absence checks."
+  - "The README and its required generated-work provenance receipt are the only intended changes."
+  - "No generalizer, transform profile, package manifest, schema, contract, policy, fixture, test, receipt, lifecycle object, release state, API route, map layer, or UI component is created or activated."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-# Archaeology Generalization Package
+# Governed Archaeology Generalization Helper Boundary
 
-> Shared helper package for Archaeology public-safe generalization and redaction support. It may help construct generalized geometry descriptors, scale bands, masking metadata, transform refs, and safe display hints, but it must not decide sensitivity, expose exact locations, create EvidenceBundles, write lifecycle records, or approve release.
+`packages/domains/archaeology/generalization/`
+
+> Reusable domain-adapter boundary for possible future Archaeology generalization support. The inspected surface is not a verified package or transform implementation: the README exists, conventional manifest and source paths were absent at the pinned snapshot, no accepted Archaeology transform profile was found, and no executable API, package-specific test suite, production consumer, transform receipt flow, or public release behavior was established.
 
 ![status](https://img.shields.io/badge/status-draft-blue)
-![root](https://img.shields.io/badge/root-packages%2Fdomains%2Farchaeology%2Fgeneralization%2F-0a7ea4)
-![authority](https://img.shields.io/badge/authority-shared%20helper%20package-0a7ea4)
-![output](https://img.shields.io/badge/generalization-not%20release-d62728)
-![sensitivity](https://img.shields.io/badge/exact%20location-deny%20by%20default-d62728)
+![implementation](https://img.shields.io/badge/generalizer-NOT%20IMPLEMENTED-yellow)
+![profiles](https://img.shields.io/badge/profiles-NOT%20ACCEPTED-orange)
+![output](https://img.shields.io/badge/generalization-not%20release-orange)
+![sensitivity](https://img.shields.io/badge/exact%20location-DENY%20by%20default-critical)
 
-**Status:** Draft  
-**Path:** `packages/domains/archaeology/generalization/README.md`  
-**Parent package:** `packages/domains/archaeology/`  
-**Responsibility root:** `packages/` — shared libraries used by apps, workers, pipelines, and tools  
-**Domain doctrine root:** `docs/domains/archaeology/`  
-**Executable domain-pipeline root:** `pipelines/domains/archaeology/`  
-**Contract/schema/policy roots:** `contracts/domains/archaeology/`, `schemas/contracts/v1/domains/archaeology/`, and `policy/domains/archaeology/`  
-**Placement posture:** helper package for generalization/redaction support only. Runtime, exports, package manifest, active tests, and implementation are `NEEDS VERIFICATION` until checked by current repo evidence.
-
----
-
-## Quick jump
-
-- [1. Purpose](#1-purpose)
-- [2. Placement and authority](#2-placement-and-authority)
-- [3. Generalization boundary](#3-generalization-boundary)
-- [4. Sensitivity and publication boundary](#4-sensitivity-and-publication-boundary)
-- [5. Anti-collapse rules](#5-anti-collapse-rules)
-- [6. What belongs here](#6-what-belongs-here)
-- [7. What does not belong here](#7-what-does-not-belong-here)
-- [8. Expected helper families](#8-expected-helper-families)
-- [9. Inputs and outputs](#9-inputs-and-outputs)
-- [10. Minimal package contract shape](#10-minimal-package-contract-shape)
-- [11. Tests and fixtures](#11-tests-and-fixtures)
-- [12. Definition of done](#12-definition-of-done)
-- [13. Open questions](#13-open-questions)
-
----
-
-## 1. Purpose
-
-`packages/domains/archaeology/generalization/` may contain reusable helper code for preparing public-safe generalized or redacted Archaeology projection shapes.
-
-It may support:
-
-- generalized geometry descriptor helpers;
-- scale-band and uncertainty-band helper utilities;
-- redaction and masking metadata helpers;
-- sensitivity-transform reference helpers;
-- public-safe display hint helpers;
-- limitation and caveat preservation helpers;
-- review-ref and release-ref preservation helpers;
-- safe missing-transform outcome helpers;
-- schema-bound validation adapters;
-- no-network fixture builders for tests.
-
-It does **not** decide that a transform is sufficient, publish exact or generalized locations, decide policy, create EvidenceBundles, write lifecycle data, or approve release.
-
-[⬆ Back to top](#top)
-
----
-
-## 2. Placement and authority
-
-| Question | Answer | Status |
-|---|---|---|
-| Why under `packages/domains/archaeology/`? | Generalization helpers are reusable Archaeology package code, not a new root. | CONFIRMED parent root pattern / NEEDS VERIFICATION for implementation |
-| Is this a sensitivity policy engine? | No. It may apply already-approved transform parameters, but policy authority stays outside this package. | CONFIRMED policy separation |
-| Is this Archaeology doctrine? | No. Doctrine and sensitivity posture belong under `docs/domains/archaeology/`. | CONFIRMED boundary posture |
-| Can this publish generalized layers? | No. It may prepare helper shapes only; publication remains a governed release decision. | CONFIRMED release separation |
-| Can this decide policy, evidence, sensitivity, or release? | No. It may preserve refs, limitations, and validation results only. | CONFIRMED governance separation |
+**Quick links:** [Purpose](#purpose) · [Authority](#authority-and-directory-rules-basis) · [Status](#current-evidence-and-maturity) · [Language](#bounded-context-and-anti-collapse-rules) · [Belongs](#what-belongs-here) · [Exclusions](#what-does-not-belong-here) · [Contract](#future-transform-contract) · [Geometry](#geometry-and-attribute-safety) · [Profiles](#transform-classes-and-profile-posture) · [Threats](#sensitivity-rights-cultural-governance-and-threat-model) · [Trust](#trust-membrane-and-lifecycle) · [Validation](#validation-and-admission) · [Rollback](#compatibility-correction-revocation-and-rollback) · [Open](#open-verification-register) · [Evidence](#evidence-ledger)
 
 > [!IMPORTANT]
-> Generalization is not release approval. A helper-produced mask, scale band, or generalized geometry descriptor remains downstream of cultural/steward review, policy, EvidenceBundle, sensitivity transform, and release state.
+> **Snapshot:** `main@4f46eaaa444bb66f1f37d5c83b8311375ce8e572`<br>
+> **Verified target:** prior README blob `3874ba04fb174c59a28b024bb74599252109943f`<br>
+> **Bounded implementation probes:** no `pyproject.toml`, `package.json`, root `__init__.py`, `src/README.md`, conventional `src/generalization/` initializer, selected root generalizer module, or package-specific README-backed test/fixture lane at the exact checked paths<br>
+> **Authority evidence:** transform and receipt contracts exist only as draft semantics with permissive scaffold schemas; the redaction-profile file is a placeholder sourced from Habitat documentation and does not establish an active Archaeology profile.
 
-[⬆ Back to top](#top)
+> [!CAUTION]
+> Generalization is a lossy protective transform, not proof of safety. A coarser point, cell, polygon, centroid, bound, label, time, count, or identifier can still disclose a site through reconstruction, linkage, repeated releases, or contextual inference. No output is public merely because a helper produced it.
 
 ---
 
-## 3. Generalization boundary
+## Purpose
 
-Allowed direction:
+A future implementation may provide deterministic, explicit-input Archaeology adapters around accepted protective-transform mechanics. Its role is to apply an already-selected, named, versioned profile to an already-authorized minimal view and produce a transform result plus receipt candidate for independent validation.
+
+It may eventually:
+
+- validate caller-supplied source geometry or attributes against an accepted input contract;
+- adapt Archaeology object semantics to a shared redaction/generalization engine;
+- apply only an upstream-authorized profile and audience scope;
+- suppress, omit, aggregate, mask, clip, simplify, bin, delay, or generalize fields when the accepted profile requires it;
+- preserve object identity, candidate/site status, source role, evidence, rights, review, sensitivity, transform, correction, and release references;
+- produce deterministic output digests and a transform-receipt candidate without persisting either;
+- return explicit blocked, no-output, invalid, unsupported, or error results without leaking controlled inputs;
+- support synthetic, sanitized, no-network tests and cross-implementation parity vectors.
+
+It must not select the profile, decide sensitivity, decide that an output is safe, expose exact or reconstructive detail, create evidence, satisfy cultural or sovereignty review, write receipts, write lifecycle state, approve release, serve public routes, build tiles, render maps, or generate authoritative narratives.
+
+[Back to top](#top)
+
+---
+
+## Authority and Directory Rules basis
+
+The existing path is compatible with Directory Rules only if it remains reusable Archaeology-specific adapter code. It does not gain policy or release authority from handling sensitive geometry.
+
+| Concern | Authority here |
+|---|---|
+| Archaeology-specific transform input/output adaptation | Supporting implementation only, if later implemented and accepted. |
+| Shared redaction/generalization mechanics | None by default - candidate shared home is [`packages/redaction/`](../../../redaction/README.md), whose implementation is also only a scaffold. |
+| Archaeology doctrine and ubiquitous language | None - [`docs/domains/archaeology/`](../../../../docs/domains/archaeology/README.md). |
+| SensitivityTransform meaning | None - [`contracts/domains/archaeology/sensitivity_transform.md`](../../../../contracts/domains/archaeology/sensitivity_transform.md). |
+| Transform-event receipt meaning | None - [`PublicationTransformReceipt`](../../../../contracts/domains/archaeology/publication_transform_receipt.md) and [`RedactionReceipt`](../../../../contracts/shared/redaction_receipt.md) semantics, pending role reconciliation. |
+| Machine-checkable shape | None - canonical schemas after accepted schema/home decisions. |
+| Profile selection and admissibility | None - [`policy/domains/archaeology/`](../../../../policy/domains/archaeology/README.md), redaction policy, and the governed evaluator. |
+| Evidence, rights, cultural/sovereignty review | None - owning evidence, registry, policy, and review authorities. |
+| Executable orchestration and lifecycle writes | None - authorized pipelines/workers and canonical lifecycle homes. |
+| Release, correction, withdrawal, and rollback | None - accepted release records and workflows. |
+| Public API, tile, map, UI, export, search, graph, and AI | None - governed delivery surfaces downstream of released artifacts. |
+
+### Shared-versus-domain dependency rule
+
+If both packages mature, the preferred dependency direction is:
 
 ```text
-approved transform parameters / EvidenceRef / review refs / policy refs / release refs
-  -> generalization helper
-  -> generalized descriptor, redaction metadata, scale band, or public-safe display hint
-  -> governed API/release surface decides exposure where authorized
+Archaeology generalization adapter
+  -> shared redaction/generalization mechanics
+  -> third-party geometry/privacy libraries
 ```
 
-Blocked direction:
+The shared package must not depend on Archaeology domain semantics. This package must not duplicate general-purpose masking, canonicalization, pseudorandom, geometry, or receipt-building mechanics unless an accepted decision assigns them here.
 
-```text
-generalization helper
-  -> sensitivity decision
-  -> exact-location disclosure
-  -> release approval
-  -> EvidenceBundle creation
-  -> lifecycle write
-  -> public map-layer authority
-  -> site confirmation
-```
-
-Generalization helpers should be deterministic, preserve all refs and caveats, and fail safe when evidence, review, policy, transform, or release state is missing or inaccessible.
-
-[⬆ Back to top](#top)
+[Back to top](#top)
 
 ---
 
-## 4. Sensitivity and publication boundary
+## Current evidence and maturity
 
-Archaeology generalization has high exposure risk. This package must preserve these boundaries:
+### Confirmed at the pinned snapshot
 
-- exact locations are not public by default;
-- generalized outputs must not leak restricted geometry, culturally sensitive context, collection-security detail, or looting-risk detail;
-- candidate and anomaly context remains candidate unless confirmed through governed review and evidence;
-- missing or inaccessible transform state should produce abstain/deny-safe outcomes, not fallback disclosure;
-- cultural review, steward review, EvidenceBundle, SensitivityTransform, ReleaseManifest, correction path, and rollback posture remain outside this package;
-- helper-derived generalized outputs are not evidence and are not release approval.
+| Evidence | Finding | Consequence |
+|---|---|---|
+| Target README | v0.1 exists at blob `3874ba0...`. | This revision updates an existing planning document. |
+| Package probes | Common manifest, initializer, source README, conventional source initializer, selected module, and package-specific test/fixture README paths were absent. | Do not claim an installable package, runtime, imports, exports, dependencies, API, or tests. |
+| Shared redaction package | `packages/redaction/` has `0.0.0` metadata, boundary READMEs, an empty initializer, and a comment-only core placeholder. | It is an architectural candidate, not usable transform code. Domain/shared ownership remains unresolved. |
+| SensitivityTransform | Draft semantic contract exists; paired `PROPOSED` schema declares no fields and permits additional properties. | Meaning guidance exists; no enforceable transform profile or input shape is established. |
+| PublicationTransformReceipt | Draft domain contract exists; paired `PROPOSED` schema declares no fields and permits additional properties. | A receipt role is proposed, not field-enforced or emitted. |
+| Shared RedactionReceipt | Draft shared semantic contract exists; schema home is open and paired scaffold declares no fields. | Shared-versus-domain receipt roles require reconciliation before implementation. |
+| Profile registry | `policy/redaction/profiles.yaml` is a 175-byte `PROPOSED` placeholder sourced from `docs/domains/habitat/CANONICAL_PATHS.md`. | No active, versioned Archaeology transform profile is established. |
+| Determinism standard | A detailed draft proposes seeded jitter and reproducibility rules but labels itself `PROPOSED`; repository paths and salt policy contain open questions. | Do not treat its algorithms, profile IDs, seed construction, or receipt paths as accepted implementation law. |
+| Geometry floor | Archaeology sensitivity guidance proposes H3-r7; Map/UI guidance identifies county/region as the operating-contract public floor and calls tighter H3 guidance lane-local/proposed. | Public precision is conflicted; fail closed to the more restrictive authorized policy until resolved. |
+| Tests and fixtures | Confirmed roots are [`tests/domains/archaeology/`](../../../../tests/domains/archaeology/README.md) and [`fixtures/domains/archaeology/`](../../../../fixtures/domains/archaeology/README.md); package-specific v0.1 paths were absent. | Do not create a competing topology or claim executable generalization tests. |
+| Workflow | `domain-archaeology.yml` is a read-only readiness-hold workflow. | It does not prove transform correctness, inference resistance, receipt closure, or release safety. |
 
-[⬆ Back to top](#top)
+### Bounded absence
+
+The named probes establish only those paths at the pinned commit. They do not prove permanent absence from history, branches, generated workspaces, external stores, differently named files, or later commits.
+
+### Maturity statement
+
+| Capability | Status |
+|---|---|
+| Generalization responsibility boundary | `CONFIRMED` by this README revision. |
+| Domain transform/receipt semantics | `CONFIRMED` draft documents; schemas remain permissive `PROPOSED` scaffolds. |
+| Shared protective-transform package | `CONFIRMED` scaffold; functional implementation not established. |
+| Active Archaeology profile and canonical precision | `NOT ESTABLISHED` / `CONFLICTED`. |
+| Generalizer implementation, exports, and dependencies | `NOT IMPLEMENTED` at checked paths. |
+| Policy, review, receipt, validation, and release wiring | `UNKNOWN` / `NEEDS VERIFICATION`. |
+| Package-specific executable tests | `NOT ESTABLISHED`. |
+| Production consumer or released layer use | `UNKNOWN`. |
+| Public safety and re-identification resistance | `NOT PROVED`. |
+
+[Back to top](#top)
 
 ---
 
-## 5. Anti-collapse rules
+## Bounded context and anti-collapse rules
+
+| Term | Meaning in this boundary |
+|---|---|
+| Sensitivity classification | Source/object risk and audience restrictions. A transform does not rewrite or erase the original classification. |
+| Transform profile | Named, versioned policy-controlled specification of allowed input, operation, parameters, output, and obligations. |
+| Generalization | Lossy reduction of spatial, temporal, attribute, or relational fidelity. It is one transform class, not a safety guarantee. |
+| Redaction | Removal or masking of controlled content. An omission alone does not prove redaction was sufficient. |
+| Suppression/withholding | Intentionally producing no value or no artifact for a controlled field/object. No output can be the only safe result. |
+| Aggregation | Combining records into a coarser statistic or geography. It does not create differential privacy or k-anonymity automatically. |
+| SensitivityTransform | Domain semantic object describing transform meaning or admissible intent; not executable code or approval. |
+| PublicationTransformReceipt | Proposed Archaeology receipt recording a specific transform application/output; not release approval. |
+| RedactionReceipt | Proposed shared receipt for a protective transform; role and schema home remain open. |
+| Public-safe derivative candidate | Transform output awaiting independent validation, policy/review checks, and release. It is not yet public. |
 
 Disallowed collapses:
 
 ```text
-generalization -> release approval
-redaction metadata -> sensitivity decision
-scale band -> public safety guarantee
-masking helper -> exact-location clearance
-transform ref -> transform completion
-review ref -> review completion
-summary geometry -> true site geometry
-fixture geometry -> production geometry
-successful package test -> lifecycle promotion
+coarser geometry -> safe geometry
+H3 cell or county label -> non-sensitive location
+deterministic output -> privacy guarantee
+random jitter -> anonymity
+aggregation -> differential privacy
+k records -> accepted k-anonymity
+profile name -> active policy
+transform execution -> sufficient transform
+receipt candidate -> persisted valid receipt
+receipt -> policy or release approval
+review ref -> review completion or consent
 public-safe flag -> ReleaseManifest
+generalized candidate -> confirmed site
+successful helper test -> lifecycle promotion
 ```
 
-Required separations:
+The original controlled record remains controlled. A derivative may receive a separate audience/release posture only through policy, review, validation, and release; transformation does not downgrade the source object in place.
 
-- generalization helper code stays under `packages/domains/archaeology/generalization/`;
-- Archaeology doctrine stays under `docs/domains/archaeology/`;
-- object meaning stays under `contracts/domains/archaeology/`;
-- schemas stay under `schemas/contracts/v1/domains/archaeology/`;
-- policy and sensitivity rules stay under `policy/domains/archaeology/` and accepted policy roots;
-- executable transform runs and lifecycle writes stay under their executable/data roots;
-- EvidenceBundles stay under proof homes;
-- release decisions stay under `release/`.
-
-[⬆ Back to top](#top)
+[Back to top](#top)
 
 ---
 
-## 6. What belongs here
+## What belongs here
 
-Appropriate source files include:
+Only evidence-backed Archaeology-specific adapter behavior should be admitted. Possible future contents include:
 
-- generalized descriptor helper functions;
-- redaction and masking metadata helpers;
-- scale-band and uncertainty-band helpers;
-- transform-ref preservation helpers;
-- review-ref and release-ref preservation helpers;
-- limitation/caveat preservation helpers;
-- safe display-hint DTO helpers;
-- missing or inaccessible transform outcome helpers;
-- schema-bound validation adapters and safe errors;
-- synthetic or sanitized fixture builders.
+- explicit conversion between accepted Archaeology contract types and shared transform-engine inputs;
+- validation of domain-specific obligations before calling shared mechanics;
+- preservation of candidate/site/object type, source role, rights, sensitivity, evidence, review, receipt, correction, and release references;
+- binding of an upstream-selected profile ID/version without choosing it;
+- safe construction of a domain transform-result and receipt candidate;
+- domain-specific reason-code mapping that cannot echo controlled values;
+- deterministic output labeling that states the transform class and remaining limitations;
+- synthetic fixture builders and parity-vector adapters linked to executable tests.
 
-A good placement test:
+Admission test:
 
-> If the file is reusable generalization support code that preserves evidence and governance refs and does not decide sensitivity, reveal sensitive locations, write lifecycle records, or approve release, it may belong here.
+> If code is Archaeology-specific adaptation around an already-authorized transform, remains pure and deterministic, performs no hidden I/O or policy selection, and cannot publish or disclose protected detail, it may belong here after the shared/domain boundary is accepted.
 
-[⬆ Back to top](#top)
+[Back to top](#top)
 
 ---
 
-## 7. What does not belong here
+## What does not belong here
 
-| Do not place here | Correct responsibility home |
+| Excluded concern | Responsibility home or disposition |
 |---|---|
-| Sensitivity policy decisions | `policy/domains/archaeology/` and accepted policy roots |
-| EvidenceBundle storage or creation | `data/proofs/evidence_bundle/` and proof tooling |
-| Archaeology doctrine and scope docs | `docs/domains/archaeology/` |
-| Archaeology object contracts | `contracts/domains/archaeology/` |
-| Archaeology schemas | `schemas/contracts/v1/domains/archaeology/` |
-| Executable generalization pipeline | `pipelines/domains/archaeology/` or accepted executable lane |
-| Lifecycle data | `data/raw`, `data/work`, `data/quarantine`, `data/processed`, `data/catalog`, `data/triplets`, `data/published` |
-| Review decisions | cultural/steward review authority roots |
-| Release decisions/manifests/corrections/rollback cards | `release/` |
-| Public API routes | `apps/governed-api/` |
-| Public map/UI rendering components | `apps/explorer-web/` or accepted UI package roots |
-| Package tests | `tests/packages/domains/archaeology/generalization/` |
-| Package fixtures | `fixtures/packages/domains/archaeology/generalization/` unless package-local convention is accepted |
+| General-purpose redaction/generalization mechanics | Candidate shared home: `packages/redaction/`, pending accepted boundary. |
+| Sensitivity, audience, profile, or release decision | Policy evaluator and release authorities. |
+| Archaeology doctrine or profile catalogue | `docs/domains/archaeology/` and accepted policy/profile roots. |
+| Canonical transform/receipt contracts and schemas | `contracts/` and `schemas/contracts/v1/`. |
+| Exact/controlled geometry and attributes | Governed restricted lifecycle/data homes; never ordinary package examples or logs. |
+| EvidenceBundle or proof creation | Accepted proof producers and `data/proofs/`. |
+| Cultural review, sovereignty determination, rights-holder decision, or consent | Accepted review and authority workflows. |
+| Receipt persistence, signing, or registry writes | Accepted receipt producer/store and signing workflow. |
+| Pipeline orchestration and lifecycle writes | `pipelines/`, workers, and canonical `data/` phases. |
+| Tiles, layer manifests, public artifacts, or catalog/triplet writes | Authorized producers and their canonical roots. |
+| Release candidates, manifests, promotion decisions, corrections, or rollback cards | `release/`. |
+| Public API routes, map rendering, UI, export, search, graph, or AI answers | Governed delivery surfaces. |
+| Realistic sensitive coordinates, IDs, names, access routes, or site narratives | Prohibited in public docs/tests/fixtures; use explicitly synthetic non-place data. |
 
-[⬆ Back to top](#top)
+Until a package-test topology is accepted, use the confirmed Archaeology roots instead of the stale v0.1 paths:
+
+- tests: [`tests/domains/archaeology/`](../../../../tests/domains/archaeology/README.md);
+- reusable fixtures: [`fixtures/domains/archaeology/`](../../../../fixtures/domains/archaeology/README.md);
+- test-local wrappers: the test-owned fixture lane documented by the Archaeology test README.
+
+[Back to top](#top)
 
 ---
 
-## 8. Expected helper families
+## Future transform contract
 
-| Helper family | Responsibility | Status |
+This section is `PROPOSED` guidance, not an implemented API or canonical schema.
+
+### Invocation boundary
+
+A future adapter should receive caller-supplied, in-memory values and call only accepted pure transform mechanics. It must not access networks, filesystems, databases, registries, proof stores, source stores, policy engines, review systems, receipt stores, release systems, map services, or secrets directly.
+
+The caller remains responsible for:
+
+1. authenticating the principal and audience;
+2. resolving source identity, evidence, rights, sensitivity, and current lifecycle/release state;
+3. obtaining an authoritative policy decision and selected profile;
+4. obtaining cultural, sovereignty, rights-holder, steward, and release review where required;
+5. providing only the minimum authorized source view;
+6. holding any required seed/key material through an accepted secret-custody mechanism;
+7. independently validating the derivative and receipt candidate;
+8. persisting receipts and approving release outside this package.
+
+### Conceptual input
+
+An accepted implementation may require typed values for:
+
+- source object identity and type;
+- authorized source geometry/attributes and explicit CRS/axis order;
+- sensitivity rank and audience tier as distinct values;
+- named profile ID, profile version, policy-decision reference, and effective time;
+- evidence, rights, cultural/steward-review, transform, release, correction, and supersession references;
+- implementation/specification version pins;
+- transform-history or release-family context needed to detect cumulative disclosure;
+- secret handle or deterministic context when an accepted profile requires it, never raw public seed material;
+- safe correlation ID.
+
+These are responsibilities, not declared field names. Contract/schema/profile decisions must precede implementation.
+
+### Local application results
+
+The helper does not create policy outcomes. A future local vocabulary may distinguish:
+
+| Local result | Meaning | Not equivalent to |
 |---|---|---|
-| `geometry` | Generalized geometry descriptors, not true site geometry. | PROPOSED |
-| `scale_band` | Scale and uncertainty band helpers. | PROPOSED |
-| `masking` | Mask/redaction metadata helpers. | PROPOSED |
-| `transform_ref` | SensitivityTransform reference preservation. | PROPOSED |
-| `review_refs` | Cultural/steward review reference preservation. | PROPOSED |
-| `display` | Public-safe display hint DTOs, not API routes. | PROPOSED |
-| `outcomes` | Missing/inaccessible transform abstain/deny-safe outcomes. | PROPOSED |
-| `validation` | Schema-bound validation adapters and safe errors. | PROPOSED |
-| `fixtures` | Synthetic/sanitized fixture builders. | NEEDS VERIFICATION |
+| `APPLIED` | Accepted mechanics produced a derivative and receipt candidate. | Safe, allowed, released, or published. |
+| `NO_OUTPUT` | The selected operation intentionally suppressed or withheld the value/artifact. | Error or evidence absence. |
+| `BLOCKED` | A caller-supplied gate or cumulative-risk rule prevented application. | A new policy decision by this package. |
+| `INVALID_INPUT` | Input failed the bound schema, CRS, geometry, or invariant checks. | Permanent rejection in every context. |
+| `UNSUPPORTED` | Profile, version, object, geometry, or operation is not implemented. | Permission to fall back to a weaker transform. |
+| `ERROR` | Unexpected local failure with public-safe diagnostics only. | Permission to expose input or retry publicly. |
 
-[⬆ Back to top](#top)
+The governed runtime maps authoritative policy and release state into `ANSWER`, `ABSTAIN`, `DENY`, or `ERROR`. An `APPLIED` result alone cannot produce `ANSWER`.
+
+### Required invariants
+
+A future implementation must:
+
+- reject missing or unknown profile/version bindings;
+- reject implicit CRS, axis order, unit, precision, or geometry-type assumptions;
+- preserve immutable source identity and never rewrite the source in place;
+- preserve candidate/anomaly/site type and source role;
+- preserve source time, valid time, rights, evidence, limitations, sensitivity, review, policy, and correction bindings;
+- produce a distinct derivative identity and digest;
+- never widen audience or lower source sensitivity;
+- never use fallback precision, default jitter, default centroid, or default cell size;
+- never emit exact geometry, original bounds, exact centroid, Z/M values, topology, vertex order, or metadata unless the selected profile explicitly allows the already-authorized field;
+- never expose seed/key/secret material or deterministic inputs that enable reversal or linkage;
+- distinguish no-output, withheld, invalid, unsupported, blocked, stale, and error states;
+- remain deterministic for the same authorized input, profile, implementation, and protected deterministic context when determinism is required;
+- enforce explicit resource bounds and reject pathological geometry safely;
+- return typed results instead of unstructured exceptions or generated prose;
+- perform no persistence, publication, or hidden I/O.
+
+[Back to top](#top)
 
 ---
 
-## 9. Inputs and outputs
+## Geometry and attribute safety
 
-| Class | Correct home | Notes |
+### Geometry preconditions
+
+Before any operation, an accepted implementation must validate:
+
+- geometry type, emptiness, dimensionality, and validity;
+- CRS identifier, axis order, units, and antimeridian/pole behavior where relevant;
+- coordinate precision and source uncertainty;
+- Z/M values, depth/elevation, bounds, centroids, and auxiliary indexes as independent disclosure surfaces;
+- multipart topology, holes, adjacency, and relationships that may reveal the protected place;
+- maximum feature, vertex, memory, and execution limits;
+- whether existence itself is controlled.
+
+Invalid geometry must not be repaired silently. Repair changes are transforms and require declared semantics, versioning, tests, and receipts where material.
+
+### Geometry outputs
+
+A derivative must state what it represents: generalized cell, region, aggregate, mask, omission, simplified footprint, or another accepted class. It must not be labeled or rendered as exact site geometry.
+
+Do not emit hidden exactness through:
+
+- bounding boxes, centers, tile extents, zoom-dependent layers, hover targets, or feature-state values;
+- precision-preserving IDs, source URLs, local names, survey-unit references, parcel joins, route/access descriptions, or collection metadata;
+- vertex count/order, simplification residue, shape fingerprints, topology, area/perimeter precision, or error messages;
+- time stamps, observation cadence, release diffs, or multiple profile outputs that allow triangulation.
+
+### Attributes, time, and counts
+
+Spatial coarsening does not protect non-spatial context. Profiles must separately address:
+
+- names, descriptions, cultural affiliations, oral-history text, custody/repository data, landowner/access information, and preservation/threat condition;
+- precise dates, event sequences, excavation phases, collection times, and update cadence;
+- small counts, rare categories, single-cell occupancy, differencing, and cross-filter reconstruction;
+- images, thumbnails, 3D models, terrain context, sensor footprints, and embedded metadata.
+
+Aggregation is not differential privacy. A `k` threshold is not k-anonymity until the population, equivalence classes, joins, suppression rules, and adversary model are defined and tested. Jitter is not anonymity and can increase false confidence.
+
+### Precision conflict rule
+
+Current docs conflict between a county/region public floor and a lane-local proposed H3-r7 refinement. Until accepted authority resolves that conflict:
+
+1. this package exposes no hard-coded public precision;
+2. policy must provide an accepted profile for the specific object, audience, and release;
+3. the more restrictive applicable requirement wins;
+4. if no safe profile is available, the output is `NO_OUTPUT` or the runtime returns `ABSTAIN`/`DENY`.
+
+[Back to top](#top)
+
+---
+
+## Transform classes and profile posture
+
+The following are transform classes, not accepted profiles:
+
+| Class | Possible operation | Principal risk |
 |---|---|---|
-| Package source | `packages/domains/archaeology/generalization/` | Shared generalization helper code only. |
-| Parent helper package | `packages/domains/archaeology/` | Domain helper parent. |
-| Evidence proof | `data/proofs/evidence_bundle/` | Referenced, not fabricated. |
-| Domain doctrine | `docs/domains/archaeology/` | Scope and sensitivity posture. |
-| Domain contracts | `contracts/domains/archaeology/` | Meaning authority. |
-| Domain schemas | `schemas/contracts/v1/domains/archaeology/` | Machine shape authority. |
-| Domain policy | `policy/domains/archaeology/` | Admissibility/exposure authority. |
-| Lifecycle data | `data/<phase>/archaeology/` | Not written here as hidden behavior. |
-| Release refs | `release/` | Referenced, not approved. |
-| Tests | `tests/packages/domains/archaeology/generalization/` | Package validation. |
-| Fixtures | `fixtures/packages/domains/archaeology/generalization/` | No-network synthetic/sanitized fixtures. |
+| Omission/withholding | Produce no public field or artifact. | Existence may still leak through metadata or differing behavior. |
+| Attribute redaction | Remove or replace controlled text/values. | Remaining fields and joins may reconstruct the value. |
+| Region/cell replacement | Replace a geometry with an approved region or cell. | Small/unique cells, centroids, and repeated releases may reveal the source. |
+| Aggregation | Combine multiple records at an accepted geography/time. | Small counts, differencing, filtering, and composition attacks. |
+| Simplification/clipping | Reduce geometry detail or extent. | Shape fingerprint, bounds, topology, or surviving vertices may remain identifying. |
+| Deterministic jitter | Offset geometry using an accepted deterministic method. | Reversal, linkage, false precision, seed exposure, and multi-release triangulation. |
+| Temporal generalization/delay | Coarsen or delay time. | Rare events, cadence, and cross-source correlation may still reveal location. |
+| Controlled derivative rendering | Rasterize or derive a view under an accepted profile. | Pixel/terrain/context metadata and zoom levels may leak detail. |
 
-[⬆ Back to top](#top)
+No class is safe for every Archaeology object. Exact sites, burials/human remains, sacred places, sovereignty-restricted knowledge, looting-risk records, or highly distinctive features may permit only withholding.
+
+### Profile admission
+
+An accepted profile must be named, versioned, immutable for replay, policy-owned, audience-scoped, object/field-scoped, explicit about transform classes and parameters, explicit about prohibited outputs, and bound to:
+
+- input and output contracts/schemas;
+- CRS, units, precision, and canonicalization rules;
+- deterministic or randomness requirements and secret custody;
+- evidence, rights, review, and release prerequisites;
+- cumulative-release and composition limits;
+- required receipt family and fields;
+- validation, inference, and parity tests;
+- correction, revocation, expiry, and rollback behavior.
+
+The current `policy/redaction/profiles.yaml` satisfies none of those burdens for Archaeology; it is only a placeholder.
+
+[Back to top](#top)
 
 ---
 
-## 10. Minimal package contract shape
+## Sensitivity, rights, cultural governance, and threat model
 
-```yaml
-package_id: kfm.packages.domains.archaeology.generalization
-status: draft
-authority: shared_domain_helper_package
-not_authority_for:
-  - sensitivity_decision
-  - exact_location_release
-  - evidence_bundle
-  - archaeology_doctrine
-  - policy_decision
-  - lifecycle_write
-  - release_decision
-allowed_responsibilities:
-  - generalized descriptor helpers
-  - redaction and masking metadata helpers
-  - scale and uncertainty band helpers
-  - sensitivity transform reference helpers
-  - review reference helpers
-  - display hint DTOs
-  - safe outcome helpers
-  - synthetic fixture builders
-required_invariants:
-  no_exact_location_publication: true
-  no_sensitivity_decision: true
-  no_hidden_lifecycle_writes: true
-  no_policy_bypass: true
-  no_evidence_fabrication: true
-  no_release_approval: true
-  generalization_output_is_not_release: true
+### Fail-closed material
+
+- exact or reconstructive site, candidate, artifact, excavation, burial, human-remains, sacred-place, collection, repository, or access-route detail;
+- restricted oral history, community-held knowledge, sovereignty-bearing context, culturally controlled interpretation, or reviewer identity/rationale;
+- private-landowner, collection-security, looting-risk, active-threat, custody, or fieldwork detail;
+- unresolved, expired, withdrawn, superseded, disputed, inaccessible, or unverifiable evidence, rights, consent, review, transform, or release state;
+- source/object existence where existence itself is controlled.
+
+### Adversaries and failure modes
+
+Assume an attacker may combine public KFM output with parcels, roads, imagery, terrain, LiDAR, historic maps, social media, collection catalogs, release history, browser/network metadata, and repeated queries.
+
+Required threat cases include:
+
+- differencing two releases or time windows;
+- comparing multiple profiles, zoom levels, exports, or audiences;
+- intersecting generalized cells with known land, terrain, route, survey, or ownership constraints;
+- correlating stable IDs, counts, update times, cache behavior, errors, or latency;
+- reconstructing from centroids, bounds, tile membership, Z/elevation, shape fingerprints, or topology;
+- exploiting deterministic outputs or exposed seed material;
+- poisoning profile selection, CRS, precision, geometry validity, or receipt references;
+- denial of service through complex or malformed geometries;
+- leakage through logs, traces, metrics, snapshots, CI artifacts, exceptions, or debug maps.
+
+### Cultural and sovereignty boundary
+
+A mechanical transform cannot decide cultural appropriateness, consent, narrative framing, or rights-holder authority. Public output receives only the material explicitly authorized for that audience; the package never receives sensitive consultation notes merely to remove them later.
+
+[Back to top](#top)
+
+---
+
+## Trust membrane and lifecycle
+
+```mermaid
+flowchart TD
+    A["Restricted source view"] --> B["Policy selects profile"]
+    B --> C["Cultural, rights, and steward gates"]
+    C --> D["Domain adapter plus shared mechanics"]
+    D --> E["Derivative and receipt candidate"]
+    E --> F["Independent safety validation"]
+    F --> G["Release decision"]
+    G --> H["Governed API or map"]
+    B --> I["DENY or WITHHOLD"]
 ```
 
-[⬆ Back to top](#top)
+The helper is one implementation step inside the membrane. It is not the trust membrane, policy engine, validator, receipt store, release gate, or public server.
+
+Lifecycle rules:
+
+- the source remains in its governed lifecycle state and sensitivity posture;
+- the derivative is a distinct object with source, profile, implementation, policy, review, receipt, and digest lineage;
+- transform output does not promote RAW, WORK, QUARANTINE, PROCESSED, CATALOG/TRIPLET, or PUBLISHED state;
+- a receipt candidate is not a persisted receipt, and a persisted receipt is not release approval;
+- every released derivative must be correctable, withdrawable, supersedable, and rollback-addressable;
+- watchers may detect changed inputs, profiles, libraries, policies, or risks but cannot publish replacements;
+- changed source, profile, implementation, CRS library, policy, review, receipt, or release binding requires re-evaluation;
+- previously safe output may become unsafe as external data, attack methods, or cumulative releases change.
+
+[Back to top](#top)
 
 ---
 
-## 11. Tests and fixtures
+## Validation and admission
 
-Recommended validation coverage:
+### Current posture
 
-```text
-tests/packages/domains/archaeology/generalization/
-├── test_generalization_boundaries.py       # PROPOSED
-├── test_generalization_not_release.py      # PROPOSED
-├── test_redaction_not_policy_decision.py   # PROPOSED
-├── test_exact_location_not_public.py       # PROPOSED
-├── test_missing_transform_abstains.py      # PROPOSED
-├── test_inaccessible_transform_denies.py   # PROPOSED
-├── test_review_ref_not_review_completion.py # PROPOSED
-├── test_no_hidden_lifecycle_writes.py      # PROPOSED
-├── test_no_release_approval.py             # PROPOSED
-└── test_root_boundary.py                   # PROPOSED
-```
+| Check | Current result |
+|---|---|
+| README structure, anchors, links, and whitespace | Required for this documentation revision. |
+| Transform/profile schema | Not admission-ready; transform schema is an empty permissive scaffold and profile registry is placeholder-only. |
+| Receipt schemas | Not admission-ready; shared and domain receipt schemas are empty permissive scaffolds. |
+| Shared redaction mechanics | Not implemented beyond metadata/README/placeholder source evidence. |
+| Archaeology generalizer unit tests | Not established. |
+| Package-specific test/fixture paths | Exact v0.1 paths absent at pinned snapshot. |
+| Geometry, parity, inference, composition, and resource tests | Not established for this package. |
+| End-to-end receipt, release, API, and map behavior | Not established. |
+| Correction/revocation/rollback drill | Not established. |
 
-Fixtures should live in `fixtures/packages/domains/archaeology/generalization/` unless a package-local convention is explicitly accepted. Fixtures should be synthetic or sanitized and must not expose controlled archaeology locations, cultural context, collection-security detail, or other restricted material unless fixture policy explicitly permits it.
+### Minimum executable test families
 
-[⬆ Back to top](#top)
+Future tests under the accepted Archaeology topology must cover at least:
+
+- no active or unknown profile fails closed;
+- no hidden profile selection or fallback parameters;
+- explicit CRS, axis order, units, precision, and geometry-type enforcement;
+- invalid, empty, multipart, antimeridian, high-dimensional, and pathological geometries;
+- source identity preserved and derivative identity distinct;
+- candidate/anomaly/site type and source role preserved;
+- exact values, bounds, centers, Z/M, topology, identifiers, names, time, counts, and metadata not leaked;
+- deterministic replay and cross-language/library parity where promised;
+- seed/key material absent from output, receipts, logs, errors, and caches;
+- repeated-release, multi-profile, differencing, linkage, and composition attacks;
+- small-count, k-anonymity, and differential-privacy claims rejected unless their full accepted contracts are satisfied;
+- cumulative transform history and release-family controls;
+- receipt-candidate content is complete but contains no protected source value;
+- transform application does not imply policy, review, release, lifecycle, or publication success;
+- no network, filesystem, registry, proof-store, policy-engine, receipt-store, release, catalog, graph, tile, or UI side effects;
+- safe errors, logs, metrics, traces, snapshots, and CI artifacts;
+- resource ceilings and denial-of-service resistance;
+- correction, profile revocation, dependency change, supersession, withdrawal, and rollback;
+- nonzero executable collection so placeholder-only suites cannot pass.
+
+Fixtures must be obviously synthetic, non-place data. Avoid Kansas-shaped plausible coordinates, real names, actual site identifiers, realistic access routes, or culturally specific narratives.
+
+### Admission gates
+
+Do not claim implementation readiness until all are true:
+
+1. shared-redaction versus Archaeology-adapter ownership is accepted;
+2. transform and receipt roles/homes are reconciled;
+3. public precision and H3/county-region conflict is resolved;
+4. at least one immutable Archaeology profile is accepted and versioned;
+5. runtime, manifest, exports, dependencies, compatibility, and supply-chain policy are explicit;
+6. typed inputs prevent missing policy, rights, review, sensitivity, evidence, profile, and release bindings;
+7. pure mechanics and adapters have deterministic/parity/resource tests;
+8. inference, composition, and cumulative-release tests pass;
+9. receipt candidate, persistence owner, validator, signature, correction, and rollback flows are bound;
+10. one governed consumer contract test passes without direct restricted-store access;
+11. cultural/sensitivity/sovereignty, geospatial/privacy, policy, security, evidence, schema, validation, release, and consumer stewards approve the slice;
+12. CI collects nonzero tests and retains only public-safe artifacts.
+
+[Back to top](#top)
 
 ---
 
-## 12. Definition of done
+## Smallest safe implementation sequence
 
-This README is done when it:
+1. Decide whether this package is needed or whether `packages/redaction/` plus configuration is sufficient.
+2. Reconcile SensitivityTransform, PublicationTransformReceipt, and RedactionReceipt roles and schema homes.
+3. Resolve the public precision conflict and select one object/field/audience use case.
+4. Author and review one immutable profile; do not implement a catalogue.
+5. Define typed inputs, derivative identity, local results, and receipt candidate.
+6. Add synthetic geometry/attribute fixtures and executable negative tests.
+7. Implement or adopt the smallest pure shared mechanic.
+8. Implement the thin Archaeology adapter with no I/O and no profile selection.
+9. Add parity, inference, composition, cumulative-release, resource, logging, and dependency-change tests.
+10. Bind one internal review or release-candidate consumer before any public route.
+11. Exercise correction, profile revocation, withdrawal, supersession, and rollback.
+12. Consider public use only after independent safety, cultural/rights, policy, and release review.
 
-- fills the empty `packages/domains/archaeology/generalization/README.md` file;
-- identifies this path as shared generalization helper-code space;
-- keeps sensitivity decisions, doctrine, contracts, schemas, policy, lifecycle data, review decisions, EvidenceBundles, and release decisions in their authority roots;
-- blocks generalization helpers from becoming sensitivity decisions, exact-location disclosure, policy approval, lifecycle promotion, proof, or release approval;
-- defines expected helper families, sensitivity posture, inputs/outputs, tests, fixtures, and open questions.
-
-Future package files are done only when they are schema-aligned, test-covered, steward-reviewed, deterministic where practical, and unable to bypass Archaeology sensitivity, cultural/steward review, lifecycle, evidence, policy, and release controls.
-
-[⬆ Back to top](#top)
+[Back to top](#top)
 
 ---
 
-## 13. Open questions
+## Compatibility, correction, revocation, and rollback
 
-| ID | Question | Status |
+A future implementation must version:
+
+- source and derivative contracts/schemas;
+- transform profile and profile registry;
+- canonicalization, CRS, geometry, privacy, and shared-library implementations;
+- deterministic/randomness method and protected context;
+- receipt contract/schema;
+- policy, review, evidence, rights, and release bindings;
+- consumer contract and public renderer behavior where applicable.
+
+Compatibility rules:
+
+- changes in geometry library, CRS database, floating-point behavior, PRNG, secret/salt, canonicalization, sorting, simplification, rounding, or serialization are behavior changes;
+- unknown fields, enums, profiles, versions, CRS values, geometry types, or operations fail closed;
+- profile changes create a new immutable version; do not edit history in place;
+- public cache keys must bind audience, profile, source version, implementation, policy/review/release state, and correction lineage as required;
+- no migration may widen exposure, silently change precision, or silently reinterpret a receipt;
+- reproducibility for reviewers does not require publishing protected source values, keys, or reversible seed material.
+
+Correction/revocation workflow owners outside this helper must:
+
+1. identify every affected source, derivative, receipt, release, tile, cache, API/UI payload, export, index, search/graph reference, and AI retrieval artifact;
+2. block the profile/implementation version and stop new derivations;
+3. withdraw or downgrade unsafe releases immediately;
+4. preserve incident, correction, supersession, and rollback lineage;
+5. re-evaluate cumulative disclosure from already released derivatives;
+6. regenerate only from an authorized source view and accepted replacement profile;
+7. verify downstream invalidation and non-disclosure;
+8. add the failure as a permanent regression and threat-model case.
+
+For this README-only revision, rollback is a Git revert of the README and paired generated receipt. Documentation rollback does not undo or authorize any transform or release.
+
+[Back to top](#top)
+
+---
+
+## Definition of done
+
+This README revision is complete when it:
+
+- states the inspected package's actual maturity without claiming implementation;
+- corrects stale package-specific test and fixture paths;
+- separates transform semantics, mechanics, profile selection, application, receipt, validation, review, policy, lifecycle, and release;
+- records the shared/domain package overlap, receipt-role ambiguity, placeholder profiles, and public-precision conflict;
+- defines explicit-input, no-I/O, deterministic, geometry, attribute, inference, cumulative-release, validation, correction, and rollback burdens;
+- labels future APIs, results, profiles, algorithms, fields, tests, and sequencing as `PROPOSED`;
+- changes no implementation, profile, schema, contract, policy, proof, test, fixture, receipt, lifecycle, release, API, tile, map, or UI artifact.
+
+README completeness is not transform correctness or publication safety.
+
+[Back to top](#top)
+
+---
+
+## Open verification register
+
+| ID | Question | Status | Required evidence/owner |
+|---|---|---|---|
+| AGN-001 | Is this package needed, or should shared `packages/redaction/` own all mechanics and adapters? | `CONFLICTED` | Package/domain architecture decision and consumer inventory. |
+| AGN-002 | Which runtime, manifest, namespace, exports, and compatibility policy apply? | `UNKNOWN` | Implemented package evidence and tests. |
+| AGN-003 | What are the distinct roles of SensitivityTransform, PublicationTransformReceipt, and RedactionReceipt? | `CONFLICTED` | Contract/schema/receipt ADR and migration plan. |
+| AGN-004 | Which schema homes and required fields are canonical? | `NEEDS VERIFICATION` | Accepted fielded schemas, validators, fixtures, and owners. |
+| AGN-005 | Which authority owns the transform profile registry? | `NEEDS VERIFICATION` | Policy/profile governance decision. |
+| AGN-006 | What is the first accepted Archaeology profile and use case? | `NOT ESTABLISHED` | Reviewed immutable profile and threat model. |
+| AGN-007 | Is the public floor county/region, H3-r7, object-specific, or always withholding for some classes? | `CONFLICTED` | Operating-contract/domain-policy reconciliation. |
+| AGN-008 | Which CRS, geometry library, canonicalization, and precision rules are accepted? | `UNKNOWN` | Geospatial ADR, version pins, and parity vectors. |
+| AGN-009 | Is seeded deterministic jitter allowed for Archaeology, and how are secrets/salts held and rotated? | `NEEDS VERIFICATION` | Privacy/security ADR, key custody, threat analysis, and tests. |
+| AGN-010 | How are repeated releases and multi-profile composition prevented from triangulating a source? | `NEEDS VERIFICATION` | Release-family ledger and composition tests. |
+| AGN-011 | Which objects/fields may only be withheld regardless of transform? | `NEEDS VERIFICATION` | Cultural/sovereignty/rights-holder and policy matrix. |
+| AGN-012 | Which k-anonymity or differential-privacy contracts, budgets, and accountants are accepted? | `NOT ESTABLISHED` | Fielded contracts, policy, implementation, and adversarial validation. |
+| AGN-013 | Who independently validates derivatives and re-identification risk? | `NEEDS VERIFICATION` | Separation-of-duties and validator ownership. |
+| AGN-014 | Who persists/signs receipts and binds them to releases? | `NEEDS VERIFICATION` | Receipt producer/store/signature/release workflow. |
+| AGN-015 | Where do executable tests and fixtures live after topology reconciliation? | `CONFLICTED` | Test/fixture owner decision and index. |
+| AGN-016 | What logs, metrics, traces, and debugging surfaces are safe? | `NEEDS VERIFICATION` | Telemetry classification, threat model, and tests. |
+| AGN-017 | How are dependency/profile vulnerabilities, corrections, revocations, and rollback propagated? | `NEEDS VERIFICATION` | End-to-end drill and consumer inventory. |
+| AGN-018 | Is any generalization implementation or derivative currently used in production/release? | `UNKNOWN` | Deployment, consumer, receipt, and release evidence. |
+
+[Back to top](#top)
+
+---
+
+## Evidence ledger
+
+| Evidence | Snapshot finding | Truth label |
 |---|---|---|
-| `PKG-DOM-ARCH-GEN-001` | Which language/runtime owns `packages/domains/archaeology/generalization/`? | UNKNOWN |
-| `PKG-DOM-ARCH-GEN-002` | Which canonical schema owns generalized geometry descriptors and transform references? | NEEDS VERIFICATION |
-| `PKG-DOM-ARCH-GEN-003` | Which package manifest controls this package, if any? | UNKNOWN |
-| `PKG-DOM-ARCH-GEN-004` | Which CI workflow validates generalization-not-release and exact-location-denial rules? | UNKNOWN |
-| `PKG-DOM-ARCH-GEN-005` | Should executable generalization transforms live under `pipelines/domains/archaeology/`, a policy root, or a release-prep lane? | NEEDS VERIFICATION / ADR |
-| `PKG-DOM-ARCH-GEN-006` | Which scale bands and masking strategies are canonical versus policy-configured? | NEEDS VERIFICATION |
+| `packages/domains/archaeology/generalization/README.md` | v0.1 planning README exists; target blob pinned above. | `CONFIRMED` |
+| `docs/doctrine/directory-rules.md` | Establishes responsibility-root placement and separation of package, policy, data, release, and public-delivery authority. | `CONFIRMED` |
+| `packages/redaction/README.md` and bounded source evidence | Shared package is a `0.0.0`/placeholder scaffold, not functional mechanics. | `CONFIRMED` scaffold |
+| `contracts/domains/archaeology/sensitivity_transform.md` plus schema | Draft semantic object; paired schema has no fields and permits additional properties. | `CONFIRMED` draft / `PROPOSED` schema |
+| `contracts/domains/archaeology/publication_transform_receipt.md` plus schema | Draft domain receipt; paired schema has no fields and permits additional properties. | `CONFIRMED` draft / `PROPOSED` schema |
+| `contracts/shared/redaction_receipt.md` plus receipt schema | Draft shared receipt semantics; schema home/fields open and scaffold is permissive. | `CONFIRMED` draft / `NEEDS VERIFICATION` authority |
+| `policy/redaction/profiles.yaml` | Placeholder only; Habitat source document; no active Archaeology profile. | `CONFIRMED` placeholder |
+| `docs/standards/REDACTION_DETERMINISM.md` | Detailed draft mechanics, profile IDs, and seed rules remain `PROPOSED` with open custody/path questions. | `CONFIRMED` document / `PROPOSED` implementation |
+| Archaeology sensitivity and Map/UI docs | H3-r7 lane guidance and county/region operating floor are not reconciled. | `CONFLICTED` |
+| Archaeology policy README | Deny-by-default intent documented; concrete policy files, tests, CI/runtime binding remain unverified. | `CONFIRMED` README / `UNKNOWN` enforcement |
+| Archaeology tests and fixtures | Domain roots confirmed; sampled tests placeholder-heavy and fixture payload inventory unverified. | `CONFIRMED` bounded evidence |
+| Archaeology workflow | Read-only readiness-hold workflow; not transform or release proof. | `CONFIRMED` |
+| Exact package/runtime/test/fixture probes | Named conventional implementation and stale package-specific README paths absent at pinned snapshot. | `CONFIRMED` bounded absence |
+| Complete implementation, consumer, derivative, and release inventory | Not exhaustively established by bounded search/direct reads. | `UNKNOWN` |
 
 ---
 
-## Maintainer note
+## Maintainer handoff
 
-Keep this package helper-focused and subordinate to Archaeology sensitivity governance. Do not add sensitivity decision logic, exact-location publication, policy decisions, lifecycle writers, EvidenceBundle writers, release decisions, public API routes, UI behavior, controlled-location examples, culturally sensitive examples, collection-security details, or generated truth claims here.
+- **Current posture:** documentation boundary only; generalizer and active profiles not implemented.
+- **Safe next action:** resolve AGN-001, AGN-003, and AGN-007 before creating code.
+- **Do not do next:** add a default H3/jitter/centroid profile, copy shared mechanics into the domain package, publish a reversible receipt, or wire a public map route.
+- **Required reviewers for implementation:** Archaeology domain, cultural/sensitivity/sovereignty, rights-holder, geospatial/privacy, policy, evidence, contract/schema, security, validation, release, and consumer owners.
+
+[Back to top](#top)


### PR DESCRIPTION
## Task contract

Update `packages/domains/archaeology/generalization/README.md` under the active KFM repository-documentation operating contract. Preserve Directory Rules, evidence-first truth labels, sensitive-domain deny-by-default behavior, and separation of transform mechanics, profile selection, evidence, cultural/sovereignty review, policy, receipts, lifecycle, release, and public delivery.

**Change posture:** documentation and provenance only. No merge, transform activation, release, or publication is requested or performed.

## Status

- Target: `packages/domains/archaeology/generalization/README.md`
- Document version: `v0.2`
- Authoring snapshot: `main@4f46eaaa444bb66f1f37d5c83b8311375ce8e572`
- Delivery base: `main@18ee0ae794037659989ea7acc87fba711a1d12ff`
- Prior target blob: `3874ba04fb174c59a28b024bb74599252109943f`
- Runtime posture: generalizer **NOT IMPLEMENTED**
- Profile posture: no accepted Archaeology transform profile established
- Human review: pending
- Public posture: exact and reconstructive location deny by default

## What changed

- Replaced planning-oriented claims with commit-pinned repository evidence and bounded absence checks.
- Corrected stale package-specific test and fixture paths to the confirmed Archaeology domain roots.
- Reframed this path as a possible Archaeology-specific adapter around shared transform mechanics, not an independent policy, privacy, or release engine.
- Recorded four unresolved architectural conflicts:
  1. shared `packages/redaction/` mechanics versus domain adapter ownership;
  2. SensitivityTransform, PublicationTransformReceipt, and shared RedactionReceipt roles/homes;
  3. placeholder-only redaction profile registry with no active Archaeology profile;
  4. county/region public precision floor versus lane-local proposed H3-r7 refinement.
- Defined explicit-input/no-I/O invocation rules, typed local results, transform invariants, geometry/attribute/time/count safety, profile admission, inference and cumulative-release threats, and resource limits.
- Added shared/domain dependency direction, trust-membrane flow, executable-test burden, smallest safe implementation sequence, correction/revocation/rollback rules, 18-item verification register, and evidence ledger.
- Added the required generated-work provenance receipt.

## What did not change

No generalizer, shared transform mechanic, profile, seed/salt/key, package manifest, dependency, contract, schema, policy, proof, receipt, fixture payload, executable test, workflow, lifecycle object, release record, API route, tile, map layer, UI component, deployment, or public behavior was created or modified.

No real coordinate, identifier, place/site name, access route, cultural detail, reviewer identity, protected payload, credential, private endpoint, or reconstructive example was added.

## Repository evidence

The update was grounded in:

- Directory Rules and the package responsibility root;
- the merged sibling evidence-projection README;
- the shared redaction package's `0.0.0`/placeholder maturity;
- SensitivityTransform and PublicationTransformReceipt contracts plus permissive scaffold schemas;
- shared RedactionReceipt semantics and its open schema posture;
- the placeholder `policy/redaction/profiles.yaml`;
- the draft redaction-determinism standard;
- Archaeology sensitivity, preservation, map/UI, policy, tests, fixtures, and readiness-hold workflow.

Confirmed, proposed, conflicted, unknown, and verification-bound claims remain visibly separate. Bounded path probes are not presented as a complete recursive inventory.

## Authority and anti-collapse

The package cannot:

- select or approve a transform profile;
- decide sensitivity, cultural appropriateness, sovereignty authority, consent, policy, or release;
- treat H3, county/region, jitter, centroid, aggregation, suppression, k-anonymity, or differential privacy as automatically safe;
- create or persist evidence, receipts, lifecycle records, tiles, catalog/triplet records, or release artifacts;
- expose exact/reconstructive detail or serve public clients.

A transform is not proof of safety. A receipt is not transform sufficiency, policy approval, cultural review, consent, release approval, or publication permission. The controlled source remains controlled; a derivative receives separate lineage and governance.

## Sensitive-domain and threat review

The README now covers:

- geometry, bounds, centroids, Z/M, topology, shape fingerprints, tile/zoom and metadata leakage;
- names, time, counts, images/3D, custody, landowner/access, preservation/threat and cultural-context leakage;
- differencing, repeated releases, multi-profile triangulation, linkage and composition attacks;
- deterministic seed/key exposure and cross-release correlation;
- malformed/pathological geometry and resource exhaustion;
- logs, traces, metrics, snapshots, cache keys, timing, errors and CI-artifact leakage;
- external correlation with parcels, roads, terrain, imagery, LiDAR, historic maps and catalogs.

Some Archaeology object classes may permit only withholding. Mechanical transforms cannot settle cultural/sovereignty or rights-holder decisions.

## Validation

Passed locally and by remote readback:

- one H1;
- balanced fenced blocks;
- closed KFM Meta Block v2;
- final newline;
- no trailing whitespace or tabs;
- repository-relative link targets resolve;
- receipt JSON parses and closes over the README SHA-256;
- no common private-key or token-prefix match;
- remote README blob: `013a04b52afec14d4bef4da919f56a96cad23af4`;
- remote receipt blob: `a8cdf5dd9385df2fc909b2abbe4f570b7d6614f6`;
- branch is two commits ahead and zero behind the delivery base;
- changed paths are exactly the README and generated receipt.

Runtime and executable transform tests were skipped because this is documentation/provenance only and no generalizer/profile is established at the checked paths.

## Base drift

During authoring, `main` advanced from `4f46eaaa...` to `18ee0ae7...`. The compare changed only `fixtures/contracts/README.md` and its generated receipt. The target remained at blob `3874ba0...`; this branch was created from the newer immutable base.

## Receipt

`data/receipts/generated/genrec-packages-domains-archaeology-generalization-readme-93901b3f.json`

README SHA-256:

`93901b3ff8a0d7adbc74ad2f47922a3d5eb6bfa922167ce0b3b0c1220108c904`

The receipt records provenance and validation only. It does not authorize merge, transform use, release, or publication. Human review remains pending.

## Rollback

Revert the two branch commits or eventual merge commit. Documentation rollback does not mutate profiles, transforms, receipts, evidence, policy, lifecycle state, release state, tiles, maps, APIs, or public artifacts.

## Reviewer focus

1. Is this package needed, or should `packages/redaction/` own all mechanics with domain configuration/adapters elsewhere?
2. How should SensitivityTransform, PublicationTransformReceipt, and RedactionReceipt divide rule, application, and audit responsibilities?
3. Which public precision rule has authority: county/region, H3-r7, object-specific policy, or withholding?
4. Is deterministic jitter ever acceptable for Archaeology, and how are seed/salt/key custody and cumulative disclosure controlled?
5. Which single object/field/audience use case should be the first thin slice?

## Checklist

- [x] Scope is the requested README plus required provenance receipt.
- [x] No shared/domain authority decision was silently made.
- [x] No profile, algorithm, receipt schema, or public precision was invented.
- [x] Sensitive-domain posture is fail closed.
- [x] Validation, correction, revocation, and rollback are documented.
- [x] Base drift and target concurrency were checked.
- [ ] Package/receipt/profile/precision ADRs resolved.
- [ ] Human domain/privacy/cultural/policy/security/release review completed.
- [ ] Merge authorized by a human maintainer.
