### PR TITLE
docs(catalog): ground DCAT catalog lane

### DIFF
--- a/data/catalog/dcat/README.md
+++ b/data/catalog/dcat/README.md
@@ -1,166 +1,250 @@
 <!-- [KFM_META_BLOCK_V2]
 doc_id: kfm://doc/data-catalog-dcat-readme
-title: data/catalog/dcat/README.md — DCAT Catalog Sublane README
-version: v0.2
-type: readme; data-lifecycle-sublane; dcat-catalog-guide
-status: draft; PROPOSED; data-root; catalog-stage; dcat; release-gated
-owners: OWNER_TBD — Data steward · Catalog steward · DCAT steward · Evidence steward · Policy steward · Release steward · Schema steward · Docs steward
-created: NEEDS VERIFICATION — greenfield stub existed before v0.1 expansion
-updated: 2026-06-24
-policy_label: public-doc; data; catalog; dcat; lifecycle; release-gated
-tags: [kfm, data, catalog, dcat, DCATv3, CATALOG, STAC, PROV, EvidenceBundle, SourceDescriptor, ReleaseManifest, CatalogBuildReceipt]
+title: data/catalog/dcat/README.md — DCAT Catalog Lane
+version: v0.3
+type: readme; directory-readme; data-lifecycle-sublane; dcat-catalog-guide
+status: draft; repository-grounded; confirmed-path; catalog-stage; dcat-profile-draft; release-gated; implementation-incomplete
+owners: OWNER_TBD — Data steward · Catalog steward · DCAT steward · Source steward · Evidence steward · Rights/sensitivity steward · Policy steward · Validation steward · Release steward · Docs steward
+created: NEEDS VERIFICATION — placeholder lineage predates v0.1
+updated: 2026-07-22
+policy_label: public-doc; data; catalog; dcat; discovery-not-truth; release-gated; sensitivity-aware
+owning_root: data/
+lifecycle_stage: CATALOG / TRIPLET
+external_vocabulary: W3C DCAT v3 — repository target; KFM profile remains draft
+truth_posture: cite-or-abstain; catalog-is-not-truth; path-presence-is-not-publication
+evidence_snapshot:
+  repository: bartytime4life/Kansas-Frontier-Matrix
+  base_commit: d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0
+  prior_blob: 07c61a743fd4712c8393b05c9fb82e98e55bf76c
 related:
   - ../README.md
   - ../../README.md
+  - ./flora/README.md
+  - ../stac/README.md
+  - ../prov/README.md
+  - ../domain/README.md
   - ../../../docs/standards/DCAT.md
+  - ../../../docs/doctrine/directory-rules.md
+  - ../../../docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md
   - ../../../docs/adr/ADR-0022-catalog-matrix--stac-+-dcat-+-prov-must-agree.md
-  - ../../../docs/doctrine/lifecycle-law.md
-  - ../../../schemas/
-  - ../../../policy/
-  - ../../../release/
+  - ../../../contracts/data/catalog_matrix.md
+  - ../../../schemas/contracts/v1/data/catalog_matrix.schema.json
+  - ../../../tools/validators/catalog/README.md
+  - ../../../tools/validators/catalog_closure/README.md
+  - ../../../policy/data/README.md
+  - ../../receipts/generated/README.md
 notes:
-  - "v0.2 adds the required README impact block, quick jumps, lifecycle diagram, evidence ledger, and stronger GitHub navigation."
-  - "DCAT records are catalog carriers and do not replace SourceDescriptor, EvidenceBundle, RunReceipt, PolicyDecision, or ReleaseManifest."
-  - "ADR-0022 requires STAC, DCAT, and PROV-O catalog records to agree by identifier, digest, and release reference for promoted releases."
-  - "Rollback target for this expansion is previous v0.1 blob SHA `6a0e1c6ea92d1353cc25cf0a4b4698fcfd28cc1f`."
+  - "This revision is documentation-only. It creates no DCAT record, profile, JSON-LD context, schema, validator, policy rule, CatalogMatrix, release, route, or published artifact."
+  - "ADR-0011 and ADR-0022 are proposed, not accepted. Their separation and catalog-closure language is recorded as proposal status, not current enforcement."
+  - "The verified CatalogMatrix schema is a permissive placeholder and the observed top-level CatalogMatrix validator raises NotImplementedError."
+  - "A bounded child-path check confirmed the Flora DCAT guide; it was not a complete recursive inventory of this directory."
 [/KFM_META_BLOCK_V2] -->
 
 <a id="top"></a>
 
-# data/catalog/dcat
+# DCAT catalog lane
 
-> DCAT catalog sublane for governed `dcat:Dataset` and `dcat:Distribution` records inside the `CATALOG / TRIPLET` lifecycle stage.
+`data/catalog/dcat/`
 
