### PR TITLE
docs(adr): converge decision index control plane

### DIFF
--- a/.github/workflows/docs-control-plane.yml
+++ b/.github/workflows/docs-control-plane.yml
@@ -1,9 +1,11 @@
-# KFM machine control-plane validation workflow.
-# Status: PROPOSED executable YAML and register meta-contract checks.
+# KFM documentation and machine control-plane validation workflow.
+# Status: PROPOSED executable YAML, register meta-contract, and ADR-index
+# coherence checks.
 #
 # Authority boundary:
-# - This workflow validates repository syntax and the currently implemented
-#   control-plane register meta contract for the checked revision.
+# - This workflow validates repository syntax, the currently implemented
+#   control-plane register meta contract, and human ADR inventory coherence for
+#   the checked revision.
 # - It does not make register entries authoritative, resolve contradictions,
 #   approve policy, change release state, promote lifecycle artifacts, or publish.
 name: docs-control-plane
@@ -165,4 +167,55 @@ jobs:
           claim that a dedicated machine JSON Schema governs every register
           field. A green result is bounded test evidence only; it is not policy,
           release, lifecycle-promotion, or publication authority.
+          EOF
+
+  adr-index-coherence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out ADR control-plane sources
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install repository test dependencies
+        run: python -m pip install -e ".[test]"
+
+      - name: Validate the canonical ADR inventory
+        run: python tools/validators/validate_adr_index.py
+
+      - name: Exercise ADR index failure paths
+        run: >-
+          python -m pytest
+          tests/validators/test_validate_adr_index.py
+          -q
+          --strict-config
+          --strict-markers
+
+      - name: Record ADR validation boundary
+        if: always()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### ADR index coherence boundary
+
+          This lane checks the canonical numbered ADR inventory, unique IDs,
+          filename/H1/link agreement, conservative source-status normalization,
+          unassigned-scaffold separation, non-duplicating register pointer, and
+          reciprocal supersession links. Its tests exercise collision, missing
+          row, status-promotion, supersession, scaffold, and duplicate-register
+          failures.
+
+          A green result proves bounded repository coherence for the checked
+          revision. It does not accept, reject, or supersede an ADR; prove the
+          described architecture is implemented; approve policy; change release
+          state; promote lifecycle data; deploy; or publish.
           EOF

--- a/data/receipts/generated/genrec-adr-control-plane-convergence-20260722-001.json
+++ b/data/receipts/generated/genrec-adr-control-plane-convergence-20260722-001.json
@@ -1,0 +1,188 @@
+{
+  "receipt_id": "genrec-adr-control-plane-convergence-20260722-001",
+  "contract_version": "3.0.0",
+  "artifact_paths": [
+    "docs/adr/README.md",
+    "docs/adr/INDEX.md",
+    "docs/registers/ADR_INDEX.md",
+    "tools/validators/validate_adr_index.py",
+    "tests/validators/test_validate_adr_index.py",
+    ".github/workflows/docs-control-plane.yml"
+  ],
+  "artifact_hashes": {
+    "docs/adr/README.md": "sha256:b831771c08ce26842cb300dee2e3828cc921fc6e4f83ffc82b5e9d655c91f991",
+    "docs/adr/INDEX.md": "sha256:766e2642f2921e62674228aa8db9f952e880de0f89721b7ed9dcc512ed726a7f",
+    "docs/registers/ADR_INDEX.md": "sha256:1d794f0e2193e325a399b202eec20021986a083788e16cebfc2b90388985b3ae",
+    "tools/validators/validate_adr_index.py": "sha256:0a618e5042c57f194099c8790d427480f1b9743f95a9f67adcd1c247ec8a9e82",
+    "tests/validators/test_validate_adr_index.py": "sha256:d6fc418b8ca5065cc5d493b96db8fcfea7bd87377a8a3bc8e551f407528bd1e7",
+    ".github/workflows/docs-control-plane.yml": "sha256:59c10e9792803d51a79ae9c077beb182a5af69908b465d30f6d5bd19cc6d7038"
+  },
+  "model_identity": {
+    "provider": "OpenAI",
+    "model": "Codex",
+    "version": "GPT-5 family Work Mode session; exact deployment identifier unavailable"
+  },
+  "prompt_or_contract": "sha256:702abd7c779fb6c41252be783610ecbe001f8f4d25d18dab5de2c5ad84cc5dc7",
+  "parameters": {
+    "seed": null,
+    "temperature": null,
+    "top_p": null,
+    "max_tokens": null,
+    "tools_enabled": [
+      "Personal Context connector",
+      "GitHub connector",
+      "git",
+      "shell",
+      "apply_patch",
+      "PDF extraction, rendering, and visual inspection"
+    ]
+  },
+  "inputs": {
+    "evidence_hashes": [
+      "sha256:759de4fcb51cf0f55896089e397d9c47481d60d9fb80ac9a44d47b2f60a0a335",
+      "sha256:8e5d61b464ef6d04b8ccb881b14c1ed063784fad585a25936c27d0ef18ebdd36",
+      "sha256:702abd7c779fb6c41252be783610ecbe001f8f4d25d18dab5de2c5ad84cc5dc7",
+      "sha256:510ee7f3aea7610c853e429bc02a9dec32b64eee970115be7dd4df1c86cc2dc5",
+      "sha256:0fbfed26c487afcf695015283e0dcb3b181ca0af33709dac8a5368f366110885",
+      "sha256:425e998e5584a7e400e99c963aba019b33ff685f9fa26b5b474d8758a3160b2a",
+      "sha256:75dc490df4e6a4c2a36531bd4fe0f3aee698bbc2df252353520cd2cb0c378c4f",
+      "sha256:f6962c272231ac92d2d206c4f4aa743ef2d94d1e1124dac78ab041cf338d3ac3",
+      "sha256:2d036d35e0f25e863dbd8169a47edb5e77b34cf639e961718126a45cdcb0342a",
+      "sha256:02ebcdb9c03e0f5ae1f1cf97874982d3d4d3d675f3d47dcf80a20eded9329fc9"
+    ],
+    "attached_docs": [
+      "Directory Rules.pdf",
+      "Kansas Frontier Matrix Repository Structure Guiding Document.md",
+      "KFM Unified Doctrine Synthesis.md",
+      "Kansas Frontier Matrix — AI Build Operating Contract.md",
+      "Kansas Frontier Matrix — Connected-Dots Architecture Brief.md"
+    ],
+    "evidence_refs": [
+      "repository:bartytime4life/Kansas-Frontier-Matrix@43f1d97954debda98691b2685c1bb75c4b63c872",
+      "issue:https://github.com/bartytime4life/Kansas-Frontier-Matrix/issues/1531#adr-control-plane-discovery-and-claim-v1",
+      "tree:docs/adr/@43f1d97954debda98691b2685c1bb75c4b63c872",
+      "path:docs/adr/README.md@43f1d97954debda98691b2685c1bb75c4b63c872",
+      "path:docs/adr/INDEX.md@43f1d97954debda98691b2685c1bb75c4b63c872",
+      "path:docs/registers/ADR_INDEX.md@43f1d97954debda98691b2685c1bb75c4b63c872",
+      "path:docs/doctrine/directory-rules.md@43f1d97954debda98691b2685c1bb75c4b63c872",
+      "path:docs/doctrine/ai-build-operating-contract.md@43f1d97954debda98691b2685c1bb75c4b63c872",
+      "path:.github/CODEOWNERS@43f1d97954debda98691b2685c1bb75c4b63c872",
+      "path:.github/workflows/docs-control-plane.yml@43f1d97954debda98691b2685c1bb75c4b63c872",
+      "path:schemas/contracts/v1/receipts/generated_receipt.schema.json@43f1d97954debda98691b2685c1bb75c4b63c872"
+    ]
+  },
+  "truth_labels": {
+    "docs/adr/README.md": "CONFIRMED",
+    "docs/adr/INDEX.md": "CONFIRMED",
+    "docs/registers/ADR_INDEX.md": "CONFIRMED",
+    "tools/validators/validate_adr_index.py": "CONFIRMED",
+    "tests/validators/test_validate_adr_index.py": "CONFIRMED",
+    ".github/workflows/docs-control-plane.yml": "CONFIRMED"
+  },
+  "validation_gates": [
+    {
+      "gate": "Directory Rules placement preflight",
+      "outcome": "PASS",
+      "reason": "Directory Rules PDF page 6 was extracted, rendered, and visually inspected; repository doctrine assigns human ADRs and registers to docs/, repo-wide validators to tools/, enforceability proof to tests/, and GitHub orchestration to .github/workflows/."
+    },
+    {
+      "gate": "Live ADR inventory and status reconciliation",
+      "outcome": "PASS",
+      "reason": "The pinned tree contains 46 direct Markdown files: 28 unique numbered records from ADR-0001 through ADR-0028, 12 unassigned scaffolds, one template, and five index/support documents. No numbered record provides verified accepted, superseded, or rejected source status."
+    },
+    {
+      "gate": "ADR index validator and negative-path tests",
+      "outcome": "PASS",
+      "reason": "The standard-library validator accepted the live 28-record/12-scaffold inventory, and all 7 collision, missing-row, status-promotion, supersession, scaffold, and duplicate-register tests passed."
+    },
+    {
+      "gate": "Documentation control-plane workflow syntax and permissions",
+      "outcome": "PASS",
+      "reason": "All 41 workflow YAML files parsed; the new adr-index-coherence job is present with a 10-minute timeout and inherits only contents: read permission with no secret, OIDC, write, deployment, release, or publication authority."
+    },
+    {
+      "gate": "Markdown, links, structure, and Mermaid",
+      "outcome": "PASS",
+      "reason": "Markdown lint reported zero issues under the repository-compatible no-line-length profile; 111 local links and fragments resolved; all three documents have one H1 and balanced KFM meta blocks; Mermaid 11.12.0 parsed the lifecycle flowchart."
+    },
+    {
+      "gate": "make validate",
+      "outcome": "PASS",
+      "reason": "Aggregate validators accepted configured valid fixtures and rejected configured invalid fixtures as expected; all 18 schema and contract tests passed in an isolated environment using repository-declared dependency ranges."
+    },
+    {
+      "gate": "make boundary-guards",
+      "outcome": "PASS",
+      "reason": "All 15 control-plane, Explorer adapter, connector/pipeline non-publisher, and Governed API boundary tests passed."
+    },
+    {
+      "gate": "ADR status transition",
+      "outcome": "SKIPPED",
+      "reason": "This convergence batch inventories and validates existing records only. It does not accept, reject, supersede, renumber, rename, move, or substantively edit any ADR."
+    },
+    {
+      "gate": "Artifacts release or performance migration",
+      "outcome": "SKIPPED",
+      "reason": "ADR-0011 remains proposed, OPEN-DR-09-b remains unresolved, and this batch changes no artifacts path or payload."
+    },
+    {
+      "gate": "Secret, sensitive-content, and publication-boundary diff scan",
+      "outcome": "PASS",
+      "reason": "The seven-path governance diff contains no credential, private key, row-level personal or genomic data, protected location, source activation, release approval, publication payload, deployment action, or default-branch write."
+    },
+    {
+      "gate": "Human review",
+      "outcome": "SKIPPED",
+      "reason": "Human review remains pending on the draft pull request."
+    }
+  ],
+  "policy_decisions": [],
+  "citations": [
+    {
+      "id": "directory-rules-pdf",
+      "validated": true,
+      "evidence_ref": "sha256:759de4fcb51cf0f55896089e397d9c47481d60d9fb80ac9a44d47b2f60a0a335"
+    },
+    {
+      "id": "kfm-main-snapshot",
+      "validated": true,
+      "evidence_ref": "repository:bartytime4life/Kansas-Frontier-Matrix@43f1d97954debda98691b2685c1bb75c4b63c872"
+    },
+    {
+      "id": "campaign-state-and-claim",
+      "validated": true,
+      "evidence_ref": "issue:https://github.com/bartytime4life/Kansas-Frontier-Matrix/issues/1531#adr-control-plane-discovery-and-claim-v1"
+    },
+    {
+      "id": "repository-directory-rules",
+      "validated": true,
+      "evidence_ref": "path:docs/doctrine/directory-rules.md@43f1d97954debda98691b2685c1bb75c4b63c872"
+    },
+    {
+      "id": "verified-codeowners-route",
+      "validated": true,
+      "evidence_ref": "path:.github/CODEOWNERS@43f1d97954debda98691b2685c1bb75c4b63c872"
+    },
+    {
+      "id": "generated-receipt-schema",
+      "validated": true,
+      "evidence_ref": "path:schemas/contracts/v1/receipts/generated_receipt.schema.json@43f1d97954debda98691b2685c1bb75c4b63c872"
+    }
+  ],
+  "human_review": {
+    "reviewer_ids": [
+      "@bartytime4life"
+    ],
+    "state": "pending",
+    "timestamp": null
+  },
+  "override_record": null,
+  "created_at": "2026-07-23T02:40:07Z",
+  "emitter": "OpenAI Codex Work Mode",
+  "links": {
+    "pr_number": null,
+    "adr_link": "docs/adr/INDEX.md",
+    "drift_register_entry": null
+  },
+  "notes": "ADR control-plane inventory, index, validator, proof, and CI convergence. This receipt records AI-authoring provenance and bounded validation only. It is not an ADR acceptance, ReviewRecord, EvidenceBundle, PolicyDecision, release approval, PromotionDecision, deployment instruction, or publication authority. ADR-0011, OPEN-DR-09-b, and artifacts/perf placement remain unresolved."
+}

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,16 +1,156 @@
-# INDEX
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/adr-index
+title: Architecture Decision Record Index
+type: register-index
+version: v1.0
+status: draft; repository-grounded
+owners:
+  - Architecture steward
+  - Docs steward
+created: 2026-07-22
+updated: 2026-07-22
+policy_label: public
+truth_posture: cite-or-abstain
+responsibility_root: docs/
+canonical_for: human ADR file inventory and decision-status crosswalk
+numbered_records: 28
+unassigned_scaffolds: 12
+related:
+  - docs/adr/README.md
+  - docs/adr/ADR-template.md
+  - docs/registers/ADR_INDEX.md
+  - docs/doctrine/directory-rules.md
+  - tools/validators/validate_adr_index.py
+tags: [kfm, adr, index, governance, decisions]
+notes:
+  - "Inventory verified at main@43f1d97954debda98691b2685c1bb75c4b63c872."
+  - "Effective status never outranks source-record status or human review."
+[/KFM_META_BLOCK_V2] -->
 