-<p>
-  <img alt="Status: draft" src="https://img.shields.io/badge/status-draft-yellow">
-  <img alt="Root: data/catalog/dcat" src="https://img.shields.io/badge/root-data%2Fcatalog%2Fdcat-blue">
-  <img alt="Lifecycle: CATALOG" src="https://img.shields.io/badge/lifecycle-CATALOG-purple">
-  <img alt="Standard: DCAT v3" src="https://img.shields.io/badge/standard-DCAT_v3-informational">
-  <img alt="Exposure: released only" src="https://img.shields.io/badge/exposure-RELEASED__ONLY-critical">
-</p>
+> Governed DCAT discovery and interchange projections at KFM's `CATALOG / TRIPLET` lifecycle stage. A catalog record can describe an artifact; it cannot make the artifact true, safe, approved, released, or public.
 
-**Status:** draft / PROPOSED  
-**Owners:** OWNER_TBD — Data steward · Catalog steward · DCAT steward · Evidence steward · Policy steward · Release steward · Schema steward · Docs steward  
-**Path:** `data/catalog/dcat/README.md`  
-**Owning root:** `data/catalog/`  
-**Lifecycle stage:** `CATALOG / TRIPLET`  
-**External vocabulary:** W3C DCAT v3  
-**Exposure posture:** RELEASED ONLY  
-**Truth posture:** CONFIRMED target was a greenfield stub · CONFIRMED parent catalog lane is RELEASED ONLY · CONFIRMED DCAT profile targets W3C DCAT v3 and names `data/catalog/dcat/` as catalog data home · CONFIRMED ADR-0022 says STAC, DCAT, and PROV must agree for promoted releases · NEEDS VERIFICATION for concrete inventory, schemas, validators, policy gates, receipts, release manifests, and routed access behavior.
+- **Evidence snapshot:** `main@d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0`
+- **Document status:** repository-grounded draft
+- **Exposure posture:** release-gated; directory presence is not publication
+**Implementation boundary:** the path and draft profile are confirmed; a production DCAT profile, validator, dedicated test/CI gate, emitted closure, and public serving behavior remain unestablished or need verification
 
-**Quick jumps:** [Purpose](#purpose) · [Lifecycle boundary](#lifecycle-boundary) · [Repo fit](#repo-fit) · [Accepted contents](#accepted-contents) · [Exclusions](#exclusions) · [Record requirements](#record-requirements) · [Guardrails](#guardrails) · [Evidence ledger](#evidence-ledger) · [Validation checklist](#validation-checklist) · [Rollback](#rollback)
+**Quick navigation:** [Purpose](#purpose) · [Authority](#authority-level) · [Status](#status) · [What belongs](#what-belongs-here) · [What does not](#what-does-not-belong-here) · [Inputs](#inputs) · [Outputs](#outputs) · [Validation](#validation) · [Review](#review-burden) · [Related folders](#related-folders) · [ADRs](#adrs) · [Last reviewed](#last-reviewed)
 
 ---
 
 ## Purpose
 
-`data/catalog/dcat/` stores or stages governed DCAT catalog records for KFM datasets and distributions.
+Use this lane for DCAT catalog projections that make governed KFM datasets, distributions, and services discoverable without copying or replacing the objects that establish source identity, evidence, policy, review, validation, or release state.
 
-A DCAT record supports catalog discovery and interoperability. It does **not** make a dataset true, public, policy-admitted, evidence-supported, or released by itself.
-
-## Lifecycle boundary
+Directory Rules place `dcat/` under `data/catalog/`, alongside `stac/`, `prov/`, and `domain/`. That is a lifecycle placement: promotion into or through this lane is a governed state transition, not a file copy.
 
 ```mermaid
-flowchart LR
-  RAW[RAW] --> WORK[WORK / QUARANTINE]
-  WORK --> PROCESSED[PROCESSED]
-  PROCESSED --> CATALOG[CATALOG / TRIPLET]
-  CATALOG --> PUBLISHED[PUBLISHED]
-  DCAT[data/catalog/dcat] --> CATALOG
+flowchart TD
+  A["RAW"] --> B["WORK / QUARANTINE"]
+  B --> C["PROCESSED"]
+  C --> D["CATALOG / TRIPLET"]
+  D --> E["PUBLISHED"]
+  F["data/catalog/dcat"] --> D
 ```
 
-`data/catalog/dcat/` is a CATALOG-stage sublane. Public exposure applies only to records tied to an approved release and governed access path.
+A DCAT record is a derived catalog carrier. It may reference authoritative objects, but it does not replace them and is not an `EvidenceBundle`, receipt, proof, `PolicyDecision`, `ReleaseManifest`, or publication decision.
 
-## Repo fit
+## Authority level
 
-| Responsibility | Correct home | Rule |
+**Catalog-stage data lane; discovery and interchange authority only.**
+
+| Concern | Authority boundary |
+|---|---|
+| External vocabulary | W3C DCAT v3 is the target named by the repository's draft DCAT standard. |
+| KFM DCAT profile | `docs/standards/DCAT.md` describes the draft profile direction. Profile IRIs, JSON-LD context, schema location, validators, and CI enforcement are not established here. |
+| Catalog instances | This lane may hold governed DCAT projections once their profile and validation requirements are satisfied. |
+| Source identity and role | Source descriptors and registry/contract authority remain outside this lane. |
+| Evidence and proof | `EvidenceRef`, `EvidenceBundle`, proof packs, and validation evidence remain in their governed homes. |
+| Admissibility | `policy/` and review records decide allow, deny, restrict, or abstain; catalog metadata does not. |
+| Release and publication | `release/` owns release decisions; `data/published/` owns approved public-safe materializations. |
+| Public access | Public clients use governed interfaces and released artifacts, not this internal catalog lane directly. |
+
+This README documents boundaries. It is not a profile, schema, policy bundle, validator, release gate, or public API contract.
+
+## Status
+
+| Surface | Label | Current repository evidence and limit |
 |---|---|---|
-| DCAT catalog records | `data/catalog/dcat/` | This lane. |
-| Parent catalog stage | `data/catalog/` | Parent CATALOG-stage lane. |
-| STAC catalog records | `data/catalog/stac/` | Spatiotemporal catalog records. |
-| PROV catalog records | `data/catalog/prov/` | Provenance catalog projection. |
-| Evidence/proof records | `data/proofs/` | EvidenceBundle and ProofPack. |
-| Receipts | `data/receipts/` | CatalogBuildReceipt, RunReceipt, validation receipts. |
-| Release decisions | `release/` | Publication authority. |
-| Published outputs | `data/published/` | Public-safe materialization after release. |
-| Schemas and policy | `schemas/`, `policy/` | Separate roots. |
-| Validators and tests | `tools/validators/`, `tests/` | Separate roots. |
+| `data/catalog/dcat/README.md` | CONFIRMED | This lane guide exists at the pinned snapshot. |
+| DCAT placement under `data/catalog/` | CONFIRMED repository path / draft doctrine | Directory Rules list `stac/`, `dcat/`, `prov/`, and `domain/` under the catalog phase. Runtime enforcement is not implied. |
+| Flora child guide | CONFIRMED | `data/catalog/dcat/flora/README.md` exists. Bounded checks of other common domain child README paths did not establish a complete directory inventory. |
+| DCAT version target | CONFIRMED draft standard | `docs/standards/DCAT.md` targets W3C DCAT v3 and is itself marked `draft`. |
+| KFM profile, namespace IRIs, context, and exact required fields | PROPOSED / NEEDS VERIFICATION | The standard contains working profile direction and placeholders; accepted machine authority was not established. |
+| Record-local validator | NEEDS VERIFICATION | `tools/validators/catalog/` is README-only in its recorded review and no dedicated executable DCAT validator was established by the bounded checks. |
+| Catalog closure | PROPOSED | ADR-0022 proposes STAC/DCAT/PROV agreement; ADR-0011 and ADR-0022 remain proposed and their catalog-matrix placement implications are unresolved. |
+| CatalogMatrix schema and validator | CONFIRMED placeholders | `schemas/contracts/v1/data/catalog_matrix.schema.json` requires only `id` and allows additional properties; `tools/validators/validate_catalog_matrix.py` raises `NotImplementedError`. |
+| Dedicated DCAT tests and CI | NEEDS VERIFICATION | The confirmed `validator-suite` workflow does not establish DCAT profile validation or catalog-closure enforcement. |
+| Emitted DCAT payloads, release linkage, and governed public routes | NEEDS VERIFICATION | No complete payload inventory, current release proof, or runtime route behavior was established by this documentation pass. |
 
-## Accepted contents
+Absence statements above are bounded to the exact paths and evidence inspected at the snapshot. They are not claims that historical, branch-local, generated, package-local, or external implementations never existed.
 
-| Content | Purpose |
+## What belongs here
+
+Subject to an accepted profile and working validation, appropriate contents include:
+
+- `dcat:Catalog`, `dcat:Dataset`, `dcat:Distribution`, and `dcat:DataService` projections for governed KFM artifacts;
+- dataset- and distribution-level discovery metadata bound to stable identifiers and immutable artifact digests;
+- catalog links to admitted source metadata, evidence/proof context, rights and sensitivity posture, validation results, review state, release state, and correction lineage where material;
+- KFM extension properties declared through an accepted namespace and JSON-LD context rather than ad hoc fields;
+- release-linked public-safe catalog projections that point only to approved distributions and governed access surfaces;
+- bounded catalog indexes or validation summaries that reference their source records and exact validation artifacts.
+
+Exact filenames, serialization packaging, extension IRIs, required fields, cardinalities, and media types are profile/schema concerns. This README does not invent them.
+
+## What does NOT belong here
+
+| Do not place or decide here | Correct responsibility boundary |
 |---|---|
-| `dcat:Dataset` records | Dataset-level catalog metadata. |
-| `dcat:Distribution` records | Distribution metadata and references. |
-| KFM extension fields | Source, evidence, release, policy, digest, rights, and sensitivity pointers. |
-| Release-linked DCAT records | DCAT records tied to ReleaseManifest references. |
-| DCAT validation summaries | Pointers to validation reports and receipts. |
+| RAW captures, working data, quarantined material, or processed datasets | `data/raw/`, `data/work/`, `data/quarantine/`, `data/processed/` |
+| STAC, PROV, domain-catalog, or graph/triplet records | Their sibling catalog lanes or `data/triplets/` |
+| SourceDescriptor instances, source admission, rights authority, or source-role authority | Governed source registry, contracts, policy, and review lanes |
+| EvidenceBundle, ProofPack, or proof payloads | `data/proofs/` |
+| Run, validation, catalog-build, AI, or generated-work receipts | `data/receipts/` |
+| Semantic contracts, JSON Schemas, JSON-LD context authority, policy rules, validator code, tests, or fixtures | `contracts/`, `schemas/`, `policy/`, `tools/`, `tests/`, `fixtures/` |
+| ReleaseManifest, PromotionDecision, correction, withdrawal, supersession, or rollback decisions | `release/` |
+| Public API responses, map layers, tiles, exports, or other released artifacts | Governed application/delivery surfaces and `data/published/` |
+| CatalogMatrix authority while its proposed homes conflict | Follow the accepted ADR/migration outcome; do not create another matrix home here by implication |
+| Generated prose or summary metadata presented as source truth | Evidence-grounded claim and governed AI surfaces |
 
-## Exclusions
+## Inputs
 
-| Do not put here | Correct home |
+A candidate DCAT record should be assembled from explicit, immutable, reviewable inputs. The following is a review contract, not proof of a current machine schema:
+
+| Input family | Minimum posture |
 |---|---|
-| RAW source files | `data/raw/` |
-| WORK/intermediate data | `data/work/` |
-| Quarantined data | `data/quarantine/` |
-| Processed datasets | `data/processed/` |
-| STAC records | `data/catalog/stac/` |
-| PROV records | `data/catalog/prov/` |
-| Triplets/graph edges | `data/triplets/` |
-| EvidenceBundle/proof records | `data/proofs/` |
-| Receipts | `data/receipts/` |
-| Release decisions | `release/` |
-| Published public products | `data/published/` |
-| JSON Schema | `schemas/` |
-| Policy rules | `policy/` |
-| Validators/tests/code | `tools/validators/`, `tests/`, implementation roots |
+| Identity | Stable dataset/service/distribution identity and version. |
+| Artifact integrity | Digest for every referenced immutable artifact or bundle. |
+| Profile | Accepted DCAT/KFM profile and context reference, including their versions or digests. |
+| Source | Admitted source references, source role, rights/license, and material obligations. |
+| Evidence | Evidence/proof references for consequential descriptions and derivation claims. |
+| Scope and time | Subject, spatial/temporal scope, and distinct source/valid/retrieval/catalog/release/correction times as applicable. |
+| Policy and sensitivity | Rights, consent, sensitivity, audience, redaction/generalization, and policy-decision references. |
+| Validation and review | Results tied to the exact candidate digest and the required human review state. |
+| Release and correction | Release candidate or immutable release reference plus supersession, withdrawal, correction, and rollback links when applicable. |
 
-## Record requirements
+Missing or conflicting inputs must remain explicit. Do not infer approval, public status, rights, or safety from a directory path, URL, metadata value, or previous release.
 
-PROPOSED until schema and validator are verified:
+## Outputs
 
-| Requirement | Meaning |
+This lane can support:
+
+- profile-conformant DCAT catalog candidates for internal review;
+- release-bound DCAT projections for approved public-safe datasets, distributions, and services;
+- references used by cross-catalog discovery, provenance, review, correction, and rollback workflows; and
+- validation or catalog-build summaries that remain subordinate to their receipts, reports, evidence, policy, and release records.
+
+### Public exposure boundary
+
+`data/catalog/dcat/` is not a public endpoint. A record becomes public only through a governed release that binds the exact record and distribution digests, evidence, rights and sensitivity disposition, validation, review, correction path, and rollback target. Public clients must receive the approved representation through governed interfaces or released artifacts.
+
+### Correction, supersession, withdrawal, and rollback
+
+Released meaning must not be silently overwritten. A corrected record should preserve prior identifiers and digests, identify the replacement or withdrawal, bind the governing decision and reviewer, invalidate affected indexes or closure claims, and allow consumers to return to the last approved representation when rollback is required.
+
+## Validation
+
+### Current implementation evidence
+
+| Check surface | Current posture |
 |---|---|
-| Stable identifier | Identifier matches the artifact identity used by catalog closure. |
-| Distribution digest | Checksum matches the released artifact or referenced bundle digest. |
-| Release reference | Public or release-linked records point to the immutable ReleaseManifest. |
-| Evidence reference | EvidenceBundle/proof context is referenced when claims depend on evidence. |
-| Source reference | SourceDescriptor/source catalog is referenced when source authority matters. |
-| Policy reference | Policy/admissibility posture is available when release or sensitivity depends on it. |
-| Closure compatibility | STAC ↔ DCAT ↔ PROV agreement holds for promoted releases. |
+| DCAT profile document | CONFIRMED draft; CI badge says TODO and multiple implementation details are proposed. |
+| Record-local catalog validator lane | CONFIRMED README-only at its recorded snapshot; executable DCAT behavior not established. |
+| Catalog closure lane | CONFIRMED README-only at its recorded snapshot; no working closure executable or release resolver established. |
+| CatalogMatrix shape | CONFIRMED permissive placeholder schema. |
+| CatalogMatrix executable | CONFIRMED top-level `NotImplementedError` stub. |
+| Repository validator workflow | CONFIRMED pull-request workflow with read-only token and no release/publication authority; DCAT coverage is not established by its presence. |
 
-## Guardrails
+### Required checks before relying on a DCAT payload
 
-- DCAT is a catalog vocabulary, not source truth.
-- DCAT, STAC, and PROV records for the same released artifact must agree on identifier, digest, and release reference.
-- EvidenceBundle, SourceDescriptor, RunReceipt, PolicyDecision, and ReleaseManifest remain separate authority objects.
-- Unreleased DCAT records are not public merely because they exist under `data/catalog/dcat/`.
+1. Bind the exact accepted DCAT version, KFM profile, namespace, JSON-LD context, and schema digest.
+2. Parse and validate the record locally without unbounded remote context or schema resolution.
+3. Verify class, identifiers, distribution/service links, media types, checksums, URLs, rights, sensitivity, scope, and time fields.
+4. Resolve source, evidence, policy, validation, review, release, and correction references without substituting one artifact family for another.
+5. Confirm every public distribution resolves only to the approved public-safe representation; fail closed on unresolved rights, sensitivity, consent, or reconstructive metadata risk.
+6. Verify STAC/DCAT/PROV agreement only under an accepted closure contract and working validator; do not claim closure from matching prose or a placeholder matrix.
+7. Exercise positive and negative fixtures, deterministic reruns, bounded-resource behavior, safe diagnostics, withdrawal, supersession, and rollback.
+8. Record the exact result in the governed report/receipt family and keep human approval separate from automated validation.
 
-## Evidence ledger
+For this README revision, the target, parent/sibling lane guides, Directory Rules, draft DCAT standard, proposed ADRs, CatalogMatrix contract/schema/stub, catalog validator guides, data policy guide, generated-receipt schema, PR template, and validator workflow were inspected. The revision changes documentation only; runtime and release tests are not evidence of this edit.
 
-| Source | Status | Supports | Limits |
-|---|---|---|---|
-| `data/catalog/dcat/README.md` prior version | CONFIRMED | Existing v0.1 DCAT sublane boundaries. | Did not include full README impact block required by the authoring standard. |
-| `data/catalog/README.md` | CONFIRMED | Parent catalog lane and RELEASED ONLY posture. | Does not prove DCAT record inventory. |
-| `docs/standards/DCAT.md` | CONFIRMED | DCAT v3 target and `data/catalog/dcat/` catalog data home. | Implementation paths and validators remain NEEDS VERIFICATION. |
-| `ADR-0022` | CONFIRMED doctrine / PROPOSED implementation | STAC/DCAT/PROV agreement invariant. | Does not prove emitted CatalogMatrix or CI enforcement. |
-| Uploaded Markdown authoring prompt | CONFIRMED instruction context | README minimums, badges, quick jumps, repo fit, exclusions, verification, rollback. | Does not prove repository implementation. |
+## Review burden
 
-## Validation checklist
+- The data/catalog and DCAT stewards review vocabulary scope, lifecycle placement, and catalog semantics.
+- Source, evidence, rights/sensitivity, and policy stewards review any fields or links that affect authority, disclosure, consent, licensing, or reconstructive risk.
+- Validation and schema stewards review profile, context, schema, validator, fixtures, and CI claims.
+- Release and correction/rollback stewards review any public, released, withdrawn, corrected, or superseded projection.
+- A generated receipt records authorship and checks; it is not human approval. The author/generator must not be treated as the sole approver for policy- or release-significant changes.
 
-- [ ] Confirm actual child directories and DCAT record files.
-- [ ] Confirm DCAT schema/profile location.
-- [ ] Confirm DCAT validator and CI checks.
-- [ ] Confirm STAC/DCAT/PROV catalog matrix closure.
-- [ ] Confirm ReleaseManifest linkage for public DCAT records.
-- [ ] Confirm EvidenceBundle, SourceDescriptor, RunReceipt, and PolicyDecision references.
-- [ ] Confirm rights, sensitivity, and publication handling.
-- [ ] Confirm withdrawal/supersession behavior for stale or failed DCAT records.
+README-only wording changes may use a smaller reviewer set when they do not adopt a profile, change an authority boundary, create a public route, or alter release/sensitivity policy. Any such substantive change triggers the corresponding governed review and, where required, an accepted ADR.
 
-## Rollback
+## Related folders
 
-Rollback is required if this lane becomes a source-data root, proof store, release-decision root, published-output root, schema root, policy root, validator root, or implementation root.
+| Path | Relationship |
+|---|---|
+| [`../README.md`](../README.md) | Parent catalog-stage boundary. |
+| [`../../README.md`](../../README.md) | Data lifecycle root. |
+| [`./flora/README.md`](./flora/README.md) | Confirmed domain-specific DCAT guide; its profile and payload implementation remain bounded separately. |
+| [`../stac/README.md`](../stac/README.md) | Spatiotemporal catalog sibling. |
+| [`../prov/README.md`](../prov/README.md) | Semantic provenance catalog sibling. |
+| [`../domain/README.md`](../domain/README.md) | Domain-scoped catalog sibling. |
+| [`../../triplets/README.md`](../../triplets/README.md) | Paired graph/relationship projection at `CATALOG / TRIPLET`. |
+| [`../../registry/README.md`](../../registry/README.md) | Source, dataset, rights, sensitivity, and other registry responsibilities. |
+| [`../../proofs/README.md`](../../proofs/README.md) | Evidence and proof support; catalog references do not replace it. |
+| [`../../receipts/README.md`](../../receipts/README.md) | Process-memory families, including validation and generation provenance. |
+| [`../../published/README.md`](../../published/README.md) | Approved public-safe materializations. |
+| [`../../../release/README.md`](../../../release/README.md) | Release, correction, withdrawal, and rollback authority. |
+| [`../../../docs/standards/DCAT.md`](../../../docs/standards/DCAT.md) | Draft KFM conformance profile direction for DCAT v3. |
+| [`../../../contracts/data/catalog_matrix.md`](../../../contracts/data/catalog_matrix.md) | Current draft semantic contract for the repository's CatalogMatrix family. |
+| [`../../../schemas/contracts/v1/data/catalog_matrix.schema.json`](../../../schemas/contracts/v1/data/catalog_matrix.schema.json) | Current permissive placeholder shape; not a DCAT profile schema. |
+| [`../../../tools/validators/catalog/README.md`](../../../tools/validators/catalog/README.md) | Record-local catalog validation boundary. |
+| [`../../../tools/validators/catalog_closure/README.md`](../../../tools/validators/catalog_closure/README.md) | Cross-record catalog-closure readiness boundary. |
+| [`../../../policy/data/README.md`](../../../policy/data/README.md) | Lifecycle admissibility and public-exposure policy boundary. |
 
-Rollback target for this expansion: previous v0.1 blob SHA `6a0e1c6ea92d1353cc25cf0a4b4698fcfd28cc1f`.
+## ADRs
+
+- [`ADR-0011`](../../../docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md) records the proposed `receipt ≠ proof ≠ catalog ≠ publication` separation. Its status is **proposed**.
+- [`ADR-0022`](../../../docs/adr/ADR-0022-catalog-matrix--stac-+-dcat-+-prov-must-agree.md) proposes release-level STAC/DCAT/PROV agreement and CatalogMatrix closure. Its status is **proposed**, its implementation paths are not established, and it does not currently prove an active release gate.
+
+No accepted ADR specific to this README revision was established. This documentation-only change preserves the existing responsibility root and creates no new path or authority.
+
+## Last reviewed
+
+- **Date:** 2026-07-22
+- **Evidence snapshot:** `main@d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0`
+- **Prior target blob:** `07c61a743fd4712c8393b05c9fb82e98e55bf76c`
+- **Current safe conclusion:** the DCAT catalog lane and draft profile direction are documented; executable profile validation, catalog closure, release linkage, and governed public behavior remain incomplete or need verification.
+- **Re-review when:** the DCAT profile/context/schema, namespace decision, catalog validator, closure ADR, CatalogMatrix authority, CI registration, public serving path, or release/correction contract changes.
+
+Before merge, close the branch/PR to restore the base state. After merge, revert the README and its generated receipt commit; do not rewrite shared history.
 
 <p align="right"><a href="#top">Back to top</a></p>

--- a/data/receipts/generated/genrec-data-catalog-dcat-readme-a99ad0f8.json
+++ b/data/receipts/generated/genrec-data-catalog-dcat-readme-a99ad0f8.json
@@ -1,0 +1,149 @@
+{
+  "receipt_id": "genrec-data-catalog-dcat-readme-a99ad0f8",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    "data/catalog/dcat/README.md"
+  ],
+  "artifact_hashes": {
+    "data/catalog/dcat/README.md": "sha256:a99ad0f8dd29df039ce06100f638756d8f1fc02b3cfe7e4bddb505ec669139e1"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "GPT-5",
+    "version": "2026-07-22-session"
+  },
+  "prompt_or_contract": "sha256:2509aad3184af800f8037a93cfe122d9d2281ee64fa4dbef658d04a81f88dc1b",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "GitHub connector",
+      "container",
+      "PDF inspection"
+    ]
+  },
+  "inputs": {
+    "attached_docs": [
+      "Directory Rules.pdf",
+      "Unified Implementation Architecture Build Manual.md"
+    ],
+    "evidence_refs": [
+      "github://bartytime4life/Kansas-Frontier-Matrix/commit/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/data/catalog/dcat/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/data/catalog/dcat/flora/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/data/catalog/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/docs/standards/DCAT.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/docs/doctrine/directory-rules.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/docs/adr/ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/docs/adr/ADR-0022-catalog-matrix--stac-+-dcat-+-prov-must-agree.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/contracts/data/catalog_matrix.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/schemas/contracts/v1/data/catalog_matrix.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/tools/validators/validate_catalog_matrix.py",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/tools/validators/catalog/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/tools/validators/catalog_closure/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/policy/data/README.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/schemas/contracts/v1/receipts/generated_receipt.schema.json",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/.github/PULL_REQUEST_TEMPLATE.md",
+      "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/.github/workflows/validator-suite.yml"
+    ]
+  },
+  "truth_labels": {
+    "data/catalog/dcat/README.md": "PROPOSED"
+  },
+  "validation_gates": [
+    {
+      "gate": "repository-and-drift-preflight",
+      "outcome": "PASS",
+      "reason": "Pinned current main; re-read the unchanged target blob; checked the merged Flora guide, parent/sibling lanes, relevant contracts/schemas/validators/policy, duplicate pull-request state, and the current pull-request validator workflow."
+    },
+    {
+      "gate": "directory-rules-placement",
+      "outcome": "PASS",
+      "reason": "The revision remains in the confirmed DCAT catalog sublane and preserves separate source, evidence, receipt, proof, schema, policy, release, published-artifact, validator, and public-interface responsibilities."
+    },
+    {
+      "gate": "authority-and-truth-labels",
+      "outcome": "PASS",
+      "reason": "The DCAT profile and both relevant ADRs remain draft/proposed; the CatalogMatrix schema and validator are described as placeholders; executable validation, closure, release linkage, and public serving remain NEEDS VERIFICATION."
+    },
+    {
+      "gate": "markdown-structure",
+      "outcome": "PASS",
+      "reason": "One H1, ordered Directory Rules folder sections, unique headings, balanced metadata and Mermaid fences, quick navigation, tables, validation, review, ADR, last-reviewed, and rollback material were checked."
+    },
+    {
+      "gate": "relative-link-readback",
+      "outcome": "PASS",
+      "reason": "Every repository-relative path linked by the README was resolved at the pinned base commit."
+    },
+    {
+      "gate": "sensitive-content-and-secret-review",
+      "outcome": "PASS",
+      "reason": "No credentials, private endpoint, exact sensitive location, restricted payload, living-person record, or reconstructive dataset join was introduced."
+    },
+    {
+      "gate": "receipt-shape-and-hash-linkage",
+      "outcome": "PASS",
+      "reason": "Receipt JSON syntax, generated-receipt schema conformance, required fields, and the README SHA-256 linkage were checked against the authored bytes."
+    },
+    {
+      "gate": "runtime-and-release-tests",
+      "outcome": "SKIPPED",
+      "reason": "Documentation-only API change; no DCAT payload, schema, validator, policy implementation, workflow, release, public route, or runtime behavior changed. Repository CI remains the draft PR's observation surface."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "EV-01",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/commit/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0"
+    },
+    {
+      "id": "EV-02",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/data/catalog/dcat/README.md"
+    },
+    {
+      "id": "EV-03",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/docs/standards/DCAT.md"
+    },
+    {
+      "id": "EV-04",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/docs/doctrine/directory-rules.md"
+    },
+    {
+      "id": "EV-05",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/docs/adr/ADR-0022-catalog-matrix--stac-+-dcat-+-prov-must-agree.md"
+    },
+    {
+      "id": "EV-06",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/schemas/contracts/v1/data/catalog_matrix.schema.json"
+    },
+    {
+      "id": "EV-07",
+      "validated": true,
+      "evidence_ref": "github://bartytime4life/Kansas-Frontier-Matrix/blob/d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0/tools/validators/validate_catalog_matrix.py"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-22T21:45:45Z",
+  "emitter": "OpenAI Codex / GPT-5",
+  "links": {
+    "pr_number": null,
+    "adr_link": null,
+    "drift_register_entry": null
+  },
+  "notes": "Documentation-only update. This receipt records authorship and validation process memory; it does not accept ADR-0011 or ADR-0022, define a DCAT profile, create a catalog payload or CatalogMatrix, prove closure, authorize publication, or satisfy human review."
+}


### PR DESCRIPTION
## Status

Draft documentation-only PR.

- Task ID: `kfm-doc-data-catalog-dcat-readme-20260722`
- Base: `main` (`d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0`)
- Head: `agent/data-catalog-dcat-readme-v0-3-20260722`
- Risk: low runtime risk; medium catalog-doctrine review

## Task contract

Upgrade `data/catalog/dcat/README.md` from its stale v0.2 guide into a repository-grounded Directory Rules folder contract. Keep catalog metadata subordinate to source, evidence, policy, validation, review, release, correction, and rollback authority. Correct proposal-versus-implementation claims and emit the required generated-work receipt.

Out of scope: DCAT payloads, profile/schema/context adoption, validator or policy implementation, CatalogMatrix implementation, tests/workflows, releases, public routes, and runtime behavior.

## What changed

- Reorganized the guide into the required folder README sequence: purpose, authority, status, accepted/excluded content, inputs, outputs, validation, review burden, related folders, ADRs, and last review.
- Preserved `data/catalog/dcat/` as a CATALOG-stage discovery/interchange lane, not source truth or a public endpoint.
- Correctly marks the KFM DCAT profile as draft and ADR-0011/ADR-0022 as proposed rather than active enforcement.
- Grounds current implementation limits: the record-validator and closure lanes are documentation-led, the CatalogMatrix schema is permissive, the observed validator is a `NotImplementedError` stub, and dedicated DCAT validation/CI remains unestablished.
- Adds explicit public-exposure, sensitivity, correction, supersession, withdrawal, and rollback boundaries.
- Adds `data/receipts/generated/genrec-data-catalog-dcat-readme-a99ad0f8.json`.

## Evidence and Directory Rules basis

Evidence was pinned at `main@d24c7bf9ee89c9bb3bd2cd14e0e60b1de6314bc0`. The target blob remained `07c61a743fd4712c8393b05c9fb82e98e55bf76c` through pre-mutation drift checks.

Directory Rules §9.1 places DCAT under `data/catalog/` in the `CATALOG / TRIPLET` lifecycle stage and keeps receipts, proofs, publication decisions, and public-safe artifacts in separate roots. Section 15 supplies the folder README contract. No new path, authority root, lifecycle boundary, or public access path is introduced.

## Workflow-trigger threat preflight

The inspected `validator-suite` workflow runs on pull requests with a GitHub-hosted runner and `contents: read`. It has no secret, write, OIDC, deployment, release, or publication authority. Its presence does not establish DCAT validator coverage. Broad repository readiness checks may still report unrelated holds.

## Validation

| Gate | Result | Notes |
|---|---|---|
| Target, authority, and drift preflight | PASS | Target, parent/siblings, Directory Rules, DCAT standard, proposed ADRs, CatalogMatrix contract/schema/stub, validator guides, policy guide, PR template, workflow, and duplicate PR state checked. |
| Markdown structure | PASS | One H1; ordered required sections; unique headings; balanced metadata/Mermaid fences; quick navigation and tables checked. |
| Relative links | PASS | Every repository-relative linked target resolved at the pinned base. |
| Truth labels and authority | PASS | Draft/proposed/placeholder/unverified states remain explicit; no implementation or release overclaim. |
| Sensitive-content review | PASS | No credentials, private endpoints, restricted payloads, exact sensitive locations, or reconstructive data joins added. |
| Receipt syntax/schema/hash | PASS | README SHA-256 is `a99ad0f8dd29df039ce06100f638756d8f1fc02b3cfe7e4bddb505ec669139e1`; receipt syntax, schema, and linkage checked. |
| Remote readback | PASS | Remote README and receipt bytes exactly match the validated authored artifacts. |
| Changed-path scope | PASS | Exactly the requested README and its generated receipt; two commits ahead, zero behind the pinned base. |
| Runtime/release tests | SKIPPED | Documentation-only; no payload, schema, validator, policy, workflow, release, route, or runtime behavior changed. |

## Review and rollback

- [ ] Catalog/data steward review
- [ ] Doctrine and truth-label review
- [ ] CI observation
- [ ] Generated receipt approval or governed override before merge

Before merge, close the PR and delete the branch. After merge, revert the two commits; do not rewrite shared history.