-**Status:** PROPOSED scaffold.  
-**Source:** `docs/domains/archaeology/VERIFICATION_BACKLOG.md`  
-**Referenced path:** `docs/adr/INDEX.md`
+# Architecture Decision Record Index
 
-This file was created because the current `docs/domains` markdown inventory lists this path as planned, expected, or linked. Fill in the authoritative content, owners, validation status, and cross-links before promoting it beyond scaffold status.
+[![numbered records](https://img.shields.io/badge/numbered_records-28-0969da)](#numbered-records)
+[![effective status](https://img.shields.io/badge/effective_status-proposed-d4a72c)](#status-interpretation)
+[![scaffolds](https://img.shields.io/badge/unassigned_scaffolds-12-6e7781)](#unassigned-scaffolds)
+[![coherence](https://img.shields.io/badge/coherence-machine_checked-1a7f37)](../../tools/validators/validate_adr_index.py)
 
-## Source Documents
+This file is the canonical human inventory for direct ADR records and unassigned ADR scaffolds under `docs/adr/`. It records what exists and how each record is classified; it does not accept a proposed decision.
 
-- `docs/domains/archaeology/VERIFICATION_BACKLOG.md`
+> [!IMPORTANT]
+> Every numbered decision below has effective status `proposed`. No tracked numbered ADR provides verified `accepted`, `superseded`, or `rejected` status at the recorded snapshot.
 
-## Notes
+## Status interpretation
 
-- Keep machine-checkable shape in `schemas/`, policy in `policy/`, fixtures in `fixtures/`, and release decisions in `release/` unless an accepted ADR says otherwise.
-- Replace this scaffold with domain-reviewed content before treating the path as canonical truth.
+| Column | Meaning |
+| --- | --- |
+| **Effective status** | Governance status normalized to `proposed`, `accepted`, `superseded`, or `rejected` |
+| **Source metadata** | What the record currently declares: `proposed`, `draft`, or `legacy-proposed` |
+| **Supersedes / Superseded by** | ADR-to-ADR relationship only; non-ADR planning artifacts are described inside the record |
+
+`draft` and `legacy-proposed` normalize conservatively to effective status `proposed`. An index edit cannot promote a record. A move to `accepted`, `superseded`, or `rejected` requires matching reviewed status in the ADR itself.
+
+## Numbered records
+
+The numbered sequence is complete and unique from `ADR-0001` through `ADR-0028` at `main@43f1d97954debda98691b2685c1bb75c4b63c872`.
+
+<!-- ADR_INDEX_TABLE_START -->
+| ID | Record | Effective status | Source metadata | Supersedes | Superseded by |
+| --- | --- | --- | --- | --- | --- |
+| `ADR-0001` | [Schema Home: `schemas/contracts/v1/` is Canonical](./ADR-0001-schema-home--schemas-contracts-v1-is-canonical.md) | `proposed` | `proposed` | — | — |
+| `ADR-0002` | [Contracts vs Schemas Split](./ADR-0002-contracts-vs-schemas-split.md) | `proposed` | `draft` | — | — |
+| `ADR-0003` | [`policy/` is canonical; `policies/` is compatibility](<./ADR-0003-policy-singular-is-canonical-(policies-is-compatibility).md>) | `proposed` | `proposed` | — | — |
+| `ADR-0004` | [`apps/governed-api/` is the Trust Membrane](./ADR-0004-apps-governed-api-is-the-trust-membrane.md) | `proposed` | `draft` | — | — |
+| `ADR-0005` | [`apps/explorer-web` is the canonical map-first shell](./ADR-0005-apps-explorer-web-is-the-canonical-map-first-shell.md) | `proposed` | `proposed` | — | — |
+| `ADR-0006` | [Only `MapLibreAdapter` Imports MapLibre](./ADR-0006-maplibre-boundary--only-maplibreadapter-imports-maplibre.md) | `proposed` | `draft` | — | — |
+| `ADR-0007` | [MapLibre GL JS Is the Sole Browser-Side Renderer](<./ADR-0007 — MapLibre GL JS Is the Sole Browser-Side Renderer.md>) | `proposed` | `legacy-proposed` | — | — |
+| `ADR-0008` | [Ollama and Local AI Runtimes Are Subordinate to the Governed API](./ADR-0008-ollama-subordinate-to-governed-api.md) | `proposed` | `draft` | — | — |
+| `ADR-0009` | [Hydrology Is the First Proof-Bearing Lane](./ADR-0009-hydrology-is-the-first-proof-bearing-lane.md) | `proposed` | `draft` | — | — |
+| `ADR-0010` | [Deny-by-Default for DNA, Rare Species, Archaeology, and Critical Infrastructure](./ADR-0010-deny-by-default-for-dna-rare-species-archaeology-infrastructure.md) | `proposed` | `draft` | — | — |
+| `ADR-0011` | [Receipts vs Proofs vs Manifests vs Catalog Separation](./ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md) | `proposed` | `proposed` | — | — |
+| `ADR-0012` | [Connector outputs land in `data/raw/` or `data/quarantine/` only](./ADR-0012-connector-outputs-to-data-raw-or-data-quarantine-only.md) | `proposed` | `draft` | — | — |
+| `ADR-0013` | [`spec_hash` and `run_id` Identity Grammar](./ADR-0013-spec_hash-and-run_id-identity-grammar.md) | `proposed` | `proposed` | — | — |
+| `ADR-0014` | [Temporal Vocabulary: Six Time Kinds Tracked](./ADR-0014-temporal-vocabulary--six-time-kinds-tracked.md) | `proposed` | `proposed` | — | — |
+| `ADR-0015` | [`data/published/<domain>/current` is governed by RollbackCard](./ADR-0015-data-published-_domain_-current-alias-is-governed-by-rollback_card.md) | `proposed` | `draft` | — | — |
+| `ADR-0016` | [Telemetry Redaction Posture](./ADR-0016-telemetry-redaction-posture.md) | `proposed` | `proposed` | — | — |
+| `ADR-0017` | [Source Descriptor Admission Process](./ADR-0017-source-descriptor-admission-process.md) | `proposed` | `proposed` | — | — |
+| `ADR-0018` | [Promotion Gate Sequence](./ADR-0018-promotion-gate-sequence.md) | `proposed` | `proposed` | — | — |
+| `ADR-0019` | [AI Adapter Contract and Finite Envelopes](./ADR-0019-ai-adapter-contract-and-finite-envelopes.md) | `proposed` | `draft` | — | — |
+| `ADR-0020` | [Abstain Is a First-Class Decision](./ADR-0020-abstain-is-a-first-class-decision.md) | `proposed` | `proposed` | — | — |
+| `ADR-0021` | [Quarantine has structured exit paths](./ADR-0021-quarantine-has-structured-exit-paths.md) | `proposed` | `proposed` | — | — |
+| `ADR-0022` | [Catalog Matrix: STAC + DCAT + PROV Must Agree](./ADR-0022-catalog-matrix--stac-+-dcat-+-prov-must-agree.md) | `proposed` | `proposed` | — | — |
+| `ADR-0023` | [Geo Manifest Signs Every PMTiles and COG Release](./ADR-0023-geo-manifest-signs-every-pmtiles-cog-release.md) | `proposed` | `proposed` | — | — |
+| `ADR-0024` | [Steward Separation of Duties for Release](./ADR-0024-steward-separation-of-duties-for-release.md) | `proposed` | `draft` | — | — |
+| `ADR-0025` | [Public Client Never Reads Canonical or Internal Stores](./ADR-0025-public-client-never-reads-canonical-internal-stores.md) | `proposed` | `draft` | — | — |
+| `ADR-0026` | [Hydrology source spine starts with WBD HUC12](./ADR-0026-hydrology-source-spine-starts-with-wbd-huc12.md) | `proposed` | `draft` | — | — |
+| `ADR-0027` | [County Focus Mode Control Plane](./ADR-0027-county-focus-mode-control-plane.md) | `proposed` | `proposed` | — | — |
+| `ADR-0028` | [State-scale Focus Mode scope and 13-domain coverage rule](<./ADR-0028 — State-scale Focus Mode scope.md>) | `proposed` | `proposed` | — | — |
+<!-- ADR_INDEX_TABLE_END -->
+
+## Unassigned scaffolds
+
+These files are tracked but do not carry assigned repository-wide ADR numbers. They are not included in the numbered decision sequence and do not reserve a number.
+
+<!-- ADR_SCAFFOLD_TABLE_START -->
+| File | Classification | Decision status |
+| --- | --- | --- |
+| [`ADR-NNNN-connectors-domain-segment.md`](./ADR-NNNN-connectors-domain-segment.md) | explicit placeholder | `not-assigned` |
+| [`ADR-XXXX-atmosphere-advisory-non-life-safety.md`](./ADR-XXXX-atmosphere-advisory-non-life-safety.md) | explicit placeholder | `not-assigned` |
+| [`ADR-XXXX-atmosphere-knowledge-character-vocabulary.md`](./ADR-XXXX-atmosphere-knowledge-character-vocabulary.md) | explicit placeholder | `not-assigned` |
+| [`ADR-XXXX-atmosphere-schema-home.md`](./ADR-XXXX-atmosphere-schema-home.md) | explicit placeholder | `not-assigned` |
+| [`ADR-archaeology-exact-location-policy.md`](./ADR-archaeology-exact-location-policy.md) | slug-only scaffold | `not-assigned` |
+| [`ADR-archaeology-source-roles.md`](./ADR-archaeology-source-roles.md) | slug-only scaffold | `not-assigned` |
+| [`ADR-focus-model-adapter-boundary.md`](./ADR-focus-model-adapter-boundary.md) | slug-only scaffold | `not-assigned` |
+| [`ADR-habitat-fauna-thin-slice.md`](./ADR-habitat-fauna-thin-slice.md) | slug-only scaffold | `not-assigned` |
+| [`ADR-habitat-modeled-vs-critical.md`](./ADR-habitat-modeled-vs-critical.md) | slug-only scaffold | `not-assigned` |
+| [`ADR-habitat-schema-home.md`](./ADR-habitat-schema-home.md) | slug-only scaffold | `not-assigned` |
+| [`ADR-habitat-source-roles.md`](./ADR-habitat-source-roles.md) | slug-only scaffold | `not-assigned` |
+| [`ADR-habitat-stewardship-zone-policy.md`](./ADR-habitat-stewardship-zone-policy.md) | slug-only scaffold | `not-assigned` |
+<!-- ADR_SCAFFOLD_TABLE_END -->
+
+Assigning one of these scaffolds requires the normal authoring workflow: inspect concurrent work, select a unique number, adopt the template, preserve any useful source attribution, update this index, and complete review. Do not merely rename a scaffold and infer acceptance.
+
+## Support documents
+
+| File | Role | Decision authority |
+| --- | --- | --- |
+| [`README.md`](./README.md) | ADR operating contract | Does not accept individual decisions |
+| [`ADR-template.md`](./ADR-template.md) | Authoring template | No decision |
+| [`NEXT_MOVE_ASSESSMENT_2026-05-13.md`](./NEXT_MOVE_ASSESSMENT_2026-05-13.md) | Historical assessment | Planning lineage only |
+| [`NORMALIZED_SUMMARY_CONSUMER_READINESS_CHECKLIST.md`](./NORMALIZED_SUMMARY_CONSUMER_READINESS_CHECKLIST.md) | Consumer-readiness checklist | Validation guidance only |
+| [`_next_move_log.md`](./_next_move_log.md) | Historical working log | Planning lineage only |
+
+## Validation and change rules
+
+Run:
+
+```bash
+python tools/validators/validate_adr_index.py
+python -m pytest tests/validators/test_validate_adr_index.py -q --strict-config --strict-markers
+```
+
+Update this index in the same pull request that:
+
+- adds or assigns an ADR number;
+- changes a source record's reviewed decision status;
+- adds or removes an unassigned scaffold through an explicitly reviewed cleanup;
+- establishes or changes an ADR-to-ADR supersession relationship;
+- renames a record after inbound-link and migration review.
+
+The validator rejects collisions, missing or extra rows, mismatched filename/H1 IDs, invalid effective statuses, source-status promotion, incomplete scaffold inventory, competing register tables, and broken supersession reciprocity.
+
+## Known limits
+
+- This index does not prove that the architecture described by an ADR is implemented.
+- It does not verify GitHub rulesets, independent review, or status-transition authorization outside the repository.
+- It does not resolve domain-local versus repository-wide ADR placement.
+- It does not accept [`ADR-0011`](./ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md) or authorize migration of `artifacts/release/` or `artifacts/perf/`.
+- It treats current `draft` and legacy `PROPOSED` metadata conservatively as `proposed`; metadata cleanup remains separate work.
+
+## Related
+
+- [ADR operating contract](./README.md)
+- [ADR template](./ADR-template.md)
+- [Human ADR cross-register](../registers/ADR_INDEX.md)
+- [Directory Rules](../doctrine/directory-rules.md)
+- [ADR index validator](../../tools/validators/validate_adr_index.py)
+- [ADR validator tests](../../tests/validators/test_validate_adr_index.py)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,546 +2,240 @@
 doc_id: kfm://doc/adr-readme
 title: docs/adr — Architecture Decision Records
 type: standard
-version: v1.1
-status: draft
-owners: Architecture steward, Docs steward
+version: v1.2
+status: draft; repository-grounded
+owners:
+  - Architecture steward
+  - Docs steward
 created: 2026-05-09
-updated: 2026-05-15
+updated: 2026-07-22
 policy_label: public
+truth_posture: cite-or-abstain
+responsibility_root: docs/
+authority_surface: human-facing architecture decision records
 related:
+  - docs/adr/INDEX.md
+  - docs/adr/ADR-template.md
   - docs/doctrine/directory-rules.md
   - docs/doctrine/authority-ladder.md
-  - docs/doctrine/lifecycle-law.md
-  - docs/doctrine/trust-membrane.md
-  - docs/doctrine/truth-posture.md
-  - docs/architecture/contract-schema-policy-split.md
+  - docs/registers/ADR_INDEX.md
   - docs/registers/DRIFT_REGISTER.md
-  - docs/registers/VERIFICATION_BACKLOG.md
-tags: [kfm, governance, adr, doctrine]
+  - tools/validators/validate_adr_index.py
+  - tests/validators/test_validate_adr_index.py
+  - .github/workflows/docs-control-plane.yml
+tags: [kfm, governance, adr, decisions, audit, control-plane]
 notes:
-  - Repository was not mounted when this README was authored or revised; every per-ADR presence claim is PROPOSED / NEEDS VERIFICATION until repo inspection.
-  - ADR-0001 (schema home) is referenced by directory-rules.md as the schema-home convention; its actual authored state and acceptance status must be verified against the mounted repo.
-  - 2026-05-15 revision strengthened README contract, verification, and index-refresh guidance without claiming implementation state.
+  - "Repository inventory is verified at main@43f1d97954debda98691b2685c1bb75c4b63c872."
+  - "File presence does not accept a decision. Every numbered ADR remains proposed until explicit reviewed status evidence says otherwise."
+  - "This README is the operating contract; docs/adr/INDEX.md is the canonical human inventory."
 [/KFM_META_BLOCK_V2] -->
 
 # `docs/adr/` — Architecture Decision Records
 
-> The audit trail of architectural reasoning for the Kansas Frontier Matrix. One file per consequential decision. Append-only history. Supersession over deletion.
+[![authority](https://img.shields.io/badge/authority-canonical-1f6feb)](../doctrine/directory-rules.md)
+[![inventory](https://img.shields.io/badge/numbered_ADRs-28-0969da)](./INDEX.md)
+[![decision status](https://img.shields.io/badge/decisions-proposed-d4a72c)](./INDEX.md)
+[![validation](https://img.shields.io/badge/index_coherence-enforced-1a7f37)](../../tools/validators/validate_adr_index.py)
+[![review route](https://img.shields.io/badge/CODEOWNERS-%40bartytime4life-8250df)](../../.github/CODEOWNERS)
 
-![authority](https://img.shields.io/badge/authority-canonical-1f6feb)
-![class](https://img.shields.io/badge/class-governance-6f42c1)
-![status](https://img.shields.io/badge/status-draft-d4a72c)
-![review](https://img.shields.io/badge/review-NEEDS%20VERIFICATION-d4a72c)
-![repo](https://img.shields.io/badge/repo-unverified-6e7781)
-![supersession](https://img.shields.io/badge/policy-never%20delete-cf222e)
-
-**Owners:** Architecture steward · Docs steward  
-**Reviewers required:** Architecture steward + at least one subsystem owner  
-**Target path:** `docs/adr/README.md`  
-**Last reviewed:** `<TODO: YYYY-MM-DD on first repo-verified PR>`
+Architecture Decision Records preserve why KFM made—or is considering—a consequential architectural choice. They are append-only governance memory: one decision per record, explicit status, evidence, consequences, alternatives, migration impact, and rollback.
 
 > [!IMPORTANT]
-> This README is doctrine-grounded but **not** repo-verified. The KFM repository was not mounted during authoring or this revision. Every claim about which ADRs currently exist on disk is **PROPOSED / NEEDS VERIFICATION** until checked against repo evidence such as `git ls-tree`, file contents, ADR metadata, and validator output. The placement rule for `docs/adr/` is CONFIRMED by Directory Rules doctrine; individual file presence is not.
+> A tracked ADR is not automatically an accepted ADR. The current numbered corpus is **CONFIRMED present** and **proposed for governance purposes**. This pass does not accept, reject, supersede, renumber, rename, or substantively edit any decision record.
+
+**Quick links:** [Verified snapshot](#verified-snapshot) · [Authority](#authority-and-boundaries) · [Inventory contract](#inventory-contract) · [Lifecycle](#decision-lifecycle) · [Naming](#naming-and-numbering) · [Authoring](#authoring-workflow) · [Validation](#validation) · [Review](#review-and-supersession) · [Open governance work](#open-governance-work)
 
 ---
 
-## Quick jump
+## Verified snapshot
 
-[Purpose](#purpose) · [README contract](#readme-contract) · [Authority](#authority-level) · [Lifecycle](#adr-lifecycle) · [What belongs here](#what-belongs-here) · [What does not](#what-does-not-belong-here) · [Inputs & outputs](#inputs--outputs) · [Naming](#naming-convention) · [Template](#adr-template) · [Authoring quickstart](#authoring-quickstart) · [Status & supersession](#status--supersession) · [Index](#index-of-adrs) · [Validation](#validation) · [Repo refresh](#first-repo-verification-pass) · [Review burden](#review-burden) · [Related](#related-folders--doctrine) · [Maintenance](#maintenance-checklist) · [FAQ](#faq)
+The table below is grounded in the tracked tree at `main@43f1d97954debda98691b2685c1bb75c4b63c872`.
 
----
+| Surface | Verified state | Meaning |
+| --- | ---: | --- |
+| Direct Markdown files | 46 | Complete direct-child inventory for this snapshot |
+| Numbered records | 28 | Unique, contiguous IDs `ADR-0001` through `ADR-0028` |
+| Numbered source metadata | 15 `proposed`; 12 `draft`; 1 legacy `PROPOSED` | All normalize conservatively to effective status `proposed` |
+| Verified accepted decisions | 0 | No numbered record declares reviewed `accepted` status |
+| Explicit `NNNN` / `XXXX` placeholders | 4 | Unassigned scaffolds; not ADR numbers |
+| Slug-only ADR scaffolds | 8 | Unassigned scaffolds; not accepted decision records |
+| Template | 1 | [`ADR-template.md`](./ADR-template.md) |
+| Index and support documents | 5 | This README, canonical index, two assessment/checklist documents, and `_next_move_log.md` |
 
-## Purpose
+The exact numbered records and unassigned scaffolds are listed in the [canonical ADR index](./INDEX.md). The human cross-register at [`docs/registers/ADR_INDEX.md`](../registers/ADR_INDEX.md) points to that inventory without maintaining a competing table.
 
-`docs/adr/` is the **canonical home** for KFM Architecture Decision Records: short, dated, append-only documents that capture *what* was decided, *why*, *what was rejected*, and *what follows*. ADRs are the answer to *"why is this done this way?"* when the rationale is no longer obvious from the code, the schema, or the policy alone.
+## Authority and boundaries
 
-ADRs are **not** designed to *make* decisions inside their own files. A merged ADR is the trace of a decision that was already reached through review — it captures rationale and consequences in a form future maintainers can search, cite, and supersede.
+Directory Rules §6.1 assigns Architecture Decision Records to `docs/adr/` inside the human-facing control plane. Authority resolves in this order:
 
-> [!NOTE]
-> ADRs explain decisions; they do not enforce them. Enforcement lives in `schemas/`, `policy/`, `tests/`, validators in `tools/`, and CI workflows. An ADR without enforcement is doctrine; an enforcer without an ADR is an unrecorded decision. KFM aims for both.
+1. KFM core invariants and doctrine.
+2. Accepted ADRs that explicitly amend Directory Rules.
+3. Directory Rules.
+4. Per-root READMEs such as this file.
+5. Domain dossiers and planning lineage.
+6. Repository convention, which is evidence of implementation—not placement authority when it conflicts with the rules.
 
----
+This directory owns decision records and their human inventory. It does not own:
 
-## README contract
+| Responsibility | Canonical home |
+| --- | --- |
+| Object meaning | [`contracts/`](../../contracts/) |
+| Machine-checkable shape | [`schemas/`](../../schemas/) |
+| Allow, deny, restrict, or abstain rules | [`policy/`](../../policy/) |
+| Enforceability proof | [`tests/`](../../tests/) |
+| Repository-wide validation logic | [`tools/validators/`](../../tools/validators/) |
+| Human registers and drift queues | [`docs/registers/`](../registers/) |
+| Receipts and proofs | [`data/receipts/`](../../data/receipts/) and [`data/proofs/`](../../data/proofs/) |
+| Release decisions, manifests, and rollback cards | [`release/`](../../release/) |
+| Build, documentation, QA, and temporary outputs | [`artifacts/`](../../artifacts/) |
 
-| Item | Value |
-|---|---|
-| **Owning root** | `docs/` — canonical documentation and governance memory |
-| **Target path** | `docs/adr/README.md` |
-| **Document role** | Directory README and operating standard for Architecture Decision Records |
-| **Audience** | Architecture steward, docs steward, subsystem owners, reviewers, implementation agents |
-| **Primary inputs** | Proposed ADRs, drift-register escalations, doctrine amendments, backfill decisions, repo-inspection findings |
-| **Primary outputs** | ADR files, index updates, supersession links, downstream references to schemas/contracts/policy/tests/release artifacts |
-| **Truth posture** | CONFIRMED doctrine / PROPOSED file inventory / UNKNOWN implementation depth until mounted-repo evidence is inspected |
-| **Public-safety posture** | Public doc; never place sensitive source details, secrets, private data, or restricted exact-location decisions here |
+An ADR may direct changes in those homes, but it does not replace their contracts, schemas, policies, tests, receipts, proofs, or release objects.
 
-This README is a **routing and governance surface**. It tells maintainers where ADRs belong, how to author them, how to keep them append-only, and how to verify the index. It does not turn the starter ADR list into current repo truth.
+## Inventory contract
 
----
+The three human surfaces have distinct responsibilities:
 
-## Authority level
+| Path | Responsibility | Must not do |
+| --- | --- | --- |
+| [`README.md`](./README.md) | Operating rules for authoring, review, status, and validation | Duplicate the full record table |
+| [`INDEX.md`](./INDEX.md) | Canonical human inventory of numbered records and unassigned scaffolds | Grant decision authority merely because a file is present |
+| [`../registers/ADR_INDEX.md`](../registers/ADR_INDEX.md) | Cross-register pointer, ownership, consumers, and validation boundary | Maintain a second ADR row set |
 
-| Property | Value |
-|---|---|
-| **Authority class** | Canonical — governance-bearing README for the ADR root |
-| **Status of this README** | Draft / NEEDS REPO VERIFICATION |
-| **Status of `docs/adr/` as a home** | CONFIRMED doctrine via Directory Rules |
-| **Status of any specific ADR file's presence** | PROPOSED / NEEDS VERIFICATION (repo not mounted) |
-| **Authority order** | Core invariants and accepted ADRs that explicitly amend Directory Rules outrank Directory Rules. This README refines the ADR root and cannot contradict doctrine. |
-| **Append-only** | Yes — accepted ADR bodies are stable; superseded and rejected ADRs are retained with links. ADRs are **never deleted**. |
-| **Change discipline** | An ADR is required for §2.4-class changes: canonical roots, schema-home rule, lifecycle phase changes, parallel-home creation, or invariant-bending. |
+The canonical index records two different facts:
 
-A draft or proposed ADR carries argument, not authority. An accepted ADR carries authority only for the decision it actually records, and only to the extent it does not silently weaken KFM core invariants.
+- **Source metadata** reports what each file currently says: `proposed`, `draft`, or legacy unstructured `PROPOSED`.
+- **Effective decision status** uses the Directory Rules vocabulary: `proposed`, `accepted`, `superseded`, or `rejected`.
 
----
+`draft` and legacy `PROPOSED` normalize to `proposed`. A row may move to `accepted`, `superseded`, or `rejected` only when the record itself carries matching reviewed status evidence. The index cannot promote a decision independently.
 
-## ADR lifecycle
+## Decision lifecycle
 
-````mermaid
+```mermaid
 flowchart LR
-    A[Need recognized] --> B[Draft ADR<br/>status: proposed]
-    B --> C{Architecture review}
-    C -->|approved| D[Merge<br/>status: accepted]
-    C -->|rejected| E[Merge<br/>status: rejected]
-    C -->|needs work| B
-    D --> F{Decision still holds?}
-    F -->|yes| D
-    F -->|no| G[Author successor ADR<br/>status: proposed]
-    G --> H{Review}
-    H -->|approved| I[Merge successor<br/>status: accepted<br/>+ link forward from old ADR<br/>old status: superseded]
-    H -->|rejected| F
+    P["proposed"] -->|review accepts| A["accepted"]
+    P -->|review rejects| R["rejected"]
+    A -->|successor accepted| S["superseded"]
+    S -->|forward link| N["successor ADR"]
+```
 
-    classDef accepted fill:#dafbe1,stroke:#2da44e,color:#1a7f37
-    classDef proposed fill:#fff8c5,stroke:#bf8700,color:#7d4e00
-    classDef rejected fill:#ffebe9,stroke:#cf222e,color:#82071e
-    classDef review fill:#ddf4ff,stroke:#0969da,color:#0550ae
+- **`proposed`** — under consideration; not binding.
+- **`accepted`** — explicitly reviewed and in force for the decision it records.
+- **`superseded`** — replaced by a later accepted ADR; retained with a forward link.
+- **`rejected`** — considered and not adopted; retained as decision history.
 
-    class D,I accepted
-    class B,G proposed
-    class E rejected
-    class F,H review
-````
+Accepted, superseded, and rejected records are never deleted. A material change to an accepted decision requires a successor ADR rather than rewriting history.
 
-**Statuses (per [Directory Rules §2.4](../doctrine/directory-rules.md#24-changes-that-require-an-adr)):** `proposed` · `accepted` · `superseded` · `rejected`. Superseded and rejected ADRs MUST be retained — they are part of the audit trail.
+## When an ADR is required
 
----
+Directory Rules §2.4 requires an ADR before:
 
-## What belongs here
+- adding, removing, or renaming a canonical root;
+- promoting a compatibility root to canonical or deprecating a canonical root;
+- changing the schema-home rule;
+- splitting or merging a lifecycle phase;
+- creating a parallel home for schemas, contracts, policy, sources, registries, releases, proofs, or receipts;
+- bending a KFM core invariant.
 
-ADR files, and only ADR files. Specifically:
+Use an ADR for other cross-component choices when code, schema, or policy alone cannot preserve the rationale. Do not use an ADR for routine typo fixes, local refactors, runbooks, release decisions, or machine-shape changes that do not alter architecture.
 
-- **Cross-cutting architectural decisions** — schema home, ID derivation, finite-outcome envelope vocabulary, watcher-as-non-publisher invariant, STAC profile, release manifest envelope, crypto stack, MapLibre adapter boundary, public-trust-path boundary, etc.
-- **Domain-scoped architectural decisions** that affect more than one component or are non-obvious from code — e.g., a domain's source-role separation, a domain's geometry-sensitivity policy.
-- **Supersession ADRs** that replace earlier decisions, written as new files with new IDs and forward/back links.
-- **Rejected proposals** that were considered seriously enough to be worth preserving as a "we considered this and chose not to" record.
+## Naming and numbering
 
-A useful threshold: *if the choice affects more than one component, or could be re-litigated by a future maintainer reading only the code, write an ADR.*
+The target pattern is:
 
----
+```text
+ADR-NNNN-kebab-case-slug.md
+```
 
-## What does NOT belong here
+Rules:
 
-> [!WARNING]
-> Putting the wrong artifact under `docs/adr/` weakens the trail and confuses readers. Use the table below to redirect.
+- `NNNN` is a permanent four-digit repository-wide ID.
+- Claim the next number only after checking the canonical index, open pull requests, and active branches.
+- The H1 must contain the same `ADR-NNNN` as the filename.
+- New records use the current template and begin with effective status `proposed`.
+- `ADR-NNNN-*` and `ADR-XXXX-*` filenames are placeholders, not reserved numeric decisions.
+- Slug-only `ADR-*.md` scaffolds remain unassigned until a reviewed PR gives them a unique numeric ID.
 
-| If the artifact is… | …it belongs in |
-|---|---|
-| Object-family **meaning** (semantic Markdown) | [`contracts/`](../../contracts/) |
-| Object **shape** (JSON Schema, JSON-LD context) | [`schemas/contracts/v1/…`](../../schemas/) |
-| Allow / deny / restrict / abstain rules | [`policy/`](../../policy/) |
-| Release manifests, promotion decisions, rollback cards, correction notices | [`release/`](../../release/) |
-| Run, validation, ingest, AI, release **receipts** | `data/receipts/` |
-| Evidence bundles, proof packs, validation reports | `data/proofs/` |
-| Operational procedures, runbooks, drills | `docs/runbooks/` |
-| Doctrine, principles, invariants | `docs/doctrine/` |
-| Architecture explainers (system context, deployment topology, governed-API description) | `docs/architecture/` |
-| Drift, contradiction, deprecation, verification backlog records | `docs/registers/` and `control_plane/` |
-| Domain-overview README, data-model walk-through, lineage | `docs/domains/<domain>/` |
-| Build outputs, generated docs, QA reports | `artifacts/` (compatibility root, tightly scoped) |
+Two tracked numbered records use legacy filenames containing spaces and an em dash (`ADR-0007` and `ADR-0028`). They remain indexed exactly as tracked. Renaming them is deferred because it requires inbound-link and history analysis; this convergence pass does not perform that migration.
 
-ADRs **MUST NOT** be used as a substitute for any of the above. An ADR can *cite* a contract, *reference* a schema, *direct* a policy, but it does not *replace* them.
+## Authoring workflow
 
----
-
-## Inputs & outputs
-
-### Inputs
-
-ADRs are produced from:
-
-- **Architecture proposals** during PR review when a §2.4-class change is on the table.
-- **Backfill drives** that record previously-undocumented decisions discovered during inspection.
-- **Drift-register entries** in [`docs/registers/DRIFT_REGISTER.md`](../registers/DRIFT_REGISTER.md) that escalate into named decisions.
-- **Open questions** from `docs/registers/VERIFICATION_BACKLOG.md` and per-domain `OPEN_QUESTIONS.md` that mature into decisions.
-- **Doctrine evolution** — when `docs/doctrine/*.md` is amended in ways that demand a recorded rationale.
-
-### Outputs
-
-Merging an ADR can trigger downstream changes (which are tracked, but live elsewhere):
-
-- Updates to `docs/doctrine/directory-rules.md` if §2.4 applies.
-- New or revised entries in `schemas/`, `contracts/`, `policy/`, `tests/`, `tools/validators/`.
-- `migrations/<kind>/` plans when the decision implies a path or schema migration.
-- `control_plane/deprecation_register.yaml` entries when an ADR deprecates a path or rule.
-- Forward-links from any prior ADR(s) being superseded.
-- `release/correction_notices/` when the decision invalidates a previously-released claim.
-
----
-
-## Naming convention
-
-The canonical filename pattern is:
-
-````
-ADR-NNNN-<kebab-case-slug>.md
-````
-
-- `NNNN` — a four-digit, zero-padded, **monotonically increasing** integer. Once assigned, an ADR's number is permanent.
-- `<kebab-case-slug>` — short, descriptive, stable. Avoid version numbers in the slug (use a successor ADR instead).
-
-> [!TIP]
-> Reserve the next number at the start of authoring so two PRs do not collide on `0007`. The drift-register or a `RESERVATIONS.md` register is a reasonable parking lot if collisions become frequent. **NEEDS VERIFICATION** whether KFM has adopted such a register.
-
-**Examples** (starter cross-cutting examples only; file presence and acceptance status remain NEEDS VERIFICATION — see [Index](#index-of-adrs)):
-
-````
-ADR-0001-schema-home.md
-ADR-0002-source-ledger-authority.md
-ADR-0003-evidencebundle-contract.md
-````
-
-**Domain-scoped ADRs** appear in the corpus with a slug-only form (e.g., `ADR-archaeology-schema-home.md`, `ADR-habitat-fauna-source-role-split.md`) and sometimes with a per-domain numeric prefix (e.g., `docs/domains/atmosphere/ADR-0001-atmosphere-lane.md`).
-
-> [!NOTE]
-> **NEEDS VERIFICATION:** whether KFM standardizes on (a) one global number series under `docs/adr/`, (b) a global series plus per-domain series under `docs/domains/<domain>/`, or (c) slug-only domain ADRs. The default this README assumes — pending an ADR to clarify it — is: **global numeric series under `docs/adr/`** for cross-cutting decisions, and per-domain ADRs under `docs/domains/<domain>/` using either slug-only names or a per-domain numeric series, with a forward-link from the domain ADR into any cross-cutting ADR it depends on. This convention is **PROPOSED** until ratified.
-
----
-
-## ADR template
-
-Copy the block below into a new file. Field names and statuses follow [Directory Rules §2.4](../doctrine/directory-rules.md#24-changes-that-require-an-adr) and the J.3 ADR pattern in the project corpus. Do not omit fields; if a field is genuinely empty, write `n/a` and explain why.
-
-````markdown
-<!-- [KFM_META_BLOCK_V2]
-doc_id: kfm://adr/NNNN
-title: ADR-NNNN — <Short title>
-type: adr
-version: v1
-status: proposed
-owners: <names or roles>
-created: YYYY-MM-DD
-updated: YYYY-MM-DD
-policy_label: public
-related:
-  - <kfm:// or repo path>
-tags: [kfm, adr]
-notes: []
-[/KFM_META_BLOCK_V2] -->
-
-# ADR-NNNN — <Short title>
-
-| Field | Value |
-|---|---|
-| **ID** | adr-NNNN |
-| **Status** | proposed \| accepted \| superseded \| rejected |
-| **Date** | YYYY-MM-DD |
-| **Deciders** | <names or roles> |
-| **Supersedes** | adr-MMMM (or `none`) |
-| **Superseded by** | adr-MMMM (or `none`) |
-| **Related** | <ADRs, ADR-amended doctrine, contracts, schemas, policies, tests> |
-| **Affects** | <repo paths or subsystems> |
-
-## Context
-
-The forces in play. The problem statement. The constraints. What evidence motivated revisiting this. What KFM invariants are touched. What is currently confusing, conflicting, or unenforced.
-
-## Evidence basis
-
-List the repo files, doctrine sections, schemas, contracts, policies, tests, source descriptors, release artifacts, drift entries, or external standards that support the decision. Mark any implementation-dependent claim as `NEEDS VERIFICATION` unless checked in the mounted repo.
-
-## Decision
-
-The choice made. State it as an imperative single sentence first, then expand. Pin concrete details (paths, names, versions, parameters, thresholds) rather than gesturing at them.
-
-## Consequences
-
-- **Positive:** what this enables, simplifies, or removes ambiguity from.
-- **Negative / costs:** what this constrains, breaks, requires migration for, or makes harder.
-- **Operational:** validators, CI, fixtures, runbooks, dashboards, or release-gate changes implied.
-- **Policy / sensitivity:** rights, sensitivity, public-access, source-role, or release-state consequences. Write `n/a` only when genuinely irrelevant.
-
-## Alternatives considered
-
-For each meaningful alternative: a one-paragraph description, why it was attractive, why it was rejected. **Do not omit this section.** A decision without alternatives looks foregone; recording the considered-and-rejected paths is the point of an ADR.
-
-## Migration & rollback
-
-- **Migration plan:** files, paths, schemas, policies, tests touched. Reference any plan under `migrations/`.
-- **Rollback plan:** how to reverse if the decision proves wrong. Reference any rollback card under `release/rollback_cards/` if the decision touches released artifacts.
-- **Sunset of mirrors / compatibility shims:** if the decision creates one, name the sunset criterion.
-
-## Open questions
-
-Things this ADR does not resolve and should be tracked elsewhere (link to `docs/registers/VERIFICATION_BACKLOG.md` or a successor ADR).
-
-## References
-
-Links to: doctrine sections, prior ADRs, schemas, contracts, policies, tests, dossiers, external standards, drift entries, release/correction artifacts, and verification backlog entries.
-````
-
----
-
-## Authoring quickstart
-
-1. **Confirm an ADR is needed.** If the change matches [Directory Rules §2.4](../doctrine/directory-rules.md#24-changes-that-require-an-adr), it is. If it affects more than one component or is non-obvious from code, it almost certainly is. When in doubt, open one — it is cheaper than re-litigating later.
-2. **Reserve a number.** Look at the index in this README, the file listing in `docs/adr/`, and any repo-approved reservation register if one exists. Take the next free `NNNN`. Note any companion domain ADR you also need (`docs/domains/<domain>/ADR-…`).
-3. **Copy the [template](#adr-template)** into `docs/adr/ADR-NNNN-<slug>.md`. Fill the meta block. Do not skip fields.
-4. **Draft with `status: proposed`.** Cite evidence — schemas, contracts, prior ADRs, dossiers, drift entries. Do not draft as a fait accompli; the alternatives section is doctrinally required.
-5. **Open a PR.** Title format: `ADR-NNNN: <short title> [proposed]`. Tag the architecture steward and the affected subsystem owners.
-6. **Run validation locally** if validators exist (see [Validation](#validation)). **NEEDS VERIFICATION** which validators are wired.
-7. **Iterate through review.** If reviewers ask for fundamental changes, those edits stay in the same file while status remains `proposed`. The ADR is rewritable until it is merged.
-8. **On merge, set `status: accepted`** in the meta block and the index table — and freeze the file body. Substantive changes happen via a successor ADR, not by rewriting accepted history.
-9. **If superseding a prior ADR:** add `Supersedes: adr-MMMM` to the new ADR, and in the same PR update the old ADR's `status` to `superseded` plus its `Superseded by:` field. Both files ship together.
-10. **Link forward and back.** Update [the index in this README](#index-of-adrs) and any per-root README that referenced the prior decision.
-
-> [!TIP]
-> An ADR is most useful when it is short and evidence-heavy. Aim for one tight page of context, one paragraph of decision, three bullets of consequence, two paragraphs of alternatives. Long ADRs become unread ADRs.
-
----
-
-## Status & supersession
-
-| Status | Meaning | Edits allowed? |
-|---|---|---|
-| `proposed` | Drafted, under review, not yet authoritative | Yes — until merged |
-| `accepted` | Merged. Authoritative. | **No.** Use a successor ADR. |
-| `superseded` | Replaced by a later ADR. Retained for audit. | Only the meta block / `superseded_by` field. |
-| `rejected` | Considered, decided against. Retained for audit. | **No.** |
-
-**Hard rules:**
-
-- ADRs are **never deleted**. A wrong-headed ADR is superseded or rejected, not removed.
-- An `accepted` ADR is **immutable** in body. Typos and dead-link fixes are permissible; substantive change requires a successor.
-- A `superseded` ADR **MUST** carry a forward link to its replacement. The replacement **MUST** carry a back link.
-- A `rejected` ADR is preserved so future readers see the path was considered.
-
----
-
-## Index of ADRs
-
-> [!NOTE]
-> The list below is the **PROPOSED starter set** drawn from the project corpus (see [References](#references)). The repository was not mounted during authoring, so each row's *file presence* is **NEEDS VERIFICATION**. ADR-0001 is referenced by Directory Rules as the schema-home convention; whether it exists on disk and whether it is accepted remain separate repo-verification questions.
->
-> When this README is next updated against a mounted repo, mark each row's status accurately, replace **NEEDS VERIFICATION** with **CONFIRMED** where appropriate, and add any ADRs not in this starter set.
-
-| ID | Title | Topic | Status (file) | Status (decision) |
-|---|---|---|---|---|
-| `ADR-0001` | [`schema-home`](./ADR-0001-schema-home.md) | Resolve `schemas/contracts/v1/` vs `contracts/` as machine-schema authority | NEEDS VERIFICATION | PROPOSED / NEEDS VERIFICATION — referenced by Directory Rules as the schema-home convention |
-| `ADR-0002` | `source-ledger-authority` | Source ledger update, supersession, and append-only rules | NEEDS VERIFICATION | PROPOSED |
-| `ADR-0003` | `evidencebundle-contract` | `EvidenceRef` → `EvidenceBundle` resolution and closure contract | NEEDS VERIFICATION | PROPOSED |
-| `ADR-0004` | `promotion-gate` | Promotion as governed state transition (not a file move) | NEEDS VERIFICATION | PROPOSED |
-| `ADR-0005` | `maplibre-layer-manifest` | Public-safe `LayerManifest` rules for the map shell | NEEDS VERIFICATION | PROPOSED |
-| `ADR-0006` | `governed-ai-runtime-envelope` | Finite-outcome envelope: `ANSWER \| ABSTAIN \| DENY \| ERROR` | NEEDS VERIFICATION | PROPOSED |
-| `ADR-0007` | `domain-lane-template` | Standard lane files, schemas, validators, tests per domain | NEEDS VERIFICATION | PROPOSED |
-| `ADR-0008` | `sensitive-location-policy` | Fail-closed treatment for sensitive exact locations | NEEDS VERIFICATION | PROPOSED |
-| `ADR-0009` | `local-exposure-security` | VPN / reverse proxy / firewall / auth / audit posture | NEEDS VERIFICATION | PROPOSED |
-| `ADR-0010` | `catalog-proof-release-separation` | Separate receipts, proofs, catalogs, releases, reviews, corrections | NEEDS VERIFICATION | PROPOSED |
-
-**Domain-scoped ADRs** are tracked in the per-domain trees and SHOULD link back to the relevant cross-cutting ADR. Examples seen in the corpus (all PROPOSED, status NEEDS VERIFICATION):
-
-- `docs/domains/atmosphere/ADR-0001-atmosphere-lane.md`
-- `docs/domains/agriculture/ADR-0001-agriculture-domain-boundary.md`
-- `docs/adr/ADR-archaeology-schema-home.md` (or its `docs/domains/archaeology/` equivalent — placement NEEDS VERIFICATION)
-- `docs/adr/ADR-hydrology-schema-home.md` and three siblings
-- `docs/adr/ADR-habitat-fauna-schema-home.md` and two siblings
-
-> [!CAUTION]
-> Two competing starter lists appear in the corpus — one in *Pipeline Living Implementation Manual v0.3* (`schema-home`, `source-ledger`, `evidencebundle`, `promotion-gate`, `maplibre-layer-manifest`, `governed-ai-runtime-envelope`, …) and one in *Pass 12 Idea Index* (`spec-normalization`, `finite-decision-outcomes`, `watcher-non-publisher`, `stac-profile`, `releasemanifest`, `crypto-stack`). The first list is used in this index because it aligns with Directory Rules' schema-home reference and the pipeline-manual starter set. **NEEDS VERIFICATION** whether the second list's topics are folded into later ADR numbers, written as separate ADRs, or absorbed into doctrine. An early housekeeping ADR to reconcile the two is recommended.
-
----
+1. Read Directory Rules and confirm the change is ADR-class.
+2. Inspect [`INDEX.md`](./INDEX.md), open ADR PRs, and active ADR branches for collisions.
+3. Copy [`ADR-template.md`](./ADR-template.md) to the next `ADR-NNNN-kebab-case-slug.md` path.
+4. Keep status `proposed`; identify owners, affected roots, evidence, alternatives, migration, and rollback.
+5. Link any superseded ADRs in both directions.
+6. Update [`INDEX.md`](./INDEX.md) in the same change.
+7. Run the ADR validator and its tests.
+8. Request the reviewers required by the affected roots. CODEOWNERS routing is not proof that review occurred.
+9. On a reviewed status transition, update the record and index together; never let the index promote the record independently.
 
 ## Validation
 
-> [!WARNING]
-> The validators and CI checks listed below are **PROPOSED**. Their existence in the current repo is **NEEDS VERIFICATION**. Do not assume an absent check is a passing check.
-
-PROPOSED gates for `docs/adr/` PRs:
-
-- **Filename pattern check** — `ADR-\d{4}-[a-z0-9-]+\.md` for files in `docs/adr/`; domain-pattern alternative for `docs/domains/<domain>/ADR-…`.
-- **Number-uniqueness check** — no two ADRs share `NNNN` in the same series.
-- **Required-fields check** — meta block + table fields complete; `status` ∈ {`proposed`, `accepted`, `superseded`, `rejected`}.
-- **Supersession-link check** — every `superseded` ADR has a valid forward link, every successor has a valid back link.
-- **Append-only check** — substantive edits to `accepted` ADRs are flagged; only meta-block tweaks and dead-link fixes are auto-allowed.
-- **Cross-link check** — links from `docs/doctrine/`, `contracts/`, `schemas/`, `policy/` to ADRs by ID resolve.
-- **Index-coherence check** — the table in this README contains every ADR in `docs/adr/` and vice versa.
-- **`docs/adr/README.md` "Last reviewed" freshness check** — flag if older than six months (per [Directory Rules §15](../doctrine/directory-rules.md#15-required-readme-contract)).
-
-PROPOSED tooling homes:
-
-- `tools/validators/adr/` (validators)
-- `.github/workflows/adr-checks.yml` (CI)
-- `tests/governance/adr/` (validator tests + golden ADRs)
-
-These paths are PROPOSED. Confirmation against the mounted repo is required before any of them is treated as canonical.
-
----
-
-## First repo verification pass
-
-Run this pass before promoting this README from `draft` or replacing `NEEDS VERIFICATION` in the ADR index.
-
-> [!CAUTION]
-> These commands are read-only discovery commands. They should be run from the mounted KFM checkout, not from an artifact workspace.
+Run from the repository root:
 
 ```bash
-pwd
-git status --short
-git branch --show-current
-git ls-tree -r --name-only HEAD docs/adr docs/doctrine docs/registers schemas contracts policy release data/receipts data/proofs 2>/dev/null | sort
-find docs/adr -maxdepth 1 -type f -name 'ADR-*.md' | sort
+python tools/validators/validate_adr_index.py
+python -m pytest tests/validators/test_validate_adr_index.py -q --strict-config --strict-markers
 ```
 
-Verification outcomes to record in the PR:
+The validator checks:
 
-- [ ] `docs/adr/README.md` exists at the expected path or is created there.
-- [ ] Every ADR file in `docs/adr/` appears in the index above.
-- [ ] Every index row with a linked file resolves to an actual file or remains `NEEDS VERIFICATION`.
-- [ ] Every ADR meta block has `status` in `proposed | accepted | superseded | rejected`.
-- [ ] Every `superseded` ADR has a forward link and every successor has a back link.
-- [ ] Directory Rules links resolve, especially authority order and §2.4 ADR triggers.
-- [ ] Any domain-scoped ADR location conflict is entered in `docs/registers/DRIFT_REGISTER.md` or resolved by an ADR.
-- [ ] Validation tooling homes are confirmed or left explicitly `PROPOSED`.
+- unique numbered IDs and exact index coverage;
+- filename, H1, link target, and index-ID agreement;
+- allowed effective status values and conservative source-status normalization;
+- separation and complete inventory of explicit placeholders and slug-only scaffolds;
+- non-duplicating canonical pointer behavior in `docs/registers/ADR_INDEX.md`;
+- reciprocal supersession links when a record is marked `superseded` or names a predecessor.
 
-Do not use a green validation run to imply the listed starter ADRs exist. File presence, decision status, and enforcement status are separate facts.
+The read-only [`docs-control-plane` workflow](../../.github/workflows/docs-control-plane.yml) runs the validator and its negative-path tests. A green result proves index coherence for the checked revision. It does not accept a decision, prove architecture implementation, approve policy, authorize release, or publish data.
 
----
+## Review and supersession
 
-## Review burden
+| Change | Required review posture |
+| --- | --- |
+| New proposed ADR | Architecture steward plus affected subsystem owner |
+| `proposed` → `accepted` | Explicit decision review from all named owners; implementation and migration gates as specified by the ADR |
+| `proposed` → `rejected` | Explicit architecture review; retain the record |
+| `accepted` → `superseded` | Accepted successor, forward/back links, and reviewed transition plan |
+| Index or README maintenance | Docs and architecture review route |
 
-| Change | Reviewers required |
-|---|---|
-| New `proposed` ADR | Architecture steward + at least one affected subsystem owner |
-| Move `proposed` → `accepted` | Architecture steward + the subsystem owners listed in the ADR's `Affects` row |
-| Move `accepted` → `superseded` (paired with successor) | Same as the successor ADR's review |
-| Move `proposed` → `rejected` | Architecture steward |
-| Edits to this README | Docs steward + Architecture steward |
-| Reorganization of `docs/adr/` itself (e.g., adding a per-domain subtree) | **A new ADR is required** per Directory Rules §2.4 |
+[`CODEOWNERS`](../../.github/CODEOWNERS) currently routes `docs/adr/`, `docs/registers/`, `tools/validators/`, and `tests/` to `@bartytime4life`. That is a verified GitHub review route, not a `ReviewRecord`, acceptance decision, separation-of-duties proof, release approval, or publication authority.
 
-`CODEOWNERS` reference: **TODO** — populate once the file exists in the mounted repo. Until then, route PRs via the PR template's reviewer list.
+## Open governance work
 
----
+The following remain unresolved and are not silently normalized by this README:
 
-## Related folders & doctrine
+- Human acceptance review for all 28 numbered ADRs.
+- Metadata normalization for 12 `draft` records and legacy ADR-0007 without changing their conservative `proposed` status.
+- Migration analysis for the two legacy space/em-dash filenames.
+- Disposition of 12 unassigned placeholder or slug-only scaffolds.
+- Resolution of repo-wide versus domain-local ADR placement where domain documents still describe competing patterns.
+- Review of [`ADR-0011`](./ADR-0011-receipts-vs-proofs-vs-manifests-vs-catalog-separation.md), which remains proposed and therefore does not yet unlock `artifacts/release/` migration.
+- `OPEN-DR-09-b` and the `artifacts/perf/` placement conflict.
 
-**Doctrine (in `docs/doctrine/`)**
-
-- [`directory-rules.md`](../doctrine/directory-rules.md) — placement law; pins ADR conventions and §2.4 triggers
-- [`authority-ladder.md`](../doctrine/authority-ladder.md) — where ADRs sit in the authority order
-- [`lifecycle-law.md`](../doctrine/lifecycle-law.md) — the invariant ADRs must respect
-- [`trust-membrane.md`](../doctrine/trust-membrane.md) — boundary ADRs cannot weaken without explicit `Consequences`
-- [`truth-posture.md`](../doctrine/truth-posture.md) — cite-or-abstain default
-
-**Architecture (in `docs/architecture/`)**
-
-- [`contract-schema-policy-split.md`](../architecture/contract-schema-policy-split.md) — context for ADR-0001
-- `system-context.md`, `deployment-topology.md`, `governed-api.md`, `map-shell.md` — frequent ADR neighbors
-
-**Registers (in `docs/registers/`)**
-
-- [`DRIFT_REGISTER.md`](../registers/DRIFT_REGISTER.md) — drift entries that frequently mature into ADRs
-- [`VERIFICATION_BACKLOG.md`](../registers/VERIFICATION_BACKLOG.md) — open questions, often ADR seeds
-- [`CANONICAL_LINEAGE_EXPLORATORY.md`](../registers/CANONICAL_LINEAGE_EXPLORATORY.md) — classifies what is canon vs lineage
-
-**Machine-readable governance (in `control_plane/`)**
-
-- `deprecation_register.yaml` — receives entries when an ADR deprecates a path or rule
-- `contradiction_register.yaml` — surfaces conflicts that may need an ADR
-
----
+Until those decisions are reviewed, use the conservative posture: inventory the file, keep the decision `proposed`, preserve reversibility, and do not grant authority by implication.
 
 ## Maintenance checklist
 
-Use this checklist when editing this README or reviewing an ADR PR.
+- [ ] Update `INDEX.md` whenever a numbered ADR or unassigned scaffold is added, removed through reviewed cleanup, assigned, or status-transitioned.
+- [ ] Preserve unique IDs and exact filename/H1 agreement.
+- [ ] Keep source metadata and effective decision status separate.
+- [ ] Require reciprocal supersession links.
+- [ ] Run the validator and negative-path tests.
+- [ ] Update `updated:` and the verified snapshot when the inventory changes.
+- [ ] Keep accepted and historical ADRs append-only.
+- [ ] Record placement conflicts in the drift register instead of normalizing them.
+- [ ] Keep receipts, proofs, policy, schemas, contracts, release objects, and data in their owning roots.
 
-- [ ] Preserve this README's H1, meta block `doc_id`, and existing section anchors unless a migration note explains the break.
-- [ ] Update `updated:` in the meta block and `Last reviewed` when a repo-verified review occurs.
-- [ ] Keep implementation claims labeled: `CONFIRMED`, `PROPOSED`, `UNKNOWN`, or `NEEDS VERIFICATION`.
-- [ ] Update the ADR index and supersession links in the same PR that adds, accepts, rejects, or supersedes an ADR.
-- [ ] Keep ADRs out of schemas, policies, release manifests, receipts, proof packs, and runbooks; route those artifacts to their responsibility roots.
-- [ ] Add or update drift/backlog entries when repo reality and this README disagree.
-- [ ] Avoid broad rewrites of accepted ADR bodies. Use successor ADRs for material changes.
+## Related
 
----
-
-## FAQ
-
-<details>
-<summary><strong>Should every architectural decision get an ADR?</strong></summary>
-
-No. Trivial choices, local refactors, and decisions fully expressed in a schema or contract typically don't. The threshold from the corpus: *if the choice affects more than one component, or is non-obvious from code, write one*. When in doubt, write one — they are cheap, and the cost of an unrecorded decision compounds.
-</details>
-
-<details>
-<summary><strong>What if a decision was made years ago and never recorded?</strong></summary>
-
-Backfill it. Author it as `proposed`, mark the `Date` as the original decision date if known (or "backfill: YYYY-MM-DD" if not), and note in `Context` that this is a retroactive ADR. Move to `accepted` once the rationale and consequences are agreed by current stewards.
-</details>
-
-<details>
-<summary><strong>Can I edit an accepted ADR?</strong></summary>
-
-Only for typos, broken links, and meta-block hygiene. Anything substantive — including changes to `Decision`, `Consequences`, or `Alternatives` — requires a successor ADR. The whole point of ADRs is that the record is stable enough to cite.
-</details>
-
-<details>
-<summary><strong>Where do domain ADRs live — here or under <code>docs/domains/&lt;domain&gt;/</code>?</strong></summary>
-
-**NEEDS VERIFICATION.** The corpus shows both patterns. The PROPOSED working rule (until an ADR ratifies it): cross-cutting decisions live in `docs/adr/` with a global numeric ID; domain-scoped decisions live under `docs/domains/<domain>/` with either a per-domain number or a slug-only filename, and link forward to any cross-cutting ADR they depend on. Do not duplicate.
-</details>
-
-<details>
-<summary><strong>What happens if an ADR conflicts with Directory Rules?</strong></summary>
-
-An accepted ADR that explicitly amends Directory Rules wins (per [authority order §2.1](../doctrine/directory-rules.md#21-authority-order)). The ADR itself MUST cite the Rules section it amends, and the Rules document SHOULD be updated in the same PR (or a follow-up PR with a forward link from §0).
-</details>
-
-<details>
-<summary><strong>How do ADRs relate to <code>CHANGELOG.md</code>?</strong></summary>
-
-`CHANGELOG.md` records *what changed* in releases. ADRs record *why an architectural choice was made*. They are complementary: a release entry might say *"Adopted `schemas/contracts/v1/` as the schema home"* and link to `ADR-0001`. The ADR carries the rationale; the changelog carries the timing and surface impact.
-</details>
-
-<details>
-<summary><strong>Can an ADR be marked <code>accepted</code> if its enforcement isn't built yet?</strong></summary>
-
-Yes — but the `Consequences` section MUST list the enforcement work as a deferred operational consequence, and the corresponding entry SHOULD land in `docs/registers/VERIFICATION_BACKLOG.md`. An accepted-but-unenforced ADR is still authoritative; it is not yet *executable*.
-</details>
-
-<details>
-<summary><strong>Are ADRs the right place to record source rights, sensitivity decisions, or release decisions?</strong></summary>
-
-No.
-- Source rights / sensitivity → `policy/sensitivity/`, `policy/rights/`, `data/registry/<domain>/sources.yaml`.
-- Release decisions → `release/manifests/`, `release/promotion_decisions/`, `release/correction_notices/`.
-
-An ADR can establish the *framework* for these decisions (e.g., ADR-0008 sets the fail-closed exact-location rule); the per-instance decisions live in policy and release artifacts.
-</details>
-
----
-
-## Last reviewed
-
-`<TODO: YYYY-MM-DD on first repo-verified PR>` — flag for review if older than six months, per [Directory Rules §15](../doctrine/directory-rules.md#15-required-readme-contract).
-
----
-
-### References
-
-- `docs/doctrine/directory-rules.md` — §0 Authority, §2.1 Authority order, §2.4 Changes that require an ADR, §6.1 `docs/`, §7.4 schema-home convention, §15 Required README contract.
-- *Kansas Frontier Matrix Pipeline Living Implementation Manual v0.3* — §28 Decision register / ADR index (PROPOSED starter set ADR-0001 through ADR-0010).
-- *KFM Pass 12 Part 2 — Idea Index, Category Atlas, and Expansion Dossier* — J.3 ADR pattern; §9.2 alternative starter set.
-- *KFM Components Pass 11 — Idea Index, Category Atlas, and Expansion Dossier* — J.4.1 ADRs for every consequential architectural choice.
-- *KFM Whole-UI / Governed AI Expansion Report* — file-home and trust-boundary ADR examples.
-- Domain dossiers (Archaeology, Agriculture, Atmosphere, Habitat/Fauna, Hydrology, Roads/Rail/Trade, Settlements/Infrastructure, Geology) — domain-scoped ADR examples.
-
-[Back to top](#docsadr--architecture-decision-records)
+- [Canonical ADR index](./INDEX.md)
+- [ADR template](./ADR-template.md)
+- [Human ADR cross-register](../registers/ADR_INDEX.md)
+- [Directory Rules](../doctrine/directory-rules.md)
+- [Authority Ladder](../doctrine/authority-ladder.md)
+- [Drift Register](../registers/DRIFT_REGISTER.md)
+- [Verification Backlog](../registers/VERIFICATION_BACKLOG.md)
+- [ADR index validator](../../tools/validators/validate_adr_index.py)
+- [ADR validator tests](../../tests/validators/test_validate_adr_index.py)
+- [Documentation control-plane workflow](../../.github/workflows/docs-control-plane.yml)

--- a/docs/registers/ADR_INDEX.md
+++ b/docs/registers/ADR_INDEX.md
@@ -1,16 +1,108 @@
-# ADR INDEX
+<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://doc/registers/adr-index
+title: ADR Index Cross-Register
+type: register-pointer
+version: v1.0
+status: draft; repository-grounded
+owners:
+  - Docs steward
+  - Architecture steward
+created: 2026-07-22
+updated: 2026-07-22
+policy_label: public
+truth_posture: cite-or-abstain
+responsibility_root: docs/
+canonical_adr_index: ../adr/INDEX.md
+related:
+  - docs/adr/INDEX.md
+  - docs/adr/README.md
+  - docs/registers/README.md
+  - docs/doctrine/directory-rules.md
+  - tools/validators/validate_adr_index.py
+tags: [kfm, registers, adr, pointer, governance]
+notes:
+  - "This file is a non-duplicating human cross-register pointer."
+  - "The canonical per-record inventory lives only in docs/adr/INDEX.md."
+[/KFM_META_BLOCK_V2] -->
 
-**Status:** PROPOSED scaffold.  
-**Source:** `docs/domains/roads-rail-trade/EXPANSION_BACKLOG.md`  
-**Referenced path:** `docs/registers/ADR_INDEX.md`
+# ADR Index Cross-Register
 
-This file was created because the current `docs/domains` markdown inventory lists this path as planned, expected, or linked. Fill in the authoritative content, owners, validation status, and cross-links before promoting it beyond scaffold status.
+[![register](https://img.shields.io/badge/register-human_pointer-0969da)](./README.md)
+[![canonical inventory](https://img.shields.io/badge/canonical_inventory-docs%2Fadr%2FINDEX.md-1a7f37)](../adr/INDEX.md)
+[![decisions](https://img.shields.io/badge/decision_authority-source_ADR_only-d4a72c)](../adr/README.md)
 
-## Source Documents
+This register connects the human register lane to the canonical Architecture Decision Record inventory without copying its rows.
 
-- `docs/domains/roads-rail-trade/EXPANSION_BACKLOG.md`
+> [!IMPORTANT]
+> The canonical ADR inventory is [`docs/adr/INDEX.md`](../adr/INDEX.md). This file must remain a pointer and consumer map. A second ADR table here would create avoidable control-plane drift.
 
-## Notes
+## Register contract
 
-- Keep machine-checkable shape in `schemas/`, policy in `policy/`, fixtures in `fixtures/`, and release decisions in `release/` unless an accepted ADR says otherwise.
-- Replace this scaffold with domain-reviewed content before treating the path as canonical truth.
+| Field | Value |
+| --- | --- |
+| Owning root | `docs/` — human-facing control plane |
+| Register lane | `docs/registers/` |
+| Canonical ADR inventory | [`docs/adr/INDEX.md`](../adr/INDEX.md) |
+| ADR operating rules | [`docs/adr/README.md`](../adr/README.md) |
+| Current numbered inventory | 28 tracked records, `ADR-0001` through `ADR-0028` |
+| Current effective decision status | All `proposed`; no verified accepted record |
+| Review route | `@bartytime4life` via `.github/CODEOWNERS` |
+| Validation | [`tools/validators/validate_adr_index.py`](../../tools/validators/validate_adr_index.py) |
+| Authority limit | Inventory and routing only; never decision acceptance, policy, release, promotion, or publication authority |
+
+## Why this is a pointer
+
+`docs/adr/INDEX.md` owns the exact file-to-ID and status crosswalk because it lives beside the records it inventories. `docs/registers/ADR_INDEX.md` provides the cross-register view needed by doctrine, drift, verification, and control-plane consumers.
+
+Keeping one row source ensures that:
+
+- an ADR addition or status transition has one human inventory to update;
+- register readers can discover the canonical decision lane;
+- validators can reject missing, extra, or conflicting rows deterministically;
+- presence, status, acceptance, implementation, and release authority remain separate facts.
+
+## Inputs and consumers
+
+| Direction | Surface | Relationship |
+| --- | --- | --- |
+| Upstream | [`docs/doctrine/directory-rules.md`](../doctrine/directory-rules.md) | Defines placement, status vocabulary, and ADR triggers |
+| Canonical record set | [`docs/adr/`](../adr/) | Holds numbered records, scaffolds, template, and canonical index |
+| Drift input | [`DRIFT_REGISTER.md`](./DRIFT_REGISTER.md) | Placement or authority conflicts may require an ADR |
+| Verification input | [`VERIFICATION_BACKLOG.md`](./VERIFICATION_BACKLOG.md) | Checkable unresolved questions may mature into ADRs |
+| Machine control plane | [`control_plane/`](../../control_plane/) | May reference decisions; does not replace human ADR records |
+| Enforcement | [`tools/validators/validate_adr_index.py`](../../tools/validators/validate_adr_index.py) | Checks file/index/status/supersession coherence |
+| CI | [`.github/workflows/docs-control-plane.yml`](../../.github/workflows/docs-control-plane.yml) | Runs the read-only coherence gate |
+
+## Update protocol
+
+1. Update the source ADR and [`docs/adr/INDEX.md`](../adr/INDEX.md) together.
+2. Run the ADR index validator and its negative-path tests.
+3. Change this pointer only when its contract, canonical target, summary, consumers, or validation path changes.
+4. Keep proposed decisions proposed until their source records carry explicit reviewed status.
+5. Preserve superseded and rejected records; never delete decision history.
+
+## Validation boundary
+
+```bash
+python tools/validators/validate_adr_index.py
+python -m pytest tests/validators/test_validate_adr_index.py -q --strict-config --strict-markers
+```
+
+A green result confirms the checked revision has one coherent human ADR inventory, valid ID/status/link relationships, complete scaffold separation, and this canonical pointer. It does not establish that any decision was correctly accepted, implemented, enforced across all runtime paths, or approved for release or publication.
+
+## Open governance work
+
+- Human status review for the 28 numbered ADRs.
+- Metadata normalization for records whose source metadata says `draft` or uses legacy structure.
+- Domain-local versus repository-wide ADR placement reconciliation.
+- Review of proposed ADR-0011 before any `artifacts/release/` migration.
+- Resolution of `OPEN-DR-09-b` and the `artifacts/perf/` placement conflict.
+
+## Related
+
+- [Canonical ADR index](../adr/INDEX.md)
+- [ADR operating contract](../adr/README.md)
+- [Registers README](./README.md)
+- [Directory Rules](../doctrine/directory-rules.md)
+- [Drift Register](./DRIFT_REGISTER.md)
+- [Verification Backlog](./VERIFICATION_BACKLOG.md)

--- a/tests/validators/test_validate_adr_index.py
+++ b/tests/validators/test_validate_adr_index.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.validators.validate_adr_index import validate_repository
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _adr(adr_id: str, status: str, title: str = "Decision") -> str:
+    return f"""<!-- [KFM_META_BLOCK_V2]
+doc_id: kfm://adr/{adr_id}
+title: {adr_id} — {title}
+type: adr
+status: {status}
+[/KFM_META_BLOCK_V2] -->
+
+# {adr_id} — {title}
+"""
+
+
+def _row(
+    adr_id: str,
+    filename: str,
+    effective: str,
+    source: str,
+    supersedes: str = "—",
+    superseded_by: str = "—",
+) -> str:
+    return (
+        f"| `{adr_id}` | [{adr_id}](./{filename}) | `{effective}` | `{source}` | "
+        f"{supersedes} | {superseded_by} |"
+    )
+
+
+def _index(rows: list[str], scaffolds: list[str] | None = None) -> str:
+    scaffold_rows = scaffolds or []
+    return "\n".join(
+        [
+            "<!-- [KFM_META_BLOCK_V2]",
+            f"numbered_records: {len(rows)}",
+            f"unassigned_scaffolds: {len(scaffold_rows)}",
+            "[/KFM_META_BLOCK_V2] -->",
+            "# Architecture Decision Record Index",
+            "<!-- ADR_INDEX_TABLE_START -->",
+            "| ID | Record | Effective status | Source metadata | Supersedes | Superseded by |",
+            "|---|---|---|---|---|---|",
+            *rows,
+            "<!-- ADR_INDEX_TABLE_END -->",
+            "<!-- ADR_SCAFFOLD_TABLE_START -->",
+            "| File | Classification | Decision status |",
+            "|---|---|---|",
+            *scaffold_rows,
+            "<!-- ADR_SCAFFOLD_TABLE_END -->",
+            "",
+        ]
+    )
+
+
+def _base_repo(tmp_path: Path) -> Path:
+    _write(
+        tmp_path / "docs/adr/README.md",
+        "# ADRs\n\nSee the [canonical ADR index](./INDEX.md).\n",
+    )
+    _write(
+        tmp_path / "docs/registers/ADR_INDEX.md",
+        "<!--\ncanonical_adr_index: ../adr/INDEX.md\n-->\n"
+        "# ADR Index Cross-Register\n\n[Canonical index](../adr/INDEX.md)\n",
+    )
+    return tmp_path
+
+
+def test_valid_index_accepts_proposed_and_draft_source_metadata(tmp_path: Path) -> None:
+    root = _base_repo(tmp_path)
+    first = "ADR-0001-first-decision.md"
+    second = "ADR-0002-second-decision.md"
+    _write(root / "docs/adr" / first, _adr("ADR-0001", "proposed", "First"))
+    _write(root / "docs/adr" / second, _adr("ADR-0002", "draft", "Second"))
+    _write(
+        root / "docs/adr/INDEX.md",
+        _index(
+            [
+                _row("ADR-0001", first, "proposed", "proposed"),
+                _row("ADR-0002", second, "proposed", "draft"),
+            ]
+        ),
+    )
+
+    assert validate_repository(root) == []
+
+
+def test_number_collision_is_rejected(tmp_path: Path) -> None:
+    root = _base_repo(tmp_path)
+    _write(root / "docs/adr/ADR-0001-first.md", _adr("ADR-0001", "proposed"))
+    _write(root / "docs/adr/ADR-0001-second.md", _adr("ADR-0001", "proposed"))
+    _write(
+        root / "docs/adr/INDEX.md",
+        _index([_row("ADR-0001", "ADR-0001-first.md", "proposed", "proposed")]),
+    )
+
+    errors = validate_repository(root)
+    assert any("number collisions" in error for error in errors)
+
+
+def test_missing_numbered_record_row_is_rejected(tmp_path: Path) -> None:
+    root = _base_repo(tmp_path)
+    _write(root / "docs/adr/ADR-0001-first.md", _adr("ADR-0001", "proposed"))
+    _write(root / "docs/adr/INDEX.md", _index([]))
+
+    errors = validate_repository(root)
+    assert any("numbered ADR missing from index: ADR-0001" in error for error in errors)
+
+
+def test_index_cannot_promote_source_status(tmp_path: Path) -> None:
+    root = _base_repo(tmp_path)
+    filename = "ADR-0001-first.md"
+    _write(root / "docs/adr" / filename, _adr("ADR-0001", "proposed"))
+    _write(
+        root / "docs/adr/INDEX.md",
+        _index([_row("ADR-0001", filename, "accepted", "proposed")]),
+    )
+
+    errors = validate_repository(root)
+    assert any("does not match source-normalized 'proposed'" in error for error in errors)
+
+
+def test_supersession_requires_reciprocal_link(tmp_path: Path) -> None:
+    root = _base_repo(tmp_path)
+    first = "ADR-0001-first.md"
+    second = "ADR-0002-second.md"
+    _write(root / "docs/adr" / first, _adr("ADR-0001", "superseded"))
+    _write(root / "docs/adr" / second, _adr("ADR-0002", "accepted"))
+    _write(
+        root / "docs/adr/INDEX.md",
+        _index(
+            [
+                _row(
+                    "ADR-0001",
+                    first,
+                    "superseded",
+                    "superseded",
+                    superseded_by="ADR-0002",
+                ),
+                _row("ADR-0002", second, "accepted", "accepted"),
+            ]
+        ),
+    )
+
+    errors = validate_repository(root)
+    assert any("ADR-0002 lacks reciprocal Supersedes link" in error for error in errors)
+
+
+def test_unassigned_scaffold_must_be_indexed(tmp_path: Path) -> None:
+    root = _base_repo(tmp_path)
+    _write(
+        root / "docs/adr/ADR-XXXX-future.md",
+        "# Future ADR\n\n**Status:** PROPOSED scaffold.\n",
+    )
+    _write(root / "docs/adr/INDEX.md", _index([]))
+
+    errors = validate_repository(root)
+    assert any("unassigned ADR scaffold missing from index" in error for error in errors)
+
+
+def test_register_must_not_duplicate_numbered_rows(tmp_path: Path) -> None:
+    root = _base_repo(tmp_path)
+    filename = "ADR-0001-first.md"
+    _write(root / "docs/adr" / filename, _adr("ADR-0001", "proposed"))
+    _write(
+        root / "docs/adr/INDEX.md",
+        _index([_row("ADR-0001", filename, "proposed", "proposed")]),
+    )
+    with (root / "docs/registers/ADR_INDEX.md").open("a", encoding="utf-8") as handle:
+        handle.write("\n| `ADR-0001` | duplicate |\n")
+
+    errors = validate_repository(root)
+    assert any("must not duplicate numbered ADR rows" in error for error in errors)

--- a/tools/validators/validate_adr_index.py
+++ b/tools/validators/validate_adr_index.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Validate KFM's human Architecture Decision Record control plane.
+
+This validator is intentionally standard-library only. It verifies repository
+structure and cross-file coherence; it does not accept an ADR, prove that a
+decision is implemented, or authorize policy, release, or publication.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+ALLOWED_EFFECTIVE_STATUSES = {"proposed", "accepted", "superseded", "rejected"}
+NUMBERED_NAME_RE = re.compile(r"^ADR-(\d{4})(?:-|\s)")
+PLACEHOLDER_NAME_RE = re.compile(r"^ADR-(?:NNNN|XXXX)(?:-|\s)")
+ADR_REF_RE = re.compile(r"ADR-\d{4}")
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\((?:<([^>]+)>|([^)]+))\)")
+
+INDEX_START = "<!-- ADR_INDEX_TABLE_START -->"
+INDEX_END = "<!-- ADR_INDEX_TABLE_END -->"
+SCAFFOLD_START = "<!-- ADR_SCAFFOLD_TABLE_START -->"
+SCAFFOLD_END = "<!-- ADR_SCAFFOLD_TABLE_END -->"
+
+
+@dataclass(frozen=True)
+class IndexRow:
+    adr_id: str
+    target: str
+    effective_status: str
+    source_metadata: str
+    supersedes: tuple[str, ...]
+    superseded_by: tuple[str, ...]
+    line: int
+
+
+@dataclass(frozen=True)
+class SourceStatus:
+    label: str
+    effective: str
+
+
+def _table_lines(text: str, start_marker: str, end_marker: str) -> list[tuple[int, str]]:
+    lines = text.splitlines()
+    try:
+        start = lines.index(start_marker)
+        end = lines.index(end_marker, start + 1)
+    except ValueError as exc:
+        raise ValueError(f"missing table marker: {exc}") from exc
+    if end <= start + 2:
+        raise ValueError(f"empty or malformed table between {start_marker} and {end_marker}")
+    return [(idx + 1, lines[idx]) for idx in range(start + 1, end)]
+
+
+def _cells(line: str) -> list[str]:
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|"):
+        return []
+    return [cell.strip() for cell in stripped.strip("|").split("|")]
+
+
+def _link_target(cell: str) -> str | None:
+    match = MARKDOWN_LINK_RE.search(cell)
+    if not match:
+        return None
+    return (match.group(1) or match.group(2) or "").strip()
+
+
+def _normalized_id(cell: str) -> str:
+    return cell.replace("`", "").strip()
+
+
+def _refs(cell: str) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(ADR_REF_RE.findall(cell)))
+
+
+def parse_numbered_index(index_path: Path) -> tuple[list[IndexRow], list[str]]:
+    errors: list[str] = []
+    try:
+        marked_lines = _table_lines(index_path.read_text(encoding="utf-8"), INDEX_START, INDEX_END)
+    except (OSError, ValueError) as exc:
+        return [], [f"{index_path}: {exc}"]
+
+    if len(marked_lines) < 2:
+        return [], [f"{index_path}: numbered table is incomplete"]
+
+    header = _cells(marked_lines[0][1])
+    expected_header = [
+        "ID",
+        "Record",
+        "Effective status",
+        "Source metadata",
+        "Supersedes",
+        "Superseded by",
+    ]
+    if header != expected_header:
+        errors.append(f"{index_path}:{marked_lines[0][0]}: expected header {expected_header!r}, found {header!r}")
+
+    rows: list[IndexRow] = []
+    for line_no, line in marked_lines[2:]:
+        cells = _cells(line)
+        if not cells:
+            continue
+        if len(cells) != 6:
+            errors.append(f"{index_path}:{line_no}: expected 6 cells, found {len(cells)}")
+            continue
+        target = _link_target(cells[1])
+        if target is None:
+            errors.append(f"{index_path}:{line_no}: record cell has no Markdown link")
+            continue
+        rows.append(
+            IndexRow(
+                adr_id=_normalized_id(cells[0]),
+                target=target,
+                effective_status=_normalized_id(cells[2]).lower(),
+                source_metadata=_normalized_id(cells[3]).lower(),
+                supersedes=_refs(cells[4]),
+                superseded_by=_refs(cells[5]),
+                line=line_no,
+            )
+        )
+    return rows, errors
+
+
+def parse_scaffold_index(index_path: Path) -> tuple[dict[str, str], list[str]]:
+    errors: list[str] = []
+    try:
+        marked_lines = _table_lines(index_path.read_text(encoding="utf-8"), SCAFFOLD_START, SCAFFOLD_END)
+    except (OSError, ValueError) as exc:
+        return {}, [f"{index_path}: {exc}"]
+
+    header = _cells(marked_lines[0][1])
+    expected_header = ["File", "Classification", "Decision status"]
+    if header != expected_header:
+        errors.append(f"{index_path}:{marked_lines[0][0]}: expected header {expected_header!r}, found {header!r}")
+
+    rows: dict[str, str] = {}
+    for line_no, line in marked_lines[2:]:
+        cells = _cells(line)
+        if not cells:
+            continue
+        if len(cells) != 3:
+            errors.append(f"{index_path}:{line_no}: expected 3 scaffold cells, found {len(cells)}")
+            continue
+        target = _link_target(cells[0])
+        if target is None:
+            errors.append(f"{index_path}:{line_no}: scaffold cell has no Markdown link")
+            continue
+        filename = Path(target).name
+        if filename in rows:
+            errors.append(f"{index_path}:{line_no}: duplicate scaffold row for {filename}")
+        rows[filename] = _normalized_id(cells[2]).lower()
+        if rows[filename] != "not-assigned":
+            errors.append(f"{index_path}:{line_no}: scaffold {filename} must be not-assigned")
+    return rows, errors
+
+
+def source_status(path: Path) -> SourceStatus:
+    text = path.read_text(encoding="utf-8")
+    meta_match = re.search(r"\[KFM_META_BLOCK_V2\](.*?)\[/KFM_META_BLOCK_V2\]", text, re.DOTALL)
+    if meta_match:
+        status_match = re.search(r"(?mi)^status:\s*([^\n#]+)", meta_match.group(1))
+        if status_match:
+            raw = status_match.group(1).strip().strip('"\'').lower()
+            raw = raw.split(";", 1)[0].strip()
+            if raw in {"draft", "proposed"}:
+                return SourceStatus(label=raw, effective="proposed")
+            if raw in ALLOWED_EFFECTIVE_STATUSES:
+                return SourceStatus(label=raw, effective=raw)
+            raise ValueError(f"unsupported KFM meta status {raw!r}")
+
+    legacy_match = re.search(r"(?mi)^adr_status:\s*([^\n#]+)", text[:6000])
+    if legacy_match:
+        raw = legacy_match.group(1).strip().lower()
+        if raw == "proposed":
+            return SourceStatus(label="legacy-proposed", effective="proposed")
+        if raw in ALLOWED_EFFECTIVE_STATUSES:
+            return SourceStatus(label=f"legacy-{raw}", effective=raw)
+        raise ValueError(f"unsupported legacy adr_status {raw!r}")
+
+    raise ValueError("no supported ADR source-status field")
+
+
+def _numbered_files(adr_dir: Path) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    collisions: dict[str, list[Path]] = {}
+    for path in sorted(adr_dir.glob("ADR-*.md")):
+        match = NUMBERED_NAME_RE.match(path.name)
+        if not match:
+            continue
+        adr_id = f"ADR-{match.group(1)}"
+        if adr_id in result:
+            collisions.setdefault(adr_id, [result[adr_id]]).append(path)
+        else:
+            result[adr_id] = path
+    if collisions:
+        rendered = "; ".join(
+            f"{adr_id}: {[path.name for path in paths]}" for adr_id, paths in sorted(collisions.items())
+        )
+        raise ValueError(f"number collisions: {rendered}")
+    return result
+
+
+def _scaffold_files(adr_dir: Path) -> set[str]:
+    scaffolds: set[str] = set()
+    for path in adr_dir.glob("ADR-*.md"):
+        if path.name == "ADR-template.md" or NUMBERED_NAME_RE.match(path.name):
+            continue
+        if PLACEHOLDER_NAME_RE.match(path.name):
+            scaffolds.add(path.name)
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "PROPOSED scaffold" in text:
+            scaffolds.add(path.name)
+    return scaffolds
+
+
+def _validate_supersession(rows: Iterable[IndexRow], errors: list[str]) -> None:
+    row_map = {row.adr_id: row for row in rows}
+    for row in row_map.values():
+        for ref in (*row.supersedes, *row.superseded_by):
+            if ref == row.adr_id:
+                errors.append(f"{row.adr_id}: supersession relationship cannot reference itself")
+            elif ref not in row_map:
+                errors.append(f"{row.adr_id}: supersession reference does not resolve: {ref}")
+
+        if row.effective_status == "superseded" and len(row.superseded_by) != 1:
+            errors.append(f"{row.adr_id}: superseded status requires exactly one Superseded by reference")
+        if row.effective_status != "superseded" and row.superseded_by:
+            errors.append(f"{row.adr_id}: Superseded by is set but effective status is {row.effective_status}")
+
+        for predecessor in row.supersedes:
+            previous = row_map.get(predecessor)
+            if previous and row.adr_id not in previous.superseded_by:
+                errors.append(f"{row.adr_id}: {predecessor} lacks reciprocal Superseded by link")
+        for successor in row.superseded_by:
+            next_row = row_map.get(successor)
+            if next_row and row.adr_id not in next_row.supersedes:
+                errors.append(f"{row.adr_id}: {successor} lacks reciprocal Supersedes link")
+
+
+def validate_repository(repo_root: Path) -> list[str]:
+    root = repo_root.resolve()
+    adr_dir = root / "docs/adr"
+    index_path = adr_dir / "INDEX.md"
+    readme_path = adr_dir / "README.md"
+    register_path = root / "docs/registers/ADR_INDEX.md"
+    errors: list[str] = []
+
+    for required in (adr_dir, index_path, readme_path, register_path):
+        if not required.exists():
+            errors.append(f"required path missing: {required.relative_to(root)}")
+    if errors:
+        return errors
+
+    try:
+        files = _numbered_files(adr_dir)
+    except ValueError as exc:
+        errors.append(str(exc))
+        files = {}
+
+    rows, parse_errors = parse_numbered_index(index_path)
+    errors.extend(parse_errors)
+    row_map: dict[str, IndexRow] = {}
+    for row in rows:
+        if row.adr_id in row_map:
+            errors.append(f"{index_path.relative_to(root)}:{row.line}: duplicate index ID {row.adr_id}")
+        row_map[row.adr_id] = row
+
+    file_ids = set(files)
+    row_ids = set(row_map)
+    for adr_id in sorted(file_ids - row_ids):
+        errors.append(f"numbered ADR missing from index: {adr_id} ({files[adr_id].name})")
+    for adr_id in sorted(row_ids - file_ids):
+        errors.append(f"index row has no numbered ADR file: {adr_id}")
+
+    for adr_id in sorted(file_ids & row_ids):
+        path = files[adr_id]
+        row = row_map[adr_id]
+        expected_target = f"./{path.name}"
+        if row.target != expected_target:
+            errors.append(f"{adr_id}: index target {row.target!r} does not match {expected_target!r}")
+        resolved = (index_path.parent / row.target).resolve()
+        if resolved != path.resolve() or not resolved.is_file():
+            errors.append(f"{adr_id}: index link does not resolve to its ADR file")
+
+        h1_match = re.search(r"(?m)^#\s+.*\b(ADR-\d{4})\b", path.read_text(encoding="utf-8"))
+        if not h1_match or h1_match.group(1) != adr_id:
+            found = h1_match.group(1) if h1_match else "none"
+            errors.append(f"{path.name}: H1 ADR ID mismatch; expected {adr_id}, found {found}")
+
+        if row.effective_status not in ALLOWED_EFFECTIVE_STATUSES:
+            errors.append(f"{adr_id}: invalid effective status {row.effective_status!r}")
+        try:
+            source = source_status(path)
+        except ValueError as exc:
+            errors.append(f"{path.name}: {exc}")
+            continue
+        if row.source_metadata != source.label:
+            errors.append(
+                f"{adr_id}: index source metadata {row.source_metadata!r} does not match {source.label!r}"
+            )
+        if row.effective_status != source.effective:
+            errors.append(
+                f"{adr_id}: effective status {row.effective_status!r} does not match source-normalized {source.effective!r}"
+            )
+
+    scaffold_rows, scaffold_errors = parse_scaffold_index(index_path)
+    errors.extend(scaffold_errors)
+    actual_scaffolds = _scaffold_files(adr_dir)
+    indexed_scaffolds = set(scaffold_rows)
+    for filename in sorted(actual_scaffolds - indexed_scaffolds):
+        errors.append(f"unassigned ADR scaffold missing from index: {filename}")
+    for filename in sorted(indexed_scaffolds - actual_scaffolds):
+        errors.append(f"scaffold index row does not resolve to an unassigned scaffold: {filename}")
+
+    index_text = index_path.read_text(encoding="utf-8")
+    count_match = re.search(r"(?m)^numbered_records:\s*(\d+)\s*$", index_text)
+    scaffold_count_match = re.search(r"(?m)^unassigned_scaffolds:\s*(\d+)\s*$", index_text)
+    if not count_match or int(count_match.group(1)) != len(files):
+        errors.append(f"INDEX.md numbered_records metadata must equal {len(files)}")
+    if not scaffold_count_match or int(scaffold_count_match.group(1)) != len(actual_scaffolds):
+        errors.append(f"INDEX.md unassigned_scaffolds metadata must equal {len(actual_scaffolds)}")
+
+    register_text = register_path.read_text(encoding="utf-8")
+    if "canonical_adr_index: ../adr/INDEX.md" not in register_text:
+        errors.append("docs/registers/ADR_INDEX.md lacks canonical_adr_index pointer")
+    if "../adr/INDEX.md" not in register_text:
+        errors.append("docs/registers/ADR_INDEX.md does not link to the canonical index")
+    if INDEX_START in register_text or re.search(r"(?m)^\|\s*`?ADR-\d{4}", register_text):
+        errors.append("docs/registers/ADR_INDEX.md must not duplicate numbered ADR rows")
+
+    readme_text = readme_path.read_text(encoding="utf-8")
+    if "[canonical ADR index](./INDEX.md)" not in readme_text:
+        errors.append("docs/adr/README.md lacks the canonical ADR index link")
+
+    _validate_supersession(rows, errors)
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+    errors = validate_repository(args.repo_root)
+    if errors:
+        print("FAIL: ADR index coherence")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    adr_dir = args.repo_root.resolve() / "docs/adr"
+    numbered = len(_numbered_files(adr_dir))
+    scaffolds = len(_scaffold_files(adr_dir))
+    print(f"PASS: ADR index coherence ({numbered} numbered records, {scaffolds} unassigned scaffolds)")
+    print("BOUNDARY: coherence is not ADR acceptance, implementation proof, release approval, or publication authority")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Converges KFM's human Architecture Decision Record control plane without changing any decision status.

- replaces the stale `docs/adr/README.md` repository-unmounted claims with a verified operating contract;
- replaces `docs/adr/INDEX.md` scaffold with the canonical 28-record inventory and 12-scaffold separation;
- converts `docs/registers/ADR_INDEX.md` into a non-duplicating canonical pointer and consumer map;
- adds a standard-library ADR index validator and seven negative-path tests;
- adds a read-only `adr-index-coherence` job to the existing documentation control-plane workflow;
- records the six authored artifacts in a schema-valid generated-work receipt.

## Evidence and authority basis

- Base: `main@43f1d97954debda98691b2685c1bb75c4b63c872`
- Campaign: #1531, state version 7
- Directory Rules §6.1: human ADRs and registers belong under `docs/`
- Directory Rules §7.5: repository-wide validation logic belongs under `tools/`
- Directory Rules §6.6: enforceability proof belongs under `tests/`
- GitHub Actions orchestration remains under `.github/workflows/`

The verified direct inventory is 46 Markdown files: 28 unique numbered records from `ADR-0001` through `ADR-0028`, 12 unassigned scaffolds, one template, and five index/support documents. Fifteen numbered records declare `proposed`, twelve declare `draft`, and ADR-0007 uses legacy unstructured `PROPOSED` metadata. All normalize conservatively to effective status `proposed`; no numbered record provides verified accepted, superseded, or rejected status.

## Validation

- `python tools/validators/validate_adr_index.py` — PASS: 28 numbered records, 12 unassigned scaffolds
- ADR validator tests — 7 passed
- `make validate` — aggregate fixture validators passed; 18 schema/contract tests passed
- `make boundary-guards` — 15 passed
- workflow YAML — all 41 files parsed; ADR job retains `contents: read`
- Markdown lint — 0 issues under the repository-compatible no-line-length profile
- local links/fragments — 111 resolved
- Mermaid 11.12.0 parser — PASS
- generated receipt — schema valid; all six artifact hashes match
- exact diff, whitespace, credential/private-key, sensitivity, and publication-boundary scans — PASS

## Boundary and non-goals

This PR does **not**:

- accept, reject, supersede, renumber, rename, move, or substantively edit any ADR;
- modify `artifacts/`, migrate `artifacts/release/`, or resolve `artifacts/perf/`;
- change a schema, contract, policy, release, promotion, publication, deployment, or runtime behavior;
- grant decision authority merely because a file is tracked;
- merge itself.

ADR-0011 remains proposed. `OPEN-DR-09-b` and the MapLibre performance-artifact placement conflict remain unresolved.

## Receipt and rollback

- Receipt: `data/receipts/generated/genrec-adr-control-plane-convergence-20260722-001.json`
- Human review: pending
- Rollback: revert this single scoped commit. No ADR status, artifact payload, release state, deployment, or publication state needs restoration.
